### PR TITLE
fix(shell): push() 함수 에러 처리 개선

### DIFF
--- a/.claude/skills/sharing-text/references/push-implementation.md
+++ b/.claude/skills/sharing-text/references/push-implementation.md
@@ -24,6 +24,7 @@ push() {
     return 1
   fi
 
+  local PUSHOVER_TOKEN="" PUSHOVER_USER=""
   source "$cred"
   [ -n "${PUSHOVER_TOKEN:-}" ] && [ -n "${PUSHOVER_USER:-}" ] || {
     echo "Error: Pushover credentials are incomplete" >&2
@@ -35,10 +36,10 @@ push() {
     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
     --data-urlencode "token=$PUSHOVER_TOKEN" \
     --data-urlencode "user=$PUSHOVER_USER" \
-    --data-urlencode "title=텍스트 공유 (${#text}자)" \
+    --data-urlencode "title=📋 텍스트 공유 (${#text}자)" \
     --data-urlencode "message=$text" \
     https://api.pushover.net/1/messages.json); then
-    echo "Pushover 전송 (${#text}자)"
+    echo "✓ Pushover 전송 (${#text}자)"
   else
     echo "Error: Pushover 전송 실패" >&2
     [ -n "$response" ] && echo "$response" >&2
@@ -64,5 +65,5 @@ push() {
 | 입력 없음 | `Usage: push <text> or pipe input` | stdout |
 | credential 파일 없음 | `Error: Pushover credentials not found` | stderr |
 | token/user 비어있음 | `Error: Pushover credentials are incomplete` | stderr |
-| HTTP 에러 / 네트워크 실패 | `Error: Pushover 전송 실패` + API 응답 body | stderr |
-| 타임아웃 (10초) | curl 에러 + `Error: Pushover 전송 실패` | stderr |
+| HTTP 에러 (4xx/5xx) | `Error: Pushover 전송 실패` + API 응답 body | stderr |
+| 네트워크 실패 / 타임아웃 | curl 에러 + `Error: Pushover 전송 실패` | stderr |

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -159,6 +159,7 @@ in
             echo "Error: Pushover credentials not found" >&2
             return 1
           fi
+          local PUSHOVER_TOKEN="" PUSHOVER_USER=""
           source "$cred"
           [ -n "''${PUSHOVER_TOKEN:-}" ] && [ -n "''${PUSHOVER_USER:-}" ] || {
             echo "Error: Pushover credentials are incomplete" >&2


### PR DESCRIPTION
## Summary
- `source` 후 `PUSHOVER_TOKEN`/`PUSHOVER_USER` 비어있는지 검증 추가
- `curl -s` → `--fail-with-body --show-error --silent --max-time 10`으로 강화
- curl exit code 기반 성공/실패 분기, 실패 시 API 응답 body stderr 출력
- 스킬 문서(`push-implementation.md`) 동기화

## Test plan
- [x] `nrs` 빌드 성공
- [x] `push "테스트"` 실제 전송 성공 확인
- [ ] credential 파일 없는 경우 에러 메시지 확인
- [ ] 빈 token으로 "credentials are incomplete" 에러 확인

Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pushover notifications now show a success indicator and message length.

* **Bug Fixes**
  * Validates Pushover credentials before sending; errors clearly when incomplete.
  * Delivery failures now report API response details when available.
  * Improved request timeout and error propagation for more reliable notifications.

* **Documentation**
  * Added an error message reference table describing new and existing outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->