### PR TITLE
fix(skill): codex exec review 플래그 구분 명확화 및 자기 교정 메커니즘

### DIFF
--- a/.claude/skills/configuring-codex/SKILL.md
+++ b/.claude/skills/configuring-codex/SKILL.md
@@ -107,3 +107,5 @@ codex -a never exec "Answer YES or NO only: Is a skill named 'configuring-codex'
 ## 레퍼런스
 
 - 상세 장애 기록 및 회귀 체크: `references/runbook-codex-compat-2026-02-08.md`
+
+문서와 CLI 동작이 다를 때는 CLAUDE.md의 "스킬 문서 불일치 시 행동 원칙"을 따른다.

--- a/.claude/skills/using-codex-exec/SKILL.md
+++ b/.claude/skills/using-codex-exec/SKILL.md
@@ -48,15 +48,18 @@ CLI 버전이 바뀌면 플래그/동작이 달라질 수 있으므로, 실행 �
 
 ## 핵심 플래그
 
-| 플래그 | 의미 | 운영 원칙 |
-|--------|------|-----------|
-| `--full-auto` | 자동 실행 편의 별칭 | 기본 실행값으로 사용 |
-| `-m <MODEL>` | 모델 지정 | 기본적으로 생략하고 기본 모델 사용 |
-| `-o <FILE>` | 마지막 에이전트 메시지 저장 | 결과 보존이 필요하면 항상 지정 |
-| `--ephemeral` | 세션 파일 미저장 | 일회성/민감 프롬프트에서 사용 |
-| `--json` | JSONL 이벤트 출력 | 파이프라인 연동 시만 사용 |
-| `-` (PROMPT 위치) | stdin에서 프롬프트 읽기 | 파이프 입력 시 명시 가능 |
-| `--skip-git-repo-check` | git 저장소 체크 건너뜀 | 저장소 외 실행이 필요한 경우에만 사용 |
+| 플래그 | 적용 | 의미 | 운영 원칙 |
+|--------|------|------|-----------|
+| `--full-auto` | 공통 | 자동 실행 편의 별칭 | 기본 실행값으로 사용 |
+| `-m <MODEL>` | 공통 | 모델 지정 | 기본적으로 생략하고 기본 모델 사용 |
+| `-o <FILE>` | exec 전용 | 마지막 에이전트 메시지 저장 | 결과 보존이 필요하면 항상 지정. **review에서는 사용 불가** — stdout 리다이렉트(`> file 2>&1`)로 대체 |
+| `--ephemeral` | 공통 | 세션 파일 미저장 | 일회성/민감 프롬프트에서 사용 |
+| `--json` | 공통 | JSONL 이벤트 출력 | 파이프라인 연동 시만 사용 |
+| `-` (PROMPT 위치) | 공통 | stdin에서 프롬프트 읽기 | 파이프 입력 시 명시 가능 |
+| `--skip-git-repo-check` | 공통 | git 저장소 체크 건너뜀 | 저장소 외 실행이 필요한 경우에만 사용 |
+| `--base <BRANCH>` | review 전용 | 비교 대상 브랜치 | PR 리뷰 시 사용 |
+| `--uncommitted` | review 전용 | 미커밋 변경 리뷰 | 로컬 self-review 시 사용 |
+| `--commit <SHA>` | review 전용 | 특정 커밋 리뷰 | 단일 커밋 검토 시 사용 |
 
 ## 모델 사용 원칙
 
@@ -207,4 +210,5 @@ cat /tmp/review-instruction.md | codex exec review - --base main --full-auto
 - 실패 대응 절차: [references/troubleshooting.md](references/troubleshooting.md)
 - 실전 명령 모음: [references/examples.md](references/examples.md)
 
-작업 도중 불일치가 보이면 현재 도움말(`codex exec --help`)을 우선 진실 원천으로 사용한다.
+문서와 CLI 동작이 다를 때는 CLAUDE.md의 "스킬 문서 불일치 시 행동 원칙"을 따른다.
+현재 도움말(`codex exec --help`, `codex exec review --help`) 출력이 이 문서보다 항상 우선하는 진실 원천이다.

