### PR TITLE
fix(cheat): title 모드 검색 범위 수정 + 미리보기 구문 강조

### DIFF
--- a/modules/shared/programs/cheat/files/scripts/cheat-browse.sh
+++ b/modules/shared/programs/cheat/files/scripts/cheat-browse.sh
@@ -52,7 +52,7 @@ if [[ "${1:-}" == "--toggle" ]]; then
     echo "reload($SELF --content)+change-header(  [content 모드] Ctrl-S: title 모드 전환)+change-prompt(content> )+change-nth(..)"
   else
     echo "title" > "$state_file"
-    echo "reload($cheat_cmd -l | tail -n +2)+change-header(  [title 모드] Ctrl-S: content 모드 전환)+change-prompt(title> )+change-nth(1)"
+    echo "reload($cheat_cmd -l | awk 'NR>1 {print \$1}')+change-header(  [title 모드] Ctrl-S: content 모드 전환)+change-prompt(title> )+change-nth(..)"
   fi
   exit 0
 fi
@@ -62,9 +62,8 @@ state_file="$(mktemp)"
 echo "title" > "$state_file"
 trap 'rm -f "$state_file"' EXIT
 
-"$cheat_cmd" -l | tail -n +2 | "$fzf_cmd" \
+"$cheat_cmd" -l | awk 'NR>1 {print $1}' | "$fzf_cmd" \
   --ansi \
-  --nth 1 \
   --header "  [title 모드] Ctrl-S: content 모드 전환" \
   --prompt "title> " \
   --preview "$SELF --preview {1}" \


### PR DESCRIPTION
## Summary

PR #104에서 도입된 `cheat-browse` fzf 브라우저의 두 가지 문제를 수정합니다.

1. **title 모드에서 검색 범위가 전체 라인에 적용되는 버그** — `--nth 1` 누락
2. **미리보기(preview)에 구문 강조가 없어 가독성이 떨어지는 문제** — awk 기반 컬러라이저 추가

---

## 문제 1: title 모드에서 fzf가 파일 경로까지 검색

### 증상

`[title 모드]`에서 `tmux`를 입력했는데, title에 "tmux"가 포함되지 않은 `nvim/custom` cheatsheet이 검색 결과에 노출됨.

### 원인

`cheat -l | tail -n +2`의 출력 형식:

```
nvim/custom     /Users/green/Workspace/nixos-config/modules/.../nvim/custom     custom,keymap,...
tmux/keybinding /Users/green/Workspace/nixos-config/modules/.../tmux/keybinding keybinding,tmux,...
```

fzf에 `--nth` 옵션이 없어서 **전체 라인**(title + 파일 경로 + 태그)을 대상으로 fuzzy 검색함.
"tmux" 입력 시, `nvim/custom` 행의 파일 경로 `/Users/green/Workspace/ni**x**os-config/**m**odules/.../chea**t**shee**t**s/nvi**m**/c**u**stom`에서 t, m, u, x 글자가 순서대로 fuzzy match에 걸림.

### 해결

| 위치 | 변경 |
|------|------|
| 초기 fzf 실행 | `--nth 1` 추가 → title 필드만 검색 |
| content 모드 전환 (Ctrl-S) | `+change-nth(..)` 추가 → 전체 필드 검색 (content 모드는 내용 검색이 목적) |
| title 모드 복귀 (Ctrl-S) | `+change-nth(1)` 추가 → title 필드만 검색 복귀 |

---

## 문제 2: 미리보기에 구문 강조 없음

### 증상

fzf 우측 미리보기 영역에 cheatsheet 내용이 모노크롬(전부 흰색)으로 표시되어 섹션 구분, 키바인딩 식별이 어려움.

### 시도한 접근

| 접근 | 결과 | 채택 여부 |
|------|------|-----------|
| `cheat -c` (cheat 내장 colorize) | 전체가 `[38;5;231m`(흰색) — cheatsheet에 `syntax` frontmatter 없으므로 무의미 | ❌ |
| `bat --language=markdown` | cheatsheet이 markdown 형식이 아니라 유의미한 하이라이팅 없음 | ❌ |
| **awk 기반 커스텀 컬러라이저** | cheatsheet 구조를 정확히 인식하여 최적의 결과 | ✅ |

### 해결: `--preview` 서브커맨드 추가

cheatsheet 파일의 구조적 패턴을 인식하는 awk 컬러라이저를 `cheat-browse.sh --preview TITLE` 서브커맨드로 추가.

**컬러링 규칙:**

| 패턴 | 판별 기준 | 색상 | 예시 |
|------|-----------|------|------|
| 섹션 헤더 | 비들여쓰기 + 비공백 라인 | **bold cyan** (`\033[1;36m`) | `대소문자 전환`, `[처음 시작 (필수 5가지)]` |
| 키바인딩 | 들여쓰기 + 첫 토큰 뒤 2칸 이상 공백 | **bold yellow** (`\033[1;33m`, 키 부분만) | `gUiw`, `Ctrl+Space`, `<leader>bd` |
| 설명/본문 텍스트 | 들여쓰기 + 단어 사이 단일 공백 | 기본색 (무색) | `ciw vs cw: cw는 커서~단어 끝만 바꿈.` |
| 빈 줄 | 공백 라인 | 그대로 출력 | |

**"2칸 이상 공백" 휴리스틱의 근거:**

