### PR TITLE
chore: update hardcoded GitHub username references to greenheadHQ

### DIFF
--- a/.claude/skills/managing-minipc/references/installation.md
+++ b/.claude/skills/managing-minipc/references/installation.md
@@ -56,7 +56,7 @@ nix --experimental-features "nix-command flakes" run github:nix-community/disko 
 ### 3. NixOS 설치
 
 ```bash
-nixos-install --flake github:shren207/nixos-config#greenhead-minipc --no-root-passwd
+nixos-install --flake github:greenheadHQ/nixos-config#greenhead-minipc --no-root-passwd
 ```
 
 ### 4. 재부팅 후 초기 설정
@@ -66,7 +66,7 @@ nixos-install --flake github:shren207/nixos-config#greenhead-minipc --no-root-pa
 sudo tailscale up
 
 # nixos-config 클론
-git clone git@github.com:shren207/nixos-config.git
+git clone git@github.com:greenheadHQ/nixos-config.git
 cd nixos-config && nrs
 ```
 

--- a/.claude/skills/managing-minipc/references/troubleshooting.md
+++ b/.claude/skills/managing-minipc/references/troubleshooting.md
@@ -19,7 +19,7 @@ NixOS MiniPC 관련 문제와 해결 방법을 정리합니다.
 **증상**: `flake.nix`를 수정하고 GitHub에 push한 후 `nixos-install --flake github:user/repo#host`를 실행해도 이전 버전이 사용됨.
 
 ```bash
-$ nixos-install --flake github:shren207/nixos-config#greenhead-minipc
+$ nixos-install --flake github:greenheadHQ/nixos-config#greenhead-minipc
 # 에러: 방금 수정한 내용이 반영되지 않음
 ```
 

--- a/.claude/skills/managing-ssh/references/troubleshooting.md
+++ b/.claude/skills/managing-ssh/references/troubleshooting.md
@@ -22,7 +22,7 @@ The agent has no identities.  # ← 키가 없음!
 
 # 일반 ssh 명령은 작동 (macOS Keychain 직접 참조)
 $ ssh -T git@github.com
-Hi shren207! You've successfully authenticated...
+Hi greenheadHQ! You've successfully authenticated...
 ```
 
 nix-daemon은 별도 프로세스로 실행되어 Keychain에 직접 접근하지 못하고, `ssh-agent`만 사용합니다.
@@ -235,7 +235,7 @@ greenhead@greenhead-minipc:~$  # 성공!
 
 ```bash
 $ ssh -T git@github.com
-Hi shren207! You've successfully authenticated...
+Hi greenheadHQ! You've successfully authenticated...
 
 $ sudo git clone git@github.com:user/repo
 git@github.com: Permission denied (publickey).

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ curl -L https://nixos.org/nix/install | sh
 
 # 2. 저장소 클론
 mkdir -p ~/Workspace && cd ~/Workspace
-git clone https://github.com/shren207/nixos-config.git
+git clone https://github.com/greenheadHQ/nixos-config.git
 cd nixos-config
 
 # 3. SSH 키 복원 (~/.ssh/id_ed25519)

--- a/modules/nixos/scripts/install-minipc.sh
+++ b/modules/nixos/scripts/install-minipc.sh
@@ -53,7 +53,7 @@ fi
 
 # 4. disko 설정 다운로드
 echo_info "disko 설정 다운로드 중..."
-curl -o /tmp/disko.nix https://raw.githubusercontent.com/shren207/nixos-config/main/hosts/greenhead-minipc/disko.nix
+curl -o /tmp/disko.nix https://raw.githubusercontent.com/greenheadHQ/nixos-config/main/hosts/greenhead-minipc/disko.nix
 
 echo_info "disko 설정 확인:"
 grep "device =" /tmp/disko.nix
@@ -92,7 +92,7 @@ echo ""
 
 # 7. NixOS 설치
 echo_info "=== NixOS 설치 시작 ==="
-echo_info "flake: github:shren207/nixos-config#greenhead-minipc"
+echo_info "flake: github:greenheadHQ/nixos-config#greenhead-minipc"
 echo ""
 
 read -p "NixOS 설치를 시작하시겠습니까? (y/N): " confirm
@@ -101,7 +101,7 @@ if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
     exit 1
 fi
 
-nixos-install --flake github:shren207/nixos-config#greenhead-minipc
+nixos-install --flake github:greenheadHQ/nixos-config#greenhead-minipc
 
 echo ""
 echo_info "=== 설치 완료! ==="

--- a/modules/nixos/scripts/post-install-minipc.sh
+++ b/modules/nixos/scripts/post-install-minipc.sh
@@ -45,13 +45,13 @@ fi
 # 3. nixos-config 클론
 if [[ ! -d ~/nixos-config ]]; then
     echo_info "nixos-config 클론 중..."
-    git clone git@github.com:shren207/nixos-config.git ~/nixos-config
+    git clone git@github.com:greenheadHQ/nixos-config.git ~/nixos-config
 fi
 
 cd ~/nixos-config
 
 # 4. git 설정
-git config user.email "shren207@naver.com"
+git config user.email "shren0812@gmail.com"
 git config user.name "greenhead"
 
 # 5. hardware-configuration.nix 복사


### PR DESCRIPTION
## 배경

GitHub username 변경(`shren207` → `greenheadHQ`) 이후, 저장소 내부 문서/스크립트에 남아 있던 old username 참조를 선제적으로 정리했습니다.

