### PR TITLE
fix(nrs): no-op 빌드 시 rebuild skip + docker cask 이름 수정

### DIFF
--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -52,7 +52,7 @@
     #      "내가 설치한 것"으로 인식하도록 등록만 수행. 이후 brew upgrade로 관리 가능.
     #
     # 따라서 nrs 실행 전에 직접 설치된 앱을 --adopt로 전환해야 한다:
-    #   brew install --cask --adopt cursor docker ...
+    #   brew install --cask --adopt cursor docker-desktop ...
     #
     # adopt 후에는 nrs(darwin-rebuild)가 해당 cask를 정상적으로 인식하여 에러 없이 통과한다.
     # cleanup="none"이므로 미adopt 앱이 남아있어도 삭제되지는 않지만,
@@ -68,7 +68,7 @@
     #         (자세한 내용: .claude/skills/managing-cursor/references/troubleshooting.md)
     # ghostty: pkgs.ghostty-bin은 CLI 바이너리만 제공하고 macOS .app 번들을 포함하지 않음.
     #          Ghostty.app은 Homebrew Cask로만 설치 가능.
-    # docker: Docker Desktop은 nixpkgs에 macOS용 패키지 없음 (CLI만 존재)
+    # docker-desktop: Docker Desktop은 nixpkgs에 macOS용 패키지 없음 (CLI만 존재)
     # fork: 상용 Git GUI, nixpkgs에 없음
     # [Homebrew에서 제거한 앱]
     # figma: 자체 업데이터가 적극적으로 버전을 변경하여 Homebrew가 관리하는 버전과 불일치 발생.
@@ -83,7 +83,7 @@
       "rectangle"
       "hammerspoon"
       "homerow"
