### PR TITLE
docs(cheat): nvim 검색 범위 키맵 추가 (LSP root vs cwd)

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/nvim/search
+++ b/modules/shared/programs/cheat/cheatsheets/nvim/search
@@ -6,18 +6,15 @@ tags: [ neovim, lazyvim, search, telescope ]
 <leader> = Space 키. which-key 팝업으로 모든 키 확인 가능.
 
   <leader>ff    파일 이름으로 검색         (Cmd+P)
+  <leader>fF    파일 이름으로 검색 — cwd   (모노레포 전체)
   <leader>fg    Git 파일 찾기
   <leader>/     텍스트 검색 (grep)         (Cmd+Shift+F)
+  <leader>sG    텍스트 검색 (grep) — cwd   (모노레포 전체)
   <leader>fb    열린 버퍼 목록             (탭 전환)
   <leader>fr    최근 파일 목록             (Recent Files)
   <leader>e     파일 탐색기 토글           (Explorer 패널)
 
-검색 범위 (모노레포에서 중요)
-
-  소문자 = LSP root (현재 패키지), 대문자 = cwd (모노레포 전체)
-
-  <leader>ff    파일 찾기 — 현재 패키지    <leader>fF    파일 찾기 — 모노레포 전체
-  <leader>/     텍스트 검색 — 현재 패키지   <leader>sG    텍스트 검색 — 모노레포 전체
+  ※ 모노레포: 소문자(ff, /)는 LSP root(현재 패키지), 대문자(fF, sG)는 cwd(전체)
 
 탐색기 (Explorer)
 


### PR DESCRIPTION
## Summary
- 모노레포에서 `<leader>/`가 LSP root(현재 패키지)만 검색하는 동작 확인 후, cwd 전체 검색 키맵을 cheatsheet에 추가
- `<leader>sG` (grep 전체), `<leader>fF` (파일 찾기 전체) 키맵과 소문자/대문자 규칙 문서화

## Test plan
- [ ] `cheat nvim/search`로 추가된 섹션 확인
- [ ] nvim에서 `<leader>C` (cheat-browse)로 검색 시 해당 내용 표시 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Neovim search cheat sheet with two new keybindings for file-name and text (grep) searches across the monorepo.
  * Clarified scope: lowercase commands target current package LSP root, uppercase commands target the full monorepo cwd.
  * Added a Mac Explorer toggle shortcut for showing/hiding hidden files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->