### PR TITLE
feat(anki): AnkiConnect ↔ Sync Server 자동 동기화 구현

### DIFF
--- a/.claude/skills/hosting-anki/SKILL.md
+++ b/.claude/skills/hosting-anki/SKILL.md
@@ -44,6 +44,7 @@ Anki 동기화 서버와 AnkiConnect API 서버의 배포, 접속, 백업, 장�
 |------|------|
 | `modules/nixos/options/homeserver.nix` | `ankiConnect` mkOption 정의 |
 | `modules/nixos/programs/anki-connect/default.nix` | Headless Anki + AnkiConnect 서비스 |
+| `modules/nixos/programs/anki-connect/sync.nix` | 자동 동기화 서비스/타이머 + 상태 파일 |
 | `modules/nixos/lib/tailscale-wait.nix` | Tailscale IP 대기 유틸리티 |
 | `libraries/constants.nix` | 포트 (`ankiConnect = 8765`) |
 
@@ -89,6 +90,11 @@ systemctl status anki-connect.service        # 상태 확인
 journalctl -u anki-connect.service -f        # 로그 실시간
 curl -s http://100.79.80.95:8765 -X POST \
   -d '{"action":"version","version":6}'      # API 응답 확인
+
+systemctl status anki-connect-sync.service    # 마지막 sync 실행 상태
+systemctl status anki-connect-sync.timer      # 주기 sync 타이머 상태
+journalctl -u anki-connect-sync.service -f    # sync 로그 실시간
+cat /var/lib/anki/sync-status.json            # 마지막 sync 결과(state file)
 ```
 
 Headless mode (offscreen Qt), 설정은 Nix store에 bake됨. 상세: [references/setup.md](references/setup.md)
@@ -102,6 +108,11 @@ homeserver.ankiSync.port = 27701;       # 포트 (기본값은 constants.nix)
 homeserver.ankiConnect.enable = true;   # AnkiConnect API 활성화
 homeserver.ankiConnect.port = 8765;     # 포트 (기본값은 constants.nix)
 homeserver.ankiConnect.profile = "server"; # Anki 프로필명
+homeserver.ankiConnect.sync = {
+  enable = true;            # 자동 sync 활성화
+  onStart = true;           # 서비스 시작 시 1회 sync
+  interval = "5m";          # 주기 sync (OnUnitActiveSec)
+};
 ```
 
 ## 핵심 절차
@@ -127,7 +138,7 @@ homeserver.ankiConnect.profile = "server"; # Anki 프로필명
 1. **첫 부팅 무한 대기**: `prefs21.db` 없으면 `NoCloseDiag.exec()` 블로킹 → ExecStartPre에서 DB 사전 생성으로 해결됨
 2. **QtWebEngine SIGABRT**: GPU 없는 headless에서 EGL 실패 → `--disable-gpu` 플래그로 해결됨
 3. **API 무응답**: `systemctl status anki-connect` → Tailscale IP 대기 실패 가능
-4. **덱 목록 비어있음/Default만**: Sync Server → AnkiConnect 컬렉션 복사 필요 (일회성, 자동 동기화 미구현)
+4. **덱 목록 비어있음/Default만**: 첫 부팅 bootstrap 실패 가능 → `journalctl -u anki-connect.service`에서 bootstrap 로그 확인
 5. **재시작 루프**: `journalctl -u anki-connect -f` → 좀비 프로세스 DB lock 또는 프로필 디렉터리 문제
 
 ## 레퍼런스

--- a/.claude/skills/hosting-anki/references/setup.md
+++ b/.claude/skills/hosting-anki/references/setup.md
@@ -42,6 +42,11 @@ ankiConnect = {
     default = "server";
     description = "Anki profile name";
   };
