### PR TITLE
fix(hammerspoon): 한글 입력소스 Claude Code 단축키 처리 개선

### DIFF
--- a/modules/darwin/programs/hammerspoon/files/init.lua
+++ b/modules/darwin/programs/hammerspoon/files/init.lua
@@ -52,8 +52,10 @@ local function convertToEngAndSendKey(bind, mods, key, restore)
     local currentInput = hs.keycodes.currentSourceID()
     local needSwitch = currentInput ~= inputEnglish
 
-    if restore and needSwitch then
-        savedInputSource = currentInput
+    if restore then
+        if needSwitch then
+            savedInputSource = currentInput
+        end
         local app = hs.application.frontmostApplication()
         restoreAppBundleID = app and app:bundleID()
     end


### PR DESCRIPTION
Closes #206

## 문제 (Problem)

Ghostty에서 입력소스가 한글일 때 Claude Code의 Ctrl 단축키가 동작하지 않는다.

**근본 원인**: Claude Code 2.1.0+의 CSI u (enhanced keyboard) 모드에서 한글 입력소스가 활성화되면, macOS 입력기가 Ctrl 키 이벤트를 가로채서 Ghostty에 전달하지 않는다.

**기존 해결책** (commit `667c7fa`): Hammerspoon이 시스템 레벨에서 키를 가로채 영어로 전환 후 키를 전달한다. 8개 키(C/U/K/W/A/E/L/F)만 처리.

**기존 한계 3가지**:

1. **누락된 키**: Ctrl+S(stash)/V(이미지 붙여넣기)/Z(suspend)/D(세션 종료)/R(역검색)/G(외부 에디터)/O(verbose)/T(태스크)/Y(kill ring) 총 9개가 처리 목록에 없음
2. **입력소스 미복원**: 영어로 전환 후 원래 입력소스(한글)로 복원하지 않아, 단축키 사용 후 매번 Caps Lock으로 수동 전환 필요
3. **체감 지연**: `hs.eventtap.keyStroke()` 기본 200ms 딜레이가 단축키 반응에 체감될 수 있음

## 구현 (Implementation)

**수정 대상**: `modules/darwin/programs/hammerspoon/files/init.lua` (단일 파일)

### 1. ghosttyCtrlKeys 배열 확장

```lua
-- Before:
local ghosttyCtrlKeys = {'c', 'u', 'k', 'w', 'a', 'e', 'l', 'f'}
-- After:
local ghosttyCtrlKeys = {'c', 'u', 'k', 'w', 'a', 'e', 'l', 'f', 's', 'v', 'z', 'd', 'r', 'g', 'o', 't', 'y'}
```

| 추가된 키 | Claude Code 기능 |
|-----------|-----------------|
| Ctrl+S | 프롬프트 stash |
| Ctrl+V | 이미지 붙여넣기 |
| Ctrl+Z | SIGTSTP/suspend |
| Ctrl+D | 세션 종료 |
| Ctrl+R | 히스토리 역검색 |
| Ctrl+G | 외부 에디터 |
| Ctrl+O | verbose 토글 |
| Ctrl+T | 태스크 목록 토글 |
| Ctrl+Y | kill ring 붙여넣기 |

### 2. 입력소스 자동 복원 (디바운스)

`convertToEngAndSendKey` 함수에 `restore` 파라미터를 추가하여, 영어 전환 후 100ms 디바운스 타이머로 원래 입력소스를 자동 복원한다.

```
한글 활성 → Ctrl+F → 영어 전환 → 키 전달 → 100ms 후 → 한글 복원
한글 활성 → Ctrl+F → Ctrl+F → Ctrl+F (연타) → 마지막 키 100ms 후 → 한글 복원 (1회)
```

### 3. 복원 안전장치 (이중 가드)

복원 타이머가 fire될 때 두 가지 조건을 확인한다:

- **수동 전환 감지**: `currentSourceID() == inputEnglish` — 사용자가 Caps Lock 등으로 수동 전환했으면 복원하지 않음
- **앱 전환 감지**: `currentBundleID == restoreAppBundleID` — 다른 앱으로 전환했으면 복원하지 않음

### 4. sticky-English 핸들러와의 호환

Ctrl+;(영어 고정), Ctrl+B(tmux prefix), Cmd+Shift+Space(Homerow)는 의도적으로 영어를 유지해야 하므로, 이 핸들러들에서 `cancelRestore()`를 호출하여 pending 복원 타이머를 무효화한다.

### 5. key repeat 보존

