### PR TITLE
fix(hammerspoon): postActivation 이중 리로드 제거

### DIFF
--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -331,8 +331,9 @@ in
     # activateSettings가 스크롤 방향을 롤백시키므로 명시적으로 재설정
     defaults write -g com.apple.swipescrolldirection -bool false
 
-    # Hammerspoon 설정 리로드 (F18 리매핑과 연동)
-    /Applications/Hammerspoon.app/Contents/Frameworks/hs/hs -c "hs.reload()" 2>/dev/null || true
+    # Hammerspoon 재시작은 nrs.sh의 restart_hammerspoon()에서 처리 (kill+open)
+    # 여기서 hs.reload()를 호출하면 nrs.sh와 이중 리로드되어 알림 2회 발생
+    # 직접 darwin-rebuild를 실행한 경우 수동으로 hsr 또는 앱 재시작 필요
 
     # Shottr 재시작 (activateSettings로 symbolic hotkeys 반영 후)
     # Shottr 미설치/GUI 세션 없음(SSH) 등에서 실패해도 activation을 중단하지 않음


### PR DESCRIPTION
## Summary
- `nrs` 실행 시 Hammerspoon "설정 리로드 완료" 알림이 2회 발송되는 문제 수정
- `postActivation`의 `hs -c "hs.reload()"` 호출 제거 — `nrs.sh`의 `restart_hammerspoon()` (kill+open)이 이미 전체 재시작을 수행하므로 중복
- `darwin-rebuild` 직접 실행 시 수동 리로드 필요하다는 주석 추가

## 원인 분석
`nrs` 실행 흐름에서 Hammerspoon이 2회 리로드됨:
1. `darwin-rebuild switch` → `postActivation` → `hs -c "hs.reload()"` (IPC 리로드)
2. `nrs.sh` → `restart_hammerspoon()` → `killall` + `open -a` (전체 재시작)

각 리로드마다 `init.lua`의 알림 코드가 실행되어 알림 2회 발송.

## Test plan
- [ ] `nrs` 실행 후 Hammerspoon 알림이 1회만 발송되는지 확인
- [ ] F18 리매핑(Capslock→F18)이 정상 동작하는지 확인
- [ ] `hsr` alias로 수동 리로드가 정상 동작하는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate Hammerspoon reloads and notifications during system configuration updates. Reload handling is now centralized through the restart script to prevent unnecessary duplicates.
  * Added guidance for manual app restart when needed after manual configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->