### PR TITLE
fix(scripts): validate-skills.sh에 pipefail 누락 — yq 실패 시 에러 은폐

### DIFF
--- a/modules/shared/scripts/validate-skills.sh
+++ b/modules/shared/scripts/validate-skills.sh
@@ -8,7 +8,7 @@
 # 의존성: yq (brew install yq 또는 nix-shell -p yq)
 # 참고: 이 스크립트는 Nix 설정에서 참조되지 않음 (수동 실행용)
 
-set -e
+set -euo pipefail
 
 echo "=== Skills Validation ==="
 echo "Date: $(date)"
@@ -29,8 +29,12 @@ done
 echo
 echo "## 2. 길이 검증 (150-260자)"
 for f in .claude/skills/*/SKILL.md; do
-  len=$(sed -n '2,/^---$/p' "$f" | head -n -1 | yq -r '.description' | wc -c)
   name=$(basename "$(dirname "$f")")
+  if ! description=$(sed -n '2,/^---$/p' "$f" | head -n -1 | yq -r '.description'); then
+    echo "❌ $name: YAML .description 파싱 실패"
+    continue
+  fi
+  len=$(printf '%s\n' "$description" | wc -c)
   if [ "$len" -lt 150 ] || [ "$len" -gt 260 ]; then
     echo "⚠️  $name: ${len}자 (범위 초과)"
   else


### PR DESCRIPTION
Closes #96

## Summary
- `set -e` → `set -euo pipefail` 변경으로 파이프라인 내 `yq` 실패 감지
- 길이 검증 파이프라인을 분리하여, `yq` 파싱 실패 시 "YAML .description 파싱 실패" 에러 메시지 출력 (기존 "0자 (범위 초과)" 오해 방지)

## Test plan
- [x] `shellcheck modules/shared/scripts/validate-skills.sh` 경고 없음
- [x] `bash modules/shared/scripts/validate-skills.sh` 전체 스킬 정상 실행 확인
- [x] pre-commit hooks (shellcheck, gitleaks, eval-tests) 통과
- [x] pre-push flake-check 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved skill validation system with enhanced error handling and more robust parsing of skill configurations. Updates ensure clearer error reporting when validation issues occur and provide more reliable processing of skill definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->