### PR TITLE
fix(mise): NixOS에서 prebuilt 바이너리 사용하도록 변경

### DIFF
--- a/modules/shared/programs/shell/nixos.nix
+++ b/modules/shared/programs/shell/nixos.nix
@@ -29,6 +29,13 @@ in
     executable = true;
   };
 
+  # NixOS: mise prebuilt 바이너리 사용 (소스 빌드 방지)
+  # NixOS에서 all_compile/node.compile 기본값이 true → Python 3.13과 Node.js configure.py 비호환 에러 발생
+  home.sessionVariables = {
+    MISE_ALL_COMPILE = "0";
+    MISE_NODE_COMPILE = "0"; # Node 전용 안전핀
+  };
+
   # NixOS 전용 패키지 (macOS는 Homebrew python3 사용)
   home.packages = [
     pkgs.python3


### PR DESCRIPTION
## Summary
- NixOS에서 mise의 `all_compile`/`node.compile` 기본값이 `true`로 설정되어 Node.js 소스 빌드 시도 → Python 3.13과 configure.py 비호환으로 설치 실패
- `MISE_ALL_COMPILE=0`, `MISE_NODE_COMPILE=0` 환경변수를 NixOS 전용 shell 설정에 추가하여 prebuilt 바이너리 사용으로 전환
- `nix-ld`가 이미 제공하는 기본 라이브러리(`stdenv.cc.cc` 포함)로 prebuilt 실행 가능 → `configuration.nix` 변경 불필요

## Test plan
- [ ] `nrs`로 설정 적용
- [ ] 새 셸에서 `echo $MISE_ALL_COMPILE $MISE_NODE_COMPILE` → `0 0` 확인
- [ ] `rm -rf ~/.local/share/mise/installs/node/20.20.0` (실패 잔재 정리)
- [ ] `mise install node@20.20.0` → prebuilt 바이너리로 설치 성공 확인
- [ ] `node -v` → `v20.20.0` 출력 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NixOS compatibility by disabling prebuilt binary usage by default, ensuring proper compilation and preventing compatibility issues on NixOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->