### PR TITLE
fix(claude): statusline plan 감지 — 세션 무관 오표시 버그 수정

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -15,7 +15,7 @@ if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
   # agent_progress 이벤트 제외 (subagent가 다른 세션 plan을 읽은 기록 필터링)
   # agent plan 파일명(-agent-) 제외
   PLAN_FILE=$(grep -v '"type":"agent_progress"' "$TRANSCRIPT" 2>/dev/null \
-    | grep -oE '"(filePath|file_path)":"[^"]*\.claude/plans/[^"]*\.md"' \
+    | grep -oE '"(filePath|file_path|planFilePath)":"[^"]*\.claude/plans/[^"]*\.md"' \
     | grep -v 'plans/[^"]*-agent-' \
     | tail -1 | sed 's/^"[^"]*":"//;s/"$//')
 fi


### PR DESCRIPTION
## Summary

- PR #215 에서 도입된 statusline plan 표시 기능의 **세션 무관 오표시 버그** 수정
- 새 worktree 세션(plan 미사용)에서도 다른 세션의 plan 파일이 statusbar에 표시되는 문제
- `cwd` 기반 `ls -t` → `transcript_path` 기반 `grep` 방식으로 전환하여 세션별 정확 감지

## Root Cause

`ls -t .claude/plans/*.md | head -1`은 세션과 무관하게 가장 최근 수정된 plan 파일을 반환. Worktree fallback도 main repo의 plans 디렉토리에서 동일한 문제 발생.

## Fix

Claude Code JSON stdin의 `transcript_path` 필드를 활용하여 현재 세션의 transcript JSONL에서 plan 파일 Read/Write 기록만 감지:
- `agent_progress` 이벤트 필터링 (subagent foreign plan 제외)
- Agent plan 파일명 필터를 `plans/` 이후 범위로 한정
- `planFilePath` 키도 매칭에 포함

## DA Review (6 rounds)

| Round | 피드백 | 조치 |
|-------|--------|------|
| R1 | agent plan 파일이 parent transcript에 포함 | `-agent-` 필터 추가 |
| R2 | `agent_progress` 이벤트의 foreign plan | `grep -v agent_progress` 추가 |
| R3 | 직접 foreign plan 읽기 | 0건 재현 → YAGNI 기각 |
| R4-P2 | transcript text false positive | JSONL escaped quotes → 불가능, 기각 |
| R4-P3 | `-agent-` 경로 범위 | `plans/` 이후로 한정 |
| R5 | `planFilePath` 키 누락 | 패턴에 추가 |
| R6 | **전부 OK** | - |

## Test plan

- [x] plan 없는 새 세션: 빈 출력
- [x] plan 있는 세션: 정확한 parent plan
- [x] agent plan이 있는 4개 세션: parent plan만 선택
- [x] subagent foreign plan 세션: agent_progress 필터로 제거
- [x] 전체 transcript slug-plan 매칭: 0건 불일치
- [x] 9MB transcript 성능: 12ms
- [x] shellcheck/gitleaks/eval-tests 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan file detection by switching from directory search to transcript-based extraction, ensuring more reliable plan file references and excluding agent-related paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->