### PR TITLE
refactor(claude): Global CLAUDE.md 정리 및 Astral 플러그인 제거

### DIFF
--- a/libraries/packages.nix
+++ b/libraries/packages.nix
@@ -29,7 +29,7 @@
     pkgs.htop # 시스템 모니터링
     pkgs.nvd # Nix 변경사항 비교
     pkgs.qrencode # QR 코드 생성 (MiniPC -> iPhone 텍스트 공유)
-    pkgs.uv # Python 패키지 관리자 (Astral ty LSP의 uvx 의존성)
+    pkgs.uv # Python 패키지 관리자
   ];
 
   # macOS 전용 패키지

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -128,7 +128,7 @@ in
     # MCP 설정 - 양방향 수정 가능
     ".claude/mcp.json".source = config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/mcp.json";
 
-    # User-scope 지침 - 양방향 수정 가능 (Astral 플러그인 등 전역 설정)
+    # User-scope 지침 - 양방향 수정 가능
     ".claude/CLAUDE.md".source = config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/CLAUDE.md";
 
     # Hooks - mkOutOfStoreSymlink로 nrs 없이 즉시 반영 (소스 파일에 chmod +x 필수)

--- a/modules/shared/programs/claude/files/CLAUDE.md
+++ b/modules/shared/programs/claude/files/CLAUDE.md
@@ -12,22 +12,3 @@
 ## 필수 스킬
 
 코드 작성, 리뷰, 리팩터링, 버그 수정, 기능 구현 등 코딩 관련 작업 시작 시 반드시 `/karpathy-guidelines` 스킬을 먼저 호출하세요.
-
-## Python (Astral)
-
-Python 프로젝트 작업 시 /astral:<skill>을 호출하세요.
-
-- `/astral:uv` - uv package manager
-- `/astral:ty` - ty type checker
-- `/astral:ruff` - ruff linter/formatter
-
-### 브라우저 자동화 도구 선택
-
-- **NixOS (Platform: linux)**: 항상 `agent-browser` 사용. Claude in Chrome 미지원 환경.
-- **macOS (Platform: darwin)**: AskUserQuestion으로 사용자에게 도구 선택을 물어보세요.
-  - **Claude in Chrome**: 실제 Chrome 브라우저 제어. 기존 로그인 세션 활용 가능, 시각적 확인 가능
-  - **agent-browser**: 헤드리스 CLI 도구. 독립 Chromium 사용, 인증 상태는 별도 관리 필요 (state save/load)
-
-이 규칙은 agent-browser 스킬의 자동 트리거보다 우선합니다.
-
-NixOS/nix-darwin 환경에서 agent-browser 문제 발생 시 `~/.claude/skills/agent-browser/references/troubleshooting.md` 참조.

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -50,16 +50,7 @@
     ]
   },
   "enabledPlugins": {
-    "plugin-dev@claude-plugins-official": true,
-    "astral@astral-sh": true
-  },
-  "extraKnownMarketplaces": {
-    "astral-sh": {
-      "source": {
-        "source": "github",
-        "repo": "astral-sh/claude-code-plugins"
-      }
-    }
+    "plugin-dev@claude-plugins-official": true
   },
   "language": "Korean",
   "alwaysThinkingEnabled": true,

--- a/modules/shared/programs/claude/files/skills/agent-browser/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/agent-browser/SKILL.md
@@ -6,6 +6,17 @@ allowed-tools: Bash(agent-browser:*)
 
 # Browser Automation with agent-browser
 
+## Tool Selection
+
+- **NixOS (Platform: linux)**: 항상 agent-browser 사용. Claude in Chrome 미지원 환경.
+- **macOS (Platform: darwin)**: AskUserQuestion으로 사용자에게 도구 선택을 물어본다.
+  - **Claude in Chrome**: 실제 Chrome 브라우저 제어. 기존 로그인 세션 활용 가능, 시각적 확인 가능.
+  - **agent-browser**: 헤드리스 CLI 도구. 독립 Chromium 사용, 인증 상태는 별도 관리 필요.
+
+이 규칙은 agent-browser 스킬의 자동 트리거보다 우선한다.
+
+NixOS/nix-darwin 환경에서 agent-browser 문제 발생 시 [references/troubleshooting.md](references/troubleshooting.md) 참조.
+
 ## Core Workflow
 
 Every browser automation follows this pattern:


### PR DESCRIPTION
## Why

Global CLAUDE.md(`~/.claude/CLAUDE.md`)는 **모든 프로젝트에 적용되는** user-scope 지침 파일이다.
현재 이 파일에 다음 두 가지 문제가 있다:

1. **Astral 플러그인 섹션이 불필요하게 존재**: `astral@astral-sh` 플러그인(uv, ty, ruff)은 도입 이후 한 번도 사용되지 않았으며, 매 세션마다 시스템 프롬프트에 불필요한 토큰을 소비한다. 해당 플러그인의 원본 저장소([astral-sh/claude-code-plugins](https://github.com/astral-sh/claude-code-plugins))는 총 8 커밋, last commit이 1달 전으로 유지보수가 활발하지 않다. uv 본체는 거의 매일 릴리스되는 것과 대조적이며, Skills가 주목받던 시기에 시범적으로 만들어진 단발성 프로젝트로 보인다. 또한 현 시점에서 uv는 이미 Python 생태계의 사실상 표준 패키지 매니저로 자리잡아 별도의 사용 패턴 가이드 스킬이 필요하지 않다.
2. **브라우저 자동화 도구 선택 규칙이 잘못된 위치에 배치**: `### 브라우저 자동화 도구 선택`이 `## Python (Astral)` 하위 h3로 잘못 중첩되어 있어 문서 구조가 혼란스럽다. 이 규칙은 agent-browser 스킬의 관심사이므로 해당 스킬로 이동하는 것이 적절하다.

## What

- Global CLAUDE.md에서 `## Python (Astral)` 섹션(16-22행) 및 `### 브라우저 자동화 도구 선택` 섹션(24-33행) 제거
- 브라우저 자동화 도구 선택 규칙을 `agent-browser` 스킬의 `## Tool Selection` 섹션으로 이동
- `settings.json`에서 `astral@astral-sh` 플러그인 및 `extraKnownMarketplaces` 제거
- 관련 주석 정리 (`default.nix`, `packages.nix`)

## References

- Astral Claude Code Plugins (총 8 commits, last activity 1달 전): https://github.com/astral-sh/claude-code-plugins
- uv 본체 (거의 매일 릴리스): https://github.com/astral-sh/uv/releases
- `~/.claude/CLAUDE.md`의 역할: https://docs.anthropic.com/en/docs/claude-code/memory#claudemd-files

## Test plan

- [ ] `nrs` 적용 후 `~/.claude/CLAUDE.md`에 스킬 라우팅 + 필수 스킬만 남아있는지 확인
- [ ] `~/.claude/skills/agent-browser/SKILL.md`에 Tool Selection 섹션 존재 확인
- [ ] `~/.claude/settings.json`에서 Astral 관련 항목 없음 확인
- [ ] macOS에서 브라우저 자동화 요청 시 agent-browser 스킬의 Tool Selection 규칙이 정상 트리거되는지 확인