--- a/.claude/skills/using-codex-exec/references/troubleshooting.md
+++ b/.claude/skills/using-codex-exec/references/troubleshooting.md
@@ -186,7 +186,28 @@ warning: Model metadata for `<model>` not found. Defaulting to fallback metadata
 2. 모델명을 강제할 필요가 없다면 기본 모델 정책으로 되돌린다.
 3. stdin/파이프 입력 관련 이상 징후가 있으면 **3번 섹션**을 함께 점검한다.
 
-## 9. 재현 가능한 최소 실행으로 복구
+## 9. `codex exec review`에 `-o` 사용 시 오류
+
+### 증상
+
+```text
+error: unexpected argument '-o' found
+```
+
+### 원인
+
+- `-o`(`--output-last-message`)는 `codex exec` 전용 플래그이며 `review` 서브커맨드에서는 지원하지 않는다.
+- `codex exec review --help`에 `-o`가 존재하지 않음으로 확인 가능하다.
+
+### 해결
+
+`review` 결과를 파일로 저장하려면 stdout 리다이렉트를 사용한다:
+
+```bash
+codex exec review --base main --full-auto > /tmp/review-result.md 2>&1
+```
+
+## 10. 재현 가능한 최소 실행으로 복구
 
 실패가 반복될 때는 아래 최소 명령으로 상태를 리셋한다.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,3 +106,17 @@ homeserver.devProxy.enable = true;
 | Cursor IDE, Nix extensions.json, duti, 확장 0개 표시 | `managing-cursor` |
 | Pushover, 텍스트 공유, MiniPC→iPhone, share text | `sharing-text` |
 | dev-proxy, dev server, 개발 서버 프록시, dev.greenhead.dev, HMR, 모바일 미리보기 | `proxying-dev-server` |
+
+## 스킬 문서 불일치 시 행동 원칙
+
+스킬 문서에 기재된 CLI 명령/플래그를 실행했는데 에러가 발생하면:
+
+1. 해당 명령의 `--help`를 실행해 실제 지원 플래그를 확인한다.
+2. 문서 내용과 실제 CLI 동작의 차이를 정리한다.
+3. 사용자에게 즉시 알린다:
+   - 에러 내용
+   - 문서에 기재된 내용 vs 실제 CLI `--help` 결과
+   - 문서 수정이 필요한지 판단을 요청
+4. 자의적으로 문서를 우회하거나 무시하고 진행하지 않는다.
+
+> CLI `--help` 출력이 스킬 문서보다 항상 우선하는 진실 원천이다.


### PR DESCRIPTION
## 배경

PR #88 코드 리뷰 중 LLM이 `using-codex-exec` 스킬을 참조하여 다음 명령을 실행했으나 실패했습니다:

```bash
codex exec review --base main --full-auto -o /tmp/codex-review-88.md 2>&1
# error: unexpected argument '-o' found
```

**근본 원인**: `-o`(`--output-last-message`) 플래그는 `codex exec` 전용이며 `codex exec review` 서브커맨드에서는 지원하지 않습니다. 스킬 문서의 핵심 플래그 테이블이 서브커맨드 구분 없이 플래그를 나열하고 있어, LLM이 review에도 `-o`가 적용된다고 잘못 추론했습니다.

**추가 문제**: CLI 버전이 변경되어 문서가 낡았을 때, LLM이 이를 자동으로 감지하고 사용자에게 알리는 메커니즘이 없었습니다.

## 변경 내용

### 1. `using-codex-exec/SKILL.md` — 플래그 테이블 정확성 개선

- 핵심 플래그 테이블에 **"적용" 열** 추가: `공통` / `exec 전용` / `review 전용`으로 각 플래그의 서브커맨드별 사용 범위를 명확히 구분
- `-o <FILE>` 행에 **"review에서는 사용 불가"** 경고와 **stdout 리다이렉트 대안**(`> file 2>&1`) 명시
- review 전용 플래그 3개(`--base`, `--uncommitted`, `--commit`)를 통합 테이블에 추가하여, 기존에 본문 하단에만 있던 정보를 빠른 참조 가능하도록 개선
- 마지막 줄의 수동적 "진실 원천" 안내를 CLAUDE.md 참조 + 구체적 help 명령 안내로 교체

