### PR TITLE
refactor(darwin): hostType별 Tailscale 의존 기능 분리

### DIFF
--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -63,9 +63,8 @@
     openssh.authorizedKeys.keys = [
       constants.sshKeys.macbook # Termius 등 외부 기기에서 접속
     ]
-    # MiniPC → Mac SSH 접속용 공개키 — personal 전용
-    # work Mac은 Tailnet 미소속이므로 MiniPC에서 SSH 접속할 일이 없다.
     ++ lib.optionals (hostType == "personal") [
+      # MiniPC는 Tailscale IP 전용 — work Mac에는 불필요
       constants.sshKeys.minipc
     ];
   };

--- a/modules/darwin/programs/folder-actions/default.nix
+++ b/modules/darwin/programs/folder-actions/default.nix
@@ -1,12 +1,5 @@
 # Folder Actions - launchd WatchPaths 기반 폴더 감시
-# 감시 폴더: ~/FolderActions/{compress-rar, compress-video, rename-asset, convert-video-to-gif, upload-immich(personal)}/
-#
-# hostType 분기:
-#   upload-immich 스크립트와 launchd agent는 personal 전용 (hostType == "personal").
-#   work Mac은 Tailnet에 속하지 않아 Immich 서버(Tailscale IP)에 접근 불가하므로
-#   upload-immich.sh 배치와 folder-action-upload-immich agent를 제외한다.
-#   shottrDefaultDir(Shottr 저장 경로)는 양쪽 Mac 모두 동일(FolderActions/upload-immich)하게 유지.
-#   폴더명이 work에서 의미가 안 맞지만, Shottr 경로 분기는 YAGNI로 판단하여 생략.
+# upload-immich는 Tailscale/Immich 의존이므로 personal 전용 (work Mac은 Tailnet 미소속)
 {
   config,
   pkgs,
@@ -44,8 +37,6 @@ in
     };
   }
   // lib.optionalAttrs (hostType == "personal") {
-    # Immich CLI 업로드 스크립트 — personal 전용
-    # work Mac은 Tailnet 미소속 → Immich 서버 접근 불가 → 스크립트 배치 불필요
     ".local/bin/upload-immich.sh" = {
       source = "${scriptsDir}/upload-immich.sh";
       executable = true;
@@ -122,10 +113,6 @@ in
     };
   }
   // lib.optionalAttrs (hostType == "personal") {
-    # Immich 자동 업로드 폴더 감시 — personal 전용
-    # shottrDefaultDir(~/FolderActions/upload-immich)에 파일이 추가되면
-    # upload-immich.sh를 실행하여 Immich 서버(Tailscale IP)로 업로드한다.
-    # work Mac은 Tailnet 미소속이므로 이 agent를 등록하지 않는다.
     folder-action-upload-immich = {
       enable = true;
       config = {

--- a/modules/darwin/programs/ssh/default.nix
+++ b/modules/darwin/programs/ssh/default.nix
@@ -35,9 +35,7 @@ in
       };
     }
     // lib.optionalAttrs (hostType == "personal") {
-      # MiniPC SSH 접속 — personal 전용
-      # MiniPC 홈서버는 Tailscale IP에만 바인딩되어 있어
-      # Tailnet에 속하지 않은 work Mac에서는 접속 불가.
+      # MiniPC는 Tailscale IP 전용 — work Mac(Tailnet 미소속)에서는 접속 불가
       "minipc" = {
         hostname = constants.network.minipcTailscaleIP;
         user = "greenhead";


### PR DESCRIPTION
## Summary

- work Mac(hostType="work")에 불필요한 Tailscale 의존 설정 3가지를 `hostType == "personal"` 조건으로 분리
  - `folder-actions/default.nix`: upload-immich 스크립트 배치 + launchd agent를 personal 전용으로
  - `ssh/default.nix`: minipc SSH matchBlock을 personal 전용으로
  - `configuration.nix`: minipc authorized_keys를 personal 전용으로
- Shottr 저장 경로 분기는 YAGNI로 판단하여 미포함 (양쪽 Mac 동일 경로 유지)
- 기존 패턴(`homebrew.nix`의 `lib.mkIf (hostType == "personal")`) 따름

Closes #86

## Test plan

- [x] `nix flake check --all-systems` 통과
- [x] lefthook pre-commit (nixfmt, gitleaks, eval-tests) 통과
- [x] lefthook pre-push (flake-check) 통과
- [ ] personal Mac에서 `nrs` 실행하여 회귀 없음 확인