### PR TITLE
fix(devShell): worktree 복귀 후 lefthook core.hooksPath 충돌 해결

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,7 +190,7 @@
             ];
             shellHook = ''
               # worktree 환경에서 공유 config에 남은 core.hooksPath를 정리
-              # (lefthook 2.x는 core.hooksPath 없이 .git/hooks/에 직접 설치)
+              # (lefthook 2.x는 core.hooksPath가 설정되어 있으면 install을 거부함)
               git config --unset-all --local core.hooksPath 2>/dev/null || true
               lefthook install 2>/dev/null || true
             '';


### PR DESCRIPTION
## Summary

<img width="1277" height="360" alt="image" src="https://github.com/user-attachments/assets/cb903519-5eb5-4a13-a240-7edb28dfc8b3" />

- Claude Code `--worktree` 병렬 작업 후 메인 워크트리 복귀 시 발생하는 lefthook `core.hooksPath` 충돌 에러 해결
- `lefthook install` 전에 local 스코프의 `core.hooksPath`를 정리하여 정상 hook 설치 보장
- lefthook 내장 `--reset-hooks-path` 대신 수동 `--local` 스코프 unset 사용 (global config 보호)

## 원인

1. `c --worktree`가 `.claude/worktrees/<name>/`에 git worktree 생성
2. 워크트리와 메인 repo가 `.git/config` 공유
3. 워크트리에서 `lefthook install` 실행 시 공유 config에 `core.hooksPath` 설정 추가
4. 메인 복귀 후 `lefthook install` 재실행 시 충돌 에러

## 대안 검토 (Devil's Advocate 7라운드)

| 대안 | 결과 |
|------|------|
| `lefthook install --reset-hooks-path` | **기각** — global `core.hooksPath`도 삭제하는 부작용 확인 |
| `lefthook install --force` | **기각** — `core.hooksPath` 설정을 유지한 채 진행하여 후속 문제 가능 |
| `extensions.worktreeConfig` | **기각** — repo 동작 모델 변경은 이 이슈에 과잉 |
| `git config --unset-all --local` | **채택** — local 스코프만 정리, global 무관, 미설정 시 no-op |

## Test plan

- [x] pre-commit hooks 통과 (nixfmt, gitleaks, shellcheck, eval-tests)
- [x] pre-push hooks 통과 (flake check --all-systems)
- [ ] `c --worktree`로 워크트리 생성 → 작업 → 메인 복귀 후 에러 미발생 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved development environment setup reliability by ensuring any shared/local hook configuration is cleared before installing project hooks, with error tolerance so setup proceeds smoothly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->