+  sync = {
+    enable = lib.mkOption { type = lib.types.bool; default = true; };
+    onStart = lib.mkOption { type = lib.types.bool; default = true; };
+    interval = lib.mkOption { type = lib.types.str; default = "5m"; };
+  };
 };
 ```
 
@@ -52,6 +57,9 @@ ankiConnect = {
 - 인증: Tailscale 네트워크 격리에 의존 (API key 불필요)
 - `prefs21.db` 사전 생성: `ExecStartPre`에서 Python/sqlite3/pickle로 `_global` + profile 엔트리 초기화 → offscreen 모드 `NoCloseDiag` 블로킹 방지
 - 프로필 자동 생성: `ExecStartPre`에서 디렉터리 + DB 보장
+- sync 설정 addon: profile open 시 custom sync URL/username 적용 + sync key 자동 초기화
+- 자동 동기화: `anki-connect-sync.service` + `anki-connect-sync.timer` (onStart + 5분 주기)
+- 상태 파일: `/var/lib/anki/sync-status.json` (마지막 시도/성공/에러 기록)
 
 ## 아키텍처 참고
 

--- a/.claude/skills/hosting-anki/references/troubleshooting.md
+++ b/.claude/skills/hosting-anki/references/troubleshooting.md
@@ -291,7 +291,8 @@ sudo chown -R anki:anki /var/lib/anki/.local/share/Anki2/server/
 sudo systemctl start anki-connect.service
 ```
 
-**주의**: 이 방법은 일회성 copy입니다. Sync Server ↔ AnkiConnect 간 자동 동기화는 아직 미구현.
+**참고**: 현재는 `anki-connect` 시작 시 bootstrap + 주기 sync가 기본 동작입니다.
+위 절차는 bootstrap이 실패했거나 lock 손상 시 사용하는 수동 복구 경로입니다.
 
 ## 서비스 재시작 루프
 

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -5,6 +5,7 @@
   config,
   lib,
   constants,
+  username,
   ...
 }:
 
@@ -98,6 +99,63 @@
         type = lib.types.str;
         default = "server";
         description = "Anki profile name";
+      };
+      sync = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Enable AnkiConnect <-> Sync Server auto sync.";
+        };
+        url = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Custom sync endpoint URL. null이면 로컬 Anki Sync Server URL을 사용.";
+        };
+        username = lib.mkOption {
+          type = lib.types.str;
+          default = username;
+          description = "Sync username used by headless Anki.";
+        };
+        onStart = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Trigger sync once after anki-connect service starts.";
+        };
+        interval = lib.mkOption {
+          type = lib.types.str;
+          default = "5m";
+          description = "OnUnitActiveSec interval for periodic sync.";
+        };
+        maxRetries = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 3;
+          description = "Maximum retry attempts per sync run.";
+        };
+        backoffBaseSec = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 5;
+          description = "Base seconds for exponential backoff (5, 10, 20...).";
+        };
+        stateFile = lib.mkOption {
+          type = lib.types.str;
+          default = "/var/lib/anki/sync-status.json";
+          description = "Path to sync status JSON used by operational checks/UI.";
+        };
+        bootstrapFromSyncServer = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Bootstrap AnkiConnect profile from Sync Server collection on first run.";
+        };
+        bootstrapMedia = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Copy media directory during one-time bootstrap.";
+        };
+        bootstrapMinCollectionBytes = lib.mkOption {
+          type = lib.types.ints.unsigned;
+          default = 262144;
+          description = "Treat local collection as empty when smaller than this threshold.";
+        };
       };
     };
 

--- a/modules/nixos/programs/anki-connect/default.nix
+++ b/modules/nixos/programs/anki-connect/default.nix
@@ -14,24 +14,99 @@
 
 let
   cfg = config.homeserver.ankiConnect;
+  syncCfg = cfg.sync;
   inherit (constants.network) minipcTailscaleIP;
 
