### PR TITLE
revert(fzf): Tab/Shift+Tab 기본값 롤백

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
@@ -19,8 +19,10 @@ fzf 셸 단축키
   ssh **<Tab>      SSH 호스트 검색
 
 [fzf 내부 조작]
-  Tab         아래로 이동 (커스텀: 기본은 toggle)
-  Shift+Tab   위로 이동
+  Tab         multi: 선택/해제 + 아래로 이동
+  Shift+Tab   multi: 선택/해제 + 위로 이동
+  Ctrl+J/N    아래로 이동
+  Ctrl+K/P    위로 이동
 
 [참고]
   Ctrl+R      Atuin이 대체 중 (fzf 히스토리 검색 비활성)

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -233,8 +233,5 @@ in
     enableZshIntegration = true;
     defaultCommand = "${lib.getExe pkgs.fd} --strip-cwd-prefix --exclude .git";
     fileWidgetCommand = "${lib.getExe pkgs.fd} --strip-cwd-prefix --exclude .git";
-    defaultOptions = [
-      "--bind=tab:down,shift-tab:up"
-    ];
   };
 }

--- a/modules/shared/programs/tmux/files/scripts/pane-note.sh
+++ b/modules/shared/programs/tmux/files/scripts/pane-note.sh
@@ -213,7 +213,7 @@ create_note(){
     tags_file=$(mktemp)
     echo "$ALL_TAGS" > "$tags_file"
     tmux display-popup -E -w 90% -h 50% \
-      "cat '$tags_file' | fzf --multi --print-query --bind='tab:toggle+down,shift-tab:toggle+up' --prompt='Tags> ' --header=\$'Tab: 기존 태그 선택/해제 | Enter: 완료 | ESC: 건너뛰기\n새 태그 입력: 프롬프트에 직접 입력 (쉼표로 여러 개 가능, 예: 긴급,중요)' > '$tmp_file'" 2>/dev/null || true
+      "cat '$tags_file' | fzf --multi --print-query --prompt='Tags> ' --header=\$'Tab: 기존 태그 선택/해제 | Enter: 완료 | ESC: 건너뛰기\n새 태그 입력: 프롬프트에 직접 입력 (쉼표로 여러 개 가능, 예: 긴급,중요)' > '$tmp_file'" 2>/dev/null || true
     rm -f "$tags_file"
     # 첫 줄: custom tag (쿼리), 나머지: 선택된 기존 태그
     local query selected_items

--- a/modules/shared/programs/tmux/files/scripts/pane-tag.sh
+++ b/modules/shared/programs/tmux/files/scripts/pane-tag.sh
@@ -88,7 +88,6 @@ set +e
 # fzf --print-query로 쿼리(직접 입력)와 선택 모두 처리
 result=$(echo "$available_tags" | grep -v '^$' | fzf --multi \
   --prompt='추가할 태그 (Tab으로 선택, 직접 입력도 가능)> ' \
-  --bind='tab:toggle+down,shift-tab:toggle+up' \
   --header="새 태그 선택 | Enter: 적용, ESC: 취소" \
   --print-query)
 fzf_exit=$?


### PR DESCRIPTION
## Summary
- fzf의 커스텀 `tab:down, shift-tab:up` 바인딩을 제거하여 fzf 기본값으로 복원
- multi-select에서 Tab으로 항목 toggle이 다시 가능해짐
- 글로벌 override를 덮어쓰기 위해 추가했던 tmux 스크립트의 인라인 바인딩도 제거
- fzf cheatsheet를 기본 동작에 맞게 갱신

## Change Intent Record
- v1 (PR #124): Tab/Space 키바인딩 통일. fzf에서 tab:down, shift-tab:up 커스텀.
- v2 (이번): Shift+Tab도 불편 + multi-select toggle 소실. 전면 롤백.
- trade-off: single-select에서 Tab 이동 불가 → multi-select toggle 복원이 더 중요.

## Test plan
- [ ] `nrs` 빌드 성공
- [ ] `echo $FZF_DEFAULT_OPTS`에 `--bind=tab:down` 없음 확인
- [ ] `ls | fzf --multi`에서 Tab toggle 동작 확인
- [ ] tmux pane-tag, pane-note Tab toggle 정상
- [ ] tmux pane-link preview 스크롤 미영향
- [ ] `cheat fzf/keybinding` 갱신 확인