### PR TITLE
feat(fzf): fzf-tab 플러그인 도입 — Tab completion에 fuzzy 검색 통합

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
@@ -1,7 +1,16 @@
 ---
-tags: [ fzf, keybinding, shell ]
+tags: [ fzf, fzf-tab, keybinding, shell ]
 ---
 fzf 셸 단축키
+
+[Tab 자동완성 — fzf-tab]
+  <Tab>        fzf-tab 퍼지 검색 자동완성 (zsh 기본 완성 대체)
+               Tab: 선택/수락, Ctrl+Space: 다중 선택 토글
+               /: continuous trigger (디렉토리 선택 후 하위 계속 탐색)
+               F1/F2: 완성 그룹 전환
+  미리보기:    파일→bat 구문 강조, 디렉토리→eza 트리
+               git branch/switch/log→커밋 이력, git diff→변경사항
+  토글:        disable-fzf-tab / enable-fzf-tab (런타임 on/off)
 
 [파일 경로 삽입]
   Ctrl+T      파일/디렉토리 퍼지 검색 → 커맨드에 경로 삽입
@@ -13,21 +22,29 @@ fzf 셸 단축키
               zoxide(z)는 방문 기록 기반, 이건 현재 위치 하위 탐색
               (원래 Alt+C이나 한글 IME 호환을 위해 리바인드)
 
-[퍼지 자동완성 (**Tab)]
+[퍼지 자동완성 (**Tab) — fzf 네이티브]
   cd **<Tab>       디렉토리만 검색
   cat **<Tab>      파일만 검색
   kill **<Tab>     프로세스 이름으로 검색 → PID 자동 입력
   ssh **<Tab>      SSH 호스트 검색
+  ※ fzf-tab 활성 시에도 **<Tab>은 fzf 네이티브로 동작 (폴백)
 
 [미리보기]
   Ctrl+T      파일: bat 구문 강조 미리보기 (우측 60%)
   Ctrl+G      디렉토리: eza 트리 미리보기 (depth 2)
 
-[fzf 내부 조작]
+[fzf 내부 조작 — Ctrl+T/Ctrl+G (독립 fzf)]
   Tab         single: 아래로 이동 / multi: 선택/해제 + 아래로 이동
   Shift+Tab   single: 위로 이동 / multi: 선택/해제 + 위로 이동
   Ctrl+J/N    아래로 이동
   Ctrl+K/P    위로 이동
 
+[fzf 내부 조작 — fzf-tab 모드]
+  Tab         수락 (선택 확정)
+  Ctrl+Space  다중 선택 토글
+  /           continuous completion (디렉토리 하위 계속 탐색)
+  F1/F2       완성 그룹 전환
+
 [참고]
   Ctrl+R      Atuin이 대체 중 (fzf 히스토리 검색 비활성)
+  FZF_DEFAULT_OPTS  fzf-tab에 영향 없음 (내부적으로 격리)

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -153,6 +153,33 @@ in
       '')
 
       #─────────────────────────────────────────────────────────────────────────
+      # fzf-tab: Tab completion을 fzf 퍼지 검색으로 대체
+      # mkAfter에서 source하여 fzf --zsh(mkOrder 910) 이후에 로드
+      # → fzf_default_completion에 expand-or-complete가 정상 저장 (무한루프 방지)
+      # → _ftb_orig_widget에 fzf-completion이 저장 (**<Tab> 폴백 보존)
+      #─────────────────────────────────────────────────────────────────────────
+      (lib.mkAfter ''
+        source ${pkgs.zsh-fzf-tab}/share/fzf-tab/fzf-tab.plugin.zsh
+
+        # Tab으로 선택 확정 (fzf-tab 기본값 tab:down → tab:accept)
+        zstyle ':fzf-tab:*' fzf-bindings 'tab:accept'
+        # '/'로 디렉토리 하위 연속 탐색
+        zstyle ':fzf-tab:*' continuous-trigger '/'
+        # F1/F2로 completion 그룹 전환
+        zstyle ':fzf-tab:*' switch-group 'F1' 'F2'
+
+        # 미리보기: 파일→bat 구문 강조, 디렉토리→eza 트리
+        zstyle ':fzf-tab:complete:*' fzf-preview \
+          'if [[ -d $realpath ]]; then ${lib.getExe pkgs.eza} --tree --level=2 --color=always $realpath; elif [[ -f $realpath ]]; then ${lib.getExe pkgs.bat} --color=always --style=numbers --line-range=:500 $realpath; fi'
+
+        # git 브랜치/ref 미리보기 (커밋 로그)
+        zstyle ':fzf-tab:complete:git-(checkout|switch|log):*' fzf-preview \
+          'git log --oneline --graph --color=always $word -- 2>/dev/null | head -20'
+        zstyle ':fzf-tab:complete:git-diff:*' fzf-preview \
+          'git diff --color=always $word 2>/dev/null | head -50'
+      '')
+
+      #─────────────────────────────────────────────────────────────────────────
       # Shell 함수 라이브러리 로딩
       #─────────────────────────────────────────────────────────────────────────
       ''


### PR DESCRIPTION
## Summary
- zsh Tab completion을 fzf-tab으로 대체하여 모든 completion에 문맥 인식 fuzzy 검색 제공
- mkAfter에서 직접 source하여 fzf `--zsh`(mkOrder 910) 이후 로드 — `fzf_default_completion` 무한루프 방지
- 파일/디렉토리/git 미리보기, Tab 선택 확정, `/` 연속 탐색 등 zstyle 설정
- 치트시트에 fzf-tab 키바인딩 섹션 추가

