### PR TITLE
fix(nrs): worktree mkOutOfStoreSymlink silent removal 방지 가드

### DIFF
--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -130,6 +130,7 @@ main() {
         fi
         return 0
     fi
+    worktree_symlink_guard
     preflight_cask_conflict_check
     cleanup_launchd_agents
     run_darwin_rebuild

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -55,6 +55,7 @@ main() {
         log_info "✅ No changes to apply. Skipping rebuild."
         return 0
     fi
+    worktree_symlink_guard
     run_nixos_rebuild
     cleanup_build_artifacts
 

--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -8,10 +8,11 @@
 # 제공 함수:
 #   parse_args, log_info, log_warn, log_error,
 #   preflight_source_build_check, preflight_cask_conflict_check,
-#   preview_changes, cleanup_build_artifacts
+#   worktree_symlink_guard, preview_changes, cleanup_build_artifacts
 #
 # 출력 변수:
 #   NO_CHANGES - preview_changes() 실행 후 true/false (store 경로 비교)
+#   MAIN_FLAKE_PATH - detect_worktree 전 경로 보존 (worktree 여부 판별용)
 #   FORCE_FLAG - --force 전달 시 true
 #   CORES_FLAG - --cores N 전달 시 "--cores N"
 #   UNINSTALLED_CASKS - preflight_cask_conflict_check에서 제거한 cask 목록 (복구용)
@@ -23,6 +24,7 @@ if [[ -z "${REBUILD_CMD:-}" ]]; then
 fi
 
 FLAKE_PATH="@flakePath@"
+MAIN_FLAKE_PATH="$FLAKE_PATH"   # detect_worktree 전 경로 보존 (worktree 여부 판별용)
 # shellcheck disable=SC2034  # NO_CHANGES는 source한 nrs.sh에서 사용
 NO_CHANGES=false
 # shellcheck disable=SC2034  # UNINSTALLED_CASKS는 nrs.sh의 run_darwin_rebuild에서 참조
@@ -60,6 +62,140 @@ detect_worktree() {
 }
 
 detect_worktree
+
+#───────────────────────────────────────────────────────────────────────────────
+# mkOutOfStoreSymlink 엔트리 추출 (awk 단일 파서, 매치 없어도 항상 exit 0)
+# 사용: extract_oos_entries "main:path/to.nix"  (git show)
+#       extract_oos_entries "/abs/path/to.nix"   (파일시스템)
+# DA Fix #1: grep|grep 파이프라인은 매치 없을 때 exit 1 → set -euo pipefail 하에서 nrs abort.
+#            awk 단일 파서로 전환하여 항상 exit 0 보장.
+# DA Fix R2-2: .mkOutOfStoreSymlink 패턴으로 문자열 리터럴 내 오탐 방지 + trailing comment strip.
+#───────────────────────────────────────────────────────────────────────────────
+extract_oos_entries() {
+    local source="$1"
+    local content
+
+    if [[ "$source" == *:* ]]; then
+        content=$(git -C "$FLAKE_PATH" show "$source" 2>/dev/null) || return 0
+    else
+        [[ -f "$source" ]] || return 0
+        content=$(cat "$source") || return 0
+    fi
+
+    printf '%s\n' "$content" | awk '
+        /^[[:space:]]*#/ { next }
+        /\.mkOutOfStoreSymlink[[:space:]]/ {
+            sub(/;[[:space:]]*#.*$/, "")
+            sub(/.*\.mkOutOfStoreSymlink[[:space:]]*/, "")
+            sub(/;[[:space:]]*$/, "")
+            if ($0 != "") print
+        }
+    ' | sort -u
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# Worktree symlink guard: worktree nrs 실행 시 main과의 mkOutOfStoreSymlink
+# 엔트리 불일치를 사전 감지하고 차단
+# - main에 추가된 엔트리가 worktree에 없으면 Home Manager가 해당 symlink을 삭제
+# - --force로 우회 가능
+#───────────────────────────────────────────────────────────────────────────────
+worktree_symlink_guard() {
+    [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]] && return 0
+
+    log_info "🔍 Checking mkOutOfStoreSymlink consistency with main..."
+
+    local merge_base
+    merge_base=$(git -C "$FLAKE_PATH" merge-base HEAD main 2>/dev/null) || {
+        log_warn "⚠️  symlink guard: cannot find merge-base with main. Skipping."
+        return 0
+    }
+
+    local changed_nix_files
+    changed_nix_files=$(git -C "$FLAKE_PATH" diff --name-only "$merge_base" main -- '*.nix' 2>/dev/null) || {
+        log_warn "⚠️  symlink guard: git diff failed. Skipping."
+        return 0
+    }
+    [[ -z "$changed_nix_files" ]] && { log_info "  ✓ No mkOutOfStoreSymlink drift."; return 0; }
+
+    # DA R1 Fix: 플랫폼별 경로 필터 — darwin nrs가 nixos-only 파일에 차단되지 않도록
+    local platform_filter
+    case "$REBUILD_CMD" in
+        darwin-rebuild)  platform_filter='^(modules/darwin/|modules/shared/|libraries/)' ;;
+        nixos-rebuild)   platform_filter='^(modules/nixos/|modules/shared/|libraries/)' ;;
+        *)               platform_filter='.' ;;
+    esac
+    changed_nix_files=$(printf '%s\n' "$changed_nix_files" | grep -E "$platform_filter" || true)
+    [[ -z "$changed_nix_files" ]] && { log_info "  ✓ No mkOutOfStoreSymlink drift."; return 0; }
+
+    local all_missing="" missing_count=0
+
+    while IFS= read -r nix_file; do
+        [[ -z "$nix_file" ]] && continue
+        local main_entries base_entries
+        main_entries=$(extract_oos_entries "main:$nix_file")
+        [[ -z "$main_entries" ]] && continue
+
+        # 3-way 비교: merge-base 대비 main에서 진짜 새로 추가된 엔트리만 플래그
+        # (DA R4 Fix: worktree가 의도적으로 제거한 엔트리를 오탐하지 않도록)
+        base_entries=$(extract_oos_entries "$merge_base:$nix_file")
+        local new_on_main
+        if [[ -z "$base_entries" ]]; then
+            new_on_main="$main_entries"
+        elif ! new_on_main=$(comm -23 <(printf '%s\n' "$main_entries") <(printf '%s\n' "$base_entries")); then
+            new_on_main="$main_entries"
+        fi
+        [[ -z "$new_on_main" ]] && continue
+
+        # Known limitation: main에서 .nix 파일이 rename된 경우, 새 경로가 worktree에
+        # 없어 false positive 발생 가능. .nix 모듈 rename은 극히 드물고 --force로 우회 가능.
+        local wt_entries
+        if [[ ! -f "$FLAKE_PATH/$nix_file" ]]; then
+            wt_entries=""
+        else
+            wt_entries=$(extract_oos_entries "$FLAKE_PATH/$nix_file")
+        fi
+
+        # 빈 wt_entries 특수 처리: printf '%s\n' ""는 빈 줄 1개를 comm에 전달하여
+        # 실제 엔트리와 빈 문자열 간 오비교 발생. comm 실패 시 fail-closed (안전 우선).
+        local only_in_main
+        if [[ -z "$wt_entries" ]]; then
+            only_in_main="$new_on_main"
+        elif ! only_in_main=$(comm -23 <(printf '%s\n' "$new_on_main") <(printf '%s\n' "$wt_entries")); then
+            only_in_main="$new_on_main"
+        fi
+
+        if [[ -n "$only_in_main" ]]; then
+            while IFS= read -r entry; do
+                [[ -z "$entry" ]] && continue
+                all_missing+="    $nix_file → $entry"$'\n'
+                ((++missing_count))
+            done <<< "$only_in_main"
+        fi
+    done <<< "$changed_nix_files"
+
+    if [[ $missing_count -eq 0 ]]; then
+        log_info "  ✓ No mkOutOfStoreSymlink drift."
+        return 0
+    fi
+
+    if [[ "$FORCE_FLAG" == true ]]; then
+        log_warn "⚠️  $missing_count mkOutOfStoreSymlink entry(s) missing vs main (--force, proceeding):"
+        echo -n "$all_missing"
+        echo ""
+        return 0
+    fi
+
+    log_error "❌ Worktree would remove $missing_count mkOutOfStoreSymlink entry(s) from main:"
+    echo -n "$all_missing"
+    echo ""
+    echo "  These entries were added to main after this worktree branched."
+    echo "  Home Manager will silently remove these symlinks during switch."
+    echo ""
+    echo "  Fix:  git merge main    # incorporate main's changes"
+    echo "        git rebase main   # or rebase onto main"
+    echo "  Skip: nrs --force       # override (symlinks WILL be removed)"
+    exit 1
+}
 
 #───────────────────────────────────────────────────────────────────────────────
 # NRS Lock: worktree 간 동시 rebuild 방지를 위한 협조적 잠금


