### PR TITLE
fix(nfu): 빌드 검증 진행 상황 미표시 문제 수정

### DIFF
--- a/scripts/fix-fod-hashes.sh
+++ b/scripts/fix-fod-hashes.sh
@@ -46,8 +46,15 @@ for (( round=1; round<=MAX_ROUNDS+1; round++ )); do
     echo "최종 검증 빌드..."
   fi
 
-  build_output=""
-  if build_output=$(nix build ".#${ATTR}" --no-link 2>&1); then
+  build_log=$(mktemp)
+  set +e
+  nix build ".#${ATTR}" --no-link 2>&1 | tee "$build_log"
+  build_rc=${PIPESTATUS[0]}
+  set -e
+  build_output=$(cat "$build_log")
+  rm -f "$build_log"
+
+  if (( build_rc == 0 )); then
     break
   fi
 


### PR DESCRIPTION
## Summary
- `nfu` 실행 시 "빌드 검증 중... (1/3)" 단계에서 진행 상황이 전혀 표시되지 않아 hang처럼 보이는 문제 수정
- `nix build` 출력을 `tee` + 임시 파일 방식으로 변경하여 실시간 진행 표시와 hash 파싱을 동시에 수행

## Change Intent Record (CIR)

### 문제 상황
`nfu`로 flake input 업데이트 후 FOD hash 검증 단계에서 10~20분간 터미널에 아무 출력 없이 멈춘 것처럼 보임. 실제로는 `nix build`가 수백 개의 패키지를 다운로드/빌드하고 있었으나, 사용자에게 전혀 피드백이 없어 에러로 인한 hang인지 정상 진행인지 판별 불가.

### 근본 원인
`scripts/fix-fod-hashes.sh`의 빌드 검증 라인:

```bash
build_output=$(nix build ".#${ATTR}" --no-link 2>&1)
```

`$()` 명령 치환이 stdout과 stderr를 **모두 변수에 캡처**하여, `nix build`의 다운로드 진행률·빌드 로그가 터미널에 전혀 출력되지 않았음.

### 선택한 해결 방법
`tee` + 임시 파일 + `PIPESTATUS` 조합:

```bash
build_log=$(mktemp)
set +e
nix build ".#${ATTR}" --no-link 2>&1 | tee "$build_log"
build_rc=${PIPESTATUS[0]}
set -e
build_output=$(cat "$build_log")
rm -f "$build_log"
```

- **`tee "$build_log"`** — 터미널에 실시간 출력 + 파일에 저장 (hash 파싱용)
- **`PIPESTATUS[0]`** — pipeline에서 `nix build`의 종료 코드를 정확히 캡처
- **`set +e` / `set -e`** — `pipefail` 환경에서 `nix build` 실패 시 스크립트가 즉시 종료되지 않도록 보호

### 검토한 대안과 기각 사유
| 대안 | 기각 사유 |
|------|-----------|
| `script` 명령으로 pseudo-tty 할당 | 불필요한 복잡성. tee만으로 충분한 피드백 제공 |
| `nix build -L` (verbose 로그) 추가 | source 빌드 시 과도한 출력. 기본 non-tty 출력만으로 활동 확인 가능 |
| `tail -f` 백그라운드 프로세스 | 경합 조건(race condition) 발생 가능. 프로세스 정리도 복잡 |
| `$(cmd) \|\| true` + 변수 캡처 유지 | 근본 문제(출력 숨김)를 해결하지 못함 |

### 영향 범위
- 변경 파일: `scripts/fix-fod-hashes.sh` (1개)
- `nfu` 외에 독립 실행(`./scripts/fix-fod-hashes.sh`)에도 동일하게 적용
- hash mismatch 감지·자동 수정 로직 변경 없음 — 출력 캡처 방식만 변경

## Test plan
- [ ] `nfu -a` 실행 시 "빌드 검증 중..." 단계에서 `nix build` 진행 상황(다운로드/빌드 로그)이 실시간 표시되는지 확인
- [ ] FOD hash mismatch 발생 시 기존처럼 자동 감지·수정이 정상 동작하는지 확인
- [ ] hash mismatch 없는 정상 빌드에서 스크립트가 성공적으로 완료되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build script reliability with improved error handling and output logging mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->