### PR TITLE
feat(homebrew): sox 추가 — Claude Code /voice 모드 지원

### DIFF
--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -35,6 +35,7 @@
     # Homebrew Formula (CLI 도구)
     brews = [
       "laishulu/homebrew/macism" # macOS 입력 소스 전환 (Neovim 한영 전환 자동화)
+      "sox" # 오디오 처리 (Claude Code /voice 모드)
     ];
 
     # Homebrew Cask (GUI 앱)


### PR DESCRIPTION
## Summary
- Homebrew `brews`에 `sox` 추가 — Claude Code `/voice` 모드의 오디오 녹음 의존성
- `nrs` 빌드 및 `sox --version` 실행으로 정상 설치 확인 완료

## Test plan
- [x] `nrs` 빌드 성공
- [x] `which sox` → `/opt/homebrew/bin/sox`
- [x] `sox --version` 정상 출력

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added audio processing tool to available Homebrew packages for macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->