### PR TITLE
feat(claude-rc): --cleanup 서브커맨드 추가

### DIFF
--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -191,28 +191,26 @@ do_cleanup() {
         local porcelain_output
         if ! porcelain_output=$(git worktree list --porcelain 2>&1); then
             log_error "git worktree list 실패 — orphan sweep 건너뜀"
-            log_info "정리 완료 — claude-rc 또는 claude-rc --detach 로 서버 재시작"
-            return
-        fi
+        else
+            local -a live_worktrees=()
+            while IFS= read -r line; do
+                [[ "$line" == worktree\ * ]] && live_worktrees+=("${line#worktree }")
+            done <<< "$porcelain_output"
 
-        local -a live_worktrees=()
-        while IFS= read -r line; do
-            [[ "$line" == worktree\ * ]] && live_worktrees+=("${line#worktree }")
-        done <<< "$porcelain_output"
-
-        for dir in "$wt_dir"/*/; do
-            [[ -d "$dir" ]] || continue
-            local canonical
-            canonical=$(realpath "$dir")
-            local is_live=false
-            for live in "${live_worktrees[@]}"; do
-                [[ "$(realpath "$live" 2>/dev/null)" == "$canonical" ]] && { is_live=true; break; }
+            for dir in "$wt_dir"/*/; do
+                [[ -d "$dir" ]] || continue
+                local canonical
+                canonical=$(realpath "$dir")
+                local is_live=false
+                for live in "${live_worktrees[@]}"; do
+                    [[ "$(realpath "$live" 2>/dev/null)" == "$canonical" ]] && { is_live=true; break; }
+                done
+                if [[ "$is_live" == false ]]; then
+                    log_info "orphan 디렉토리 삭제: $(basename "$dir")"
+                    rm -rf "$dir"
+                fi
             done
-            if [[ "$is_live" == false ]]; then
-                log_info "orphan 디렉토리 삭제: $(basename "$dir")"
-                rm -rf "$dir"
-            fi
-        done
+        fi
     fi
 
     # 세션 내부: cleanup 완료 후 세션 종료 (이 셸도 함께 종료됨)


### PR DESCRIPTION
Closes #227.

> **🚨 YAGNI 경고**: 이 PR은 `claude remote-control`의 세션 관리 미비에 대한 **임시 workaround**다.
> Anthropic이 아래 upstream 이슈를 해결하면 이 서브커맨드 전체가 불필요해질 수 있다:
>
> - [anthropics/claude-code#28917](https://github.com/anthropics/claude-code/issues/28917) — 종료된 RC 세션 revoke 명령
> - [anthropics/claude-code#32050](https://github.com/anthropics/claude-code/issues/32050) — idle 세션 자동 종료
> - [anthropics/claude-code#26725](https://github.com/anthropics/claude-code/issues/26725) — worktree 자동 GC
>
> 위 이슈가 해결되면 `do_cleanup()` 함수와 관련 코드를 제거할 것.
> 코드에도 동일한 주석을 남겨두었다 (`claude-rc.sh` L154-161).

## 배경: 왜 이 PR이 필요한가

`claude remote-control`에서 Claude Desktop/앱 세션을 **disconnect**(나가기/탭 닫기)하면,
서버 측 bridge 프로세스가 종료되지 않고 재접속 대기 상태로 남는다.
이는 upstream의 **의도된 동작**(disconnect ≠ end session)이지만,
상시 서버 환경에서는 "zombie" 세션이 누적되어 capacity를 소진시킨다.

```
# disconnect 후 실제 출력 — 아무도 연결되어 있지 않지만 슬롯 점유
Capacity: 3/5
```

### disconnect vs end session

| 동작 | 트리거 | 서버 측 결과 |
|------|--------|-------------|
| **disconnect** | 앱 나가기, 탭 닫기, 네트워크 끊김 | bridge 프로세스 유지, capacity 점유 유지 |
| **end session** | claude.ai/code에서 "End Session" 클릭 | bridge 프로세스 종료, worktree 정리, capacity 회복 |

### upstream 현황

`claude remote-control`은 아직 Research Preview 상태이며, 다음 메커니즘이 부재:
- stale 세션 revoke 명령 ([#28917](https://github.com/anthropics/claude-code/issues/28917) — OPEN)
- idle 세션 자동 종료 ([#32050](https://github.com/anthropics/claude-code/issues/32050) — OPEN)
- worktree GC ([#26725](https://github.com/anthropics/claude-code/issues/26725) — OPEN)

→ upstream 수정 전까지의 **workaround**로 `claude-rc --cleanup`을 추가한다.

## CIR (Change Intent Record)

| 항목 | 내용 |
|------|------|
| **무엇을** | `claude-rc --cleanup` 서브커맨드 추가 |
| **왜** | disconnect된 zombie 세션이 capacity를 영구 점유하는 문제의 workaround |
| **어떻게** | reset-style 전략: tmux kill-session → git worktree prune → orphan directory sweep |
| **영향 범위** | `modules/nixos/scripts/claude-rc.sh` 단일 파일 (+71 lines) |
| **수명** | upstream에서 세션 revoke/idle timeout이 구현되면 **제거 대상** (코드 주석에도 명시) |

## ADR (Architecture Decision Records)

### ADR-1: reset-style vs heuristic PID tracking

**결정**: reset-style (stop → prune → sweep)

**근거**: DA R1 피드백에서 heuristic `pgrep` PID 추적이 fuzzy + race-prone임을 지적.
`tmux kill-session`이 process tree 전체를 일괄 종료하므로 개별 PID 추적이 불필요하다.
서버 전체를 reset하고 사용자가 수동으로 재시작(`claude-rc --detach`)하는 것이 더 단순하고 확실하다.

**기각된 대안**: Issue #227에서 제안된 `pgrep -f "claude.*--session-id"` 기반 프로세스 식별.
세션 ID 패턴이 upstream 변경에 취약하고, race condition 위험이 있다.

### ADR-2: cleanup과 restart 분리

**결정**: cleanup 후 사용자가 수동으로 `claude-rc --detach`로 재시작

**근거**: YAGNI — cleanup과 restart는 분리된 관심사.
자동 재시작이 필요하면 `claude-rc --cleanup && claude-rc --detach`로 조합 가능.

### ADR-3: 세션 내부 실행 시 self-kill 방지

**결정**: 세션 내부 감지 시 cleanup을 먼저 수행하고 `tmux kill-session`을 최후 동작으로 이동

**근거**: DA R1 피드백. `do_stop()` → `tmux kill-session`이 현재 셸도 함께 종료하므로,
이후의 worktree prune/orphan sweep이 실행되지 않는 버그.
외부 실행 시에는 기존 순서(stop → prune → sweep) 유지.

### ADR-4: git worktree list 실패 시 안전 중단

**결정**: `git worktree list --porcelain` 실패 시 orphan sweep을 건너뛰고 즉시 return

**근거**: DA R2 피드백. 실패 시 `live_worktrees`가 빈 배열이 되어
`.claude/worktrees/` 하위 모든 디렉토리가 orphan으로 오분류 → `rm -rf`로 데이터 손실.
"정리하지 않는 것"이 "잘못 정리하는 것"보다 안전하다.

### ADR-5: `--expire=now` 사용

**결정**: `git worktree prune --expire=now`

**근거**: DA R1 피드백. Git의 기본 expire 정책(3개월)으로 인해
방금 죽은 stale worktree entry가 prune되지 않을 수 있다.
cleanup은 명시적 사용자 의도이므로 즉시 prune이 적절하다.

### ADR-6: 확인 프롬프트 없음

**결정**: `--cleanup` 실행 시 사용자 확인 없이 즉시 실행

**근거**: 개인 전용 MiniPC 환경. 실행 결과는 로그로 출력되며,
재시작은 사용자 수동 실행이므로 파괴적 동작의 범위가 제한적.

## 구현 상세

### 3단계 cleanup 파이프라인

```
┌─────────────────────────────────────────────────────────┐
│  1. do_stop (tmux kill-session)                         │
│     └─ 모든 child process 일괄 종료 (bridge 포함)       │
│                                                         │
│  2. git worktree prune --expire=now --verbose           │
│     └─ 디렉토리가 사라진 stale git admin entry 정리     │
│                                                         │
│  3. orphan directory sweep                              │
│     └─ .claude/worktrees/ 하위 중                       │
│        git worktree list에 없는 디렉토리 rm -rf         │
│     └─ realpath 정규화로 심볼릭 링크/상대 경로 안전 비교 │
└─────────────────────────────────────────────────────────┘
```

### 세션 내부 실행 플로우

```
외부에서 실행:          내부(tmux pane)에서 실행:
  do_stop               (skip do_stop)
  ↓                     ↓
  prune                 prune
  ↓                     ↓
  orphan sweep          orphan sweep
  ↓                     ↓
  "정리 완료" 출력      "정리 완료 — 세션 종료 중..."
                        ↓
                        tmux kill-session (이 셸도 종료됨)
```

### 변경된 코드 영역 (4곳)

| 위치 | 변경 내용 |
|------|-----------|
| `usage()` L46 | `--cleanup` 도움말 추가 |
| `parse_args()` L103 | `--cleanup) ACTION="cleanup"` case 추가 |
| `do_cleanup()` L157-215 | cleanup 함수 신규 (59줄) |
| main dispatch L308 | `cleanup) do_cleanup ;;` case 추가 |

## 커밋 이력

| 커밋 | 설명 |
|------|------|
| `239d5da` | feat: `--cleanup` 서브커맨드 최초 구현 |
| `51dfa04` | fix: DA R1 — 세션 내부 실행 시 self-kill 방지 |
| `fabf7b2` | fix: DA R2 — git worktree list 실패 시 orphan sweep 안전 중단 |

## Human Test Plan

### 사전 조건
- MiniPC에 SSH 접속 (`ssh minipc`)
- `claude-rc`가 설치된 상태 (`nrs` 빌드 완료)

### 테스트 시나리오

#### 1. 도움말 확인
```bash
claude-rc --help
# 기대: --cleanup 옵션이 표시됨
```

#### 2. 정리할 것 없음 (idempotent)
```bash
# 서버가 실행 중이지 않은 상태에서:
claude-rc --cleanup
# 기대 출력:
#   [claude-rc] 실행 중인 세션 없음
#   [claude-rc] 정리 완료 — claude-rc 또는 claude-rc --detach 로 서버 재시작

# 2회 연속 실행해도 동일 출력 (idempotent)
claude-rc --cleanup
```

#### 3. 전체 reset 플로우
```bash
# 1) 서버 시작
claude-rc --detach

# 2) Claude Desktop/앱에서 세션 연결 후 disconnect (탭 닫기)

# 3) capacity 점유 확인 (tmux attach 후 로그 확인)
claude-rc --attach
# Capacity: 1/5 (zombie 확인) → Ctrl+B D로 detach

# 4) cleanup 실행
claude-rc --cleanup
# 기대 출력:
#   [claude-rc] 서버 종료됨
#   [claude-rc] worktree prune:    ← stale entry가 있을 때만
#   Removing worktrees/xxx: ...
#   [claude-rc] orphan 디렉토리 삭제: bridge-session_xxx  ← orphan이 있을 때만
#   [claude-rc] 정리 완료 — claude-rc 또는 claude-rc --detach 로 서버 재시작

# 5) 서버 재시작 후 capacity 복구 확인
claude-rc --detach
# Capacity: 0/5 확인
```

#### 4. 세션 내부에서 cleanup
```bash
# 1) 서버 시작 + attach
claude-rc

# 2) 다른 pane 또는 같은 pane에서 cleanup 실행
claude-rc --cleanup
# 기대: cleanup 수행 후 세션 종료 (터미널로 복귀)
```

#### 5. stale worktree 디렉토리 정리
```bash
# 1) orphan 디렉토리 수동 생성
mkdir -p ~/Workspace/nixos-config/.claude/worktrees/fake-orphan

# 2) cleanup 실행
claude-rc --cleanup
# 기대: [claude-rc] orphan 디렉토리 삭제: fake-orphan

# 3) 디렉토리 삭제 확인
ls ~/Workspace/nixos-config/.claude/worktrees/fake-orphan
# 기대: No such file or directory
```

#### 6. 반복 실행 (idempotent)
```bash
claude-rc --cleanup
claude-rc --cleanup
# 기대: 2회째는 "실행 중인 세션 없음" + "정리 완료" (정리할 것 없음)
```