### PR TITLE
feat(atuin): 호스트별 inline_height 동적 분리

### DIFF
--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -186,7 +186,7 @@ in
       network_connect_timeout = 5;
       local_timeout = 5;
       style = "compact";
-      inline_height = 9;
+      inline_height = if pkgs.stdenv.isDarwin then 40 else 9;
       show_help = false;
       update_check = false;
       search_mode = "fulltext";


### PR DESCRIPTION
## Summary

- Atuin `inline_height`를 호스트별로 분리: MacBook(40), MiniPC(9 유지)
- MacBook 전체 화면에서 히스토리 표시 개수 ~6개 → ~35개로 확대

Closes #87

## Test plan

- [x] `nix flake check --all-systems` 통과
- [ ] MacBook에서 Atuin TUI(위 방향키) 실행 시 ~35개 항목 표시 확인
- [ ] MiniPC에서 기존과 동일하게 ~6개 항목 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell program configuration to optimize terminal display height. The adjustment increases vertical spacing on macOS systems while maintaining existing settings on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->