### PR DESCRIPTION
Closes #217

## 문제

worktree에서 `nrs`를 실행하면, **main에 머지된 다른 PR의 `mkOutOfStoreSymlink` 기반 `home.file` 엔트리가 silent하게 제거**된다.

### 재현 시나리오

1. main에서 worktree 생성 (`wt new feature-x`)
2. 다른 PR이 main에 머지되어 새 `mkOutOfStoreSymlink` 엔트리 추가 (예: `nrs-lock-guard.sh`)
3. worktree에서 `nrs` 실행
4. Home Manager가 worktree의 flake을 평가 → 분기 시점의 `default.nix` 사용 → 새 엔트리 없음
5. Home Manager가 profile을 **전체 교체** → 새 엔트리의 symlink이 **삭제됨**
6. 에러 메시지 없음, 경고 없음 — **완전히 silent**

### 실제 영향

| 피해 PR | 삭제된 것 | 결과 |
|---------|----------|------|
| [#213](https://github.com/greenheadHQ/nixos-config/pull/213) | `~/.claude/hooks/nrs-lock-guard.sh` | nrs lock 시스템 **전체 비활성화** — AI agent가 동시 rebuild 가능 |
| [#215](https://github.com/greenheadHQ/nixos-config/pull/215) | `~/.claude/scripts/statusline.sh` | Claude Code statusbar broken symlink |

### 근본 원인

```
nixosConfigPath (flake.nix)
  → 항상 메인 레포 경로 (/Users/green/Workspace/nixos-config)
  → mkOutOfStoreSymlink 타깃은 메인 레포 파일을 가리킴 (불변)

BUT: worktree의 default.nix는 분기 시점 스냅샷
  → 분기 이후 main에 추가된 home.file 엔트리가 없음
  → Home Manager가 해당 symlink을 "불필요"로 판단하고 삭제
```

**영향 범위**: `mkOutOfStoreSymlink` 기반 엔트리 21개 전체가 위험:
- Claude Code: settings.json, mcp.json, CLAUDE.md, hooks 4개, skills 5개, statusline.sh (13개)
- Codex: config.toml, AGENTS.md, skills 3개 (5개)
- VSCode: settings.json, keybindings.json (2개)
- Neovim: .config/nvim (1개)

## 해결

`rebuild-common.sh`에 `worktree_symlink_guard()` 함수를 추가하여, worktree `nrs` 실행 시 main과의 엔트리 불일치를 **사전 감지하고 차단**한다.

### 핵심 설계: 3-way merge-base 비교

```
merge-base (분기 시점)  ←→  main (현재)  ←→  worktree (작업중)

1. main에서 merge-base 대비 변경된 .nix 파일 식별
2. 플랫폼 필터 적용 (darwin nrs → modules/darwin/ + modules/shared/ 만)
3. 각 파일에서 mkOutOfStoreSymlink 엔트리 추출 (awk 단일 파서)
4. new_on_main = main_entries - base_entries  (진짜 새 엔트리)
5. missing = new_on_main - wt_entries  (worktree에 없는 새 엔트리)
6. missing > 0 → 차단 (--force로 우회 가능)
```

**왜 2-way가 아닌 3-way인가**: 단순 `main - worktree` 비교는 worktree가 **의도적으로 제거한** 엔트리도 오탐한다. merge-base를 기준으로 main에서 "진짜 새로 추가된" 엔트리만 감지해야 정확하다.

### 추가된 함수

#### `extract_oos_entries()`
```bash
# 사용:
#   extract_oos_entries "main:path/to.nix"     → git show로 읽기
#   extract_oos_entries "/abs/path/to.nix"      → 파일시스템에서 읽기
# 반환: sorted unique mkOutOfStoreSymlink 인수 목록
```
- awk 단일 파서 (grep 파이프라인 대신) → `set -euo pipefail` 하에서 매치 없어도 exit 0 보장
- `.mkOutOfStoreSymlink ` 패턴으로 함수 호출만 매칭 (주석/문자열 리터럴 제외)
- trailing comment (`; # ...`) 사전 제거

#### `worktree_symlink_guard()`
- `FLAKE_PATH == MAIN_FLAKE_PATH` → skip (메인 레포에서는 오버헤드 0)
- merge-base 실패 → graceful skip (경고만)
- 플랫폼 필터: `REBUILD_CMD` 기반으로 관련 경로만 스캔
- `NO_CHANGES` 체크 이후 실행 → 무변경 stale worktree는 차단하지 않음
- `--force` → 경고 출력 후 진행

### 호출 위치

두 `nrs.sh` 모두 `NO_CHANGES` early return **이후**, switch **이전**에 호출:

```
darwin nrs.sh:  preview_changes → NO_CHANGES check → worktree_symlink_guard → switch
nixos nrs.sh:   preview_changes → NO_CHANGES check → worktree_symlink_guard → switch
```

이 위치가 중요한 이유: `NO_CHANGES=true`이면 switch 자체가 안 되므로 symlink 삭제도 없다. guard가 preview 전에 있으면 무해한 stale worktree까지 차단하는 false positive 발생.

## 대안 분석 (기각 사유)

| 접근법 | 기각 사유 |
|--------|----------|
| rebase 강제 | 워크플로우 파괴 — worktree에서 WIP 작업 중 rebase 강제는 비현실적 |
| nixosConfigPath 오버라이드 | 전역 변수 의미 변경, worktree 삭제 시 고아 symlink, 아키텍처 변경 필요 |
| main 파일 복사 | main repo 오염, cleanup 불가, 의도치 않은 git diff |

## Known Limitations

| 항목 | 설명 | 수용 근거 |
|------|------|-----------|
| 텍스트 기반 파싱 | mkOutOfStoreSymlink 여러 줄에 걸치면 감지 실패 | 현재 코드베이스에서 모두 한 줄 패턴 |
| RHS 비교 | 같은 source + 다른 destination이면 drift 미감지 | 현재 RHS 값 모두 unique |
| .nix 파일 rename | main에서 rename 시 false positive | 극히 드문 이벤트, `--force` 우회 가능 |
| `main` 하드코딩 | 로컬 main이 stale하면 최근 변경 감지 불가 | graceful fallback (경고 후 skip) |
| Nix 변수 해석 불가 | `${claudeMcpFile}` 등 변수 값 변경 감지 불가 | 해당 변수들은 플랫폼 조건부이지 브랜치 간 변경 없음 |

## DA 피드백 루프 (6 rounds)

| Round | Reviewer | 발견 | 조치 |
|-------|----------|------|------|
| R1 | Codex (gpt-5.4) | darwin nrs가 nixos-only 파일에 차단됨 | 플랫폼별 경로 필터 추가 |
| R2 | Opus 4.6 | `cat` 에러 핸들링 불일관, `comm` 주석 부정확 | `\|\| return 0` 추가, 주석 정정 |
| R3 | Codex | RHS 비교 한계, 파일 rename false positive | accepted trade-off, 주석 문서화 |
| R4 | Codex | worktree 의도적 제거를 오탐 | 3-way merge-base 비교로 전환 |
| R5 | Codex | NO_CHANGES인 worktree까지 차단 | guard를 NO_CHANGES 체크 뒤로 이동 |
| R6 | Codex | primary checkout 토픽 브랜치, 변수 해석 | scope 밖 (worktree 한정), 이론적 |

## Human Test 가이드

### 사전 준비

```bash
# 1. main에서 fix/nrs-regression 머지 (또는 로컬에서 시뮬레이션)
git checkout main && git merge fix/nrs-regression

# 2. main에서 nrs 실행하여 기준 시스템 구성
nrs
```

### Test 1: main에서 nrs — guard skip 확인

```bash
git checkout main
nrs
# 예상: guard 로그 없음 (FLAKE_PATH == MAIN_FLAKE_PATH → skip)
# 확인: "Checking mkOutOfStoreSymlink" 메시지가 출력되지 않아야 함
```

### Test 2: stale worktree에서 nrs — 차단 확인

```bash
# stale worktree 생성 (main보다 이전 시점)
wt new test-guard

# worktree에서 main의 최신 엔트리를 하나 제거하여 drift 시뮬레이션
# (실제로는 main에 새 엔트리를 추가하고 worktree는 그대로 두면 됨)
# 시뮬레이션: main에서 새 mkOutOfStoreSymlink 추가
git checkout main
# modules/shared/programs/claude/default.nix에 테스트 엔트리 추가:
#   ".claude/test-guard".source = config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/test-guard";
git add -A && git commit -m "test: add dummy mkOutOfStoreSymlink entry"

# worktree로 돌아가서 nrs
cd .claude/worktrees/test-guard
nrs

# 예상 출력:
# ❌ Worktree would remove 1 mkOutOfStoreSymlink entry(s) from main:
#     modules/shared/programs/claude/default.nix → "${claudeFilesPath}/test-guard"
#
#   Fix:  git merge main
#         git rebase main
#   Skip: nrs --force
```

### Test 3: stale worktree에서 nrs --force — 경고 후 진행

```bash
cd .claude/worktrees/test-guard
nrs --force

# 예상: 경고 출력 후 정상 진행
# ⚠️  1 mkOutOfStoreSymlink entry(s) missing vs main (--force, proceeding):
#     modules/shared/programs/claude/default.nix → "${claudeFilesPath}/test-guard"
# 🔨 Applying changes...
```

### Test 4: up-to-date worktree에서 nrs — 통과 확인

```bash
cd .claude/worktrees/test-guard
git merge main  # main의 변경사항 반영

nrs
# 예상: guard 통과
# 🔍 Checking mkOutOfStoreSymlink consistency with main...
#   ✓ No mkOutOfStoreSymlink drift.
```

### Test 5: NO_CHANGES인 stale worktree — guard 실행 안 됨

```bash
# 이미 현재 시스템이 이 worktree에서 빌드된 상태라면:
nrs
# 예상: preview_changes에서 NO_CHANGES=true → early return
# guard 메시지 없이 "✅ No changes to apply." 출력
```

### 정리

```bash
# 테스트용 커밋 되돌리기
git checkout main
git reset --hard HEAD~1  # 테스트 엔트리 제거

# 테스트 worktree 삭제
wt rm test-guard
```

## 수정 파일

| 파일 | 변경 |
|------|------|
| `modules/shared/scripts/rebuild-common.sh` | `MAIN_FLAKE_PATH`, `extract_oos_entries()`, `worktree_symlink_guard()` 추가 (+138줄) |
| `modules/darwin/scripts/nrs.sh` | `worktree_symlink_guard` 호출 추가 (+1줄) |
| `modules/nixos/scripts/nrs.sh` | `worktree_symlink_guard` 호출 추가 (+1줄) |