### 2. `using-codex-exec/references/troubleshooting.md` — 인시던트 문서화

- **#9 항목 신설**: `codex exec review`에 `-o` 사용 시 발생하는 `unexpected argument '-o' found` 에러의 증상/원인/해결 절차 문서화
- 해결책으로 stdout 리다이렉트 패턴 제시 (`codex exec review --base main --full-auto > /tmp/review-result.md 2>&1`)
- 기존 #9(재현 최소 실행)를 #10으로 번호 조정

### 3. `CLAUDE.md` — 공통 자기 교정 원칙 도입

- **"스킬 문서 불일치 시 행동 원칙"** 섹션 신설 (스킬 라우팅 테이블 다음)
- 스킬 문서대로 CLI 명령을 실행했는데 에러가 발생하면:
  1. `--help`를 실행해 실제 지원 플래그 확인
  2. 문서 내용 vs 실제 CLI 동작 차이 정리
  3. 사용자에게 즉시 알림 (에러 내용, 문서 vs CLI 차이, 수정 필요 여부 판단 요청)
  4. 자의적으로 문서를 우회하지 않음
- **진실 원천 계층 선언**: `> CLI --help 출력이 스킬 문서보다 항상 우선하는 진실 원천이다.`
- CLAUDE.md는 항상 컨텍스트에 로드되므로, 모든 스킬 사용 시 자동 적용됨

### 4. `configuring-codex/SKILL.md` — CLAUDE.md 참조 추가

- 파일 끝에 CLAUDE.md의 불일치 행동 원칙을 참조하는 한 줄 추가
- 전체 절차를 복사하지 않고 참조만 남겨 DRY 원칙 준수 (중복 시 3곳 drift 위험 방지)

## 설계 결정

### 왜 CLAUDE.md에 공통 원칙을 두는가?

- CLAUDE.md는 모든 세션에서 항상 로드되므로, 별도 파일 없이 모든 스킬에 자동 적용
- 개별 스킬에 전체 절차를 복사하면 3곳(CLAUDE.md + 2개 스킬)이 drift할 위험
- 각 스킬은 한 줄 참조만 남기고, 스킬 특화 정보(어떤 `--help`를 실행할지)만 보충

### 왜 플래그 테이블을 확장했는가?

- LLM은 테이블을 구조화된 데이터로 파싱하므로, "적용" 열이 있으면 서브커맨드 범위를 정확히 판단
- review 전용 플래그를 같은 테이블에 넣어 한 곳에서 전체 플래그 맵을 볼 수 있음
- 기존에 본문 중간에만 있던 `--base`, `--uncommitted`, `--commit`의 발견성 향상

## 검증

- `codex exec --help` 출력에서 `-o` 존재 확인 ✅
- `codex exec review --help` 출력에서 `-o` 부재 확인 ✅
- pre-commit 훅 전체 통과 (gitleaks, ai-skills-consistency, eval-tests) ✅
- pre-push flake-check 통과 ✅

## Test plan

- [ ] `codex exec --help` 출력의 플래그 목록이 수정된 테이블의 "exec 전용" + "공통" 항목과 일치하는지 확인
- [ ] `codex exec review --help` 출력의 플래그 목록이 수정된 테이블의 "review 전용" + "공통" 항목과 일치하는지 확인
- [ ] 새 세션에서 `codex exec review --base main --full-auto -o /tmp/test.md`를 실행하여 에러 발생 확인 후, LLM이 troubleshooting.md #9를 참조하여 stdout 리다이렉트 대안을 제시하는지 확인
- [ ] 새 세션에서 존재하지 않는 플래그를 사용하여 에러 발생 시, LLM이 CLAUDE.md의 불일치 원칙에 따라 `--help`를 실행하고 사용자에게 문서 불일치를 알리는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for resolving discrepancies between documentation and CLI behavior
  * Enhanced troubleshooting with error resolution for the `-o` flag in review commands
  * Clarified flag availability across different command contexts
  * Added documentation for new command-line flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->