### PR TITLE
fix(copyparty): 세션 영속성 볼륨 마운트로 재시작 후 403 해결

### DIFF
--- a/.agents/skills/hosting-copyparty/SKILL.md
+++ b/.agents/skills/hosting-copyparty/SKILL.md
@@ -97,6 +97,7 @@ sudo copyparty-update             # 실제 업데이트 (pull → digest 비교 
 |------|--------|------|
 | `/var/lib/docker-data/copyparty/hists` | SSD | DB/인덱스/썸네일 캐시 |
 | `/var/lib/docker-data/copyparty/config` | SSD | 설정 파일 (0700) |
+| `/var/lib/docker-data/copyparty/sessions` | SSD | 세션 DB/salt/iphash (0700) |
 | `/mnt/data` | HDD | 전체 파일 저장소 |
 
 ## Known Issues
@@ -141,6 +142,12 @@ sudo copyparty-update             # 실제 업데이트 (pull → digest 비교 
 **이미지 태그**
 - `copyparty/ac:latest` 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
 - 기본 `copyparty/copyparty` 이미지는 썸네일 미지원
+
+**세션 데이터 영속성**
+- CopyParty는 세션 DB(`sessions.db`)와 인증 salt(`ah-salt.txt`, `dk-salt.txt`, `fk-salt.txt`), `iphash`를 `/cfg/copyparty/`에 저장
+- 이 경로가 볼륨 마운트되지 않으면 컨테이너 재시작 시 세션 유실 → 403 에러
+- 해결: `${dockerData}/copyparty/sessions:/cfg/copyparty` 볼륨 마운트 (0700)
+- 세션 문제 발생 시 `sessions/` 디렉토리 내용을 비우고 재시작하면 초기화됨
 
 ## 자주 발생하는 문제
 

--- a/.claude/skills/hosting-copyparty/SKILL.md
+++ b/.claude/skills/hosting-copyparty/SKILL.md
@@ -97,6 +97,7 @@ sudo copyparty-update             # 실제 업데이트 (pull → digest 비교 
 |------|--------|------|
 | `/var/lib/docker-data/copyparty/hists` | SSD | DB/인덱스/썸네일 캐시 |
 | `/var/lib/docker-data/copyparty/config` | SSD | 설정 파일 (0700) |
+| `/var/lib/docker-data/copyparty/sessions` | SSD | 세션 DB/salt/iphash (0700) |
 | `/mnt/data` | HDD | 전체 파일 저장소 |
 
 ## Known Issues
@@ -141,6 +142,12 @@ sudo copyparty-update             # 실제 업데이트 (pull → digest 비교 
 **이미지 태그**
 - `copyparty/ac:latest` 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
 - 기본 `copyparty/copyparty` 이미지는 썸네일 미지원
+
+**세션 데이터 영속성**
+- CopyParty는 세션 DB(`sessions.db`)와 인증 salt(`ah-salt.txt`, `dk-salt.txt`, `fk-salt.txt`), `iphash`를 `/cfg/copyparty/`에 저장
+- 이 경로가 볼륨 마운트되지 않으면 컨테이너 재시작 시 세션 유실 → 403 에러
+- 해결: `${dockerData}/copyparty/sessions:/cfg/copyparty` 볼륨 마운트 (0700)
+- 세션 문제 발생 시 `sessions/` 디렉토리 내용을 비우고 재시작하면 초기화됨
 
 ## 자주 발생하는 문제
 

--- a/.claude/skills/hosting-copyparty/references/troubleshooting.md
+++ b/.claude/skills/hosting-copyparty/references/troubleshooting.md
@@ -170,3 +170,29 @@ Copyparty Docker 이미지의 `-c` 플래그는 설정값(global, accounts)은 �
 - 로컬 Mac에서 `nrs` 실행 → darwin-rebuild만 됨, MiniPC에는 적용 안 됨
 - git push 없이 MiniPC에서 `git pull` → 변경사항 없음
 - flake 기반이라 **git에 추가되지 않은 파일은 빌드에 포함되지 않음**
+
+## 9. 컨테이너 재시작 후 403 에러 (세션 유실)
+
+**증상**: 컨테이너 재시작 후 로그인 상태가 풀리고 "오류 403: 접근 거부됨" 발생
+
+**원인**:
+CopyParty는 세션 DB(`sessions.db`)와 인증 salt 파일들을 컨테이너 내부 `/cfg/copyparty/`에 저장.
+이 경로가 볼륨 마운트되지 않으면 컨테이너 재시작 시 모든 세션 데이터 유실.
+salt 파일 유실 시 기존 세션 쿠키가 전부 무효화되어 재로그인 필요.
+
+**진단**:
+```bash
+# 세션 디렉토리 볼륨 마운트 확인
+sudo podman inspect copyparty --format '{{range .Mounts}}{{.Destination}} {{end}}' | grep copyparty
+
+# 호스트 세션 디렉토리 확인
+sudo ls -la /var/lib/docker-data/copyparty/sessions/
+# 예상: sessions.db, ah-salt.txt, dk-salt.txt, fk-salt.txt, iphash
+
+# 컨테이너 종료 코드 확인 (137 = OOM kill)
+sudo podman inspect copyparty --format '{{.State.ExitCode}}'
+```
+
+**해결**:
+- `copyparty.nix`에서 `${dockerData}/copyparty/sessions:/cfg/copyparty` 볼륨 마운트 확인
+- 세션 초기화 필요 시: `sudo rm /var/lib/docker-data/copyparty/sessions/*` 후 컨테이너 재시작

