### PR TITLE
feat(vaultwarden): 백업 실패 시 Pushover 알림 추가

### DIFF
--- a/modules/nixos/programs/docker/vaultwarden-backup.nix
+++ b/modules/nixos/programs/docker/vaultwarden-backup.nix
@@ -27,6 +27,7 @@ let
       coreutils
       findutils
       gzip
+      curl # service-lib.sh의 send_notification에서 사용
     ];
     text = ''
       # service-lib.sh 로드 (send_notification 사용)


### PR DESCRIPTION
## Summary
- vaultwarden-backup 서비스에 Pushover 실패 알림 추가
- `service-lib.sh` 소싱 + `cleanup_on_error` trap 패턴 적용 (karakeep-backup과 동일)
- 백업 실패 시 priority=1 Pushover 알림 전송

Closes #78

## Test plan
- [x] `nix eval --impure --file tests/eval-tests.nix` 통과
- [x] `nix flake check` 통과 (pre-push hook)
- [ ] MiniPC에서 `nrs` 빌드 성공 확인
- [ ] `sudo systemctl start vaultwarden-backup` 정상 완료 시 알림 미수신 확인
- [ ] 실패 시나리오에서 Pushover 알림 수신 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vaultwarden backup service now sends Pushover notifications to alert you when backup operations fail or encounter errors
  * Added Pushover credential management configuration to enable error notifications for the backup service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->