### PR TITLE
fix(claude-wrapper): slow path에서 Killed: 9 에러 수정

### DIFF
--- a/modules/shared/programs/claude/files/scripts/claude-wrapper.sh
+++ b/modules/shared/programs/claude/files/scripts/claude-wrapper.sh
@@ -80,19 +80,17 @@ if acquire_lock; then
           else . end
         )
       ' "$cfg" > "$tmp" 2>/dev/null && [ -s "$tmp" ] && jq empty "$tmp" >/dev/null 2>&1; then
-        mv -- "$tmp" "$cfg" 2>/dev/null || true
-        tmp=""  # mv 성공 시 cleanup에서 삭제하지 않도록
+        if mv -- "$tmp" "$cfg" 2>/dev/null; then
+          tmp=""  # mv 성공 시 cleanup에서 삭제하지 않도록
+        fi
       else
         echo "claude-wrapper: jq patch failed, skipping trust injection" >&2
       fi
     fi
   fi
 
-  # trap 먼저 제거: bash 5.3에서 compound command 경계(fi)에서
-  # EXIT trap이 재발동하는 버그 방지
+  # trap 먼저 제거 후 명시적 cleanup: exec 전에 불필요한 child process fork 방지
   trap - EXIT INT TERM
-
-  # lock 해제 (tmp은 대부분 비어있으므로 가드로 불필요한 fork 방지)
   [[ -n "${tmp:-}" ]] && rm -f "$tmp" 2>/dev/null
   [[ -d "$lockdir" ]] && rm -rf -- "$lockdir" 2>/dev/null
 fi


### PR DESCRIPTION
## 요약

새 디렉토리(워크트리 등)에서 `c` alias 실행 시 trust injection slow path에서 매번 `Killed: 9` 에러가 출력되던 문제를 수정합니다.

```
/Users/glen/.local/bin/claude-wrapper.sh: line 95: 57001 Killed: 9    rm -f "${tmp:-}" 2> /dev/null
```

Claude Code 자체는 정상 시작되지만, 터미널에 에러 메시지가 항상 표시되어 사용자 경험을 해칩니다.

## 문제 분석

### 재현 조건

1. `.claude.json`에 **아직 등록되지 않은 새 경로**에서 `c` 실행
2. 대표적으로 `wt`로 워크트리를 생성한 직후 발생 (매번 새 경로)
3. 이미 등록된 디렉토리에서는 fast path(line 26)로 빠져서 미발생

### 에러 메시지 해석

```
line 95: 57001 Killed: 9    rm -f "${tmp:-}" 2> /dev/null
```

- **line 95** = `fi` (compound command 경계) — `rm` 명령이 있는 라인이 아님
- **표시된 명령** = `cleanup()` 함수 내부(line 58)의 `rm -f "${tmp:-}" 2> /dev/null`
- **Killed: 9** = SIGKILL (signal 9)

bash가 trap 발동 시점의 LINENO(`fi` = line 95)를 보고하면서, 실행된 명령은 trap handler 내부의 `rm`을 표시한 것입니다.

### 근본 원인: bash 5.3 + `trap -` + compound command 경계

**수정 전 실행 순서:**

```
Line 65:  trap cleanup EXIT INT TERM    ← trap 설정
Line 92:  rm -f "${tmp:-}" 2>/dev/null  ← 명시적 cleanup (rm -f "" fork)
Line 93:  rm -rf -- "$lockdir"          ← 명시적 cleanup
Line 94:  trap - EXIT INT TERM          ← trap 해제 시도
Line 95:  fi                            ← ⚠️ compound command 경계에서 EXIT trap 재발동
Line 97:  exec "$claude_bin" "$@"       ← Claude Code 시작
```

**Nix bash 5.3**(macOS 기본 bash 3.2가 아닌)에서 `trap - EXIT`이 `if...fi` compound command 내부에서 실행될 때, `fi` 경계에서 EXIT trap이 한 번 더 발동하는 것으로 추정됩니다.

이때 `cleanup()` → `rm -f ""` (빈 문자열)이 fork되고, 거의 동시에 `exec "$claude_bin"`이 프로세스 이미지를 교체하면서 `rm` 자식 프로세스가 고아가 되어 macOS에 의해 SIGKILL됩니다.

