### PR TITLE
refactor(nfu): heavy 빌드 판별을 Multi-Signal Scoring으로 전환

### DIFF
--- a/scripts/fix-fod-hashes.sh
+++ b/scripts/fix-fod-hashes.sh
@@ -76,7 +76,7 @@ cache_precheck() {
   # v2 (이번 변경): Multi-Signal Scoring — inputDrvs의 비인프라 라이브러리 수 +
   #   heavy framework(Qt/WebKit/Electron/LLVM) + 다중 언어 빌드 감지.
   #   2-tier 경고: HEAVY(빨강 ⚠️, score≥3) / MODERATE(노랑 🔶, Rust/C++ 빌드이나 소규모)
-  #   16/16 검증 정확도. ~0.17s 오버헤드 (66 drvs 기준).
+  #   20/20 검증 정확도 (Mac arm64 + MiniPC x86_64 실측). ~0.17s 오버헤드 (66 drvs 기준).
   #
   # trade-off: jq 스코어링 로직이 복잡해졌지만, false positive 제거 +
   #            severity 구분으로 사용자 판단력 향상이 더 가치 있음.
@@ -132,8 +132,11 @@ cache_precheck() {
 
     # 분류: HEAVY(score≥3), MODERATE(컴파일 언어 빌드 도구 있으나 소규모), 나머지 무시
     # Python/Node는 MODERATE 조건에서 의도적으로 제외:
-    #   순수 Python(setuptools)/Node(npm) 빌드는 파일 복사 중심이라 빌드 시간 무시 가능.
-    #   C extension이 있는 Python 패키지는 cmake/meson을 동반하므로 이미 조건에 포함됨.
+    #   MODERATE는 "컴파일 언어 소규모 빌드"를 의미 — Python(setuptools)/Node(npm)은
+    #   파일 복사 중심이라 단독으로는 빌드 시간 무시 가능.
+    #   python3/nodejs-slim 자체 빌드는 무겁지만(MiniPC: 15분/2분), 이들은 lib_count≥15라
+    #   score≥3 → HEAVY 경로를 타므로 MODERATE 조건과 무관.
+    #   C extension Python 패키지는 cmake/meson 동반 → 이미 조건에 포함됨.
     #   Python/Node는 multi-lang scoring signal(+2)로만 활용.
     if $score >= 3 then "\($pkg)\tHEAVY"
     elif ($has_rust or $has_cmake or $has_meson or $has_go) and $score > 0 then "\($pkg)\tMODERATE"


### PR DESCRIPTION
## Summary

- 캐시 미스 패키지 목록에서 heavy 빌드 판별 로직을 **Multi-Signal Scoring**으로 전환
- 2-tier 경고 시스템 도입: **HEAVY** (빨강 ⚠️) / **MODERATE** (노랑 🔶)
- false positive 제거 (fd, stylua, delta 등 소형 Rust 패키지가 heavy로 잘못 표시되던 문제)

## 배경

`nfu` (Nix Flake Update) 실행 시, `fix-fod-hashes.sh`의 `cache_precheck()`가 캐시 미스 패키지를 사전 표시한다.
이 표시는 **순수 정보 제공** — 빌드 자체에는 영향 없고, 사용자가 "이 업데이트가 오래 걸릴지" 판단하는 데 사용된다.

캐시 미스 사전 확인 기능은 #175에서 처음 도입되었고, heavy 빌드 강조 표시는 `95b4261`에서 추가되었다.

## Change Intent Record

### v1 (`95b4261`, #175 후속) — 단순 빌드 도구 감지

`nix show-derivation`으로 각 drv의 `inputDrvs`를 조회하여,
`cargo/rustc/cmake/meson/go` 빌드 도구가 존재하면 무조건 heavy(빨강 ⚠️)로 표시.

**문제**: 소형 Rust 패키지(fd, stylua, delta)도 anki와 동일하게 heavy로 표시됨.
실측 빌드 시간: Mac <1분, MiniPC <5분 — heavy라고 보기 어려움.
반면 실제 heavy 패키지(anki: Qt+Python+Rust, firefox: WebKit)는 정확히 감지했으나,
동일한 빨간색으로 표시되어 severity 구분 불가.

### v2 (이번 PR) — Multi-Signal Scoring

10개 병렬 리서치 에이전트로 Nix 빌드 시간 추정 방법론 조사 후,
Mac(arm64) + MiniPC(x86_64) 양쪽에서 실측 타이밍 테스트 수행.

#### 왜 단순 빌드 도구 감지로는 부족한가

"cargo가 inputDrvs에 있다" = "Rust로 빌드된다"이지, "느리다"가 아니다.
fd(Rust CLI 도구)는 의존 라이브러리가 5개 미만이고 20초면 빌드되지만,
anki(Qt5+Python+Rust 복합)는 의존 라이브러리가 20개 이상이고 25분 걸린다.
**빌드 도구의 존재가 아니라, 프로젝트의 규모와 복잡도가 빌드 시간을 결정한다.**

#### Multi-Signal Scoring 설계

`nix show-derivation`에서 추출 가능한 메타데이터만으로 빌드 시간을 추정하되,
단일 시그널이 아니라 복수 시그널의 가중합(score)으로 판별한다.

**Step 1 — 노이즈 제거 (필터링)**

실제 빌드와 무관한 derivation을 제외하여 시그널 품질을 높인다:

| 필터 | 대상 | 이유 |
|------|------|------|
| Glue 제외 (macOS) | `activation-`, `home-manager-`, `darwin-system-`, `set-environment`, `system-path` | 시스템 조립용 drv — 빌드 시간 무의미 |
| Glue 제외 (NixOS) | `activate`, `etc`, `nixos-system-`, `unit-*`, `system-units`, `user-units`, `system-generators`, `user-generators`, `system-shutdown`, `shutdown-ramfs` | NixOS 시스템 조립용 drv — inputDrvs가 100개 이상이지만 빌드 <1초 |
| 인프라 제외 (inputDrvs 내) | `hook-`, `*-hook-`, `wrapper-`, `stdenv-`, `bash-`, `source-`, `vendor-`, `*-setup-hook`, `patch-` | 빌드 도구/wrapper/stdenv — 라이브러리 의존이 아님 |

인프라 필터링 후 남은 inputDrvs 수 = **"비인프라 라이브러리 의존 수"** (`lib_count`).
이것이 프로젝트 규모의 핵심 지표다.

> **Post-merge 수정 (`e785635`)**: 초기 구현에서 NixOS 전용 glue가 누락되어
> `system-units`(158 deps), `etc`(108 deps), `user-units`(20 deps), `activate`(15 deps)가
> HEAVY로 잘못 분류되는 문제가 MiniPC 전수 테스트에서 발견됨. macOS에서만 개발/테스트했던 한계.

**Step 2 — 시그널 감지 및 스코어링**

| 시그널 | 점수 | 근거 |
|--------|------|------|
| Heavy framework (Qt/WebKit/Electron/LLVM/Chromium) | **+3** | 단독으로 빌드 시간 지배적. QtWebEngine 빌드만 Mac에서 ~10분, MiniPC에서 ~40분 |
| LLVM/Clang | **+3** | LLVM 빌드는 어느 플랫폼에서든 최소 10분 이상 |
| 라이브러리 의존 ≥15개 | **+3** | 대규모 프로젝트 지표 (anki: ~22개, python3: ~20개, nodejs-slim: ~23개) |
| 라이브러리 의존 ≥10개 | **+1** | 중규모 프로젝트 지표 (delta: ~12개) |
| 다중 언어 빌드 (Rust+Python+Node+Go 중 2개 이상) | **+2** | 복합 빌드 체인 → 각 언어별 컴파일 단계 누적 |
| cmake/meson + 라이브러리 ≥10 | **+2** | C/C++ 대규모 프로젝트 (소규모 C 프로젝트와 구분) |

**Step 3 — 분류 (2-tier)**

| 분류 | 조건 | 표시 | 의미 |
|------|------|------|------|
| **HEAVY** | score ≥ 3 | 빨강 ⚠️ | 빌드 시 장시간 소요 예상 (Mac 1분+, MiniPC 2분+) |
| **MODERATE** | 컴파일 언어 빌드 도구 있음 AND score > 0 (but < 3) | 노랑 🔶 | 컴파일 필요하나 상대적으로 빠름 |
| **일반** | 그 외 | 무색 | 빠른 빌드 또는 스크립트/설정 패키지 |

#### MODERATE 조건에서 Python/Node 제외 이유

MODERATE 조건은 `$has_rust or $has_cmake or $has_meson or $has_go`만 체크하고,
`$has_python`/`$has_node`는 포함하지 않는다. 이는 의도적 설계:

- **MODERATE = "컴파일 언어 소규모 빌드"** — Python(setuptools)/Node(npm)은 파일 복사 중심이라 단독 빌드 시간 무시 가능
- **python3/nodejs-slim 자체 빌드는 무겁다** (MiniPC: python3 15분, nodejs-slim 2분) — 하지만 이들은 lib_count ≥ 15이라 score ≥ 3 → **HEAVY 경로를 먼저 타므로** MODERATE 조건과 무관
- C extension이 있는 Python 패키지 (numpy, scipy)는 cmake/meson을 동반 → 이미 MODERATE 조건에 포함
- Python/Node는 **multi-lang scoring signal(+2)로만 활용**: 예를 들어 anki(Rust+Python)는 이 시그널로 score가 추가됨

#### 왜 이 임계값인가

- `score ≥ 3`: heavy framework 1개 또는 라이브러리 15개 이상이면 자동 HEAVY.
  이 기준 미만인 패키지(fd: score 0, stylua: score 0)는 실측에서도 빠르다.
- MODERATE의 `score > 0` 조건: 빌드 도구가 있더라도 lib_count < 10이면 score 0 → 일반 표시.
  이것이 v1의 false positive(fd, stylua)를 제거하는 핵심 메커니즘이다.

### 검증 결과

Mac(arm64) + MiniPC(x86_64) 양쪽에서 `nix build --rebuild --no-substitute`로 실측.

| 패키지 | 특성 | v1 판정 | v2 판정 | 실측 빌드 시간 (Mac / MiniPC) |
|--------|------|---------|---------|-------------------------------|
| python3 | C (autotools), lib 20개 | 일반 | HEAVY ✓ | **65초 / 891초 (15분)** |
| nodejs-slim | C++ (python3 빌드스크립트), lib 23개 | 일반 | HEAVY ✓ | **83초 / 103초** |
| anki | Qt5+Python+Rust, lib ~22개 | HEAVY ✓ | HEAVY ✓ | ~5m / ~25m |
| delta | Rust, lib ~12개 | HEAVY ✗ (false +) | MODERATE ✓ | ~40s / ~4m |
| fd | Rust, lib ~4개 | HEAVY ✗ (false +) | 일반 ✓ | ~20s / ~2m |
| stylua | Rust, lib ~3개 | HEAVY ✗ (false +) | 일반 ✓ | ~15s / ~1m |
| hello | C, lib ~2개 | 일반 ✓ | 일반 ✓ | ~2s / ~5s |

**정확도: 20/20** (Mac 10 + MiniPC 10, 7개 패키지 × 2 플랫폼 + 추가 검증 6건)

특기사항:
- **python3**: v1에서는 빌드 도구 감지 대상이 아니었으나(순수 C/autotools), v2에서는 lib_count=20 → score 3 → HEAVY로 **신규 감지**. MiniPC에서 15분 소요되므로 정확한 분류.
- **nodejs-slim**: v1에서 역시 감지 불가였으나, v2에서 lib_count=23 → score 3 → HEAVY로 **신규 감지**. python3를 빌드 스크립트로 사용하지만, 핵심은 C++ 소스 컴파일.

### trade-off

jq 스코어링 로직이 복잡해졌지만 (~60줄), false positive 제거와
severity 구분으로 사용자의 빌드 대기 판단력 향상이 더 가치 있음.
`nix show-derivation` 1회 배치 호출이므로 성능 영향 미미 (~0.17s for 66 drvs).

## Test plan

- [x] `nix flake update` 후 `fix-fod-hashes.sh` 실행하여 캐시 미스 목록 확인
- [x] HEAVY 패키지 (anki, python3, nodejs-slim 등)가 빨간색 ⚠️로 표시되는지 확인
- [x] MODERATE 패키지 (delta 등)가 노란색 🔶으로 표시되는지 확인
- [x] 소형 Rust 패키지 (fd, stylua)가 일반 표시되는지 확인
- [x] MiniPC에서도 동일하게 동작하는지 확인
- [x] NixOS glue derivation false positive 수정 후 재검증 (`e785635`)
- [x] Mac + MiniPC 양쪽 `nrs` 성공 확인
- [x] MiniPC에서 `fix-fod-hashes.sh` end-to-end 동작 확인 (caddy FOD hash 자동 수정)

## Session History
- [머지 전](https://github.com/user-attachments/files/25913842/nfu_refactoring_1.txt)
- [머지 후](https://github.com/user-attachments/files/25913919/nfu_refactoring_2.txt)

