### PR TITLE
fix(fzf): fzf-tab Tab 바인딩 기본값 복원 — 독립 fzf와 일관성 확보

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/fzf/keybinding
@@ -5,7 +5,7 @@ fzf 셸 단축키
 
 [Tab 자동완성 — fzf-tab]
   <Tab>        fzf-tab 퍼지 검색 자동완성 (zsh 기본 완성 대체)
-               Tab: 선택/수락, Ctrl+Space: 다중 선택 토글
+               Tab/Shift+Tab: 아래/위 이동, Enter: 수락, Ctrl+Space: 다중 선택 토글
                /: continuous trigger (디렉토리 선택 후 하위 계속 탐색)
                F1/F2: 완성 그룹 전환
   미리보기:    파일→bat 구문 강조, 디렉토리→eza 트리
@@ -40,7 +40,9 @@ fzf 셸 단축키
   Ctrl+K/P    위로 이동
 
 [fzf 내부 조작 — fzf-tab 모드]
-  Tab         수락 (선택 확정)
+  Tab         아래로 이동 (독립 fzf와 동일)
+  Shift+Tab   위로 이동
+  Enter       수락 (선택 확정)
   Ctrl+Space  다중 선택 토글
   /           continuous completion (디렉토리 하위 계속 탐색)
   F1/F2       완성 그룹 전환

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -161,8 +161,14 @@ in
       (lib.mkAfter ''
         source ${pkgs.zsh-fzf-tab}/share/fzf-tab/fzf-tab.plugin.zsh
 
-        # Tab으로 선택 확정 (fzf-tab 기본값 tab:down → tab:accept)
-        zstyle ':fzf-tab:*' fzf-bindings 'tab:accept'
+        # === Change Intent Record ===
+        # v1 (PR #188): LLM 추천으로 tab:accept 설정 — Tab 2-tap 빠른 확정 흐름
+        # v2 (이번 변경): tab:accept 제거, fzf-tab 기본값 tab:down 복원
+        #    독립 fzf(Ctrl+T/G)의 tab:toggle-down(PR #185)과 동작 불일치 해소.
+        #    Enter가 이미 보편적 accept 키이고, 단일 결과는 팝업 없이 자동 수락됨.
+        #    trade-off: Tab 2-tap 빠른 확정을 잃지만, 모든 fzf 컨텍스트에서
+        #              Tab=아래이동 일관성 확보가 더 가치 있음.
+
         # '/'로 디렉토리 하위 연속 탐색
         zstyle ':fzf-tab:*' continuous-trigger '/'
         # F1/F2로 completion 그룹 전환


### PR DESCRIPTION
## Summary
- fzf-tab의 `tab:accept` 바인딩을 제거하고 기본값 `tab:down`을 복원
- 독립 fzf(Ctrl+T/G, PR #185)와 fzf-tab 간 Tab 키 동작 일관성 확보
- 치트시트를 변경된 동작에 맞게 업데이트

## Change Intent Record

### 배경

PR #188(fzf-tab 도입)과 PR #185(fzf single-select Tab 바인딩)가 병합된 후,
Tab 키 동작이 fzf 컨텍스트에 따라 불일치하는 문제가 발견됨:

| 컨텍스트 | Tab 동작 (변경 전) | 출처 |
|---------|-------------------|------|
| 독립 fzf (Ctrl+T, Ctrl+G, pipe) | `toggle-down` (아래 이동) | PR #185 `FZF_DEFAULT_OPTS` |
| fzf-tab (cd \<Tab\>, git checkout \<Tab\>) | `accept` (즉시 선택 확정) | PR #188 zstyle |

### 의사결정 이력

- **v1 (PR #188)**: LLM이 `tab:accept`를 추천 — "Tab으로 완성 트리거 → Tab으로 바로 확정"하는 2-tap 흐름.
  사용자가 이 옵션을 충분히 검수하지 않고 계획을 승인하여 의도하지 않은 동작이 병합됨.
- **v2 (이번 변경)**: `tab:accept` 제거, fzf-tab 하드코딩 기본값 `tab:down` 복원.

### 근거

1. **일관성**: Tab = 아래 이동이 모든 fzf 컨텍스트(독립 fzf, fzf-tab)에서 동일하게 동작
2. **보편성**: Enter = accept는 fzf의 보편적 관례이며 학습 비용 제로
3. **불필요성**: fzf-tab은 결과가 1개일 때 팝업 없이 자동 수락하므로 Tab 2-tap 빠른 확정이 실제로 필요한 경우가 드묾
4. **출처 검증**: fzf-tab 소스(`-ftb-fzf:31`)에서 기본 바인딩이 `tab:down,btab:up`임을 확인.
   `FZF_DEFAULT_OPTS`는 완전히 격리됨(`-ftb-fzf:85-88`)

### trade-off

Tab 2-tap 빠른 확정을 잃지만, 모든 fzf 컨텍스트에서 Tab=아래이동
일관성 확보가 더 가치 있음.

## 변경 후 동작

| 컨텍스트 | Tab | Shift+Tab | Enter |
|---------|-----|-----------|-------|
| 독립 fzf (Ctrl+T/G) | 아래 이동 | 위로 이동 | 수락 |
| fzf-tab (Tab 완성) | 아래 이동 | 위로 이동 | 수락 |

## Test plan
- [ ] `cd <Tab>` → fzf-tab 팝업에서 Tab = 아래 이동, Enter = 선택 확인
- [ ] `git checkout <Tab>` → 동일 동작 확인
- [ ] `Ctrl+T` → 독립 fzf에서 Tab = 아래 이동 (기존 동작 유지)
- [ ] `Ctrl+G` → 독립 fzf에서 Tab = 아래 이동 (기존 동작 유지)
- [ ] `disable-fzf-tab` / `enable-fzf-tab` 런타임 토글 정상 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted fzf-tab keybindings for consistent navigation behavior: Tab moves to next item, Shift+Tab moves to previous item, Enter confirms selection
  * Restored default fzf-tab behavior across shell contexts for streamlined tab navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->