### 환경 정보

| 항목 | 값 |
|------|------|
| bash | Nix bash 5.3.9 (`aarch64-apple-darwin25.2.0`) |
| rm | Nix coreutils 9.10 (ad-hoc signed multicall binary) |
| macOS | Sequoia (Darwin 24.6.0) |
| `.claude.json` | 244KB, 153개 프로젝트 엔트리 |

## 수정 내용

### 1. `cleanup()` 함수에 빈 문자열 가드 추가

```diff
 cleanup() {
-  rm -f "${tmp:-}" 2>/dev/null
-  rm -rf -- "$lockdir" 2>/dev/null
+  [[ -n "${tmp:-}" ]] && rm -f "$tmp" 2>/dev/null
+  [[ -d "$lockdir" ]] && rm -rf -- "$lockdir" 2>/dev/null
 }
```

**효과**: EXIT trap이 예기치 않게 발동되더라도 `tmp`이 비어있으면 `rm`을 fork하지 않습니다. 정상 흐름에서는 `mv` 성공 후 `tmp=""`이므로 fork 자체가 발생하지 않아 `Killed: 9`의 원인이 제거됩니다.

### 2. `trap -`을 명시적 cleanup 앞으로 이동

```diff
-  # lock 해제 (trap도 있지만 명시적으로)
-  rm -f "${tmp:-}" 2>/dev/null
-  rm -rf -- "$lockdir" 2>/dev/null
+  # trap 먼저 제거: bash 5.3에서 compound command 경계(fi)에서
+  # EXIT trap이 재발동하는 버그 방지
   trap - EXIT INT TERM
+
+  # lock 해제 (tmp은 대부분 비어있으므로 가드로 불필요한 fork 방지)
+  [[ -n "${tmp:-}" ]] && rm -f "$tmp" 2>/dev/null
+  [[ -d "$lockdir" ]] && rm -rf -- "$lockdir" 2>/dev/null
```

**효과**: trap을 먼저 해제하므로 `fi` 경계에서 재발동 가능성을 차단합니다. 이후 명시적 cleanup은 trap 없이 실행되어 이중 실행 위험이 없습니다.

### 3. 명시적 cleanup에도 가드 적용

**효과**: `[[ -n "${tmp:-}" ]]`와 `[[ -d "$lockdir" ]]`로 불필요한 외부 바이너리 fork를 방지합니다. bash 내장 `[[` 테스트만으로 판단하므로 SIGKILL 위험이 없습니다.

### 안전성 분석

| 시나리오 | 수정 전 | 수정 후 |
|----------|---------|---------|
| 정상 흐름 (mv 성공, tmp="") | `rm -f ""` fork → Killed: 9 | `[[ -n "" ]]` = false → fork 없음 |
| mv 실패 (tmp≠"") | `rm -f "$tmp"` 정상 삭제 | `[[ -n "$tmp" ]]` = true → 동일 |
| 스크립트 크래시 (trap 내) | cleanup()에서 `rm -f ""` fork | `[[ -n "" ]]` = false → fork 없음 |
| trap 해제 후 ~ fi 사이 크래시 | lockdir 누수 (stale lock) | 동일 (다음 실행 시 stale lock 감지) |

**fail-open 계약 유지**: 어떤 경로에서도 마지막 `exec "$claude_bin" "$@"`에 도달하는 구조는 변경 없습니다.

## 테스트

- [x] shellcheck 통과
- [x] `nrs` 없이 즉시 반영 확인 (`mkOutOfStoreSymlink` → 소스 파일 직접 참조)
- [ ] 새 워크트리에서 `c` 실행 시 `Killed: 9` 에러 미출력 확인
- [ ] 이미 등록된 디렉토리에서 `c` 실행 시 기존 동작 유지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup and exit handling to more reliably manage temporary files and lock directories, preventing errors and unwanted child-process activity during shutdown.

* **Performance**
  * Reduced unnecessary filesystem operations by making removals conditional and reordering cleanup steps for more efficient teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->