### PR TITLE
docs(claude): VSCode 확장 유지 결정 CIR 기록

### DIFF
--- a/modules/darwin/programs/vscode/default.nix
+++ b/modules/darwin/programs/vscode/default.nix
@@ -123,6 +123,22 @@ in
           hashicorp.terraform
 
           # Claude Code
+          # === Change Intent Record ===
+          # VSCode 확장 anthropic.claude-code 유지 결정 (2026-03-12)
+          #
+          # 검토 배경: CLI auto-updater(~/.local/bin/claude)와 Nix 패키지(확장 의존성)로
+          #   업데이트 채널이 이중화됨. 확장 제거하여 Nix 채널 제거를 검토.
+          #
+          # 거부 이유: 다음 2개 기능이 확장의 WebSocket MCP 서버에 의존함을 확인:
+          #   1) Cmd+Opt+K 단축키 — 에디터 선택 영역을 @mention으로 Claude 프롬프트에 삽입
+          #      (확장 package.json의 keybindings에 등록, CLI에는 이 기능 없음)
+          #   2) ide - getDiagnostics (MCP) — 확장이 WebSocket MCP 서버를 띄우고
+          #      ~/.claude/ide/<port>.lock 파일로 CLI와 연결. CLI는 MCP 클라이언트일 뿐,
+          #      vscode.languages.getDiagnostics() API는 확장 호스트에서만 호출 가능.
+          #
+          # trade-off: nrs 시 nixpkgs 경유로 claude-code Nix 패키지도 갱신되어
+          #   업데이트 채널이 이중화되나, Nix 쪽은 DISABLE_AUTOUPDATER=1로 격리되어
+          #   터미널 CLI(auto-updater)와 충돌하지 않음. 실질적 부작용 없음.
           anthropic.claude-code
         ])
 

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -18,6 +18,9 @@ let
 in
 {
   # Binary Claude Code 설치 (Node.js 버전 의존성 없음)
+  # CIR: curl install.sh 방식 유지 — Nix 패키지(VSCode 확장 의존성)와 별개 채널이지만,
+  #   auto-updater가 터미널 CLI를 항상 최신으로 유지하므로 이 방식이 최적.
+  #   VSCode 확장 쪽 Nix 패키지는 DISABLE_AUTOUPDATER=1로 격리됨 (vscode/default.nix CIR 참조)
   home.activation.installClaudeCode = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     if [ ! -f "$HOME/.local/bin/claude" ]; then
       echo "Installing Claude Code binary..."


### PR DESCRIPTION
## 배경: 업데이트 채널 이중화 발견

<img width="2352" height="397" alt="Pasted Graphic 14" src="https://github.com/user-attachments/assets/a5c2ffef-7b0d-4953-a178-cd055bdc8f07" />

nixos-config이 Claude Code를 선언적으로 관리하는 방식을 조사하던 중, **업데이트 채널이 2개** 공존하고 있음을 발견했다:

| 채널 | 바이너리 위치 | 업데이트 방식 | 사용처 |
|------|-------------|-------------|--------|
| **CLI auto-updater** | `~/.local/bin/claude` → `~/.local/share/claude/versions/` | 실행 시 자동 감지, 재시작 시 적용 | 터미널 CLI |
| **Nix 패키지** (nixpkgs) | `/nix/store/.../claude-code-<ver>/bin/claude` | `nrs` 실행 시 nixpkgs 업데이트와 함께 | VSCode 확장 의존성 |

`nrs` 출력에서 `claude-code 2.1.66 → 2.1.70` 같은 Nix 패키지 업데이트가 보이는 이유는, `vscode/default.nix`에서 설치하는 VSCode 확장 `anthropic.claude-code`가 **런타임 의존성으로 `claude-code` CLI Nix 패키지를 끌고 오기 때문**이었다.

Nix 래퍼를 확인한 결과, 이 Nix 패키지는 `DISABLE_AUTOUPDATER=1`로 auto-updater를 비활성화하여 터미널 CLI와는 격리되어 있었다.

## 질문: VSCode 확장을 제거해도 되는가?

터미널 CLI만 사용하고 VSCode의 Claude Code 패널(채팅 UI)은 사용하지 않으므로, 확장을 제거하면 Nix 채널을 없앨 수 있다. 단, 아래 2개 기능이 확장에 의존하는지 확인이 필요했다:

1. **`Cmd+Opt+K` 단축키** — VSCode에서 선택한 코드를 Claude Code 터미널 프롬프트에 @mention으로 삽입
2. **`ide - getDiagnostics` (MCP)** — Claude Code가 VSCode의 LSP 진단(타입 에러, 린트 경고 등)을 조회

## 조사 결과: 두 기능 모두 확장 필수

5개 Opus 에이전트를 병렬로 실행하여 공식 문서, GitHub 이슈, 확장 `package.json`, Nix store 바이너리를 교차 검증했다.

### 1. Cmd+Opt+K 단축키

- 확장의 `package.json`의 `contributes.keybindings`에 등록된 VSCode 커맨드 `claude-code.insertAtMentioned`
- CLI의 keybinding 시스템(`~/.claude/keybindings.json`)에는 이 기능이 존재하지 않음
- 확장 제거 시 → **단축키 사라짐**

### 2. ide - getDiagnostics (MCP)

클라이언트-서버 아키텍처:

- 확장이 WebSocket MCP 서버를 띄우고, `~/.claude/ide/<port>.lock` 파일로 CLI에 연결 정보를 알림
- CLI는 MCP **클라이언트**일 뿐, `vscode.languages.getDiagnostics()` API는 VSCode 확장 호스트에서만 호출 가능
- 확장 제거 시 → lock 파일 없음 → 서버 없음 → **getDiagnostics 완전히 사라짐**

### 결론: 확장 유지

두 기능 모두 VSCode 확장의 WebSocket MCP 서버에 의존하므로, 업데이트 이중 채널을 감수하고 확장을 유지한다.

## 이 PR의 변경 내용

코드 변경 없이, 위 의사결정을 **CIR (Change Intent Record)** 형식의 인라인 주석으로 기록:

| 파일 | CIR 유형 | 내용 |
|------|----------|------|
| `modules/darwin/programs/vscode/default.nix` | 블록 CIR (16줄) | `anthropic.claude-code` 선언부에 유지 결정 근거 |
| `modules/shared/programs/claude/default.nix` | 한줄 CIR (3줄) | `installClaudeCode` 근처에 curl install.sh 방식 유지 근거 |

이 기록은 미래에 "VSCode 확장 왜 있지? 제거해도 되나?"라는 질문이 나왔을 때 동일한 조사를 반복하지 않도록 의사결정 맥락을 보존한다.

## Change Intent Record
- v1 (이번): VSCode 확장 제거로 Nix 업데이트 채널 제거 검토
  → Cmd+Opt+K(@mention 삽입)와 getDiagnostics(LSP 진단)가 확장의 WebSocket MCP 서버에 의존함을 확인하여 거부

trade-off: nrs 시 nixpkgs 경유로 claude-code Nix 패키지도 갱신되어 이중 채널이지만, Nix 쪽은 DISABLE_AUTOUPDATER=1로 격리되어 실질적 충돌 없음.

## Test plan
- [x] `nix flake check` 통과 (pre-push hook에서 검증됨)
- [x] 기존 `nrs` 빌드에 영향 없음 (주석만 추가)