-  ankiWithConnect = pkgs.anki.withAddons [
-    (pkgs.ankiAddons.anki-connect.withConfig {
-      config = {
-        webBindAddress = minipcTailscaleIP;
-        webBindPort = cfg.port;
-        webCorsOriginList = [
-          "http://localhost"
-          "http://localhost:3000"
-          "http://localhost:5173"
-          "http://${minipcTailscaleIP}"
-        ];
+  syncUrl =
+    if syncCfg.url != null then
+      syncCfg.url
+    else
+      "http://${minipcTailscaleIP}:${toString config.homeserver.ankiSync.port}/";
+  normalizedSyncUrl = if lib.strings.hasSuffix "/" syncUrl then syncUrl else "${syncUrl}/";
+
+  localSyncServerEnabled = config.homeserver.ankiSync.enable && syncCfg.url == null;
+
+  syncConfigAddon =
+    if !syncCfg.enable then
+      null
+    else
+      pkgs.anki-utils.buildAnkiAddon {
+        pname = "nixos-sync-config";
+        version = "1.0";
+        src = pkgs.writeTextDir "__init__.py" ''
+          import aqt
+          from pathlib import Path
+          import traceback
+
+          custom_sync_url = ${builtins.toJSON normalizedSyncUrl}
+          sync_username = ${builtins.toJSON syncCfg.username}
+          sync_password_file = Path(${builtins.toJSON config.age.secrets.anki-connect-sync-password.path})
+
+          def set_server() -> None:
+              pm = aqt.mw.pm
+
+              if custom_sync_url:
+                  pm.set_custom_sync_url(custom_sync_url)
+              if sync_username:
+                  pm.set_sync_username(sync_username)
+
+              # 이미 sync key가 있으면 재로그인하지 않음.
+              if pm.profile.get("syncKey"):
+                  return
+
+              if not sync_username:
+                  print("[anki-connect-sync] sync username is empty")
+                  return
+
+              if not sync_password_file.exists():
+                  print(f"[anki-connect-sync] sync password file not found: {sync_password_file}")
+                  return
+
+              password = sync_password_file.read_text().strip()
+              if not password:
+                  print("[anki-connect-sync] sync password file is empty")
+                  return
+
+              try:
+                  auth = aqt.mw.col.sync_login(
+                      username=sync_username,
+                      password=password,
+                      endpoint=pm.sync_endpoint(),
+                  )
+                  pm.set_sync_key(auth.hkey)
+                  pm.set_sync_username(sync_username)
+                  pm.set_current_sync_url(None)
+                  pm.save()
+                  print("[anki-connect-sync] sync auth initialized")
+              except Exception as err:
+                  print(f"[anki-connect-sync] sync login failed: {err}")
+                  traceback.print_exc()
+
+          aqt.gui_hooks.profile_did_open.append(set_server)
+        '';
       };
-    })
-  ];
+
+  ankiWithConnect = pkgs.anki.withAddons (
+    [
+      (pkgs.ankiAddons.anki-connect.withConfig {
+        config = {
+          webBindAddress = minipcTailscaleIP;
+          webBindPort = cfg.port;
+          webCorsOriginList = [
+            "http://localhost"
+            "http://localhost:3000"
+            "http://localhost:5173"
+            "http://${minipcTailscaleIP}"
+          ];
+        };
+      })
+    ]
+    ++ lib.optionals (syncConfigAddon != null) [ syncConfigAddon ]
+  );
 in
 {
+  imports = [ ./sync.nix ];
+
   config = lib.mkIf cfg.enable {
     # 시스템 사용자
     users.users.anki = {
@@ -41,14 +116,29 @@ in
     };
     users.groups.anki = { };
 
+    assertions = [
+      {
+        assertion = !syncCfg.enable || syncCfg.username != "";
+        message = "homeserver.ankiConnect.sync.username must not be empty.";
+      }
+      {
+        assertion = !syncCfg.enable || config.homeserver.ankiSync.enable || syncCfg.url != null;
+        message = "Enable homeserver.ankiSync or set homeserver.ankiConnect.sync.url when sync is enabled.";
+      }
+    ];
+
     # systemd 서비스
     systemd.services.anki-connect = {
       description = "Headless Anki with AnkiConnect API";
       after = [
         "tailscaled.service"
         "network.target"
-      ];
-      wants = [ "tailscaled.service" ];
+      ]
+      ++ lib.optionals localSyncServerEnabled [ "anki-sync-server.service" ];
+      wants = [
+        "tailscaled.service"
+      ]
+      ++ lib.optionals localSyncServerEnabled [ "anki-sync-server.service" ];
       wantedBy = [ "multi-user.target" ];
 
       environment = {
@@ -75,10 +165,14 @@ in
                             ANKI2_DIR="/var/lib/anki/.local/share/Anki2"
                             PROFILE_DIR="$ANKI2_DIR/${cfg.profile}"
                             PREFS_DB="$ANKI2_DIR/prefs21.db"
+                            BOOTSTRAP_MARKER="$PROFILE_DIR/.bootstrap-from-sync-server.done"
+                            SYNC_SERVER_DIR="/var/lib/anki-sync-server/${syncCfg.username}"
+                            SYNC_SERVER_COLLECTION="$SYNC_SERVER_DIR/collection.anki2"
+                            LOCAL_COLLECTION="$PROFILE_DIR/collection.anki2"
 
                             # 프로필 디렉터리 보장
                             if [ ! -d "$PROFILE_DIR" ]; then
-                              mkdir -p "$PROFILE_DIR"
+                              ${pkgs.coreutils}/bin/mkdir -p "$PROFILE_DIR"
                             fi
 
                             # prefs21.db 초기화 (첫 부팅 시)
@@ -93,16 +187,42 @@ in
               db.execute('INSERT OR REPLACE INTO profiles VALUES (?, ?)', ('_global', pickle.dumps(meta)))
               profile = {'mainWindowGeom': None, 'mainWindowState': None, 'numBackups': 50, 'lastOptimize': int(time.time()), 'searchHistory': [], 'syncKey': None, 'syncMedia': True, 'autoSync': True, 'allowHTML': False, 'importMode': 1, 'lastColour': '#00f', 'stripHTML': True, 'deleteMedia': False}
               db.execute('INSERT OR REPLACE INTO profiles VALUES (?, ?)', ('${cfg.profile}', pickle.dumps(profile)))
-              db.commit()
-              db.close()
-              "
+                              db.commit()
+                              db.close()
+                              "
                             fi
 
-                            chown -R anki:anki "$ANKI2_DIR"
+                            # 기존 수동 cp 워크어라운드를 대체하기 위한 1회 부트스트랩.
+                            # 로컬 컬렉션이 사실상 비어있으면 Sync Server 데이터를 먼저 복사한다.
+                            if [ "${lib.boolToString syncCfg.enable}" = "true" ] && \
+                               [ "${lib.boolToString syncCfg.bootstrapFromSyncServer}" = "true" ] && \
+                               [ ! -f "$BOOTSTRAP_MARKER" ] && \
+                               [ -f "$SYNC_SERVER_COLLECTION" ]; then
+                              src_size="$(${pkgs.coreutils}/bin/stat -c%s "$SYNC_SERVER_COLLECTION" 2>/dev/null || echo 0)"
+                              dst_size="$(${pkgs.coreutils}/bin/stat -c%s "$LOCAL_COLLECTION" 2>/dev/null || echo 0)"
+                              min_collection_bytes="${toString syncCfg.bootstrapMinCollectionBytes}"
+
+                              if [ "$src_size" -gt 0 ] && [ "$dst_size" -lt "$min_collection_bytes" ]; then
+                                echo "anki-connect bootstrap: copy collection from sync server"
+                                ${pkgs.coreutils}/bin/cp "$SYNC_SERVER_COLLECTION" "$LOCAL_COLLECTION"
+
+                                if [ "${lib.boolToString syncCfg.bootstrapMedia}" = "true" ] && [ -d "$SYNC_SERVER_DIR/media" ]; then
+                                  ${pkgs.coreutils}/bin/mkdir -p "$PROFILE_DIR/collection.media"
+                                  ${pkgs.rsync}/bin/rsync -a --delete "$SYNC_SERVER_DIR/media/" "$PROFILE_DIR/collection.media/"
+                                fi
+                              fi
+
+                              ${pkgs.coreutils}/bin/touch "$BOOTSTRAP_MARKER"
+                            fi
+
+                            ${pkgs.coreutils}/bin/chown -R anki:anki "$ANKI2_DIR"
             ''
           )
         ];
         ExecStart = "${ankiWithConnect}/bin/anki -p ${cfg.profile}";
+        ExecStartPost = lib.optionals (syncCfg.enable && syncCfg.onStart) [
+          "+${pkgs.systemd}/bin/systemctl --no-block start anki-connect-sync.service"
+        ];
 
         Restart = "on-failure";
         RestartSec = 10;

--- a/modules/nixos/programs/anki-connect/sync.nix
+++ b/modules/nixos/programs/anki-connect/sync.nix
@@ -1,0 +1,172 @@
+# modules/nixos/programs/anki-connect/sync.nix
+# AnkiConnect -> Sync Server 자동 동기화 (on-start + 주기 타이머)
+{
+  config,
+  pkgs,
+  lib,
+  constants,
+  ...
+}:
+
+let
+  cfg = config.homeserver.ankiConnect;
+  syncCfg = cfg.sync;
+  inherit (constants.network) minipcTailscaleIP;
+
+  syncUrl =
+    if syncCfg.url != null then
+      syncCfg.url
+    else
+      "http://${minipcTailscaleIP}:${toString config.homeserver.ankiSync.port}/";
+  normalizedSyncUrl = if lib.strings.hasSuffix "/" syncUrl then syncUrl else "${syncUrl}/";
+
+  localAnkiConnectUrl = "http://${minipcTailscaleIP}:${toString cfg.port}";
+  localSyncServerEnabled = config.homeserver.ankiSync.enable && syncCfg.url == null;
+
+  syncScript = pkgs.writeShellApplication {
+    name = "anki-connect-sync";
+    runtimeInputs = with pkgs; [
+      coreutils
+      curl
+      jq
+      util-linux
+    ];
+    text = ''
+      set -eu
+
+      STATE_FILE="${syncCfg.stateFile}"
+      API_URL="${localAnkiConnectUrl}"
+      SYNC_ENDPOINT="${normalizedSyncUrl}"
+      MAX_RETRIES="${toString syncCfg.maxRetries}"
+      BACKOFF_BASE_SEC="${toString syncCfg.backoffBaseSec}"
+      LOCK_FILE="/var/lib/anki/.anki-connect-sync.lock"
+
+      mkdir -p "$(dirname "$STATE_FILE")"
+      mkdir -p "/var/lib/anki"
+
+      exec 9>"$LOCK_FILE"
+      if ! flock -n 9; then
+        echo "anki-connect-sync: another sync run is already active, skipping."
+        exit 0
+      fi
+
+      write_state() {
+        now="$1"
+        result="$2"
+        error="$3"
+        last_success="$4"
+
+        jq -n \
+          --arg now "$now" \
+          --arg result "$result" \
+          --arg error "$error" \
+          --arg endpoint "$SYNC_ENDPOINT" \
+          --arg last_success "$last_success" \
+          '{
+            lastAttemptAt: $now,
+            lastSuccessAt: (if $last_success == "" then null else $last_success end),
+            result: $result,
+            error: (if $error == "" then null else $error end),
+            endpoint: $endpoint
+          }' > "$STATE_FILE"
+      }
+
+      attempt=1
+      delay="$BACKOFF_BASE_SEC"
+      last_error=""
+
+      while [ "$attempt" -le "$MAX_RETRIES" ]; do
+        started_at="$(date -Iseconds)"
+        curl_rc=0
+        response="$(
+          curl \
+            --silent \
+            --show-error \
+            --max-time 120 \
+            --header "Content-Type: application/json" \
+            --data '{"action":"sync","version":6}' \
+            "$API_URL" 2>&1
+        )" || curl_rc=$?
+
+        if [ "$curl_rc" -eq 0 ]; then
+          api_error="$(printf '%s' "$response" | jq -r '.error // empty' 2>/dev/null || echo "__parse_error__")"
+          if [ "$api_error" = "" ]; then
+            write_state "$started_at" "success" "" "$started_at"
+            echo "anki-connect-sync: success (attempt $attempt/$MAX_RETRIES)"
+            exit 0
+          fi
+          if [ "$api_error" = "__parse_error__" ]; then
+            last_error="invalid sync response: $response"
+          else
+            last_error="anki-connect error: $api_error"
+          fi
+        else
+          last_error="curl exit $curl_rc: $response"
+        fi
+
+        echo "anki-connect-sync: failed (attempt $attempt/$MAX_RETRIES): $last_error"
+
+        if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+          sleep "$delay"
+          delay="$((delay * 2))"
+        fi
+        attempt="$((attempt + 1))"
+      done
+
+      now="$(date -Iseconds)"
+      previous_success="$(jq -r '.lastSuccessAt // empty' "$STATE_FILE" 2>/dev/null || true)"
+      write_state "$now" "error" "$last_error" "$previous_success"
+
+      exit 1
+    '';
+  };
+in
+{
+  config = lib.mkIf (cfg.enable && syncCfg.enable) {
+    # headless Anki 프로세스가 읽을 수 있도록 별도 경로에 복호화
+    age.secrets.anki-connect-sync-password = {
+      file = ../../../../secrets/anki-sync-password.age;
+      owner = "anki";
+      group = "anki";
+      mode = "0400";
+    };
+
+    systemd.services.anki-connect-sync = {
+      description = "AnkiConnect periodic sync";
+      after = [
+        "anki-connect.service"
+        "network-online.target"
+      ]
+      ++ lib.optionals localSyncServerEnabled [ "anki-sync-server.service" ];
+      wants = [
+        "anki-connect.service"
+        "network-online.target"
+      ]
+      ++ lib.optionals localSyncServerEnabled [ "anki-sync-server.service" ];
+      partOf = [ "anki-connect.service" ];
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "anki";
+        Group = "anki";
+        ExecStart = "${syncScript}/bin/anki-connect-sync";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+      };
+    };
+
+    systemd.timers.anki-connect-sync = {
+      description = "Periodic AnkiConnect sync trigger";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        Unit = "anki-connect-sync.service";
+        OnBootSec = "90s";
+        OnUnitActiveSec = syncCfg.interval;
+        Persistent = true;
+        RandomizedDelaySec = "30s";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- `homeserver.ankiConnect.sync.*` 옵션 추가
- headless Anki 프로필 open 시 custom sync URL/username/sync key 자동 설정 addon 추가
- `anki-connect-sync.service` + `anki-connect-sync.timer` 추가 (onStart + 주기 sync)
- 지수 백오프(기본 3회) + 상태 파일(`/var/lib/anki/sync-status.json`) 기록
- 첫 배포 시 Sync Server 컬렉션/미디어를 AnkiConnect 프로필로 1회 bootstrap
- hosting-anki 스킬 문서 업데이트

## Changed Files
- `modules/nixos/options/homeserver.nix`
- `modules/nixos/programs/anki-connect/default.nix`
- `modules/nixos/programs/anki-connect/sync.nix`
- `.claude/skills/hosting-anki/SKILL.md`
- `.claude/skills/hosting-anki/references/setup.md`
- `.claude/skills/hosting-anki/references/troubleshooting.md`

## Validation
- `nix eval .#nixosConfigurations.greenhead-minipc.config.system.build.toplevel.drvPath --raw`
- `./tests/run-eval-tests.sh`
- pre-push `flake-check`

Closes #66


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization for AnkiConnect with configurable enable, startup, and interval settings
  * Added sync status tracking to monitor synchronization attempts and results
  * Added bootstrap functionality to initialize local collections from a sync server with optional media sync
  * Added automatic retry logic with configurable retry attempts and backoff behavior for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->