cheatsheet의 키바인딩 라인은 `  key      description` 형태로 키와 설명 사이에 항상 2칸 이상의 공백 정렬이 있음.
반면 설명 텍스트는 일반 문장이므로 단어 사이가 단일 공백.
이 차이를 `match(rest, /  /)` (연속 2칸 공백)로 판별하여 키바인딩과 설명 텍스트를 정확히 구분.

**예시 — 올바르게 분류되는 케이스:**

```
Ctrl+Space   선택 확장    → "Ctrl+Space" = yellow (2칸+ 공백 뒤에 설명)
gc (Visual)       선택 영역 주석 토글  → "gc (Visual)" = yellow (첫 2칸+ 공백이 ) 뒤에 위치)
ciw vs cw: cw는 커서~단어 끝만 바꿈.  → 기본색 (모든 공백이 단일)
실전: 커서를 변수 위에 두고...        → 기본색 (모든 공백이 단일)
```

### Codex 리뷰 피드백 반영

`codex exec review --uncommitted --full-auto`로 코드 리뷰를 수행한 결과, **P2 이슈 1건** 발견:

> **Enter 액션에서 pager 동작이 사라짐** — `enter:become($SELF --preview {1})`로 변경하면서 cheat의 설정된 pager(`pager: less -FRX`)를 우회. 긴 cheatsheet을 Enter로 열 때 interactive pager 없이 즉시 종료.

**대응:** `enter:become($SELF --preview {1} | less -FRX)` — awk 컬러 출력을 `less -FRX`로 파이프하여 구문 강조 + 페이저 동작 모두 유지.

- `-F`: 한 화면에 들어가면 즉시 종료 (짧은 cheatsheet은 pager 불필요)
- `-R`: ANSI 색상 코드 통과 (컬러 유지)
- `-X`: 종료 시 화면 지우지 않음

---

## 변경 파일

- `modules/shared/programs/cheat/files/scripts/cheat-browse.sh` — 유일한 변경 파일

---

## 커밋 구성

| 커밋 | 설명 |
|------|------|
| `67542df` fix(cheat): title 모드에서 fzf가 경로까지 검색하는 문제 수정 | `--nth 1` + `change-nth` 추가 |
| `26e7e70` feat(cheat): fzf 미리보기에 구문 강조 추가 | `--preview` 서브커맨드 + `less -FRX` 파이프 |

---

## Test plan

### title 모드 검색 범위 수정 확인

- [ ] `nrs` 실행 후 `cheat-browse` 열기 (tmux `prefix+C` 또는 nvim `<leader>C` 또는 터미널 직접 실행)
- [ ] `[title 모드]`에서 `tmux` 입력 → `tmux/keybinding`만 표시되고 `nvim/*`은 표시되지 않는지 확인
- [ ] `[title 모드]`에서 `nvim` 입력 → `nvim/*` cheatsheet들만 표시되는지 확인
- [ ] `Ctrl-S`로 content 모드 전환 → 전체 내용 검색이 정상 동작하는지 확인 (예: `surround` 입력 시 여러 cheatsheet의 관련 라인 표시)
- [ ] `Ctrl-S`로 다시 title 모드 복귀 → 검색이 title 필드로 다시 제한되는지 확인

### 미리보기 구문 강조 확인

- [ ] 아무 cheatsheet 선택 시 우측 미리보기에 색상이 적용되는지 확인:
  - 섹션 헤더: **cyan** (밝은 청록)
  - 키바인딩: **yellow** (노란색, 키 부분만)
  - 설명 텍스트: 기본 터미널 색상
- [ ] `nvim/combo` cheatsheet에서 설명 텍스트(`ciw vs cw: ...`)가 노란색이 아닌 기본색인지 확인
- [ ] `tmux/keybinding` cheatsheet에서 `Ctrl-s`, `Ctrl-r` 등 키바인딩이 노란색으로 표시되는지 확인

### Enter 키 동작 확인

- [ ] 짧은 cheatsheet (예: `nvim/buffer`) 선택 후 Enter → 컬러 출력이 바로 표시되고 pager 없이 종료 (`less -F` 동작)
- [ ] 긴 cheatsheet (예: `nvim/combo`) 선택 후 Enter → `less` pager가 열리고 `q`로 종료 가능한지 확인
- [ ] pager 내에서 ANSI 컬러가 정상 표시되는지 확인 (`less -R` 동작)

### 호출 경로별 동작 확인

- [ ] tmux `prefix+C` (display-popup) → 정상 동작
- [ ] nvim `<leader>C` (Snacks.terminal) → 정상 동작
- [ ] 터미널에서 `cheat-browse` 직접 실행 → 정상 동작

## 비교

### AS-IS

<img width="470" height="98" alt="image" src="https://github.com/user-attachments/assets/3de047a3-bb57-4911-8fd3-00a3c498c8b4" />


<img width="1568" height="939" alt="image" src="https://github.com/user-attachments/assets/dd351d39-d83d-4cf2-a630-0e936e6b1933" />


### TO-BE

<img width="470" height="80" alt="image" src="https://github.com/user-attachments/assets/b06deecd-3e48-4c84-888a-106ab52ceecb" />


<img width="1579" height="954" alt="image" src="https://github.com/user-attachments/assets/e00c46c4-4239-4a19-b40e-8c8e79fa67dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview display with enhanced content highlighting.
  * Fixed content enumeration and retrieval by title.
  * Enhanced fuzzy matching to filter on primary field.
  * Refined navigation behavior for viewing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->