### PR TITLE
feat(nrs): macOS Touch ID 제거 — build/cleanup sudo 제거 + NOPASSWD

### DIFF
--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -21,6 +21,12 @@
   # Touch ID for sudo
   security.pam.services.sudo_local.touchIdAuth = true;
 
+  # darwin-rebuild를 Touch ID 없이 실행 (nrs 자동화용)
+  # 보안: NixOS는 이미 wheelNeedsPassword=false (ALL 명령 NOPASSWD). 이것은 더 제한적.
+  security.sudo.extraConfig = ''
+    ${username} ALL=(root) NOPASSWD: /run/current-system/sw/bin/darwin-rebuild
+  '';
+
   # 사용자 설정
   users.users.${username} = {
     shell = pkgs.zsh;

--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -83,7 +83,7 @@ preview_changes() {
     log_info "🔨 Building (${offline_tag}${label})..."
 
     # shellcheck disable=SC2086
-    if ! sudo "$REBUILD_CMD" build --flake "$FLAKE_PATH" $OFFLINE_FLAG; then
+    if ! "$REBUILD_CMD" build --flake "$FLAKE_PATH" $OFFLINE_FLAG; then
         log_error "❌ Build failed!"
         exit 1
     fi
@@ -111,8 +111,8 @@ cleanup_build_artifacts() {
     count=$(echo "$links" | grep -c . 2>/dev/null || echo 0)
 
     if [[ "$count" -gt 0 ]]; then
-        # result는 sudo rebuild로 생성되어 root 소유. 삭제할 때도 root 권한 필요
-        echo "$links" | xargs sudo rm -f
+        # result는 일반 사용자 build로 생성되어 사용자 소유
+        echo "$links" | xargs rm -f
         log_info "  ✓ Removed $count result symlink(s)"
     fi
 }


### PR DESCRIPTION
## Motivation

macOS에서 `nrs` 실행 시 두 가지 문제:

1. **Touch ID 반복 요청**: build, switch, cleanup 각 단계마다 sudo가 Touch ID를 요구하여 매번 2~3회 지문 인식 필요. 설정 변경할 때마다 반복되어 불편
2. **SSH 원격 실행 불가**: Claude Code 세션 등에서 `ssh mac`으로 MacBook에 접속한 상태에서 `nrs` 실행 시, Touch ID 인증을 처리할 방법이 없어 sudo가 완전히 차단됨

## Summary

- `rebuild-common.sh`의 build/cleanup 단계에서 불필요한 `sudo` 제거
- macOS에 `darwin-rebuild` 단일 명령 NOPASSWD sudoers 규칙 추가
- `nrs` 실행 시 Touch ID 요청 2~3회 → 0회 (첫 적용 후)

## Changes

### `modules/shared/scripts/rebuild-common.sh`
- `preview_changes()`: `sudo "$REBUILD_CMD" build` → `"$REBUILD_CMD" build` (Nix daemon이 빌드 처리하므로 root 불필요)
- `cleanup_build_artifacts()`: `sudo rm` → `rm` (사용자 build로 result 심링크가 사용자 소유)

### `modules/darwin/configuration.nix`
- `security.sudo.extraConfig`로 `darwin-rebuild` NOPASSWD 규칙 추가
- switch 단계의 `sudo`는 유지하되, Touch ID 프롬프트 없이 실행

## Security context

- NixOS(MiniPC)는 이미 `wheelNeedsPassword = false` (모든 sudo 명령 NOPASSWD)
- macOS에서 `darwin-rebuild` 단일 명령만 NOPASSWD → NixOS보다 더 제한적
- 개인 머신의 동일 위협 모델 범위 내

## Test plan

- [x] `nix flake check` 통과
- [x] pre-commit hooks 전체 통과
- [x] macOS worktree에서 `nrs` 실행 → 정상 동작 확인
- [x] 두 번째 `nrs` 실행 → Touch ID 0회 확인
- [ ] SSH 원격 접속 상태에서 `nrs` 실행 가능 확인
- [ ] NixOS에서 `nrs`/`nrp` 정상 동작 확인