### PR TITLE
refactor(claude): viewing-immich-photo를 정적 스킬로 전환하여 Nix 생성 비대칭 제거

### DIFF
--- a/.agents/skills/viewing-immich-photo
+++ b/.agents/skills/viewing-immich-photo
@@ -1,0 +1,1 @@
+../../.claude/skills/viewing-immich-photo

--- a/.claude/skills/viewing-immich-photo/SKILL.md
+++ b/.claude/skills/viewing-immich-photo/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: viewing-immich-photo
+description: |
+  Immich photo viewer: resolve photo paths, display images.
+  Triggers: "view immich photo", "이미치 사진 확인", "immich 파일 보여줘",
+  "immich 사진 보여줘", paths containing "/var/lib/docker-data/immich/upload-cache"
+  or "/var/lib/docker-data/immich".
+---
+
+# Immich 사진 확인
+
+macOS 또는 NixOS 환경에서 immich 사진 경로를 받아 이미지를 확인하는 방법입니다.
+
+## 경로 검증 (보안)
+
+요청된 경로가 immich 디렉토리 내부인지 먼저 확인:
+- 허용 경로: `/var/lib/docker-data/immich/upload-cache/` 또는 `/var/lib/docker-data/immich/`
+- `..` 포함 경로는 거부 (path traversal 방지)
+
+## 플랫폼 감지
+
+환경 정보에서 플랫폼 확인:
+- `<env>` 블록의 `Platform: darwin` → macOS
+- `<env>` 블록의 `Platform: linux` → NixOS
+
+## macOS에서 실행 시
+
+MiniPC에 저장된 파일이므로 SSH로 가져온 후 Read 도구로 확인합니다.
+
+### 단계
+
+1. 경로가 `/var/lib/docker-data/immich/upload-cache`로 시작하는지 확인
+2. SSH로 파일을 `/tmp`에 복사 (확장자 유지)
+3. Read 도구로 이미지 확인
+4. 삭제 불필요 (`/tmp`는 시스템 자동 정리)
+
+### 명령어
+
+```bash
+# 확장자 추출하여 유지
+EXT="${FILE_PATH##*.}"
+ssh minipc "cat <원본경로>" > "/tmp/immich_photo_$(date +%s).$EXT"
+```
+
+**주의**: `minipc`는 SSH config에 정의된 호스트 alias.
+
+## NixOS에서 실행 시
+
+로컬 파일이므로 경로를 직접 Read 도구에 전달합니다.
+
+## 경로 패턴
+
+| 유형 | 경로 패턴 |
+|------|----------|
+| 업로드 캐시 | `/var/lib/docker-data/immich/upload-cache/UUID/xx/xx/file.ext` |
+| 라이브러리 | `/var/lib/docker-data/immich/library/UUID/YYYY/MM/file.ext` |
+
+## 경로 변환 (Immich API → 호스트)
+
+| Immich API 경로 | 호스트 경로 |
+|-----------------|-------------|
+| `/usr/src/app/upload/upload/` | `/var/lib/docker-data/immich/upload-cache/` |
+
+## 지원 파일 형식
+
+Read 도구는 이미지를 시각적으로 표시:
+- 이미지: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`
+- 동영상: 확인 불가 (메타데이터만 표시)
+
+**참고**: Scriptable 업로드는 항상 `.jpg`로 저장됨
+
+## 오류 처리
+
+| 상황 | 대응 |
+|------|------|
+| SSH 연결 실패 | `tailscale status` 확인, `ssh minipc "echo ok"` 테스트 |
+| 파일 없음 | 경로 오타 확인, Immich API 경로→호스트 경로 변환 확인 |
+| 권한 없음 | 파일 소유자/권한 확인 (`ls -la <path>`) |

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 # direnv cache (nix-direnv가 devShell 평가 결과 캐싱)
 .direnv/
 
-# Nix로 생성되는 Claude Code 스킬 (symlink → /nix/store/)
-.claude/skills/viewing-immich-photo/
-
 # 업데이트 스크립트 백업 파일 (중단 시 잔류 가능)
 *.bak
 

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -4,7 +4,6 @@
   config,
   pkgs,
   lib,
-  constants,
   nixosConfigPath,
   ...
 }:
@@ -13,91 +12,6 @@ let
   claudeDir = ./files;
   # mkOutOfStoreSymlink용 절대 경로 (양방향 수정 가능)
   claudeFilesPath = "${nixosConfigPath}/modules/shared/programs/claude/files";
-
-  # viewing-immich-photo 스킬 (constants 참조로 경로 중앙 관리)
-  viewingImmichPhotoSkill = pkgs.writeTextFile {
-    name = "SKILL.md";
-    text = ''
-      ---
-      name: viewing-immich-photo
-      description: |
-        Immich photo viewer: resolve photo paths, display images.
-        Triggers: "view immich photo", "이미치 사진 확인", "immich 파일 보여줘",
-        "immich 사진 보여줘", paths containing "${constants.paths.immichUploadCache}"
-        or "${constants.paths.dockerData}/immich".
-      ---
-
-      # Immich 사진 확인
-
-      macOS 또는 NixOS 환경에서 immich 사진 경로를 받아 이미지를 확인하는 방법입니다.
-
-      ## 경로 검증 (보안)
-
-      요청된 경로가 immich 디렉토리 내부인지 먼저 확인:
-      - 허용 경로: `${constants.paths.immichUploadCache}/` 또는 `${constants.paths.dockerData}/immich/`
-      - `..` 포함 경로는 거부 (path traversal 방지)
-
-      ## 플랫폼 감지
-
-      환경 정보에서 플랫폼 확인:
-      - `<env>` 블록의 `Platform: darwin` → macOS
-      - `<env>` 블록의 `Platform: linux` → NixOS
-
-      ## macOS에서 실행 시
-
-      MiniPC에 저장된 파일이므로 SSH로 가져온 후 Read 도구로 확인합니다.
-
-      ### 단계
-
-      1. 경로가 `${constants.paths.immichUploadCache}`로 시작하는지 확인
-      2. SSH로 파일을 `/tmp`에 복사 (확장자 유지)
-      3. Read 도구로 이미지 확인
-      4. 삭제 불필요 (`/tmp`는 시스템 자동 정리)
-
-      ### 명령어
-
-      ```bash
-      # 확장자 추출하여 유지
-      EXT="''${FILE_PATH##*.}"
-      ssh minipc "cat <원본경로>" > "/tmp/immich_photo_$(date +%s).$EXT"
-      ```
-
-      **주의**: `minipc`는 SSH config에 정의된 호스트 alias.
-
-      ## NixOS에서 실행 시
-
-      로컬 파일이므로 경로를 직접 Read 도구에 전달합니다.
-
-      ## 경로 패턴
-
-      | 유형 | 경로 패턴 |
-      |------|----------|
-      | 업로드 캐시 | `${constants.paths.immichUploadCache}/UUID/xx/xx/file.ext` |
-      | 라이브러리 | `${constants.paths.dockerData}/immich/library/UUID/YYYY/MM/file.ext` |
-
-      ## 경로 변환 (Immich API → 호스트)
-
-      | Immich API 경로 | 호스트 경로 |
-      |-----------------|-------------|
-      | `/usr/src/app/upload/upload/` | `${constants.paths.immichUploadCache}/` |
-
-      ## 지원 파일 형식
-
-      Read 도구는 이미지를 시각적으로 표시:
-      - 이미지: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`
-      - 동영상: 확인 불가 (메타데이터만 표시)
-
-      **참고**: Scriptable 업로드는 항상 `.jpg`로 저장됨
-
-      ## 오류 처리
-
-      | 상황 | 대응 |
-      |------|------|
-      | SSH 연결 실패 | `tailscale status` 확인, `ssh minipc "echo ok"` 테스트 |
-      | 파일 없음 | 경로 오타 확인, Immich API 경로→호스트 경로 변환 확인 |
-      | 권한 없음 | 파일 소유자/권한 확인 (`ls -la <path>`) |
-    '';
-  };
 in
 {
   # Worktree 심링크 정리: .wt/ 아래 Claude 관리 경로(files/*)를 가리키는 stale 심링크 제거
@@ -128,14 +42,6 @@ in
     else
       echo "Claude Code already installed at $HOME/.local/bin/claude"
     fi
-  '';
-
-  # 프로젝트 스킬 생성 (viewing-immich-photo)
-  # Nix로 생성하여 constants.nix 경로 참조 → 경로 변경 시 자동 반영
-  home.activation.createImmichPhotoSkill = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    SKILL_DIR="${nixosConfigPath}/.claude/skills/viewing-immich-photo"
-    $DRY_RUN_CMD mkdir -p "$SKILL_DIR"
-    $DRY_RUN_CMD ln -sf "${viewingImmichPhotoSkill}" "$SKILL_DIR/SKILL.md"
   '';
 
   # ~/.claude/ 디렉토리 관리 (선택적 파일만)

--- a/modules/shared/programs/claude/files/skills/maintaining-skills/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/maintaining-skills/SKILL.md
@@ -97,7 +97,6 @@ CLAUDE.md 라우팅 테이블이 존재하는 파일을 모두 수집한다:
 
 글로벌 스킬에 한해:
 - `modules/shared/programs/claude/default.nix`의 `mkOutOfStoreSymlink` 항목과 실제 스킬 디렉토리가 매칭되는지
-- Nix 생성 스킬(viewing-immich-photo 등)이 올바르게 배포되는지
 
 ## Phase 3: 보고서 생성
 


### PR DESCRIPTION
## Summary

- `viewing-immich-photo` 스킬을 Nix `writeTextFile` 동적 생성에서 **정적 파일**로 전환
- 22개 스킬 중 유일했던 비대칭 생성 패턴 제거 → 전체 스킬이 동일 패턴으로 통일
- 파생 인프라(전용 activation, gitignore, edge case 문서) 일괄 제거

## Background

### 문제: 22개 스킬 중 1개만 다른 생성 패턴

PR #38 (`07e82e5`)에서 `.agents/skills/` 투영을 디렉토리 심링크로 전환할 때, `viewing-immich-photo`는 "Nix 생성 스킬이라 worktree에 소스 없음"으로 edge case 처리되었다.

이 비대칭의 연쇄 영향:

| 파생 문제 | 원인 |
|-----------|------|
| 전용 activation 스크립트 (`createImmichPhotoSkill`) | Nix store에서 worktree로 심링크 생성 필요 |
| `.claude/skills/viewing-immich-photo/` gitignore 엔트리 | 워크트리에 소스가 없으니 무시해야 함 |
| `.agents/skills/viewing-immich-photo` 커밋 불가 | 심링크 대상이 clone 시 존재하지 않음 (dangling) |
| PR #38에서 edge case 별도 문서화 | 21개와 다른 패턴이니 설명 필요 |
| PR #41 (`5c6824d`) 이후 staged artifact 혼란 | activation 부산물이 staged 되어 커밋 여부 판단 필요 |

### 근본 원인: 과잉 추상화

`viewing-immich-photo`가 Nix 생성인 이유는 `constants.nix` 경로 참조 **2개**:

```nix
${constants.paths.immichUploadCache}  → /var/lib/docker-data/immich/upload-cache
${constants.paths.dockerData}         → /var/lib/docker-data
```

이 인프라 경로는 사실상 변하지 않는다. 변한다면 대규모 마이그레이션이고, SKILL.md 한 줄 고치는 건 그 작업의 극히 일부이다. **거의 변하지 않는 값 2개를 DRY하려고 22개 스킬 중 1개만 완전히 다른 생성 패턴을 유지하는 것은 과잉 추상화**였다.

## Changes

### 1. `.claude/skills/viewing-immich-photo/SKILL.md` — 정적 파일 생성 (NEW)

Nix 동적 생성 대신 경로를 하드코딩한 정적 파일. 다른 21개 project-scope 스킬과 동일 패턴.

| Before | After |
|--------|-------|
| `pkgs.writeTextFile` → `/nix/store/` | `.claude/skills/viewing-immich-photo/SKILL.md` (real file) |
| Nix evaluation 필요 | 직접 편집 가능 |
| `nrs` 없이 수정 불가 (read-only Nix store) | git commit 즉시 반영 |

### 2. `modules/shared/programs/claude/default.nix` — Nix 생성 인프라 제거 (-94 lines)

| 제거 항목 | 역할 |
|-----------|------|
| `viewingImmichPhotoSkill` (`pkgs.writeTextFile`) | SKILL.md 동적 생성 |
| `createImmichPhotoSkill` (activation script) | worktree에 Nix store 심링크 배치 |
| `constants` 파라미터 | 위 두 항목에서만 사용됨 |

### 3. `.agents/skills/viewing-immich-photo` — Codex 투영 심링크 커밋 (NEW)

```
viewing-immich-photo -> ../../.claude/skills/viewing-immich-photo
```

다른 21개 스킬과 동일하게 커밋. 이전에는 심링크 대상이 Nix 생성이라 clone 시 dangling → 커밋 불가였음.

### 4. `.gitignore` — Nix 생성 스킬 전용 패턴 제거

```diff
-# Nix로 생성되는 Claude Code 스킬 (symlink → /nix/store/)
-.claude/skills/viewing-immich-photo/
```

더 이상 gitignore가 필요 없음 — 실파일이 git에 직접 추적됨.

### 5. `maintaining-skills/SKILL.md` — "Nix 생성 스킬" 감사 항목 제거

```diff
-  - Nix 생성 스킬(viewing-immich-photo 등)이 올바르게 배포되는지
```

Nix 생성 스킬 카테고리가 더 이상 존재하지 않으므로 감사 체크리스트에서 제거.

## Before/After 비교

```
# Before: viewing-immich-photo (유일한 비대칭 스킬)
                        ┌─ .gitignore 엔트리 필요
                        │
  constants.nix ──┐     ├─ createImmichPhotoSkill activation 필요
                  ▼     │
  pkgs.writeTextFile ───┤
       │                ├─ .agents/skills/ 커밋 불가 (dangling)
       ▼                │
  /nix/store/SKILL.md   └─ PR마다 edge case 문서화 필요
       │
       ▼ (activation)
  .claude/skills/viewing-immich-photo/SKILL.md (symlink → nix store)

# After: viewing-immich-photo (다른 21개와 동일)
  .claude/skills/viewing-immich-photo/SKILL.md (real file, git-tracked)
       ▲
       │ (directory symlink)
  .agents/skills/viewing-immich-photo (committed, like all 21 others)
```

## References

| 참조 | 내용 |
|------|------|
| PR [#38](https://github.com/greenheadHQ/nixos-config/pull/38) (`07e82e5`) | 디렉토리 심링크 전환 — viewing-immich-photo edge case 최초 발생 |
| PR [#41](https://github.com/greenheadHQ/nixos-config/pull/41) (`5c6824d`) | activation 심링크 가드 — viewing-immich-photo 부산물 staged 문제 촉발 |
| `constants.nix` L48-50 | `paths.dockerData`, `paths.immichUploadCache` — 하드코딩 대상 경로 |

## Test plan

- [x] `nixfmt` — 통과
- [x] `gitleaks` — 통과
- [x] `ai-skills-consistency` — 통과 (viewing-immich-photo 투영 누락 경고 해소)
- [x] `eval-tests` — 통과
- [x] `nix flake check` (pre-push) — 통과
- [ ] macOS `nrs` 실행 후 `.claude/skills/viewing-immich-photo/SKILL.md`가 실파일로 유지 확인
- [ ] `.agents/skills/viewing-immich-photo` 심링크 체인 정상 동작 확인
- [ ] `git status` clean 상태 확인 (activation 부산물 없음)