### PR TITLE
fix(karakeep): 대용량 HTML 크롤러 타임아웃 해결 및 리소스 증설

### DIFF
--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -97,13 +97,13 @@
     };
     karakeep = {
       app = {
-        memory = "1536m";
-        memorySwap = "2g";
+        memory = "2g";
+        memorySwap = "3g";
         cpus = "1";
       };
       chrome = {
-        memory = "1g";
-        memorySwap = "1536m";
+        memory = "2g";
+        memorySwap = "3g";
         cpus = "1";
       };
       meilisearch = {

--- a/modules/nixos/programs/docker/karakeep.nix
+++ b/modules/nixos/programs/docker/karakeep.nix
@@ -150,6 +150,9 @@ in
         CRAWLER_FULL_PAGE_ARCHIVE = "false";
         CRAWLER_STORE_SCREENSHOT = "true";
         CRAWLER_VIDEO_DOWNLOAD = "false";
+        CRAWLER_NUM_WORKERS = "2";
+        CRAWLER_JOB_TIMEOUT_SEC = "180";
+        CRAWLER_SCREENSHOT_TIMEOUT_SEC = "30";
         MAX_ASSET_SIZE_MB = "100";
         INFERENCE_LANG = "korean";
         INFERENCE_ENABLE_AUTO_SUMMARIZATION = "true";


### PR DESCRIPTION
## Summary

- SingleFile 확장으로 북마킹 시 14MB+ base64 인라인 HTML이 크롤러 타임아웃(60초)을 초과하여 재시도 루프에 빠지는 문제 해결
- 크롤러 환경변수 3개 추가 (워커 수, job 타임아웃, 스크린샷 타임아웃)
- 워커 2개 동시 운영 및 대용량 HTML 렌더링을 지원하도록 app/chrome 메모리 증설

## Changes

### 환경변수 (`karakeep.nix`)
| 변수 | 값 | 기본값 | 근거 |
|------|-----|--------|------|
| `CRAWLER_NUM_WORKERS` | `2` | 1 | 큐 블로킹 방지 |
| `CRAWLER_JOB_TIMEOUT_SEC` | `180` | 60 | 관측 73초의 2.5배 마진 |
| `CRAWLER_SCREENSHOT_TIMEOUT_SEC` | `30` | 5 | 대용량 HTML 렌더링 시간 확보 |

### 리소스 (`constants.nix`)
| 컨테이너 | 필드 | 변경 전 | 변경 후 |
|-----------|------|---------|---------|
| app | memory | 1536m | 2g |
| app | memorySwap | 2g | 3g |
| chrome | memory | 1g | 2g |
| chrome | memorySwap | 1536m | 3g |

## Test plan

- [ ] MiniPC에서 `nrs`로 설정 적용
- [ ] `sudo podman stats --no-stream` — 새 메모리 제한 반영 확인
- [ ] Karakeep에서 14MB+ HTML 페이지 재북마킹 — 타임아웃 없이 완료 확인
- [ ] 동시에 다른 페이지 북마킹 — 큐 블로킹 없이 처리 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for the application and Chrome service to improve performance and stability
  * Added new configuration parameters for crawler worker count, job timeout, and screenshot timeout settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->