-      "docker"
+      "docker-desktop"
       "fork"
       "monitorcontrol"
     ];

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -104,8 +104,14 @@ main() {
     cd "$FLAKE_PATH" || exit 1
 
     echo ""
-    cleanup_launchd_agents
     preview_changes "preview" "Changes to be applied:"
+    if [[ "$NO_CHANGES" == true ]]; then
+        cleanup_build_artifacts
+        echo ""
+        log_info "✅ No changes to apply. Skipping rebuild."
+        return 0
+    fi
+    cleanup_launchd_agents
     run_darwin_rebuild
     restart_hammerspoon
     cleanup_build_artifacts

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -46,6 +46,12 @@ main() {
 
     echo ""
     preview_changes "preview" "Changes to be applied:"
+    if [[ "$NO_CHANGES" == true ]]; then
+        cleanup_build_artifacts
+        echo ""
+        log_info "✅ No changes to apply. Skipping rebuild."
+        return 0
+    fi
     run_nixos_rebuild
     cleanup_build_artifacts
 


### PR DESCRIPTION
## 배경

`nrs`(rebuild wrapper) 실행 시 설정 변경이 전혀 없어도 전체 apply 사이클이 실행되는 문제가 있었다.

preview 단계에서 이미 변경 없음을 보여주고 있음에도:

```
📋 Changes to be applied:
No version or selection state changes.
Closure size: 548 -> 548 (0 paths added, 0 paths removed, delta +0, disk usage +0B).
```

그 이후로 아래 과정이 전부 불필요하게 실행되었다:

- `sudo darwin-rebuild switch` (sudo 비밀번호 입력 필요)
- `setting up groups/users/pam/etc...`
- `restarting Dock...` (화면 깜빡임)
- `Homebrew bundle...` (API JSON 다운로드 포함, 수초 소요)
- 모든 Home Manager activation 스크립트 재실행
- Hammerspoon 재시작

또한 Homebrew에서 `Warning: docker was renamed to docker-desktop` 경고가 2회 반복 출력되고 있었다.

## 문제 분석

### 1. no-op 빌드에서 apply를 건너뛰는 로직 부재

기존 `nrs.sh`의 `main()` 흐름:

```
cleanup_launchd_agents → preview_changes → run_darwin_rebuild → restart_hammerspoon → cleanup_build_artifacts
```

`preview_changes()`는 `darwin-rebuild build`로 `./result`를 생성하고 `nvd diff`로 차이를 보여주지만, 그 결과를 활용하는 분기가 없었다. 변경 유무와 관계없이 항상 `darwin-rebuild switch`가 실행되었다.

### 2. cleanup_launchd_agents 순서 문제 (no-op skip 도입 시 회귀 위험)

기존 코드에서 `cleanup_launchd_agents`는 preview **이전에** 실행된다. 이 함수는:
- `launchctl bootout`으로 `com.green.*` 에이전트를 언로드
- `~/Library/LaunchAgents/com.green.*.plist` 파일을 삭제

만약 no-op skip만 단순히 추가하면(cleanup 순서를 바꾸지 않으면), 에이전트가 정리된 상태에서 rebuild를 건너뛰게 되어 **에이전트가 재등록되지 않는 회귀**가 발생한다. `cleanup_launchd_agents`의 목적은 `darwin-rebuild switch` 시 `setupLaunchAgents` activation이 멈추는 것을 방지하는 것이므로, `build` 전이 아닌 `switch` 직전에 실행해도 안전하다.

### 3. docker cask 이름 변경

Homebrew가 `docker` cask를 `docker-desktop`으로 rename했지만, `homebrew.nix`에서 여전히 구 이름을 사용 중이었다.

## 해결

### no-op 감지 메커니즘

`preview_changes()` 함수 끝에서 Nix store 경로를 비교한다:

```bash
if [[ "$(readlink ./result)" == "$(readlink /run/current-system)" ]]; then
    NO_CHANGES=true
fi
```

- `./result`: `*-rebuild build`가 생성한 새 시스템 derivation의 store 경로
- `/run/current-system`: 현재 활성화된 시스템의 store 경로

Nix derivation은 **content-addressed**이므로 store 경로가 동일하면 설정이 바이트 단위로 완전히 같다. 오탐(변경이 있는데 no-op으로 판정)은 **원리적으로 불가능**하다. 미탐(no-op인데 변경 있음으로 판정)은 `readlink` 실패 시 발생할 수 있지만, 이 경우 현재와 동일하게 rebuild가 실행되므로 회귀가 아니다.

### 변경된 darwin nrs.sh 흐름

```
BEFORE:  cleanup_launchd → preview → rebuild → hammerspoon → cleanup_artifacts
AFTER:   preview → [no-op?] → skip & exit
                  → [changes?] → cleanup_launchd → rebuild → hammerspoon → cleanup_artifacts
```

### 변경된 nixos nrs.sh 흐름

```
BEFORE:  preview → rebuild → cleanup_artifacts
AFTER:   preview → [no-op?] → skip & exit
                  → [changes?] → rebuild → cleanup_artifacts
```

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `modules/shared/scripts/rebuild-common.sh` | `preview_changes()`에서 store 경로 비교 → `NO_CHANGES` 플래그 설정. 헤더/docstring에 출력 변수 문서화 |
| `modules/darwin/scripts/nrs.sh` | no-op 시 early return. `cleanup_launchd_agents`를 rebuild 직전으로 이동 (에이전트 유실 방지) |
| `modules/nixos/scripts/nrs.sh` | 동일한 no-op skip 로직 적용 |
| `modules/darwin/programs/homebrew.nix` | `"docker"` → `"docker-desktop"` (cask 이름 + 주석 + adopt 가이드 예시) |

## Test plan

- [ ] Mac에서 설정 변경 없이 `nrs` 실행 → `✅ No changes to apply. Skipping rebuild.` 메시지 출력, sudo 미요청, Dock 미재시작 확인
- [ ] Mac에서 설정 변경 후 `nrs` 실행 → 기존과 동일하게 launchd cleanup → rebuild → Hammerspoon 재시작 수행
- [ ] no-op skip 후 launchd 에이전트 정상 동작 확인 (`launchctl list | grep com.green`)
- [ ] `brew bundle` 실행 시 `docker was renamed to docker-desktop` 경고 미출력 확인
- [ ] MiniPC에서 설정 변경 없이 `nrs` 실행 → no-op skip 동작 확인

## 비교

### AS-IS

<img width="598" height="1014" alt="image" src="https://github.com/user-attachments/assets/aec203d1-49e3-46c8-ac6e-6e640dab7368" />

> 변경사항 유무 상관없이 항상 이렇게 전체 빌드사이클 실행

### TO-BE

<img width="494" height="966" alt="image" src="https://github.com/user-attachments/assets/74b1973f-ac81-4efb-8a32-8bbe4be5d76b" />

> 변경사항 있는 경우 (`docker` 버그도 해결)

<img width="765" height="330" alt="image" src="https://github.com/user-attachments/assets/141980d3-fe20-4e02-92c9-2e3d4f4af960" />

> 변경사항 없는 경우