### PR TITLE
fix(codex): user-scope 글로벌 스킬 심링크 누락 수정

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -26,9 +26,15 @@ in
     # 글로벌 AGENTS.md - Claude의 CLAUDE.md와 동일 소스 공유
     ".codex/AGENTS.md".source = config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/CLAUDE.md";
 
-    # 글로벌 스킬: agent-browser (Claude와 동일 소스 공유)
+    # 글로벌 스킬 (Claude와 동일 소스 공유)
     ".codex/skills/agent-browser".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/agent-browser";
+    ".codex/skills/maintaining-skills".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/maintaining-skills";
+    ".codex/skills/managing-github-issues".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/managing-github-issues";
+    ".codex/skills/syncing-codex-harness".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/syncing-codex-harness";
   };
 
   # ─── NixOS: Codex CLI 바이너리 설치 (GitHub releases) ───

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -148,12 +148,14 @@ else
   warn "$HOME/.codex/AGENTS.md 없음"
 fi
 
-# ~/.codex/skills/agent-browser
-if [ -d "$HOME/.codex/skills/agent-browser" ]; then
-  pass "$HOME/.codex/skills/agent-browser 존재"
-else
-  warn "$HOME/.codex/skills/agent-browser 없음"
-fi
+# ~/.codex/skills/ 글로벌 스킬 검증
+for skill in agent-browser maintaining-skills managing-github-issues syncing-codex-harness; do
+  if [ -d "$HOME/.codex/skills/$skill" ]; then
+    pass "$HOME/.codex/skills/$skill 존재"
+  else
+    warn "$HOME/.codex/skills/$skill 없음"
+  fi
+done
 
 echo ""
 echo "=== 원본 무결성 확인 ==="


### PR DESCRIPTION
## Background

이 프로젝트는 Claude Code와 Codex CLI 두 에이전트 도구를 동시에 사용합니다.
User-scope 스킬은 `~/.claude/skills/`(Claude Code)와 `~/.codex/skills/`(Codex CLI) 양쪽에
심링크되어야 각 도구에서 글로벌 스킬로 발견됩니다.

현재 user-scope 스킬 4개가 존재하며, `modules/shared/programs/claude/default.nix`에서
`~/.claude/skills/`로의 심링크는 4개 모두 설정되어 있었습니다.
그러나 `modules/shared/programs/codex/default.nix`에서 `~/.codex/skills/`로의 심링크는
`agent-browser` 1개만 설정되어 있어, 나머지 3개가 Codex CLI에서 발견되지 않았습니다.

## Problem

| 스킬 | `~/.claude/skills/` | `~/.codex/skills/` |
|------|:-------------------:|:-------------------:|
| `agent-browser` | O | O |
| `maintaining-skills` | O | **X (누락)** |
| `managing-github-issues` | O | **X (누락)** |
| `syncing-codex-harness` | O | **X (누락)** |

Codex CLI는 `~/.codex/skills/`에서 글로벌 스킬을 스캔하므로
([codex-structure.md 참조](modules/shared/programs/claude/files/skills/syncing-codex-harness/references/codex-structure.md#L62)),
누락된 3개 스킬은 Codex에서 사용할 수 없었습니다.

## Changes

### 1. `modules/shared/programs/codex/default.nix`

누락된 3개 스킬의 `home.file` 심링크 엔트리를 추가합니다.
기존 `agent-browser`와 동일한 패턴(`mkOutOfStoreSymlink` + `claudeFilesPath`)을 사용하여
Claude Code와 Codex CLI가 동일한 스킬 소스를 참조하도록 합니다 (single source of truth).

```
~/.codex/skills/<name>
  → /nix/store/.../home-manager-files/.codex/skills/<name>
    → /Users/green/Workspace/nixos-config/modules/shared/programs/claude/files/skills/<name>/
```

### 2. `scripts/ai/verify-ai-compat.sh`

글로벌 스킬 검증 섹션을 `agent-browser` 단일 if문에서
4개 스킬 전체를 순회하는 for 루프로 변경하여,
향후 글로벌 스킬 추가/제거 시 검증 누락을 방지합니다.

## Result

| 스킬 | `~/.claude/skills/` | `~/.codex/skills/` |
|------|:-------------------:|:-------------------:|
| `agent-browser` | O | O |
| `maintaining-skills` | O | **O** |
| `managing-github-issues` | O | **O** |
| `syncing-codex-harness` | O | **O** |

## Test plan

- [x] `nrs` 빌드 성공
- [x] `ls -la ~/.codex/skills/` — 4개 심링크 존재 및 타겟 유효 확인
- [x] 각 심링크에서 `SKILL.md` 접근 가능 확인
- [x] `verify-ai-compat` 실행 — "검증 완전 통과"
- [x] pre-commit hooks 전체 통과 (nixfmt, shellcheck, gitleaks, ai-skills-consistency, eval-tests)
- [x] pre-push `flake-check` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new skills are now available in Codex: maintaining-skills, managing-github-issues, and syncing-codex-harness.

* **Chores**
  * Updated system verification to validate the newly added skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->