### PR TITLE
fix(folder-actions): ffmpeg -nostdin 추가로 다중 파일 처리 시 누락 해결 (#95)

### DIFF
--- a/modules/darwin/programs/folder-actions/files/scripts/compress-video.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/compress-video.sh
@@ -30,7 +30,7 @@ find "$WATCH_DIR" -type f -maxdepth 1 \( -iname "*.mp4" -o -iname "*.mov" -o -in
     echo "[$(date)] 압축 시작: $filename"
 
     # H.265 압축 (hvc1 태그로 Apple 호환성 확보)
-    if ffmpeg -i "$f" \
+    if ffmpeg -nostdin -i "$f" \
         -c:v libx265 -preset fast -crf 28 -tag:v hvc1 \
         -c:a eac3 -b:a 224k \
         -y "$output_path" 2>/dev/null; then

--- a/modules/darwin/programs/folder-actions/files/scripts/convert-video-to-gif.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/convert-video-to-gif.sh
@@ -34,7 +34,7 @@ find "$WATCH_DIR" -type f -maxdepth 1 \( -iname "*.mp4" -o -iname "*.mov" -o -in
     echo "[$(date)] GIF 변환 시작: $filename (${FPS}fps, ${WIDTH}px)"
 
     # GIF 변환
-    if ffmpeg -hide_banner -loglevel error -y \
+    if ffmpeg -nostdin -hide_banner -loglevel error -y \
         -i "$f" \
         -vf "fps=${FPS},scale=${WIDTH}:-1:flags=lanczos" \
         -c:v gif -f gif "$output_path" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- `compress-video.sh`와 `convert-video-to-gif.sh`의 ffmpeg 호출에 `-nostdin` 플래그 추가
- `find | while read` 루프에서 ffmpeg가 stdin을 소비하여 다중 파일 처리 시 첫 번째만 처리되는 버그 수정

## Changes

| File | Change |
|------|--------|
| `compress-video.sh:33` | `ffmpeg -i` → `ffmpeg -nostdin -i` |
| `convert-video-to-gif.sh:37` | `ffmpeg -hide_banner` → `ffmpeg -nostdin -hide_banner` |

## Test plan

- [ ] `shellcheck -S warning` 두 파일 모두 SC2095 경고 없음 (CI 통과로 확인)
- [ ] `compress-video` 감시 폴더에 비디오 3개 → 3개 모두 H.265 압축 완료
- [ ] `convert-video-to-gif` 감시 폴더에 비디오 2개 → 2개 모두 GIF 변환 완료
- [ ] 단일 파일 처리에 회귀 없음
- [ ] 다중 파일 중 1개 손상 파일 포함 → 해당 파일만 실패, 나머지 정상 처리

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential freezing issues during H.265 video compression
  * Fixed potential freezing issues when converting videos to GIF format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->