`hs.hotkey.bind`에 `repeatfn`을 추가하여 비-Ghostty 앱에서 키를 누르고 있을 때 네이티브 key repeat 동작을 유지한다. (DA 1차 피드백으로 추가)

### 6. keystroke 딜레이 단축

`hs.eventtap.keyStroke` 딜레이를 200ms → 10ms(`KEYSTROKE_DELAY = 10000`)로 대폭 단축.

## Change Intent Record (CIR)

### 설계 결정

| 항목 | 결정 | 근거 |
|------|------|------|
| 복원 방식 | 100ms 디바운스 타이머 | 연타 시 마지막 키 기준으로 1회만 복원. 각 키마다 즉시 복원하면 한글↔영어 깜빡임 발생 |
| 글로벌 상태 | 바인딩별 상태 불필요 | 입력소스는 시스템 전역이므로 `savedInputSource` 하나로 충분 |
| `restore` 기본값 | `nil` (falsy) | 기존 호출자(Ctrl+;, Ctrl+B)는 복원 불필요 → 하위 호환성 유지 |
| `needSwitch` 가드 | 연타 시 `savedInputSource` 갱신 방지 | 이미 영어이면(`needSwitch=false`) 최초 저장한 한글 소스ID 유지 |
| `restoreAppBundleID` 갱신 | `restore=true`면 항상 갱신 | `needSwitch`와 무관하게 현재 앱 bundleID를 추적해야 크로스앱 연타 시 정확한 가드 수행 (DA 3차 피드백) |
| `cancelRestore()` | sticky-English 핸들러에서 호출 | Ctrl+F → Ctrl+B 시나리오에서 tmux prefix 후 한글로 복원되면 안 됨 |
| `KEYSTROKE_DELAY` | 10000 (10ms) | hs.eventtap.keyStroke의 delay 파라미터는 마이크로초 단위. 200ms(기본)→10ms로 체감 지연 해소 |
| `repeatfn` 추가 | pressedfn과 동일 함수 전달 | 비-Ghostty 앱에서 Ctrl+V(페이지다운) 등 long-press 시 네이티브 repeat 보존 (DA 1차 피드백) |
| 복원 전 앱 가드 | `bundleID` 비교 | Ghostty에서 Ctrl+F → Cmd+Tab(앱전환) → 타이머 fire 시, 다른 앱의 입력소스를 건드리지 않음 |

### 변경하지 않는 것

| 항목 | 이유 |
|------|------|
| VSCode 대응 | Ghostty만 CSI u 모드 문제가 있음. VSCode는 별도 입력 처리 경로 사용 |
| Escape/Tab 추가 | 한글 조합 중 동작과 충돌 위험. 별도 이슈로 분리 필요 |

### 연타 시나리오 추적

| 시나리오 | 기대 동작 | 메커니즘 |
|----------|----------|---------|
| Alt+F × 3 (한글) | 마지막 키 100ms 후 한글 복원 | 첫번째: savedInputSource=한글, 타이머 시작. 두번째: needSwitch=false → 갱신 안 함(한글 유지), 타이머 리셋. 세번째: 동일. 100ms 후 복원 |
| Ctrl+F → Ctrl+B (한글) | tmux prefix 후 영어 유지 | Ctrl+B에서 `cancelRestore()` → 타이머 취소, savedInputSource=nil |
| Ctrl+F → Caps Lock (한글) | 수동 전환 존중 | 타이머 fire 시 `currentSourceID() ≠ English` → 복원 스킵 |
| Ctrl+F → Ctrl+; (한글) | 영어 유지 | Ctrl+;에서 `cancelRestore()` → 타이머 취소 |
| Ctrl+F → 앱 전환 (한글) | 복원 안 함 | 타이머 fire 시 `currentBundleID ≠ restoreAppBundleID` → 복원 스킵 |
| 이미 영어 → Ctrl+K | 전환/복원 모두 안 함 | needSwitch=false → 저장 안 함 → 타이머 시작 안 함 |
| Terminal Alt+F → Ghostty Ctrl+F (크로스앱 연타) | Ghostty에서 한글 복원 | restoreAppBundleID가 Ghostty로 갱신 → 가드 통과 → 복원 (DA 3차 피드백으로 수정) |

## DA (Devil's Advocate) 피드백 루프

4라운드 수행. 유효한 피드백 2건 선별 반영, 3건 기각.

### 1차 DA

