### PR TITLE
refactor(packages): programs.*.enable 중복 제거 및 packages.nix 정리

### DIFF
--- a/libraries/packages.nix
+++ b/libraries/packages.nix
@@ -1,5 +1,5 @@
 # libraries/packages.nix
-# 공통 패키지 정의 (lib 스타일 - 명시적 pkgs.* 참조로 출처 추적 용이)
+# 공통 패키지 정의 — programs.*.enable으로 관리되지 않는 CLI 도구만 포함
 { pkgs }:
 
 {
@@ -9,24 +9,14 @@
     pkgs.bat # cat 대체 (구문 강조)
     pkgs.eza # ls 대체 (아이콘, 색상)
     pkgs.fd # find 대체 (빠른 파일 검색)
-    pkgs.fzf # fuzzy finder
     pkgs.ripgrep # grep 대체 (빠른 텍스트 검색)
-    pkgs.zoxide # cd 대체 (디렉토리 점프)
 
     # 개발 도구
-    pkgs.tmux # 터미널 멀티플렉서
-    pkgs.gh # GitHub CLI
-    pkgs.git # 버전 관리
     pkgs.shellcheck # 쉘 스크립트 린터
-
-    # 쉘 도구
-    pkgs.starship # 프롬프트 커스터마이징
-    pkgs.atuin # 쉘 히스토리 동기화
 
     # 기타 유틸리티
     pkgs.curl # HTTP 클라이언트
     pkgs.jq # JSON 처리
-    pkgs.htop # 시스템 모니터링
     pkgs.nvd # Nix 변경사항 비교
     pkgs.qrencode # QR 코드 생성 (MiniPC -> iPhone 텍스트 공유)
     pkgs.uv # Python 패키지 관리자
@@ -34,7 +24,6 @@
 
   # macOS 전용 패키지
   darwinOnly = [
-    pkgs.broot # 파일 탐색기 TUI
     pkgs.ffmpeg # 미디어 처리
     pkgs.imagemagick # 이미지 처리
     pkgs.rar # 압축
@@ -44,9 +33,13 @@
 
   # NixOS 전용 패키지
   nixosOnly = [
-    pkgs.ghostty # Terminfo (SSH 접속 시 필요)
+    # TERM 환경변수: SSH 접속 시 클라이언트가 서버에 자신의 터미널 종류를 알리는 값.
+    # 서버는 이 값으로 terminfo DB를 조회해 색상, 커서 이동 등 터미널 제어 방법을 결정한다.
+    # Mac Ghostty는 TERM=xterm-ghostty를 전달하므로, 서버에 해당 terminfo가 없으면
+    # vim/tmux/less 등에서 "unknown terminal type" 에러가 발생한다.
+    # Termius 등 다른 SSH 클라이언트는 자체 TERM(보통 xterm-256color)을 사용하므로 무관.
+    pkgs.ghostty.terminfo
     pkgs.lm_sensors # 하드웨어 온도 모니터링 (sensors 명령어)
     pkgs.mise # 런타임 버전 관리
-    pkgs.mosh # 모바일 쉘 (불안정한 네트워크용)
   ];
 }


### PR DESCRIPTION
## Summary

- `packages.nix`에서 `programs.*.enable`으로 이미 관리되는 중복 패키지 9개 제거
  - shared: tmux, git, gh, starship, atuin, fzf, zoxide
  - darwinOnly: broot (분류 오류 — 실제로 양 플랫폼 shared 모듈)
  - nixosOnly: mosh
- 미사용 패키지 `htop` 제거
- `pkgs.ghostty` → `pkgs.ghostty.terminfo` (headless 서버에 전체 터미널 불필요, **GUI 종속성 180개 / -603.8MB 절감**)
- 빈 섹션 제거 및 알파벳 정렬 통일
- 파일 헤더 주석 갱신 (역할 명확화)

### ghostty.terminfo을 설치하는 이유

SSH 접속 시 클라이언트는 `TERM` 환경변수를 통해 서버에 자신의 터미널 종류를 알린다. 서버는 이 값으로 terminfo 데이터베이스를 조회해 색상 지원, 커서 이동, 화면 지우기 등 터미널 제어 방법을 결정한다.

Mac의 Ghostty 터미널은 `TERM=xterm-ghostty`를 전달한다. MiniPC에 해당 terminfo가 없으면 vim, tmux, less 등에서 "unknown terminal type" 에러가 발생한다.

기존에는 `pkgs.ghostty` (전체 터미널 에뮬레이터)를 설치하고 있었으나, headless 서버에는 GUI가 불필요하므로 `pkgs.ghostty.terminfo` (terminfo 데이터만) 으로 변경하여 180개 GUI 종속성 / 603.8MB를 절감했다.

<img width="300" alt="스크린샷, 2026-02-20 오후 10 40 54" src="https://github.com/user-attachments/assets/8ffa485f-ef77-424c-ad43-7a49d3505811" />

> **참고**: 이 terminfo는 Mac Ghostty에서 SSH 접속하는 경우에만 필요하다. iPhone의 Termius 등 다른 SSH 클라이언트는 자체 TERM 값(보통 `xterm-256color`)을 사용하므로 이 패키지와 무관하다. (사진은 Termius의 Terminal 설정 화면. `TERM` 변수를 설정할 수 있는 것을 확인할 수 있다)

## Test plan

- [x] `nix eval --impure --file tests/eval-tests.nix` 통과
- [x] pre-commit hooks 전부 통과 (nixfmt, gitleaks, ai-skills-consistency, eval-tests)
- [x] macOS `nrs` (darwin-rebuild) 정상 빌드
- [x] MiniPC `nrs` (nixos-rebuild) 정상 빌드
- [x] MiniPC `infocmp ghostty` — terminfo 정상 인식 확인

### macOS 회귀 테스트

| 패키지 | 상태 | 비고 |
|---|---|---|
| tmux, git, gh, starship, atuin, fzf, zoxide | 정상 | `programs.*.enable`이 관리 |
| broot | 정상 | `programs.broot.enable`이 관리 |
| htop | 제거 확인 | 의도된 제거 |
| bat, eza, fd, rg, shellcheck, curl, jq, nvd, qrencode, uv | 정상 | packages.nix에 잔류 |

### MiniPC 회귀 테스트

| 패키지 | 상태 | 비고 |
|---|---|---|
| tmux, git, gh, starship, atuin, fzf, zoxide | 정상 | `programs.*.enable`이 관리 |
| broot | 정상 | `programs.broot.enable`이 관리 (양 플랫폼) |
| mosh-server | 정상 | `programs.mosh.enable`이 관리 |
| ghostty terminfo | 정상 | `infocmp ghostty` 성공, terminfo 경로 정상 인식 |
| sensors, mise | 정상 | packages.nix nixosOnly에 잔류 |
| bat, eza, fd, rg, shellcheck, curl, jq, nvd, qrencode, uv | 정상 | packages.nix shared에 잔류 |