### PR TITLE
feat(darwin): 한글 폰트 Apple SD Gothic Neo 명시적 폴백 지정

### DIFF
--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -296,12 +296,12 @@ nix-darwin의 `fonts.packages` 옵션을 사용하여 폰트를 선언적으로 
 
 **폰트 사용처:**
 
-| 앱       | 설정 파일                                           | 폰트 이름                |
-| -------- | --------------------------------------------------- | ------------------------ |
-| Ghostty  | `modules/darwin/programs/ghostty/default.nix`       | JetBrainsMono Nerd Font  |
-| Cursor   | `modules/darwin/programs/cursor/files/settings.json` | JetBrainsMono Nerd Font  |
+| 앱       | 설정 파일                                           | 영문 폰트                | 한글 폴백                |
+| -------- | --------------------------------------------------- | ------------------------ | ------------------------ |
+| Ghostty  | `modules/darwin/programs/ghostty/default.nix`       | JetBrainsMono Nerd Font  | Apple SD Gothic Neo      |
+| Cursor   | `modules/darwin/programs/cursor/files/settings.json` | JetBrainsMono Nerd Font  | Apple SD Gothic Neo      |
 
-CJK(한글 등) 문자는 macOS 시스템 폰트(Apple SD Gothic Neo 등)가 자동으로 폴백 처리한다.
+한글은 Apple SD Gothic Neo(macOS 시스템 내장 폰트)를 앱별 font-family 폴백으로 명시적 지정한다.
 
 **설치 경로:** `/Library/Fonts/Nix Fonts/`
 

--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -82,6 +82,10 @@ in
   # 향후 Sarasa와 유사한 합성 폰트(예: M+ 계열, Monaspace + CJK 합성 등)를 고려할 때
   # 반드시 사용 중인 모든 모니터의 PPI를 확인하고, ~200 PPI 미만 모니터가 있다면 사용을 피할 것.
   # 이 폰트를 다시 설치하려면 git log에서 이 커밋을 참조할 것.
+  #
+  # [현재 폰트 전략]
+  # 영문: JetBrainsMono Nerd Font (Nix 설치, 단일 설계 폰트로 저DPI에서도 깔끔)
+  # 한글: Apple SD Gothic Neo (macOS 시스템 내장 폰트, 앱별 font-family 폴백으로 지정)
   fonts.packages = [
     pkgs.nerd-fonts.jetbrains-mono
   ];

--- a/modules/darwin/programs/cursor/files/settings.json
+++ b/modules/darwin/programs/cursor/files/settings.json
@@ -17,10 +17,10 @@
   // ============================================================================
   // 폰트 설정
   // ============================================================================
-  "editor.fontFamily": "JetBrainsMono Nerd Font", // 에디터 기본 폰트
+  "editor.fontFamily": "JetBrainsMono Nerd Font, 'Apple SD Gothic Neo'", // 영문: JetBrains Mono, 한글: Apple SD Gothic Neo
   "editor.fontLigatures": true, // 리가처 활성화 (=>, !==, -> 등 합자 표시)
-  "editor.codeLensFontFamily": "JetBrainsMono Nerd Font", // CodeLens(참조 수 등) 폰트
-  "editor.inlayHints.fontFamily": "JetBrainsMono Nerd Font", // 인라인 힌트(타입 추론 등) 폰트
+  "editor.codeLensFontFamily": "JetBrainsMono Nerd Font, 'Apple SD Gothic Neo'", // CodeLens(참조 수 등) 폰트
+  "editor.inlayHints.fontFamily": "JetBrainsMono Nerd Font, 'Apple SD Gothic Neo'", // 인라인 힌트(타입 추론 등) 폰트
 
   // ============================================================================
   // 에디터 기본 설정