closes #170

## Test plan

### 0. 빌드 적용
```zsh
nrs
```
빌드 성공 후 **새 터미널(또는 새 tmux pane)을 열어야** 변경된 `.zshrc`가 로드된다.

### 1. 무한루프 방지 검증 (가장 먼저)
```zsh
# fzf_default_completion이 올바른 값인지 확인
echo $fzf_default_completion
# 기대값: expand-or-complete
# NG값: fzf-tab-complete (이 값이면 무한루프 — 즉시 롤백)

# ^I 바인딩 확인
bindkey '^I'
# 기대값: "^I" fzf-tab-complete
```

### 2. 핵심 기능 — fzf-tab fuzzy 검색
```zsh
# 기본 파일 completion → fzf 팝업이 뜨는지 확인
ls <Tab>
# 기대: fzf fuzzy 검색 UI가 나타남, 타이핑하면 필터링됨

# 디렉토리 completion + eza 트리 미리보기
cd <Tab>
# 기대: 디렉토리 목록 + 우측에 eza 트리 미리보기

# 파일 선택 시 bat 미리보기
cat <Tab>
# 기대: 파일 목록 + 우측에 bat 구문 강조 미리보기
```

### 3. Tab 선택 확정 (tab:accept)
```zsh
ls <Tab>
# fzf UI에서 원하는 항목으로 이동 후 Tab 누르기
# 기대: 즉시 선택 확정되어 커맨드라인에 삽입
# (기본값은 tab:down이라 아래로만 이동하는데, 우리는 tab:accept로 변경)
```

### 4. Continuous trigger — `/` 디렉토리 연속 탐색
```zsh
cd <Tab>
# 디렉토리 하나 선택 후 `/` 키 누르기
# 기대: 선택한 디렉토리 안으로 들어가서 하위 디렉토리 completion이 이어짐
# (Tab으로 확정하지 않고 `/`를 누르면 drill-down)
```

### 5. 다중 선택 (Ctrl+Space)
```zsh
ls <Tab>
# Ctrl+Space로 여러 항목 토글 선택 → Tab으로 확정
# 기대: 선택한 파일들이 모두 커맨드라인에 삽입 (공백 구분)
```

### 6. 그룹 전환 (F1/F2)
```zsh
# completion 그룹이 여러 개인 경우 (예: 명령어 + 파일)
git <Tab>
# F1/F2로 그룹 간 전환
# 기대: 다른 completion 그룹으로 전환됨
```

### 7. Git 미리보기
```zsh
# git checkout 브랜치 completion + 커밋 로그 미리보기
cd ~/Workspace/nixos-config  # git 레포 안에서
git checkout <Tab>
# 기대: 브랜치 목록 + 우측에 git log --oneline --graph 미리보기

git diff <Tab>
# 기대: 변경 파일 목록 + 우측에 diff 미리보기
# (변경 파일이 없으면 completion 자체가 안 뜸 — 정상)
```

### 8. 비회귀 — 기존 fzf 위젯
```zsh
# Ctrl+T: 파일 경로 삽입 (fzf 네이티브)
vim <Ctrl+T>
# 기대: fzf 파일 검색 UI (fzf-tab과 별도)

# Ctrl+G: 디렉토리 점프 (Alt+C 리맵)
<Ctrl+G>
# 기대: fzf 디렉토리 검색 → cd

# **<Tab>: fzf 네이티브 fuzzy completion (폴백)
cd **<Tab>
# 기대: fzf 네이티브 파일/디렉토리 검색 (fzf-tab이 아닌 fzf-completion)
```

### 9. 비회귀 — Atuin, Zoxide, autosuggestions
```zsh
# Ctrl+R: Atuin 히스토리 검색
<Ctrl+R>
# 기대: Atuin UI (fzf 아님)

# Zoxide
z <partial-dir-name>
# 기대: 정상 디렉토리 점프

# autosuggestions
ls<우측 화살표>
# 기대: 회색 제안이 표시되고 → 로 수락 가능
```

### 10. Nix completion
```zsh
nix build nixpkgs#<Tab>
# 기대: 패키지 이름 fuzzy 검색 (느릴 수 있음 — 정상)

nix flake <Tab>
# 기대: 서브커맨드 completion (check, build, update 등)
```

### 11. 엣지 케이스
```zsh
# 런타임 토글
disable-fzf-tab
ls <Tab>
# 기대: 일반 zsh completion (fzf UI 없음)

enable-fzf-tab
ls <Tab>
# 기대: fzf-tab 복귀

# 빈 디렉토리
mkdir /tmp/fzf-tab-test && cd /tmp/fzf-tab-test
ls <Tab>
# 기대: 매치 없음 — 크래시/행 없이 정상 종료

# 대규모 completion
ls /nix/store/<Tab>
# 기대: 많은 항목이지만 fzf가 처리 — 반응 확인 (약간 느릴 수 있음)
```

### 롤백 (문제 발생 시)
```zsh
# 즉시 롤백 (재빌드 불필요)
disable-fzf-tab

# 완전 롤백
# shell/default.nix에서 fzf-tab mkAfter 블록 제거 → nrs
```