| 지적 | 심각도 | 판정 | 조치 |
|------|--------|------|------|
| 비-Ghostty 앱에서 새 키(S/V/Z/D 등) key repeat 소실 | P2 | **수용** | `hs.hotkey.bind`에 `repeatfn` 추가 — `handler` 함수를 pressedfn과 repeatfn에 동시 전달 |
| 100ms 내 수동 입력소스 전환 시 복원이 이를 덮어씀 | P3 | **기각** | Caps Lock/F18 토글 시 `currentSourceID()`가 한글로 변경되므로 `== inputEnglish` 가드에 의해 복원 자동 스킵. DA의 "currentSourceID()가 여전히 ABC" 주장은 사실과 다름 |

### 2차 DA

| 지적 | 심각도 | 판정 | 조치 |
|------|--------|------|------|
| Ctrl+R/S/V 등 modal 단축키에서 100ms 후 한글 복원이 검색 입력 방해 | P2 | **기각** | 이전에는 한글에서 Ctrl+R 자체가 동작하지 않았으므로 엄격히 개선. 복원 안 하면 검색 완료 후 매번 수동 한글 전환 필요 → 더 나쁨. DA가 Ctrl+V를 "quoted insert"(터미널)로 해석했지만 Claude Code에서는 "이미지 붙여넣기"(one-shot) |
| Ctrl+D/Z/V 등 destructive key에 repeatfn 위험 | P2 | **기각** | 1차 DA에서 repeatfn 없음을 P2로 지적 → 상충. 네이티브 OS key repeat과 동일 동작. Ghostty+한글 경로는 이전에 아예 동작하지 않아 회귀 대상 없음 |

### 3차 DA

| 지적 | 심각도 | 판정 | 조치 |
|------|--------|------|------|
| `needSwitch=false`일 때 `restoreAppBundleID` 미갱신 → 크로스앱 연타 시 stale bundleID로 가드 | P2 | **수용** | `restore=true`면 `needSwitch`와 무관하게 항상 `restoreAppBundleID` 갱신. `savedInputSource`만 `needSwitch` 조건부 유지 |

### 4차 DA

> "I did not find a discrete regression. The new restore/debounce behavior appears internally consistent, and the file remains syntactically valid."

**LGTM** — 추가 지적 없음.

## Human Test 방법

`nrs` 실행 후 Ghostty에서 다음을 수행합니다:

### 사전 조건
- 입력소스를 **한글**로 전환 (Caps Lock)
- Ghostty에서 Claude Code 실행 (`claude`)

### 테스트 항목

| # | 테스트 | 기대 결과 | 통과 기준 |
|---|--------|----------|----------|
| 1 | 한글에서 Ctrl+S 입력 | Claude Code stash 동작 | 키가 먹히고, ~100ms 후 입력소스가 한글로 복원됨 |
| 2 | 한글에서 Ctrl+V 입력 | 이미지 붙여넣기 프롬프트 | 동일 |
| 3 | 한글에서 Ctrl+Z 입력 | Claude Code suspend | suspend 후 한글 복원. `fg`로 복귀 가능 |
| 4 | 한글에서 Ctrl+D 입력 | 세션 종료 | 정상 종료 |
| 5 | 한글에서 Ctrl+R/G/O/T/Y | 각 기능 동작 | 키가 먹히고 한글 복원 |
| 6 | 한글에서 Ctrl+C/U/K/W/A/E/L/F | 기존 키 동작 | 기존 동작 유지 + 한글 복원 (신규) |
| 7 | 한글에서 Alt+F 3회 연타 | 커서 3단어 이동 | 마지막 키 ~100ms 후 한글 1회 복원 |
| 8 | 한글에서 Ctrl+F → Ctrl+; | Ctrl+; 후 영어 유지 | 복원 타이머가 취소되어 영어 유지 |
| 9 | 한글에서 Ctrl+F → Ctrl+B | tmux prefix 후 영어 유지 | 복원 타이머가 취소되어 영어 유지 |
| 10 | **영어**에서 Ctrl+S | 정상 동작 | 전환/복원 없이 즉시 동작 |
| 11 | **Safari**에서 Ctrl+S | 저장 다이얼로그 | 네이티브 동작 유지 |
| 12 | **Safari**에서 Ctrl+V 길게 누르기 | 연속 붙여넣기 | key repeat 동작 (repeatfn 검증) |
| 13 | 딜레이 체감 | 기존 대비 빠름 | 200ms→10ms 차이 체감 |

### 빠른 검증 (3분)
1. Ghostty에서 한글 → `Ctrl+L` (화면 지움 + 한글 복원 확인)
2. Ghostty에서 한글 → `Ctrl+S` (stash 동작 확인)
3. Safari에서 `Ctrl+V` 길게 누르기 (repeat 확인)
4. Ghostty에서 한글 → `Ctrl+F` → `Ctrl+;` (영어 유지 확인)