### PR TITLE
feat(fzf): single-select 모드 Tab/Shift+Tab 커서 이동 바인딩

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
@@ -24,8 +24,8 @@ fzf 셸 단축키
   Ctrl+G      디렉토리: eza 트리 미리보기 (depth 2)
 
 [fzf 내부 조작]
-  Tab         multi: 선택/해제 + 아래로 이동
-  Shift+Tab   multi: 선택/해제 + 위로 이동
+  Tab         single: 아래로 이동 / multi: 선택/해제 + 아래로 이동
+  Shift+Tab   single: 위로 이동 / multi: 선택/해제 + 위로 이동
   Ctrl+J/N    아래로 이동
   Ctrl+K/P    위로 이동
 

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -237,6 +237,9 @@ in
     defaultCommand = "${lib.getExe pkgs.fd} --strip-cwd-prefix --exclude .git";
     fileWidgetCommand = "${lib.getExe pkgs.fd} --strip-cwd-prefix --exclude .git";
     changeDirWidgetCommand = "${lib.getExe pkgs.fd} --type d --strip-cwd-prefix --exclude .git";
+    defaultOptions = [
+      "--bind=tab:toggle-down,shift-tab:toggle-up"
+    ];
     fileWidgetOptions = [
       "--preview 'if [ -d {} ]; then ${lib.getExe pkgs.eza} --tree --level=2 --color=always {}; else ${lib.getExe pkgs.bat} --color=always --style=numbers --line-range=:500 {}; fi'"
       "--preview-window=right:60%:wrap"


### PR DESCRIPTION
## Summary
- fzf `defaultOptions`에 `tab:toggle-down,shift-tab:toggle-up` 명시적 바인딩 추가
- single-select 모드에서 Tab/Shift+Tab으로 커서 상하 이동 가능
- cheatsheet에 single/multi 모드별 동작 구분 반영

## Test plan
- [x] `export FZF_DEFAULT_OPTS="--bind=tab:toggle-down,shift-tab:toggle-up"` 후 `ls | fzf`에서 Tab/Shift+Tab 커서 이동 확인