### PR TITLE
fix: pre-rebuild-check 스크립트 정상 동작하도록 수정

### DIFF
--- a/modules/darwin/programs/atuin/default.nix
+++ b/modules/darwin/programs/atuin/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 let
   homeDir = config.home.homeDirectory;
@@ -6,8 +11,8 @@ let
 
   # 모니터링 설정 (Single Source of Truth)
   # 참고: 실제 sync는 atuin 내장 auto_sync가 담당 (sync_frequency = 1m)
-  syncCheckInterval = 600;        # 10분 (초) - watchdog 상태 체크 주기
-  syncThresholdMinutes = 5;       # 5분 이상 동기화 안 되면 경고
+  syncCheckInterval = 600; # 10분 (초) - watchdog 상태 체크 주기
+  syncThresholdMinutes = 5; # 5분 이상 동기화 안 되면 경고
 
   # Hammerspoon용 JSON 설정 파일
   monitorConfigJson = builtins.toJSON {

--- a/modules/darwin/programs/cursor/default.nix
+++ b/modules/darwin/programs/cursor/default.nix
@@ -1,6 +1,12 @@
 # Cursor (VS Code fork) 설정
 # Homebrew Cask로 앱 설치, Nix로 확장 관리
-{ config, pkgs, lib, nixosConfigPath, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  nixosConfigPath,
+  ...
+}:
 
 let
   cursorDir = ./files;
@@ -16,10 +22,46 @@ let
 
   # Cursor로 열 파일 확장자 목록
   codeExtensions = [
-    "txt" "text" "md" "mdx" "js" "jsx" "ts" "tsx" "mjs" "cjs"
-    "json" "yaml" "yml" "toml" "css" "scss" "sass" "less" "nix"
-    "sh" "bash" "zsh" "py" "rb" "go" "rs" "lua" "sql" "graphql" "gql"
-    "xml" "svg" "conf" "ini" "cfg" "env" "gitignore" "editorconfig" "prettierrc" "eslintrc"
+    "txt"
+    "text"
+    "md"
+    "mdx"
+    "js"
+    "jsx"
+    "ts"
+    "tsx"
+    "mjs"
+    "cjs"
+    "json"
+    "yaml"
+    "yml"
+    "toml"
+    "css"
+    "scss"
+    "sass"
+    "less"
+    "nix"
+    "sh"
+    "bash"
+    "zsh"
+    "py"
+    "rb"
+    "go"
+    "rs"
+    "lua"
+    "sql"
+    "graphql"
+    "gql"
+    "xml"
+    "svg"
+    "conf"
+    "ini"
+    "cfg"
+    "env"
+    "gitignore"
+    "editorconfig"
+    "prettierrc"
+    "eslintrc"
   ];
 
   # 확장 목록 정의
@@ -64,22 +106,24 @@ let
 
   # extensions.json 생성 (Cursor GUI가 확장을 인식하도록)
   # Cursor 원본 형식: identifier, version, location, relativeLocation, metadata
-  extensionsJson = pkgs.writeTextDir
-    "share/vscode/extensions/extensions.json"
-    (builtins.toJSON (map (ext: {
-      identifier.id = ext.vscodeExtUniqueId;
-      version = ext.version;
-      location = {
-        "$mid" = 1;
-        path = "${extensionsPath}/${ext.vscodeExtUniqueId}";
-        scheme = "file";
-      };
-      relativeLocation = ext.vscodeExtUniqueId;
-      metadata = {
-        installedTimestamp = 0;
-        targetPlatform = "undefined";
-      };
-    }) cursorExtensions));
+  extensionsJson = pkgs.writeTextDir "share/vscode/extensions/extensions.json" (
+    builtins.toJSON (
+      map (ext: {
+        identifier.id = ext.vscodeExtUniqueId;
+        version = ext.version;
+        location = {
+          "$mid" = 1;
+          path = "${extensionsPath}/${ext.vscodeExtUniqueId}";
+          scheme = "file";
+        };
+        relativeLocation = ext.vscodeExtUniqueId;
+        metadata = {
+          installedTimestamp = 0;
+          targetPlatform = "undefined";
+        };
+      }) cursorExtensions
+    )
+  );
 
   # 모든 확장을 하나의 디렉토리로 통합
   combinedExtensions = pkgs.buildEnv {
@@ -97,8 +141,8 @@ in
     echo "Setting Cursor as default editor for code files..."
 
     # 1. 개별 확장자 설정
-    ${lib.concatMapStringsSep "\n" (ext:
-      "${pkgs.duti}/bin/duti -s ${cursorBundleId} .${ext} all"
+    ${lib.concatMapStringsSep "\n" (
+      ext: "${pkgs.duti}/bin/duti -s ${cursorBundleId} .${ext} all"
     ) codeExtensions}
 
     # 2. 범용 UTI(Uniform Type Identifier) 설정

--- a/modules/darwin/programs/hammerspoon/default.nix
+++ b/modules/darwin/programs/hammerspoon/default.nix
@@ -1,5 +1,10 @@
 # Hammerspoon 설정 (macOS 키보드/자동화)
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 let
   hammerspoonDir = ./files;

--- a/modules/darwin/programs/keybindings/default.nix
+++ b/modules/darwin/programs/keybindings/default.nix
@@ -1,7 +1,12 @@
 # macOS 키 바인딩 설정 (https://github.com/ttscoff/KeyBindings)
 # - ₩ 키 입력 시 ` (백틱) 입력
 # - Option+4 입력 시 ₩ (원화) 입력
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
 {
   home.file."Library/KeyBindings/DefaultKeyBinding.dict".source = ./files/DefaultKeyBinding.dict;

--- a/scripts/pre-rebuild-check.sh
+++ b/scripts/pre-rebuild-check.sh
@@ -9,11 +9,11 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$ROOT_DIR"
 
 echo "═══ Flake Check ═══"
-nix flake check
+nix flake check --no-build --all-systems
 
 echo
 echo "═══ Format Check ═══"
-nix fmt -- --check .
+git ls-files '*.nix' | xargs nixfmt --check
 
 echo
 echo "✓ 모든 검증 통과"


### PR DESCRIPTION
## Summary

- `nix flake check`에 `--no-build --all-systems` 추가 (lefthook pre-push와 동일)
- `nix fmt -- --check .`를 `git ls-files '*.nix' | xargs nixfmt --check`로 교체 (formatter 출력 미존재 문제 해결)
- 감지된 4개 파일 nixfmt 포매팅 적용

Closes #51

## Test plan

- [x] `bash scripts/pre-rebuild-check.sh` → exit 0, "모든 검증 통과"
- [x] lefthook pre-commit 전체 통과
- [x] lefthook pre-push (flake-check) 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted function parameter declarations across multiple configuration modules for improved readability.
  * Expanded code extensions list to separate lines for better clarity.

* **Chores**
  * Updated build check scripts to use enhanced flake validation flags and improved format checking commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->