### PR TITLE
fix(rebuild): activation-script을 known-trivial 패턴에 추가

### DIFF
--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -119,6 +119,7 @@ preflight_source_build_check() {
         '-unit-.*\.(service|socket|timer|mount|target|path|slice)\.drv$'
         '-system-units\.drv$'   '-etc\.drv$'
         '-activate\.drv$'       '-nixos-system-'        '-user-environment\.drv$'
+        '-activation-script\.drv$'
         '-with-addons-'
     )
     local filter_regex


### PR DESCRIPTION
## Summary
- `activation-script` derivation을 pre-flight 소스 빌드 체크의 known-trivial 패턴에 추가
- NixOS 설정 조립 derivation임에도 trivial 패턴에 누락되어 불필요한 소스 빌드 경고가 발생하던 문제 수정

## Test plan
- [ ] `nrs` 실행 시 `activation-script`에 대한 소스 빌드 경고가 더 이상 표시되지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Activation-script derivation entries will no longer generate build prompts during dry-run checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->