--- a/modules/darwin/programs/ghostty/default.nix
+++ b/modules/darwin/programs/ghostty/default.nix
@@ -3,15 +3,16 @@
 
 {
   xdg.configFile."ghostty/config".text = ''
-    # 폰트 설정 — Ghostty font-family
+    # 폰트 설정 — Ghostty font-family fallback chain
     #
     # font-family를 여러 줄 지정하면 fallback chain으로 동작한다.
     # 각 문자를 렌더링할 때 1순위 폰트에서 글리프를 먼저 찾고,
     # 없는 경우에만 2순위 이하로 넘어간다.
-    # CJK(한글 등) 문자는 macOS 시스템 폰트가 자동으로 폴백 처리한다.
     #
-    # 폰트를 추가하려면 font-family 줄을 아래에 추가하면 된다.
+    # 1순위: JetBrainsMono Nerd Font — 영문/숫자/기호/Nerd Font 아이콘
+    # 2순위: Apple SD Gothic Neo — 한글 (macOS 시스템 내장 폰트)
     font-family = JetBrainsMono Nerd Font
+    font-family = Apple SD Gothic Neo
 
     # macOS Option 키를 Alt로 사용 (왼쪽만)
     macos-option-as-alt = left


### PR DESCRIPTION
## Summary

한글(CJK) 렌더링 시 사용할 폰트를 macOS 암묵적 자동 폴백에서 **Apple SD Gothic Neo 명시적 지정**으로 전환한다.

### 배경

현재 Ghostty(터미널)와 Cursor(IDE)에서 `JetBrainsMono Nerd Font`만 font-family로 설정되어 있고, 한글 글리프가 필요할 때 macOS CoreText가 시스템 폰트 중 하나를 자동으로 선택한다. 이 방식은 동작하지만, **어떤 한글 폰트가 사용되는지 선언적으로 제어되지 않는다.**

### 변경 전후

|  | Before | After |
|--|--------|-------|
| 영문 | JetBrainsMono Nerd Font | JetBrainsMono Nerd Font (변경 없음) |
| 한글 | macOS가 자동 선택 (암묵적) | Apple SD Gothic Neo (명시적 폴백) |

### 동작 원리 — font-family 폴백 체인

**Ghostty**: `font-family`를 여러 줄 지정하면 fallback chain으로 동작한다. 각 문자를 렌더링할 때 1순위 폰트에서 글리프를 먼저 찾고, 없는 경우에만 2순위 이하로 넘어간다.

```
font-family = JetBrainsMono Nerd Font   ← 1순위: 영문/숫자/기호/Nerd Font 아이콘
font-family = Apple SD Gothic Neo       ← 2순위: 한글 (macOS 시스템 내장 폰트)
```

**Cursor (VS Code 기반)**: CSS font-family 문법을 따르므로 쉼표로 구분하여 폴백을 지정한다.

```json
"editor.fontFamily": "JetBrainsMono Nerd Font, 'Apple SD Gothic Neo'"
```

영문 글리프는 JetBrains Mono에서 전부 매칭되므로 Apple SD Gothic Neo에 도달하지 않는다. 한글 글리프만 폴백으로 넘어간다.

### Apple SD Gothic Neo를 선택한 이유

- macOS에 기본 내장된 시스템 폰트 → **Nix `fonts.packages` 추가 설치 불필요**
- `fc-list | grep -i 'apple sd'`로 폰트 이름(`Apple SD Gothic Neo`) 사전 검증 완료
- 이전에 시도한 Sarasa Mono K Nerd Font는 저DPI 모니터(DELL S2725DS 27" QHD, 109 PPI)에서 가독성 저하로 제거됨 — Apple SD Gothic Neo는 macOS 네이티브 렌더링 최적화가 되어 있어 이 문제 없음

### Sarasa Mono K 제거 히스토리 주석 처리

`configuration.nix`의 기존 Sarasa 히스토리 주석(25줄)은 **그대로 보존**한다. PPI 임계값, 모니터 모델별 테스트 결과, 합성 폰트의 서브픽셀 힌팅 한계 등 향후 폰트 재검토 시 필요한 핵심 의사결정 근거가 포함되어 있기 때문이다. 기존 주석 아래에 `[현재 폰트 전략]` 블록을 추가하여 현행 전략을 명시했다.

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `modules/darwin/programs/ghostty/default.nix` | `font-family = Apple SD Gothic Neo` 폴백 라인 추가, 주석을 폴백 체인 설명으로 업데이트 |
| `modules/darwin/programs/cursor/files/settings.json` | `editor.fontFamily`, `codeLensFontFamily`, `inlayHints.fontFamily` 3개 속성에 `'Apple SD Gothic Neo'` 폴백 추가 |
| `modules/darwin/configuration.nix` | `fonts.packages` 위에 `[현재 폰트 전략]` 주석 블록 추가 (기존 Sarasa 주석 보존) |
| `.claude/skills/managing-macos/references/features.md` | 폰트 사용처 테이블에 `한글 폴백` 컬럼 추가, 설명 문구 현행화 |

## NixOS 영향

**없음.** 모든 변경 파일이 `modules/darwin/` 하위에 위치하므로 NixOS(MiniPC)에 전혀 영향을 미치지 않는다. Apple SD Gothic Neo는 macOS 시스템 폰트이므로 NixOS에 존재하지 않지만, NixOS 모듈이 이 설정을 로드하지 않으므로 문제없다.

## 주의사항

Ghostty의 CJK 폰트 메트릭스 처리가 macOS CoreText 자동 폴백과 다르게 동작할 수 있다. `nrs` 후 Ghostty에서 한글 글리프 크기/간격이 기존과 동일한지 주의 깊게 확인하고, 문제 발생 시 Ghostty 변경만 롤백한다.

## Test plan

- [ ] `nrs`로 darwin-rebuild 실행 — 빌드 성공 확인
- [ ] Ghostty에서 한글 텍스트 입력 → 글리프 크기/간격이 기존 대비 정상인지 확인
- [ ] Cursor에서 한글 포함 파일 열기 → Apple SD Gothic Neo로 렌더링되는지 확인
- [ ] `/Library/Fonts/Nix Fonts/`에 변경 없음 확인 (시스템 폰트이므로 Nix 설치 대상 아님)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated font documentation to include Korean fallback specifications and clarify the explicit font strategy.

* **Improvements**
  * Configured Apple SD Gothic Neo as an explicit fallback font for Korean text in Cursor and Ghostty to enhance character coverage and rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->