### PR TITLE
fix(hammerspoon): 한글 입력소스 Ctrl/Alt 단축키 → 영어 전환만 수행 (PR #214 롤백)

### DIFF
--- a/modules/darwin/programs/hammerspoon/files/init.lua
+++ b/modules/darwin/programs/hammerspoon/files/init.lua
@@ -15,10 +15,6 @@ remapper:register()
 --------------------------------------------------------------------------------
 
 local inputEnglish = "com.apple.keylayout.ABC"
-local restoreTimer = nil
-local savedInputSource = nil
-local restoreAppBundleID = nil
-local KEYSTROKE_DELAY = 10000  -- 10ms (기본 200ms에서 단축, 체감 지연 해소)
 
 -- 앱 감지 헬퍼
 local terminalBundleIDs = {
@@ -38,99 +34,58 @@ local function isGhostty()
     return app and app:bundleID() == "com.mitchellh.ghostty"
 end
 
--- 복원 취소 헬퍼 (sticky-English 액션이 pending 복원 무효화)
-local function cancelRestore()
-    if restoreTimer then restoreTimer:stop() end
-    restoreTimer = nil
-    savedInputSource = nil
-    restoreAppBundleID = nil
-end
-
 -- 공통 함수: 영어로 전환 후 키 전달 (재귀 방지 포함)
--- restore=true: 키 입력 후 100ms 디바운스로 원래 입력소스 복원
-local function convertToEngAndSendKey(bind, mods, key, restore)
-    local currentInput = hs.keycodes.currentSourceID()
-    local needSwitch = currentInput ~= inputEnglish
-
-    if restore then
-        if needSwitch then
-            savedInputSource = currentInput
-        end
-        local app = hs.application.frontmostApplication()
-        restoreAppBundleID = app and app:bundleID()
-    end
-
-    if needSwitch then
+local function convertToEngAndSendKey(bind, mods, key)
+    if hs.keycodes.currentSourceID() ~= inputEnglish then
         hs.keycodes.currentSourceID(inputEnglish)
     end
-
     bind:disable()
-    hs.eventtap.keyStroke(mods, key, KEYSTROKE_DELAY)
+    hs.eventtap.keyStroke(mods, key)
     bind:enable()
-
-    if restore and savedInputSource then
-        if restoreTimer then restoreTimer:stop() end
-        restoreTimer = hs.timer.doAfter(0.1, function()
-            local app = hs.application.frontmostApplication()
-            local currentBundleID = app and app:bundleID()
-            if hs.keycodes.currentSourceID() == inputEnglish
-               and currentBundleID == restoreAppBundleID then
-                hs.keycodes.currentSourceID(savedInputSource)
-            end
-            savedInputSource = nil
-            restoreTimer = nil
-            restoreAppBundleID = nil
-        end)
-    end
 end
 
 -- Ctrl + ; → 영어 전환
 local control_semicolon_bind
 control_semicolon_bind = hs.hotkey.bind({'ctrl'}, ';', function()
-    cancelRestore()
     convertToEngAndSendKey(control_semicolon_bind, {'ctrl'}, ';')
 end)
 
 -- Cmd + Shift + Space → 영어 전환 후 Homerow 실행
 local command_shift_space_bind
 command_shift_space_bind = hs.hotkey.bind({'cmd', 'shift'}, 'space', function()
-    cancelRestore()
     if hs.keycodes.currentSourceID() ~= inputEnglish then
         hs.keycodes.currentSourceID(inputEnglish)
     end
-    hs.eventtap.keyStroke({'cmd', 'shift'}, 'space', KEYSTROKE_DELAY)
+    hs.eventtap.keyStroke({'cmd', 'shift'}, 'space')
     command_shift_space_bind:disable()
-    hs.eventtap.keyStroke({'cmd', 'shift'}, 'space', KEYSTROKE_DELAY)
+    hs.eventtap.keyStroke({'cmd', 'shift'}, 'space')
     command_shift_space_bind:enable()
 end)
 
 -- Ctrl + B → 영어 전환 후 tmux prefix 전달 (전역)
 local ctrl_b_bind
 ctrl_b_bind = hs.hotkey.bind({'ctrl'}, 'b', function()
-    cancelRestore()
     convertToEngAndSendKey(ctrl_b_bind, {'ctrl'}, 'b')
 end)
 
 --------------------------------------------------------------------------------
 -- Ghostty 전용: Ctrl 키 조합 (CSI u 모드 우회)
--- Claude Code에서 한글 입력소스일 때 Ctrl 단축키가 동작하지 않는 문제 해결
--- 영어 전환 후 키 전달, 100ms 디바운스로 원래 입력소스 복원
+-- Claude Code 2.1.0+ 에서 한글 입력소스일 때 Ctrl 단축키가 동작하지 않는 문제 해결
 --------------------------------------------------------------------------------
 
 local ghosttyCtrlKeys = {'c', 'u', 'k', 'w', 'a', 'e', 'l', 'f', 's', 'v', 'z', 'd', 'r', 'g', 'o', 't', 'y'}
 
 for _, key in ipairs(ghosttyCtrlKeys) do
     local bind
-    local function handler()
+    bind = hs.hotkey.bind({'ctrl'}, key, function()
         if isGhostty() then
-            convertToEngAndSendKey(bind, {'ctrl'}, key, true)
+            convertToEngAndSendKey(bind, {'ctrl'}, key)
         else
             bind:disable()
-            hs.eventtap.keyStroke({'ctrl'}, key, KEYSTROKE_DELAY)
+            hs.eventtap.keyStroke({'ctrl'}, key)
             bind:enable()
         end
-    end
-    bind = hs.hotkey.bind({'ctrl'}, key, handler, nil, handler)
+    end)
 end
 
 --------------------------------------------------------------------------------
@@ -138,20 +93,19 @@ end
 -- Opt+B/F (단어 이동)가 한글 입력소스에서 동작하지 않는 문제 해결
 --------------------------------------------------------------------------------
 
-local terminalOptKeys = {'b', 'f'}
+local terminalOptKeys = {'b', 'f', 'd'}
 
 for _, key in ipairs(terminalOptKeys) do
     local bind
-    local function handler()
+    bind = hs.hotkey.bind({'alt'}, key, function()
         if isTerminalApp() then
-            convertToEngAndSendKey(bind, {'alt'}, key, true)
+            convertToEngAndSendKey(bind, {'alt'}, key)
         else
             bind:disable()
-            hs.eventtap.keyStroke({'alt'}, key, KEYSTROKE_DELAY)
+            hs.eventtap.keyStroke({'alt'}, key)
             bind:enable()
         end
-    end
-    bind = hs.hotkey.bind({'alt'}, key, handler, nil, handler)
+    end)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- PR #214 직전 상태로 `git checkout`으로 정확히 롤백
- ghosttyCtrlKeys 8→17개, terminalOptKeys에 Alt+D 추가 (키맵 확장만)
- 6회의 시도 끝에 CSI u 모드의 근본적 한계를 인정

## Change Intent Record

### 배경

Ghostty 터미널의 CSI u (enhanced keyboard) 모드에서 한글 입력소스일 때 Ctrl+C, Ctrl+L 등 단축키가 동작하지 않는 문제. Claude Code 2.1.0+가 CSI u를 적극 활용하면서 발견.

### 시도 이력

---

#### v1 (667c7fa) — hs.hotkey + convertToEngAndSendKey

**코드:**
```lua
local function convertToEngAndSendKey(bind, mods, key)
    if hs.keycodes.currentSourceID() ~= inputEnglish then
        hs.keycodes.currentSourceID(inputEnglish)
    end
    bind:disable()
    hs.eventtap.keyStroke(mods, key)  -- 합성 이벤트 생성
    bind:enable()
end

for _, key in ipairs(ghosttyCtrlKeys) do
    local bind
    bind = hs.hotkey.bind({'ctrl'}, key, function()
        if isGhostty() then
            convertToEngAndSendKey(bind, {'ctrl'}, key)
        else
            bind:disable()
            hs.eventtap.keyStroke({'ctrl'}, key)
            bind:enable()
        end
    end)
end
```

**실패 증거 — Hammerspoon 콘솔 로그:**
```
-- 1번 누름인데 2번 실행됨:
hotkey: Disabled hotkey ⌃C    ← 1차 (실제 키 입력)
hotkey: Enabled hotkey ⌃C
hotkey: Disabled hotkey ⌃C    ← 2차 (합성 이벤트 재포착)
hotkey: Enabled hotkey ⌃C
```

**원인:** `hs.eventtap.keyStroke` 내부에서 `usleep()`으로 runloop을 블로킹. 합성 keyDown 이벤트가 윈도우 서버 큐에서 처리되기 전에 `bind:enable()`이 실행되어, 재활성화된 핫키가 합성 이벤트를 재포착. Hammerspoon의 `hs.hotkey`는 Carbon Event Manager `RegisterEventHotKey` 기반으로 이벤트 소비 후 재게시(disable→keyStroke→enable)가 구조적으로 재진입에 취약 ([#1230](https://github.com/Hammerspoon/hammerspoon/issues/1230), [#2081](https://github.com/Hammerspoon/hammerspoon/issues/2081)).

---

#### v2 (PR #214, 0d56597) — KEYSTROKE_DELAY 10ms + 복원 타이머 + 안전장치

**코드 (v1 대비 변경점):**
```lua
local KEYSTROKE_DELAY = 10000  -- 200ms → 10ms
local restoreTimer, savedInputSource, restoreAppBundleID = nil, nil, nil

local function convertToEngAndSendKey(bind, mods, key, restore)
    -- ...영어 전환...
    bind:disable()
    hs.eventtap.keyStroke(mods, key, KEYSTROKE_DELAY)  -- 10ms 딜레이
    bind:enable()

    if restore and savedInputSource then
        restoreTimer = hs.timer.doAfter(0.1, function()  -- 100ms 후 복원
            -- 앱 전환 감지, 수동 전환 감지 안전장치
            if hs.keycodes.currentSourceID() == inputEnglish
               and currentBundleID == restoreAppBundleID then
                hs.keycodes.currentSourceID(savedInputSource)
            end
        end)
    end
end
```

**실패 증거 — 동일한 이중 실행 로그:**
```
-- KEYSTROKE_DELAY를 10ms로 줄여도 동일:
hotkey: Disabled hotkey ⌃L
hotkey: Enabled hotkey ⌃L
hotkey: Disabled hotkey ⌃L    ← 합성 이벤트 재포착 여전
hotkey: Enabled hotkey ⌃L
```

**원인:** `usleep(10ms)`이 runloop을 블로킹하는 것은 200ms와 동일. 딜레이 크기와 무관하게 `bind:enable()` 시점에 합성 이벤트가 아직 윈도우 서버 큐에 남아있음. `hs.eventtap.keyStroke` 구현:
```lua
-- Hammerspoon 내부 (eventtap.lua:275-277):
module.event.newKeyEvent(modifiers, character, true):post(targetApp)
timer.usleep(keyDelay)  -- runloop 블로킹!
module.event.newKeyEvent(modifiers, character, false):post(targetApp)
-- usleep 후 즉시 반환 → bind:enable() 실행 → 합성 이벤트 아직 큐에 있음
```

---

#### v3 (PR #224 시도 1) — Ghostty AppleScript "send key"

**코드:**
```lua
local ghosttyKeyScript = 'tell application "Ghostty" to send key "%s" modifiers "%s"'
    .. ' to focused terminal of selected tab of front window'

local function sendKeyToGhostty(key, mods)
    local ok = hs.osascript.applescript(string.format(ghosttyKeyScript, key, mods))
    return ok
end

-- 핸들러에서:
if isGhostty() then
    if not sendKeyToGhostty(key, "control") then
        convertToEngAndSendKey(bind, {'ctrl'}, key, true)  -- fallback
    end
end
```

**PoC — AppleScript는 성공하지만 키 미전달:**
```
-- Hammerspoon IPC 테스트:
hs> ok = hs.osascript.applescript([[tell application "Ghostty" to send key "l"
    modifiers "control" to focused terminal of selected tab of front window]])
hs> print(ok)       --> true    (AppleScript 성공)
hs> -- 그러나 터미널 화면이 지워지지 않음 (Ctrl+L 미동작)

-- perform action, input text는 동작:
hs> hs.osascript.applescript([[tell application "Ghostty" to perform action
    "reset" on focused terminal of selected tab of front window]])
--> true, 화면이 실제로 리셋됨

-- 실행 시간 측정:
hs> elapsed = 26.2ms  -- 성능은 문제 없음
```

**원인:** Ghostty의 `send key` AppleScript 명령은 **UI 레이어에서만 처리**되어 PTY 입력 스트림까지 도달하지 않음. Ghostty 커뮤니티에서도 실제 터미널 입력에는 `input text`를 사용하고 `send key`는 UI 네비게이션용으로만 사용 ([#10201](https://github.com/ghostty-org/ghostty/discussions/10201), [#2934](https://github.com/ghostty-org/ghostty/discussions/2934)). AppleScript 기능 자체가 1.3.0 preview이며, `send key`의 터미널 입력 전달은 향후 개선 예정([#5891](https://github.com/ghostty-org/ghostty/discussions/5891)).

---

#### v4 (PR #224 시도 2) — boolean guard + 50ms 타이머

**코드:**
```lua
for _, key in ipairs(ghosttyCtrlKeys) do
    local bind
    local guard = false  -- 재진입 방지 플래그
    local function handler()
        if guard then return end  -- 재진입 차단
        if isGhostty() then
            guard = true
            convertToEngAndSendKey(bind, {'ctrl'}, key, true)
            hs.timer.doAfter(0.05, function() guard = false end)  -- 50ms 후 해제
        else
            bind:disable()
            hs.eventtap.keyStroke({'ctrl'}, key, KEYSTROKE_DELAY)
            bind:enable()
        end
    end
    bind = hs.hotkey.bind({'ctrl'}, key, handler, nil, handler)
end
```

**PoC — Lua 레벨에서는 guard 동작, 실제 핫키에서는 무효:**
```lua
-- 동기 테스트: guard 정상 동작
hs> local guard = false
hs> function test()
      if guard then return "BLOCKED" end
      guard = true; return "PASSED"
    end
hs> test()  --> "PASSED"
hs> test()  --> "BLOCKED"  ✓ guard 동작

-- 그러나 실제 Ctrl+C 핫키 → 콘솔 로그:
hotkey: Disabled hotkey ⌃C    ← 1차 handler (guard=true 설정)
hotkey: Enabled hotkey ⌃C
hotkey: Disabled hotkey ⌃C    ← 2차 handler (guard가 안 막음!)
hotkey: Enabled hotkey ⌃C
```

**원인:** 합성 이벤트 재포착은 **커널/윈도우 서버 레벨**에서 발생. `CGEventPost`가 윈도우 서버에 이벤트를 전달하고, Carbon Event Manager가 핫키 콜백을 디스패치하는 과정이 **Lua VM 외부에서 진행**되어 Lua boolean 체크로는 차단 불가 ([#1230](https://github.com/Hammerspoon/hammerspoon/issues/1230)).

---

#### v5 (PR #224 시도 3) — hs.eventtap 아키텍처 전환

**코드:**
```lua
-- hs.hotkey 대신 hs.eventtap 사용 → 합성 이벤트 제로
local inputSwitchTap = hs.eventtap.new(
    {hs.eventtap.event.types.keyDown},
    function(event)
        local flags = event:getFlags()
        local keyCode = event:getKeyCode()

        if flags.ctrl and not flags.cmd and not flags.alt
           and isGhostty() and ghosttyCtrlKeySet[keyCode] then
            -- 입력소스만 전환, 원본 이벤트 그대로 통과
            if hs.keycodes.currentSourceID() ~= inputEnglish then
                hs.keycodes.currentSourceID(inputEnglish)
            end
        end

        return false  -- 원본 이벤트 통과 (합성 이벤트 없음!)
    end
)
inputSwitchTap:start()
```

**PoC — 일반 쉘 OK, Claude Code CSI u 미동작:**
```
# 일반 Ghostty 쉘 (한글 입력소스):
$ Ctrl+L → ✅ 화면 지워짐 (eventtap이 영어로 전환 후 원본 이벤트 통과)
$ Ctrl+C → ✅ ^C 출력

# Claude Code 세션 (CSI u 모드, 한글 입력소스):
claude> Ctrl+L → ❌ 미동작
claude> Ctrl+C → ❌ 미동작
# eventtap에서 영어로 전환했지만, CSI u 인코딩 시점에서
# 이미 한글 IME 상태가 반영된 이벤트가 전달됨
```

**원인:** Ghostty는 모든 키보드 이벤트를 macOS 텍스트 입력 시스템(`-interpretKeyEvents:`)을 통해 처리 ([#2934](https://github.com/ghostty-org/ghostty/discussions/2934)). eventtap에서 입력소스를 전환해도, **이미 생성된 keyDown 이벤트의 IME 처리 결과**는 변경되지 않음. CSI u 인코딩은 IME 처리 후 일어나므로 한글 상태가 영향.

---

#### v6 (이번) — v1으로 회귀 + 키맵 확장

**최종 결정:**
```lua
-- PR #214 직전 상태(667c7fa)를 git checkout으로 정확히 복원
-- 변경: ghosttyCtrlKeys 8→17개, terminalOptKeys에 'd' 추가
local ghosttyCtrlKeys = {'c','u','k','w','a','e','l','f','s','v','z','d','r','g','o','t','y'}
local terminalOptKeys = {'b', 'f', 'd'}
```

**trade-off:** 이중 실행 가능성이 있으나:
- 키 미전달(v3), guard 무효(v4), CSI u 미동작(v5)보다 **동작은 함**
- 복원 타이머/안전장치(v2)의 복잡성 없이 단순
- Alt+B/F/D는 이중 실행 문제 없음 (Ctrl 키만 해당)

### 미래 참조

이 문제의 근본 원인은 **Ghostty CSI u 모드 + macOS 한글 IME**의 조합. 해결하려면:
1. Ghostty가 CSI u 모드에서 한글 IME를 무시하고 raw keycode 기반 인코딩
2. Claude Code가 한글 입력소스 감지하여 fallback 처리
3. macOS가 Ctrl+key에서 IME 자동 bypass

Hammerspoon 레벨 workaround는 근본적 한계 확인.

### 관련 이슈
- Hammerspoon: [#1230](https://github.com/Hammerspoon/hammerspoon/issues/1230), [#2081](https://github.com/Hammerspoon/hammerspoon/issues/2081), [#2419](https://github.com/Hammerspoon/hammerspoon/issues/2419), [#2395](https://github.com/Hammerspoon/hammerspoon/issues/2395)
- Ghostty: [#2934](https://github.com/ghostty-org/ghostty/discussions/2934), [#10201](https://github.com/ghostty-org/ghostty/discussions/10201), [#5891](https://github.com/ghostty-org/ghostty/discussions/5891)
- 한글 IME: [Karabiner #1602](https://github.com/pqrs-org/Karabiner-Elements/issues/1602), [opencode #8652](https://github.com/anomalyco/opencode/issues/8652)

### 테스트 환경

| 도구 | 버전 |
|------|------|
| Claude Code | 2.1.76 |
| Ghostty | 1.3.1 (stable) |
| Hammerspoon | 1.0.0 |
| macOS | Sequoia 15.5 (Darwin 24.6.0) |

## Test plan

- [x] 한글에서 Ctrl+L → 영어 전환 + 키 전달
- [x] 한글에서 Alt+B/F/D → 영어 전환 + 단어 이동/삭제
- [ ] Ctrl+;, Ctrl+B → 기존과 동일
- [ ] Safari 등 비-Ghostty → 기본 동작 유지