--- a/modules/nixos/programs/docker/copyparty.nix
+++ b/modules/nixos/programs/docker/copyparty.nix
@@ -54,6 +54,7 @@ in
     systemd.tmpfiles.rules = [
       "d ${dockerData}/copyparty/hists 0755 root root -"
       "d ${dockerData}/copyparty/config 0700 root root -"
+      "d ${dockerData}/copyparty/sessions 0700 root root -" # 세션 DB + salt + iphash
     ];
 
     # 비밀번호 주입 서비스 (컨테이너 시작 전 실행)
@@ -87,6 +88,7 @@ in
       volumes = [
         "${configPath}:/cfg/config.conf:ro"
         "${dockerData}/copyparty/hists:/cfg/hists"
+        "${dockerData}/copyparty/sessions:/cfg/copyparty" # 세션 영속성
         "${mediaData}:/data"
       ];
       environment = {


### PR DESCRIPTION
## Summary

CopyParty 컨테이너가 재시작될 때마다 세션 DB와 인증 salt 파일이 유실되어 **403 "접근 거부됨" 에러**가 반복 발생하는 문제를 수정합니다.

### 근본 원인

CopyParty는 세션 데이터를 컨테이너 내부 `/cfg/copyparty/`에 저장합니다:
- `sessions.db` — 세션 DB (로그인 상태)
- `ah-salt.txt`, `dk-salt.txt`, `fk-salt.txt` — 인증 salt (쿠키 서명)
- `iphash` — IP 해시 데이터

이 경로가 볼륨 마운트되지 않아 컨테이너 재시작(OOM kill exit 137 포함) 시 모든 세션 데이터가 소멸됩니다. salt 파일이 재생성되면 기존 세션 쿠키가 전부 무효화되어 **재로그인이 필요**합니다.

최근 7일간 19회의 컨테이너 재시작이 관찰되었으며, 매번 `creating new sessions-db /cfg/copyparty/sessions.db` 로그가 출력되어 세션 DB가 매번 새로 생성되고 있음을 확인했습니다.

### 해결 방법

`/cfg/copyparty/` 경로를 호스트의 SSD(`/var/lib/docker-data/copyparty/sessions/`)에 볼륨 마운트하여 세션 데이터가 컨테이너 재시작 후에도 유지되도록 합니다.

## Changes

### `modules/nixos/programs/docker/copyparty.nix` (핵심 — 2줄 추가)

1. **tmpfiles rule**: `sessions` 디렉토리 생성 (0700 root:root)
2. **volume mount**: `${dockerData}/copyparty/sessions:/cfg/copyparty` 추가

### `.claude/skills/hosting-copyparty/SKILL.md` + `.agents/skills/` (문서)

- 스토리지 구조 테이블에 `sessions` 행 추가
- Known Issues에 "세션 데이터 영속성" 항목 추가

### `.claude/skills/hosting-copyparty/references/troubleshooting.md` (문서)

- 항목 9 "컨테이너 재시작 후 403 에러 (세션 유실)" 추가
- 증상, 원인, 진단 명령어, 해결 방법 기술

## 사전 검증

- SSH로 `/cfg/copyparty/` 내용물 확인: 모든 파일이 **런타임 생성** (이미지 내장 파일 없음)
- 빈 볼륨 마운트로 이미지 파일을 shadow할 위험 없음
- `iphash`는 일반 파일 (64 bytes), 디렉토리 아님

## 의도적으로 제외한 것 (YAGNI)

- **메모리 제한 상향**: OOM은 세션 유실의 트리거일 뿐, 근본 원인이 아님 (별도 이슈)
- **`--ses-db` CLI 옵션**: 디렉토리 전체 마운트가 salt 파일까지 포함하므로 불필요
- **sessions.db 마이그레이션**: 버전 업그레이드 시 문제 발생하면 `sessions/` 비우면 해결

## 리스크

- **첫 배포 시 1회 세션 초기화**: 빈 볼륨으로 시작하므로 기존 세션 무효화 (재로그인 1회, 불가피)
- **회귀 없음**: 볼륨 마운트 추가는 순수 추가 변경

## Test plan

- [ ] MiniPC에서 `git pull && nrs` 빌드 성공
- [ ] `/var/lib/docker-data/copyparty/sessions/` 디렉토리 생성 확인 (0700)
- [ ] `sudo podman inspect copyparty` — 볼륨 마운트 `/cfg/copyparty` 확인
- [ ] 세션 파일 생성 확인: `sessions.db`, `*-salt.txt`, `iphash`
- [ ] 웹 UI 로그인 후 `sudo systemctl restart podman-copyparty` → 세션 유지 (403 없음)