### PR TITLE
feat(shell): recall resume 시 RECALL_CLAUDE_CMD로 권한 우회 모드 활성화

### DIFF
--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -43,6 +43,12 @@ in
     "$HOME/.local/bin"
   ];
 
+  # recall resume 시 dangerously-skip-permissions 활성화
+  # shell alias 'c'와 동일 플래그 — recall은 exec()로 직접 실행하므로 alias 무시됨
+  home.sessionVariables = {
+    RECALL_CLAUDE_CMD = "claude --dangerously-skip-permissions --mcp-config $HOME/.claude/mcp.json --resume {id}";
+  };
+
   # Shell aliases (공통)
   home.shellAliases = {
     # 파일 목록 (eza 사용)


### PR DESCRIPTION
## Summary

[recall](https://github.com/zippoxer/recall) TUI에서 Claude Code 세션을 resume할 때 `--dangerously-skip-permissions`가 적용되지 않는 문제를 `RECALL_CLAUDE_CMD` 환경변수 설정으로 해결한다.

## Background: recall이란?

[recall](https://github.com/zippoxer/recall)은 Claude Code, Codex CLI, Factory(Droid), OpenCode 등 AI 코딩 도구의 대화 세션 기록을 **전문 검색(full-text search)하고 resume할 수 있는 Rust TUI 도구**다.

- `~/.claude/projects/**/*.jsonl` 등 세션 파일을 [Tantivy](https://github.com/quickwit-oss/tantivy) 인덱스에 색인
- BM25 + phrase boost + recency decay 랭킹으로 세션 검색
- Enter 키로 선택한 세션을 즉시 resume (해당 CLI 도구를 `exec()` 시스템콜로 실행)

## 문제

recall TUI에서 Claude Code 세션을 선택하여 Enter로 resume하면, **`--dangerously-skip-permissions` 플래그 없이** 세션이 복귀된다.

Shell alias `c`에는 이 플래그가 포함되어 있지만:
```nix
c = "claude --dangerously-skip-permissions --mcp-config ~/.claude/mcp.json";
```

recall로 resume하면 매번 권한 확인 프롬프트가 뜨고, 기존 작업 흐름이 끊긴다. Claude Code는 **세션 내부에서 이 플래그를 활성화하는 방법을 제공하지 않으므로**, 실행 시점에 플래그를 주입하는 것이 유일한 방법이다.

## 원인 분석

두 가지 요인이 결합된 문제:

### 1. recall의 기본 resume 커맨드에 플래그 없음

recall 소스코드 [`session.rs`](https://github.com/zippoxer/recall/blob/main/src/session.rs)에서 Claude Code 세션의 기본 resume 커맨드는:
```rust
SessionSource::ClaudeCode => (
    "claude".to_string(),
    vec!["--resume".to_string(), self.id.clone()],
),
```
→ 단순히 `claude --resume {session_id}`만 실행. 사용자 커스텀 플래그는 포함되지 않음.

### 2. Shell alias는 `exec()` 시스템콜에서 무시됨

recall은 세션 resume 시 [`main.rs`](https://github.com/zippoxer/recall/blob/main/src/main.rs)에서 `exec()` 시스템콜을 직접 호출한다:
```rust
let err = std::process::Command::new(&program).args(&args).exec();
```
이것은 **shell을 거치지 않고 바이너리를 직접 실행**한다. Shell alias(`alias c='claude --dangerously-skip-permissions ...'`)는 bash/zsh의 기능이지, OS 레벨의 개념이 아니므로:
- alias를 `c`에서 `claude`로 변경해도 동일하게 무시됨
- shell function으로 정의해도 동일하게 무시됨
- `exec()` → `execvp()` 시스템콜은 `$PATH`에서 바이너리를 찾아 직접 실행

## 해결

recall은 이 사용 사례를 위해 [`RECALL_CLAUDE_CMD` 환경변수](https://github.com/zippoxer/recall/blob/main/src/session.rs)를 지원한다:

```rust
fn resume_command(&self) -> (String, Vec<String>) {
    let env_var = match self.source {
        SessionSource::ClaudeCode => "RECALL_CLAUDE_CMD",
        // ...
    };
    if let Ok(cmd) = std::env::var(env_var) {
        let cmd = cmd.replace("{id}", &self.id);
        let parts: Vec<&str> = cmd.split_whitespace().collect();
        // ...
    }
}
```

환경변수 값에서 `{id}`를 실제 세션 ID로 치환한 뒤, `split_whitespace()`로 파싱하여 실행한다.

### 변경 내용

`modules/shared/programs/shell/default.nix`에 `home.sessionVariables` 추가:
```nix
home.sessionVariables = {
  RECALL_CLAUDE_CMD = "claude --dangerously-skip-permissions --mcp-config $HOME/.claude/mcp.json --resume {id}";
};
```

### 설계 결정

| 결정 | 이유 |
|------|------|
| `$HOME` 사용 (`~` 대신) | 환경변수 설정 시 tilde expansion이 보장되지 않음. 기존 `darwin.nix`의 `ICLOUD = "$HOME/Library/..."` 패턴과 일관 |
| `{id}` 리터럴 보존 | Nix는 `${...}`만 interpolation, shell도 `{id}`를 변수로 해석하지 않음 → 리터럴로 보존되어 recall이 치환 |
| `default.nix`(공통)에 배치 | macOS/NixOS 양쪽 모두 recall 사용 가능. Home Manager `sessionVariables`는 attribute-set 옵션이므로 `darwin.nix`/`nixos.nix`의 기존 변수와 충돌 없이 머지 |

## References

- [recall GitHub 레포](https://github.com/zippoxer/recall) — v0.5.0
- [recall `session.rs` — `RECALL_CLAUDE_CMD` 처리](https://github.com/zippoxer/recall/blob/main/src/session.rs) — `resume_command()` 함수
- [recall `main.rs` — `exec()` 시스템콜](https://github.com/zippoxer/recall/blob/main/src/main.rs) — resume 실행 경로
- [Home Manager `sessionVariables` 옵션](https://nix-community.github.io/home-manager/options.xhtml#opt-home.sessionVariables) — attribute-set 머지 동작
- [Claude Code `--dangerously-skip-permissions` 문서](https://docs.anthropic.com/en/docs/claude-code/security#understanding---dangerously-skip-permissions) — 실행 시점 플래그 필수

## Test plan

- [ ] `nrs` 빌드 성공 (macOS)
- [ ] 새 shell 세션에서 `echo $RECALL_CLAUDE_CMD` → `claude --dangerously-skip-permissions --mcp-config /Users/green/.claude/mcp.json --resume {id}` 출력 확인
- [ ] recall TUI에서 임의 세션 선택 후 Enter → 권한 우회 모드로 복귀 확인

Closes #218