### PR TITLE
feat(uptime-kuma): upgrade container tag to v2

### DIFF
--- a/modules/nixos/programs/docker/uptime-kuma.nix
+++ b/modules/nixos/programs/docker/uptime-kuma.nix
@@ -24,7 +24,7 @@ in
     virtualisation.oci-containers.containers.uptime-kuma = {
       # Rolling tag: uptime-kuma-update 스크립트가 이미지 digest로 버전 관리.
       # 새 환경 구성 시 현재 운영 버전과 다를 수 있음 (재현성 trade-off)
-      image = "louislam/uptime-kuma:1";
+      image = "louislam/uptime-kuma:2";
       autoStart = true;
       volumes = [ "${dockerData}/uptime-kuma/data:/app/data" ];
       environment = {


### PR DESCRIPTION
## Summary
- Uptime Kuma 컨테이너 이미지 태그를 `1` → `2`로 업그레이드

## Test plan
- [ ] `nrs`로 MiniPC에 적용 후 컨테이너 정상 기동 확인
- [ ] Uptime Kuma 웹 UI 접속 및 기존 모니터 데이터 유지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Uptime Kuma Docker container image to version 2. All existing configurations and settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->