### PR TITLE
fix(claude): statusline plan 아이콘 — clear context 후 사라지는 버그 수정

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -11,6 +11,14 @@ TRANSCRIPT=$(echo "$input" | jq -r '.transcript_path // empty')
 # ※ 이전 ls -t 방식은 세션과 무관하게 가장 최근 파일을 반환하여
 #   다른 세션의 plan을 오표시하는 버그가 있었음 (worktree fallback 포함).
 PLAN_FILE=""
+STATE_FILE=""
+
+if [ -n "$TRANSCRIPT" ]; then
+  # 상태 파일: project 디렉토리에 저장 (worktree별 격리)
+  # context clear 후 새 transcript에 plan 기록이 없을 때 fallback으로 사용
+  STATE_FILE="$(dirname "$TRANSCRIPT")/.statusline-plan"
+fi
+
 if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
   # agent_progress 이벤트 제외 (subagent가 다른 세션 plan을 읽은 기록 필터링)
   # agent plan 파일명(-agent-) 제외
@@ -20,7 +28,18 @@ if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
     | tail -1 | sed 's/^"[^"]*":"//;s/"$//')
 fi
 
+# --- State file 관리 ---
+if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ] && [ -n "$STATE_FILE" ]; then
+  # transcript에서 plan 감지 성공 + 파일 존재 확인 → 상태 파일에 저장
+  printf '%s' "$PLAN_FILE" > "$STATE_FILE" 2>/dev/null
+elif [ -z "$PLAN_FILE" ] && [ -n "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
+  # transcript에서 감지 실패 (context clear 등) → 상태 파일에서 복원
+  PLAN_FILE=$(cat "$STATE_FILE" 2>/dev/null)
+fi
+
 # --- 출력 ---
+# stale state file은 [ -f "$PLAN_FILE" ]에 의해 아이콘 미표시,
+# 새 plan 생성 시 자연 덮어쓰기로 갱신됨
 if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
   # OSC 8 하이퍼링크로 Cmd+Click 시 plan 파일 열림
   # \e[4;36m = underline + cyan → 클릭 가능한 링크 느낌


### PR DESCRIPTION
Closes #230
Close #225 

## Summary

- "clear context" 선택 시 새 transcript가 생성되어 plan 참조가 없어지면 📝 Plan 아이콘이 사라지는 버그 수정
- transcript grep을 1차로 유지하되, project 디렉토리의 `.statusline-plan` state file을 fallback으로 추가
- plan 파일이 디스크에서 삭제되면 `[ -f ]` 검증으로 stale 아이콘 방지

## 원인 분석

"clear context"(option 1)는 새 transcript 파일을 생성한다.
`statusline.sh`는 transcript에서 plan 파일 Read/Write 기록을 grep하여 감지하므로,
새 transcript에는 plan 참조가 없어 아이콘이 표시되지 않는다.
다른 선택지(2-4)에서는 동일 transcript를 유지하므로 문제없음.

## 변경 내용

`statusline.sh`에 state file fallback 로직 추가 (19줄):

| 단계 | 동작 |
|------|------|
| 1 | `STATE_FILE = $(dirname "$TRANSCRIPT")/.statusline-plan` 경로 결정 |
| 2 | transcript grep (기존 로직 그대로 유지) |
| 3 | grep 성공 + plan 파일 존재 → state file에 경로 캐시 |
| 4 | grep 실패 → state file에서 경로 복원 (fallback) |
| 5 | `[ -f "$PLAN_FILE" ]`로 디스크 존재 확인 후 아이콘 표시 |

## 의도적 트레이드오프

같은 프로젝트 내 별도 세션이 이전 세션의 plan을 state fallback으로 표시할 수 있음.
- Claude Code JSON에 session lineage 개념이 없어 per-session scoping 구현 불가
- plan 파일이 디스크에 존재할 때만 표시 → 무효한 정보가 아님
- 현재 버그(아이콘 완전 사라짐)가 false positive보다 심각

## PR #222 회귀 방지

| 항목 | 안전 이유 |
|------|----------|
| cross-worktree | worktree마다 project hash가 다름 → 별도 state file |
| 1차 감지 | transcript grep 그대로 유지 |
| ls -t / worktree fallback | 미사용 |
| 삭제된 plan | `[ -f "$PLAN_FILE" ]`로 검증 |

## Test plan

### 사전 조건
- `nrs`로 변경된 statusline.sh 적용 완료

### 1. 정상 세션 — 아이콘 표시
1. `claude` 실행
2. `/plan` 또는 plan mode 진입하여 plan 파일 생성
3. statusbar에 📝 Plan 아이콘 표시 확인

### 2. Clear context — 아이콘 유지 (핵심 테스트)
1. 위 세션에서 context limit 도달 또는 ExitPlanMode 도구 실행
2. **"Yes, clear context and auto-accept edits"** (option 1) 선택
3. 새 세션 시작 후 statusbar에 📝 Plan 아이콘이 **여전히 표시**되는지 확인
4. `ls ~/.claude/projects/*/.statusline-plan` 으로 state file 생성 확인

### 3. Plan 파일 삭제 — 아이콘 사라짐
1. 위 세션에서 plan 파일을 수동 삭제: `rm ~/.claude/plans/<plan-file>.md`
2. 다음 statusbar 갱신 시 📝 아이콘이 **사라지는지** 확인
3. state file은 남아있지만 `[ -f ]` 실패로 아이콘 미표시

### 4. Plan 없는 새 세션 — 아이콘 미표시
1. plan 없는 프로젝트에서 `claude` 실행
2. statusbar에 📝 아이콘이 **없는지** 확인

### 5. --resume 후 아이콘 유지
1. plan이 있는 세션 종료 후 `claude --resume` 실행
2. statusbar에 📝 Plan 아이콘 표시 확인

### 6. 자동 검증
- [x] shellcheck 통과
- [x] pre-commit hooks 통과 (shellcheck, gitleaks, eval-tests)
- [x] flake-check 통과