### PR TITLE
fix(backup): karakeep-backup/immich-backup runtimeInputs에 curl 추가

### DIFF
--- a/modules/nixos/programs/docker/immich-backup.nix
+++ b/modules/nixos/programs/docker/immich-backup.nix
@@ -25,6 +25,7 @@ let
       podman
       coreutils
       findutils
+      curl # service-lib.sh의 send_notification에서 사용
     ];
     text = ''
       # service-lib.sh 로드 (send_notification 사용)

--- a/modules/nixos/programs/docker/karakeep-backup.nix
+++ b/modules/nixos/programs/docker/karakeep-backup.nix
@@ -26,6 +26,7 @@ let
       coreutils
       findutils
       gzip
+      curl # service-lib.sh의 send_notification에서 사용
     ];
     text = ''
       # service-lib.sh 로드 (send_notification 사용)


### PR DESCRIPTION
## Summary

- `karakeep-backup.nix`와 `immich-backup.nix`의 `writeShellApplication` `runtimeInputs`에 `curl` 추가
- `send_notification()`이 내부적으로 `curl`을 호출하지만 PATH에 없어 백업 실패 시 Pushover 알림이 사일런트 실패하던 문제 수정
- `vaultwarden-backup.nix` (#158)과 동일한 패턴 적용

## Test plan

- [ ] `nrs`로 NixOS 설정 빌드 성공 확인
- [ ] `systemctl cat karakeep-backup` / `systemctl cat immich-db-backup`에서 wrapper PATH에 curl 포함 확인
- [ ] 백업 실패 유발 시 Pushover 알림 수신 확인

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled notification functionality for backup services by adding required runtime dependencies, allowing notifications to be sent during backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->