### PR TITLE
refactor(rebuild): pre-flight allowlist → blocklist 전환

### DIFF
--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -113,7 +113,7 @@ preflight_source_build_check() {
     [[ -z "$build_drvs" ]] && { log_info "  ✓ All packages cached."; return 0; }
 
     # known-heavy: 소스 빌드 시 장시간 소요되는 패키지 (Rust 컴파일 등)
-    # 각 항목은 패키지명 접두사. 매칭: ^<name>-[0-9] (버전 번호가 뒤따르는 패키지만 포착)
+    # 각 항목은 패키지명 접두사. 매칭: ^<name>-[0-9]+\.[0-9]+ (semver 시작 필수)
     # 예: "anki" → anki-25.09.2, anki-25.09.2-vendor 매칭 (anki-addon-* 등은 제외)
     # 추가 방법: 배열에 패키지명만 추가 (예: "firefox")
     #
@@ -123,24 +123,38 @@ preflight_source_build_check() {
     # v3 (이번 변경): allowlist 방식이 두더지 잡기(끝없는 패턴 추가)임을 확인,
     #    원래 구상대로 known-heavy blocklist로 회귀. 미등록 패키지는 무시(수동 관리).
     #    trade-off: 새 무거운 패키지 추가 시 수동 등록 필요하나,
-    #              false positive 0%로 사용자 경험이 압도적으로 나음.
+    #              false positive를 크게 줄여 사용자 경험이 압도적으로 나음.
     local heavy_packages=(
         anki    # 로컬 overlay (doInstallCheck=false) → Hydra 캐시 없음, 항상 소스 빌드
         mise    # Rust 패키지 → flake update 후 캐시 미스 시 장시간 빌드
     )
 
+    # 빈 배열 guard — heavy_packages가 비면 체크 자체를 비활성화
+    if ((${#heavy_packages[@]} == 0)); then
+        log_warn "⚠️  heavy_packages is empty; preflight detection disabled."
+        return 0
+    fi
+
     # 패키지명 추출 (해시 제거, .drv 제거)
     local pkg_names
-    pkg_names=$(echo "$build_drvs" | sed 's|.*/[a-z0-9]\{32\}-||; s|\.drv$||' | sort -u)
+    pkg_names=$(printf '%s\n' "$build_drvs" | sed 's|.*/[a-z0-9]\{32\}-||; s|\.drv$||' | sort -u)
 
-    # heavy_packages 매칭 regex 생성: ^anki-[0-9]|^mise-[0-9]
+    # heavy_packages 매칭 regex 생성: ^anki-[0-9]+\.[0-9]+|^mise-[0-9]+\.[0-9]+
+    # semver 시작(X.Y)을 요구하여 anki-addon-*, mise-plugin-* 등 비패키지 제외
     local heavy_regex
-    heavy_regex=$(printf '|^%s-[0-9]' "${heavy_packages[@]}")
+    heavy_regex=$(printf '|^%s-[0-9]+\\.[0-9]+' "${heavy_packages[@]}")
     heavy_regex="${heavy_regex:1}"
 
-    local matched_heavy
-    matched_heavy=$(echo "$pkg_names" | grep -E -- "$heavy_regex" || true)
-    [[ -z "$matched_heavy" ]] && { log_info "  ✓ No heavy source builds."; return 0; }
+    local matched_heavy=""
+    local grep_rc=0
+    matched_heavy=$(printf '%s\n' "$pkg_names" | grep -E -- "$heavy_regex") || grep_rc=$?
+    case $grep_rc in
+        0) ;;  # matches found
+        1) ;;  # no matches (정상)
+        *) log_error "  ✗ Invalid heavy regex: $heavy_regex"; return 1 ;;
+    esac
+
+    [[ -z "$matched_heavy" ]] && { log_info "  ✓ No known-heavy source builds."; return 0; }
 
     # 보고할 패키지명은 매칭된 heavy 패키지만
     pkg_names="$matched_heavy"


### PR DESCRIPTION
## Summary
- pre-flight 소스 빌드 체크를 known-trivial **allowlist**에서 known-heavy **blocklist**로 전환
- `rebuild-common.sh`, `activation-script.drv` 등의 false positive 완전 제거
- 초기 blocklist: `anki` (로컬 overlay), `mise` (Rust, flake update 후 캐시 미스)

## Change Intent Record
- v1 (b9cd235): known-heavy blocklist 구상 → 관리 부담 우려로 allowlist 채택
- v2 (f09a575): activation-script false positive → 패턴 추가로 대응
- v3 (이번): allowlist의 근본적 한계(두더지 잡기) 확인, 원래 구상대로 blocklist로 회귀

trade-off: 새 무거운 패키지 추가 시 수동 등록 필요하지만,
false positive 제로로 사용자 경험이 압도적으로 나음.

## Test plan
- [ ] `nrs` 실행 → `rebuild-common.sh` 같은 trivial derivation 무시 확인
- [ ] anki/mise 소스 빌드 시에만 경고 출력 확인
- [ ] `nrs --force` → 경고만 출력 후 진행 확인
- [ ] `nrp` → `--warn-only` 모드 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to an allowlist-based detection for known heavy packages to reduce false positives.
  * Limits preflight checks to relevant heavy packages and disables the check with a warning if the allowlist is empty.
  * Improves user-facing diagnostics by listing only heavy packages that would be built from source.
  * Retains existing force/warn-only behaviors for proceeding despite detections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->