GitHub가 일부 URL 리다이렉트를 제공하더라도, 향후 old namespace 재사용/리다이렉트 정책 변화 시 설치 스크립트와 문서 신뢰성이 깨질 수 있어 하드코딩 참조를 직접 교체했습니다.

## 목표

1. `nixos-config` 내부에서 MiniPC 설치/운영 경로에 사용되는 old username 참조 제거
2. post-install 스크립트의 git 이메일 기본값을 현재 사용 이메일로 정정
3. 관련 레퍼런스 문서(Claude skills)의 예시 출력/명령까지 일관화
4. 로컬(Mac) + 원격(MiniPC) workspace의 Git remote URL도 새 username으로 동기화

## 변경 범위

### 1) 코드/문서 수정 (이 PR에 포함)

총 6개 파일, 11개 라인 치환

- `README.md`
  - 설치 가이드 clone URL 변경
  - `https://github.com/shren207/nixos-config.git`
  - → `https://github.com/greenheadHQ/nixos-config.git`

- `modules/nixos/scripts/install-minipc.sh`
  - disko 다운로드 raw URL owner 변경
  - flake 안내 메시지 변경
  - `nixos-install --flake` 참조 owner 변경

- `modules/nixos/scripts/post-install-minipc.sh`
  - `git clone` SSH URL owner 변경
  - 기본 git 이메일 변경
  - `shren207@naver.com` → `shren0812@gmail.com`

- `.claude/skills/managing-minipc/references/installation.md`
  - 설치 명령의 flake owner 변경
  - clone 명령 SSH URL owner 변경

- `.claude/skills/managing-minipc/references/troubleshooting.md`
  - troubleshooting 예시 명령의 flake owner 변경

- `.claude/skills/managing-ssh/references/troubleshooting.md`
  - SSH 성공 메시지 예시 문자열 변경
  - `Hi shren207!` → `Hi greenheadHQ!` (2곳)

### 2) 워크스페이스 운영 변경 (PR 외 실행 작업)

아래는 코드 파일 변경이 아니라, 실제 환경의 remote 정합성을 맞추기 위해 수행한 운영 작업입니다.

#### Mac Workspace remote 업데이트 (9개)

- `~/Workspace/nixos-config` (`origin`)
- `~/Workspace/TIL` (`origin`)
- `~/Workspace/anki-card-templates` (`origin`)
- `~/Workspace/awesome-anki` (`origin`)
- `~/Workspace/frontend-fundamentals-mock-exam-1` (`origin`)
- `~/Workspace/locatorjs` (`fork`)
- `~/Workspace/nano-banana-pro-image-translation` (`origin`)
- `~/Workspace/renpy` (`origin`)
- `~/Workspace/vscode-translator` (`origin`)

모든 대상에서 `github.com/shren207/...` → `github.com/greenheadHQ/...`로 변경 확인.

#### MiniPC Workspace remote 업데이트 (3개)

SSH(`minipc`)로 아래 변경 수행:

- `~/Workspace/nixos-config` (`origin`)
  - `git@github.com:greenheadHQ/nixos-config.git`
- `~/Workspace/awesome-anki` (`origin`)
  - `https://github.com/greenheadHQ/awesome-anki`
- `~/Workspace/locatorjs` (`origin`)
  - `https://github.com/greenheadHQ/locatorjs.git`

## 검증

### A. 문자열 잔여 검사

요청된 검증 명령(`grep -R ...`) 실행 시, 아래 경로의 잔여 문자열만 관찰됨:

- `.claude/plans/virtual-tickling-codd.md` (계획 문서 자체)
- `.wt/**`, `.direnv/**` (worktree/flake input 복제본)

실제 작업 트리 기준으로는 아래 필터 검증 결과 `0건`:

```bash
rg -n 'shren207' /Users/green/Workspace/nixos-config \
  --glob '*.md' --glob '*.sh' --glob '*.nix' \
  --glob '!.direnv/**' --glob '!.wt/**' \
  --glob '!.claude/plans/virtual-tickling-codd.md'
```

### B. remote URL 검증

- Mac 9개 대상 repo: `remote -v` 확인 완료
- MiniPC 3개 대상 repo: `ssh minipc 'git -C ... remote -v'` 확인 완료

### C. 연결 동작 검증

- `git -C ~/Workspace/nixos-config fetch --prune` 성공

### D. hook/체크

커밋/푸시 시 자동 훅 통과:

- pre-commit: `gitleaks`, `shellcheck`, `ai-skills-consistency`, `eval-tests`
- pre-push: `flake-check` (flake outputs 평가 포함)

## 영향도 및 리스크

- 기능 로직 변경 없음 (문서/문자열 참조 변경만 포함)
- MiniPC 설치/초기화 절차에서 old username 참조로 인한 미래 리다이렉트 의존성 제거
- post-install의 git 기본 이메일이 실제 사용 이메일로 정합화됨

## 롤백 전략

필요 시 이 PR revert 1회로 코드 변경은 전부 되돌릴 수 있습니다.
(단, Mac/MiniPC remote URL 변경은 운영 환경 변경이므로 별도 역변경 필요)

## 체크리스트

- [x] 요청된 파일 변경 범위 반영
- [x] Mac Workspace remote 9개 변경
- [x] MiniPC remote 3개 변경
- [x] 문자열 잔여 검증
- [x] remote/fetch 동작 검증


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NixOS installation and troubleshooting guides to reference the new repository source
  * Updated Getting Started guide with correct repository URL

* **Chores**
  * Updated Git user configuration details
  * Updated SSH authentication message references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->