### PR TITLE
fix(copyparty): ACL에 move 권한 추가하여 이름 변경 허용

### DIFF
--- a/modules/nixos/programs/docker/copyparty.nix
+++ b/modules/nixos/programs/docker/copyparty.nix
@@ -36,7 +36,7 @@ let
     [/]
       /data
       accs:
-        rwda: greenhead
+        rwmda: greenhead
     CONF
     chmod 0600 ${configPath}
   '';


### PR DESCRIPTION
## Summary
- Copyparty ACL에 `m`(move) 권한 플래그 추가 (`rwda` → `rwmda`)
- Copyparty는 rename을 내부적으로 move로 처리하므로 `m` 플래그 누락 시 "이 폴더에 이동 권한이 없습니다" 에러 발생

## Test plan
- [ ] MiniPC에서 `nrs` 적용
- [ ] Copyparty 웹 UI에서 파일/폴더 이름 변경 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Copyparty account permissions configuration to reflect proper access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->