### PR TITLE
fix(darwin): Figma cask 제거 및 Homebrew 업그레이드 정책 도입

### DIFF
--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -75,13 +75,15 @@ darwinOnly = [ ... pkgs.패키지명 ];
 
 ```nix
 # cleanup = "none" — 선언되지 않은 앱을 삭제하지 않음 (수동 설치 cask 보호)
+# upgrade = true + greedyCasks = true — 자체 업데이터 앱의 버전 드리프트 방지
 homebrew.casks = [
   "codex" "cursor" "ghostty" "raycast" "rectangle"
   "hammerspoon" "homerow" "docker"
-  "fork" "slack" "figma" "monitorcontrol"
+  "fork" "slack" "monitorcontrol"
 ];
 homebrew.brews = [ "laishulu/homebrew/macism" ]; # Neovim 한영 전환
 # shottr → Nix 패키지로 관리 (libraries/packages.nix darwinOnly)
+# figma → Homebrew에서 제거 (자체 업데이터가 버전을 변경하여 adopt 시 버전 충돌)
 ```
 
 **새 Mac 세팅 시**: 직접 설치된 앱은 `brew install --cask --adopt <앱>`으로 Homebrew 관리로 전환 필요.

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -336,10 +336,7 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | Docker         | 컨테이너                   |
 | Fork           | Git GUI                    |
 | Slack          | 메신저                     |
-| Figma          | 디자인                     |
 | MonitorControl | 외부 모니터 밝기 조절      |
-
-> **참고**: boring-notch는 의도적으로 선언에서 제외. 수동 설치 cask로 유지하며, cleanup="none"이므로 삭제되지 않음.
 
 ### Nix 패키지로 관리하는 GUI 앱
 
@@ -357,7 +354,23 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | Ghostty | `pkgs.ghostty-bin`은 CLI 바이너리만 제공하고 macOS .app 번들을 포함하지 않음. Ghostty.app은 Homebrew Cask로만 설치 가능. |
 | Docker  | Docker Desktop은 nixpkgs에 macOS용 패키지 없음 (CLI만 존재) |
 | Fork    | 상용 Git GUI, nixpkgs에 없음 |
-| Figma   | nixpkgs에 Linux 비공식 래퍼(`figma-linux`)만 존재, macOS 공식 앱 미지원 |
+
+### 업그레이드 정책
+
+`onActivation.upgrade = true` + `greedyCasks = true` 조합으로 버전 드리프트를 방지합니다.
+
+- **upgrade = true**: `nrs` 실행 시 `brew upgrade`를 자동 실행
+- **greedyCasks = true**: `auto_updates` 속성이 있는 cask도 `brew upgrade` 대상에 포함
+
+자체 업데이터가 있는 앱(Cursor, Slack 등)이 Homebrew와 독립적으로 버전을 변경해도, `nrs` 실행 시 Homebrew가 최신 버전으로 동기화합니다.
+
+### Homebrew 관리에서 제외한 앱
+
+| 앱 | 사유 |
+| --- | --- |
+| Figma | 자체 업데이터가 적극적으로 버전을 변경하여 Homebrew 관리 버전과 불일치. adopt 시 버전 차이로 설치 거부됨. 자체 업데이터에 위임. |
+
+> `cleanup = "none"`이므로 cask 목록에서 제거해도 기존 `/Applications/Figma.app`은 삭제되지 않습니다.
 
 ### Brew Formula
 
@@ -404,7 +417,7 @@ brew install --cask --adopt cursor:
 brew install --cask --adopt cursor
 
 # 여러 앱 일괄 adopt (Nix 패키지로 관리하는 shottr 제외)
-for cask in codex cursor ghostty raycast rectangle hammerspoon homerow docker fork slack figma monitorcontrol; do
+for cask in codex cursor ghostty raycast rectangle hammerspoon homerow docker fork slack monitorcontrol; do
   brew install --cask --adopt "$cask" || echo "FAILED: $cask"
 done
 

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -15,8 +15,17 @@
     # 선언되지 않은 앱 정리
     onActivation = {
       autoUpdate = true;
-      cleanup = "none"; # 선언되지 않은 앱을 자동 삭제하지 않음 (boring-notch 등 수동 설치 cask 보호)
+      upgrade = true; # 선언된 모든 패키지를 최신 버전으로 업그레이드
+      cleanup = "none"; # 선언되지 않은 앱을 자동 삭제하지 않음
     };
+
+    # [업그레이드 정책]
+    # upgrade=true + greedyCasks=true 조합:
+    # - upgrade=true: nrs 실행 시 brew upgrade를 자동 실행
+    # - greedyCasks=true: auto_updates가 있는 cask도 brew upgrade 대상에 포함
+    # 자체 업데이터가 있는 앱(Cursor, Slack 등)이 Homebrew와 독립적으로 버전을 변경해도
+    # nrs 실행 시 Homebrew가 최신 버전으로 동기화하여 버전 드리프트를 방지한다.
+    greedyCasks = true;
 
     # Homebrew Tap (서드파티 저장소)
     taps = [
@@ -61,9 +70,10 @@
     #          Ghostty.app은 Homebrew Cask로만 설치 가능.
     # docker: Docker Desktop은 nixpkgs에 macOS용 패키지 없음 (CLI만 존재)
     # fork: 상용 Git GUI, nixpkgs에 없음
-    # figma: nixpkgs에 Linux 비공식 래퍼만 존재 (figma-linux), macOS 공식 앱 미지원
+    # [Homebrew에서 제거한 앱]
+    # figma: 자체 업데이터가 적극적으로 버전을 변경하여 Homebrew가 관리하는 버전과 불일치 발생.
+    #        adopt 시 버전 불일치로 설치 거부됨. 자체 업데이터에 위임.
     #
-    # 참고: boring-notch는 의도적으로 제외 (수동 설치 cask로 유지, cleanup="none"이므로 삭제되지 않음)
     casks = [
       "codex"
       "cursor"
@@ -75,7 +85,6 @@
       "docker"
       "fork"
       "slack"
-      "figma"
       "monitorcontrol"
     ];
 


### PR DESCRIPTION
## Summary

- Figma cask 제거: 자체 업데이터가 버전을 변경하여 Homebrew adopt 시 버전 불일치로 설치 거부되는 문제 해결
- `upgrade = true` + `greedyCasks = true` 도입: 나머지 자체 업데이터 앱(Cursor, Slack 등)의 버전 드리프트 방지
- boring-notch 관련 언급 전체 제거 (더 이상 사용하지 않음)

## Test plan

- [x] `nrs` 실행 성공 — Figma 관련 install 시도 사라짐, `brew bundle complete! 13 Brewfile dependencies`
- [x] Brewfile 아티팩트에 figma 부재 확인, 전체 cask에 `greedy: true` 적용 확인
- [x] `/Applications/Figma.app` 기존대로 유지됨 (`cleanup=none`)