### PR TITLE
fix(codex): PR#38 사후 방어 — activation 심링크 가드 + gitignore 부산물 패턴

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 !AGENTS.override.md
 !.agents/
 .codex/
+
+# Codex sync 부산물 (.agents/ 심링크 경유로 .claude/에 생성되는 파일)
+.claude/skills/*/agents/
+.claude/skills/*/references/references


### PR DESCRIPTION
## 배경

PR #38 (`refactor(codex): 스킬 투영을 디렉토리 심링크로 전환`) 머지 후 다음 문제가 발생:

1. **git diff/stash 깨짐**: `nrs`(Nix activation)가 `.agents/skills/`를 심링크로 전환했으나, 로컬 `main`이 `git pull` 전이라 HEAD는 여전히 디렉토리 구조를 기대 → git이 "is beyond a symbolic link" 에러 발생, `git stash` 불가
2. **untracked 부산물**: codex sync가 `.agents/skills/` 심링크를 경유해 `.claude/skills/*/agents/openai.yaml`과 `references/references`(broken symlink) 생성

## 원인 분석

```
타임라인:
1. PR#38 GitHub에서 머지 (origin/main 전진)
2. 로컬에서 git pull 없이 nrs 실행
3. activation script이 .agents/skills/* 디렉토리를 심링크로 교체
4. git HEAD(디렉토리 구조) ≠ 파일시스템(심링크) → 불일치 상태
5. git stash 시도 → "is beyond a symbolic link" 에러로 실패
```

## 변경 내용

### 1. `modules/shared/programs/codex/default.nix` — activation 심링크 가드

**미래 방어 조치**: git이 추적하는 실디렉토리(= `git pull` 전 상태)를 심링크로 덮어쓰지 않도록 가드 추가.

```bash
# 미래 방어: git이 추적하는 실디렉토리를 심링크로 덮어쓰지 않음
if [ -d "$target_link" ] && [ ! -L "$target_link" ]; then
  if ${pkgs.git}/bin/git -C "$PROJECT_DIR" ls-files --error-unmatch \
       "$target_link/SKILL.md" >/dev/null 2>&1; then
    echo "Skipping .agents/skills/$skill_name: git-tracked directory (run 'git pull' first)"
    continue
  fi
fi
```

**동작 방식:**
| 상태 | 동작 |
|------|------|
| `.agents/skills/foo`가 올바른 심링크 | 스킵 (기존 로직) |
| `.agents/skills/foo`가 git 추적 실디렉토리 | **스킵 + 경고** (새 가드) |
| `.agents/skills/foo`가 미추적 디렉토리 | 제거 후 심링크 생성 |
| `.agents/skills/foo`가 존재하지 않음 | 심링크 생성 |

**참고**: 이 가드는 PR#38 자체를 방지하지 않습니다 (해당 시점에는 이 코드가 아직 없었으므로). 향후 유사한 디렉토리→심링크 전환이 발생할 때를 대비한 **미래 방어**입니다.

추가로 `git` → `${pkgs.git}/bin/git`으로 변경하여 프로젝트 전체의 Nix store path 사용 관례에 맞춤.

### 2. `.gitignore` — codex sync 부산물 패턴

```gitignore
.claude/skills/*/agents/
.claude/skills/*/references/references
```

- `.agents/skills/*` 심링크 경유로 `.claude/skills/` 안에 생성되는 codex 전용 파일이 untracked로 노출되지 않도록 차단
- 기존 정상 파일(`references/hotkeys.md` 등)은 영향 없음 (`git check-ignore`로 검증 완료)

## 검증

### Devil's Advocate Review (Opus 4.6, 2라운드)

| 라운드 | 이슈 | 심각도 | 조치 |
|--------|------|--------|------|
| R1 | 가드 코멘트가 PR#38 수정인 것처럼 오해 유발 | MEDIUM | 미래 방어용임을 명확히 기재 |
| R1 | bare `git` → Nix store path 필요 | LOW | `${pkgs.git}/bin/git` 사용 |
| R1 | 고아 정리에 같은 가드 없음 | LOW | 실질적 트리거 불가 → 수정 불필요 판정 |
| R2 | 새로운 이슈 | — | 없음, ship 가능 판정 |

### 자동화 검증
- `nixfmt` — 통과
- `gitleaks` — 통과
- `eval-tests` — 통과
- `nix flake check` (pre-push) — 통과
- `ai-skills-consistency` — 기존 `viewing-immich-photo` 투영 누락 경고만 (본 PR과 무관)

## 테스트 계획

- [ ] macOS에서 `nrs` 실행 후 `.agents/skills/` 심링크 정상 유지 확인
- [ ] `git status`가 clean 상태인지 확인
- [ ] `.claude/skills/*/agents/`와 `references/references`가 gitignore 되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety checks during project synchronization to prevent accidental overwriting of tracked project directories; the system now skips overwriting and displays a warning message instead.

* **Chores**
  * Updated ignore patterns to exclude generated sync artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->