### PR TITLE
feat(karakeep): SingleFile 중복 북마크 제출 시 Pushover 알림 추가

### DIFF
--- a/modules/nixos/programs/docker/karakeep-singlefile-bridge/files/singlefile-bridge.py
+++ b/modules/nixos/programs/docker/karakeep-singlefile-bridge/files/singlefile-bridge.py
@@ -502,17 +502,22 @@ class SingleFileBridgeHandler(BaseHTTPRequestHandler):
                     return
 
                 if status == 200:
-                    resp = parse_json_body(body)
-                    if resp.get("alreadyExists"):
-                        title = resp.get("title") or resp.get("content", {}).get("title") or ""
-                        created = format_created_at(resp.get("createdAt"))
-                        short = shorten_url(source_url)
-                        send_pushover(
-                            f"이미 아카이빙됨: {short}\n제목: {title}\n저장일: {created}",
-                            0,
-                        )
-                    elif not resp:
-                        log(f"duplicate check: failed to parse response for {source_url}")
+                    try:
+                        resp = parse_json_body(body)
+                        if resp.get("alreadyExists"):
+                            content = resp.get("content")
+                            nested_title = content.get("title") if isinstance(content, dict) else ""
+                            title = resp.get("title") or nested_title or ""
+                            created = format_created_at(resp.get("createdAt"))
+                            short = shorten_url(source_url)
+                            send_pushover(
+                                f"이미 아카이빙됨: {short}\n제목: {title}\n저장일: {created}",
+                                0,
+                            )
+                        elif not resp:
+                            log(f"duplicate check: failed to parse response for {source_url}")
+                    except Exception as notify_exc:  # noqa: BLE001
+                        log(f"duplicate notification failed for {source_url}: {notify_exc}")
 
                 self.respond_bytes(status or 502, body, content_type)
                 return


### PR DESCRIPTION
## Summary
- SingleFile로 이미 아카이빙된 URL을 재제출하면 "이미 아카이빙됨" Pushover 알림 발송
- 기존에는 중복 제출 시 아무런 피드백이 없어 저장 실패로 오해할 수 있었음
- singlefile-bridge 소형 파일 경로에서 Karakeep API 응답의 `alreadyExists` 필드 감지

## Changes
- `format_created_at()` 헬퍼: ISO 8601/Unix timestamp → YYYY-MM-DD 변환
- 소형 파일 경로에서 HTTP 200 + `alreadyExists` 감지 → Pushover 알림
- 알림 내용: URL + 제목 + 기존 저장일 (priority=0)
- fail-open: JSON 파싱 실패 시 경고 로그만, 원본 응답 변경 없음

## Test plan
- [ ] `nrs`로 singlefile-bridge 서비스 재시작
- [ ] 기존 중복 URL(spencer.wtf)로 SingleFile 재제출
- [ ] Pushover 알림 수신 확인 (URL + 제목 + 저장일)
- [ ] 새 URL로 SingleFile 제출 → 기존 동작 정상 확인 (알림 미발송)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sends notifications when an item already exists, including archive status, title, creation date, and shortened source URL.

* **Bug Fixes**
  * Improved parsing/normalization of creation timestamps from various formats (ISO strings and epoch).
  * Added error handling and logging around duplicate-detection and notification steps to avoid flow interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->