### PR TITLE
fix(claude): chrome-devtools MCP npm registry 명시로 E401 해결

### DIFF
--- a/modules/shared/programs/claude/files/mcp.darwin.json
+++ b/modules/shared/programs/claude/files/mcp.darwin.json
@@ -8,7 +8,10 @@
         "--autoConnect",
         "--channel=stable",
         "--no-usage-statistics"
-      ]
+      ],
+      "env": {
+        "npm_config_registry": "https://registry.npmjs.org/"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

<img width="629" height="82" alt="image" src="https://github.com/user-attachments/assets/bbc67552-ffc9-430a-b812-184aedcc750e" />

- `.npmrc`의 CodeArtifact 레지스트리 + 만료된 인증 토큰으로 인해 `npx chrome-devtools-mcp@latest` 실행 시 E401 에러 발생
- MCP 서버 설정에 `env.npm_config_registry`를 명시하여 공식 npm 레지스트리(`https://registry.npmjs.org/`)를 직접 사용하도록 수정
- 기존 `.npmrc` 설정을 건드리지 않는 비침습적 해결

## Test plan
- [x] `/mcp` 명령으로 `chrome-devtools` MCP 서버 연결 성공 확인
- [ ] `nrs` 후에도 설정이 유지되는지 확인