### PR TITLE
test(anki): AnkiConnect config API 계약 검증 및 운영 가드레일 강화

### DIFF
--- a/.claude/skills/hosting-anki/SKILL.md
+++ b/.claude/skills/hosting-anki/SKILL.md
@@ -133,6 +133,7 @@ homeserver.ankiConnect.sync = {
 2. `getConfig` 미존재 key 조회 시 `result: null` 확인
 3. `setConfig` 저장 후 동일 key `getConfig` round-trip 확인
 4. 미허용 key(`other.prefix`) 저장 시 `config key is not allowed` 오류 확인
+5. 포트 매핑 확인 (`ss -tlnp | grep -E '8765|27701'`) → 두 포트 모두 LISTEN 상태
 
 ## 핵심 절차
 
@@ -144,6 +145,12 @@ homeserver.ankiConnect.sync = {
 ## 주의사항
 
 - **로그인 UI에 "AnkiWeb" 표시**: 커스텀 sync 서버에서도 로그인 다이얼로그에 "AnkiWeb 아이디"로 표시됨 → 셀프호스팅 자격증명 입력하면 정상 동작
+
+### Nix↔Python 계약
+
+- **값 계약** (`allowedKeyPrefixes`, `maxValueBytes`, 포트 번호): `eval-tests.nix`가 Nix 옵션 기본값을 알려진 Python patch defaults에 하드 핀으로 고정 (Nix 측 드리프트 자동 감지, Python patch 측은 PR 리뷰로 방어)
+- **키 이름 계약** (`configApiEnable` 등 문자열): eval 시점 자동 검증 불가 → `default.nix` 주석 경고 + PR 리뷰로 방어
+- 키 이름 불일치 시 Python patch가 fail-closed defaults 사용: API 비활성화, `['awesomeAnki.']`, `65536`
 
 ## 자주 발생하는 문제
 

--- a/.claude/skills/hosting-anki/references/setup.md
+++ b/.claude/skills/hosting-anki/references/setup.md
@@ -68,6 +68,7 @@ ankiConnect = {
 - key allowlist: 기본 `awesomeAnki.` prefix만 허용
 - 값 크기 제한: UTF-8 JSON 직렬화 기준 64KB
 - 로그 민감값 보호: `getConfig/setConfig` 요청/응답의 값(`params.val`, `result`)은 redaction 처리
+- Nix↔Python 계약 검증: `eval-tests.nix`가 Nix 옵션 기본값을 알려진 Python patch defaults에 하드 핀으로 고정 + 포트 매핑(ankiConnect=8765, ankiSync=27701) 검증
 - 자동 동기화: `anki-connect-sync.service` + `anki-connect-sync.timer` (onStart + 5분 주기)
 - 상태 파일: `/var/lib/anki/sync-status.json` (마지막 시도/성공/에러 기록)
 

--- a/.claude/skills/hosting-anki/references/troubleshooting.md
+++ b/.claude/skills/hosting-anki/references/troubleshooting.md
@@ -380,6 +380,7 @@ nix build .#nixosConfigurations.greenhead-minipc.config.system.build.toplevel
 1. `homeserver.ankiConnect.configApi.enable = true` 확인
 2. `modules/nixos/programs/anki-connect/default.nix`의 config key 이름과 patch 상수 계약 일치 확인
 3. `nrs` 재배포 후 `systemctl restart anki-connect.service`
+4. `nix eval --impure --file tests/eval-tests.nix`로 계약 테스트(allowed prefixes/max bytes 정합성) 통과 확인
 
 ## `config API settings are invalid` 오류
 

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -121,12 +121,20 @@ in
         allowedKeyPrefixes = lib.mkOption {
           type = nonEmptyPrefixList;
           default = [ "awesomeAnki." ];
-          description = "Allowed key prefixes for config API writes/reads.";
+          description = ''
+            Allowed key prefixes for config API writes/reads.
+            Keys not matching any prefix are rejected with "config key is not allowed".
+            Must match CONFIG_API_DEFAULT_ALLOWED_PREFIXES in the AnkiConnect patch.
+          '';
         };
         maxValueBytes = lib.mkOption {
           type = lib.types.ints.positive;
           default = 65536;
-          description = "Maximum serialized UTF-8 JSON payload size per config value.";
+          description = ''
+            Maximum serialized UTF-8 JSON payload size per config value.
+            Values exceeding this limit are rejected with "config value exceeds size limit".
+            Must match CONFIG_API_DEFAULT_MAX_VALUE_BYTES in the AnkiConnect patch.
+          '';
         };
       };
       sync = {

--- a/modules/nixos/programs/anki-connect/default.nix
+++ b/modules/nixos/programs/anki-connect/default.nix
@@ -97,8 +97,13 @@ let
     [
       (ankiConnectAddon.withConfig {
         config = {
-          # Keep key names in sync with constants in anki-connect-config-actions.patch:
-          # CONFIG_API_CONFIG_KEY_ENABLE / _ALLOWED_PREFIXES / _MAX_VALUE_BYTES
+          # Nix<->Python config contract: key names must match constants in
+          # anki-connect-config-actions.patch (CONFIG_API_CONFIG_KEY_*).
+          # ⚠️ WARNING: key 이름 변경 시 Python patch 상수도 반드시 동시 수정할 것.
+          # 불일치 시 Python이 fail-closed defaults를 사용:
+          #   configApiEnable -> False (API 비활성화)
+          #   configApiAllowedKeyPrefixes -> ['awesomeAnki.']
+          #   configApiMaxValueBytes -> 65536
           webBindAddress = minipcTailscaleIP;
           webBindPort = cfg.port;
           webCorsOriginList = [

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -408,6 +408,35 @@ let
       name = "Test 5e: ankiConnect.configApi.maxValueBytes가 옵션 기본값과 일치해야 함";
       cond = ankiConfigApi.maxValueBytes == ankiConfigApiMaxValueBytesDefault;
     }
+    # ── Nix↔Python 상수 정합성 하드 핀 ──────────────────────────
+    # Nix 옵션 기본값을 알려진 Python patch defaults에 하드 핀으로 고정.
+    # Nix 측 드리프트만 자동 감지 — Python patch 측 드리프트는 PR 리뷰로 방어.
+    {
+      name = "Test 5e-2: ankiConnect.configApi.allowedKeyPrefixes가 Python 패치 기본값 [\"awesomeAnki.\"]과 일치해야 함";
+      cond = ankiConfigApi.allowedKeyPrefixes == [ "awesomeAnki." ];
+    }
+    {
+      name = "Test 5e-3: ankiConnect.configApi.maxValueBytes가 Python 패치 기본값 65536과 일치해야 함";
+      cond = ankiConfigApi.maxValueBytes == 65536;
+    }
+    # ── 포트 매핑 고정 ──────────────────────────────────────────
+    # constants.nix 포트 상수 변경 시 회귀를 감지한다.
+    {
+      name = "Test 5e-4: constants.network.ports.ankiConnect가 8765이어야 함";
+      cond = constants.network.ports.ankiConnect == 8765;
+    }
+    {
+      name = "Test 5e-5: constants.network.ports.ankiSync가 27701이어야 함";
+      cond = constants.network.ports.ankiSync == 27701;
+    }
+    {
+      name = "Test 5e-6: homeserver.ankiConnect.port가 constants 포트(8765)와 일치해야 함";
+      cond = nixosCfg.homeserver.ankiConnect.port == constants.network.ports.ankiConnect;
+    }
+    {
+      name = "Test 5e-7: homeserver.ankiSync.port가 constants 포트(27701)와 일치해야 함";
+      cond = nixosCfg.homeserver.ankiSync.port == constants.network.ports.ankiSync;
+    }
     {
       # Codex 피드백: SSH 경화 설정은 Tailscale 경계와 독립적인 보안 레이어
       name = "Test 5f: openssh PermitRootLogin이 'no'이어야 함";


### PR DESCRIPTION
## Summary

- eval-tests.nix: Nix↔Python 상수 정합성 하드 핀 및 포트 매핑 고정 테스트 6건 추가
- homeserver.nix: configApi 옵션 description에 에러 동작 및 계약 참조 명시
- default.nix: 계약 키 주석에 Python fail-closed defaults + 키 변경 경고 보완
- hosting-anki 스킬 문서: Nix↔Python 계약, 포트 검증 절차 추가

## 검증 증적

### eval-tests.nix

```
$ nix eval --impure --file tests/eval-tests.nix
true
```

### miniPC SSH curl 테스트 (6건)

| # | 테스트 | 결과 |
|---|--------|------|
| 1 | `version` 응답 | `{"result": 6, "error": null}` |
| 2 | `getConfig` 미존재 key | `{"result": null, "error": null}` |
| 3 | `setConfig` + `getConfig` round-trip | set: `{"result": null, "error": null}` / get: `{"result": {"issue": 77, "test": true}, "error": null}` |
| 4 | 미허용 prefix 거부 | `{"result": null, "error": "config key is not allowed"}` |
| 5 | 포트 리스닝 확인 | 8765, 27701 모두 LISTEN |
| 6 | 테스트 key 정리 + 확인 | cleanup: `{"result": null, "error": null}` / verify: `{"result": null, "error": null}` |

### DA 피드백 루프

- 1차 (커밋 전): NGMI 1건 — "Python과 직접 대조" 표현 과장 → "하드 핀 간접 감지"로 완화 반영
- 2차 (push 전): OK — 이상 없음 (YAGNI/NGMI/REGRESSION/SECURITY 모두 통과)

## Test plan

- [x] `nix eval --impure --file tests/eval-tests.nix` → `true`
- [x] `ssh minipc` curl 테스트 6건 전부 예상 응답
- [x] pre-commit hooks 통과 (eval-tests, nixfmt, gitleaks, ai-skills-consistency)
- [x] pre-push hook 통과 (flake-check --all-systems)
- [x] codex exec DA 피드백 루프 2회 완료

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added port verification steps (8765, 27701) for Anki Connect configuration validation
  * Enhanced setup and troubleshooting guides with configuration contract details
  * Expanded option descriptions for better clarity

* **Tests**
  * Added validation tests to verify Nix↔Python configuration contract compliance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->