### PR TITLE
fix(darwin): Shottr defaults write 에러 핸들링 추가

### DIFF
--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -68,7 +68,7 @@
         ./programs/vscode
         ./programs/folder-actions
         ./programs/ghostty
-        # ./programs/shottr  # TEMP: macOS sandbox defaults write 오류로 임시 비활성화
+        ./programs/shottr
         ./programs/shortcuts
         ./programs/keybindings
         ./programs/ssh

--- a/modules/darwin/programs/shottr/default.nix
+++ b/modules/darwin/programs/shottr/default.nix
@@ -21,6 +21,13 @@ let
   shottrDomain = "cc.ffitch.shottr";
   shottrDefaultFolder = "${homeDir}/${constants.macos.paths.shottrDefaultFolderRelative}";
   shottrLicensePath = "${config.xdg.configHome}/shottr/license";
+  shottrDefaultsWriteHelper = ''
+    _shottr_defaults_write() {
+      if ! /usr/bin/defaults write "$@" 2>/dev/null; then
+        echo "Warning: defaults write $2 failed (sandbox restriction?). Skipping."
+      fi
+    }
+  '';
 in
 {
   # 경로 가드: 폴더/북마크 이슈를 조기에 알림
@@ -47,19 +54,20 @@ in
   # Carbon key codes:
   #   1=18(0x12) 2=19(0x13) 3=20(0x14) O=31(0x1F)
   home.activation.applyShottrCoreSettings = lib.hm.dag.entryAfter [ "checkShottrFolderAndWarn" ] ''
-    /usr/bin/defaults write "${shottrDomain}" defaultFolder "${shottrDefaultFolder}"
-    /usr/bin/defaults write "${shottrDomain}" saveFormat "Auto"
-    /usr/bin/defaults write "${shottrDomain}" KeyboardShortcuts_fullscreen -string '{"carbonModifiers":768,"carbonKeyCode":18}'   # ⇧⌘1
-    /usr/bin/defaults write "${shottrDomain}" KeyboardShortcuts_area -string '{"carbonKeyCode":20,"carbonModifiers":768}'          # ⇧⌘3
-    /usr/bin/defaults write "${shottrDomain}" KeyboardShortcuts_scrolling -string '{"carbonModifiers":768,"carbonKeyCode":19}'     # ⇧⌘2
-    /usr/bin/defaults write "${shottrDomain}" KeyboardShortcuts_ocr -string '{"carbonModifiers":6400,"carbonKeyCode":31}'          # ⌃⌥⌘O
+    ${shottrDefaultsWriteHelper}
+    _shottr_defaults_write "${shottrDomain}" defaultFolder "${shottrDefaultFolder}"
+    _shottr_defaults_write "${shottrDomain}" saveFormat "Auto"
+    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_fullscreen -string '{"carbonModifiers":768,"carbonKeyCode":18}'   # ⇧⌘1
+    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_area -string '{"carbonKeyCode":20,"carbonModifiers":768}'          # ⇧⌘3
+    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_scrolling -string '{"carbonModifiers":768,"carbonKeyCode":19}'     # ⇧⌘2
+    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_ocr -string '{"carbonModifiers":6400,"carbonKeyCode":31}'          # ⌃⌥⌘O
 
     # Manual Scrolling Capture 활성화
     # Auto Scroll Capture는 Terminal, VS Code 등 비표준 스크롤 앱에서 화면이 짤림.
     # Manual 모드는 사용자가 직접 스크롤하며 캡처하므로 이런 앱에서도 정상 동작.
     # ref: https://shottr.cc/kb/faq
     # ref: https://hurricane-flower-fdf.notion.site/Manual-Scrolling-Capture-120d943b739b80bf868dd1009eeadc17
-    /usr/bin/defaults write "${shottrDomain}" scrollingManualEnabled -bool true
+    _shottr_defaults_write "${shottrDomain}" scrollingManualEnabled -bool true
   '';
 
   # 라이센스 pre-fill (agenix secret → defaults write)
@@ -71,6 +79,7 @@ in
   home.activation.applyShottrLicenseFromSecret =
     lib.hm.dag.entryAfter [ "applyShottrCoreSettings" "setupLaunchAgents" ]
       ''
+        ${shottrDefaultsWriteHelper}
         _waited=0
         while [ ! -f "${shottrLicensePath}" ] && [ "$_waited" -lt 5 ]; do
           sleep 1
@@ -84,10 +93,10 @@ in
           kc_vault="$(sed -n 's/^KC_VAULT=//p' "${shottrLicensePath}" | tail -n 1 | tr -d '\r')"
 
           if [ -n "$kc_license" ]; then
-            /usr/bin/defaults write "${shottrDomain}" kc-license -string "$kc_license"
+            _shottr_defaults_write "${shottrDomain}" kc-license -string "$kc_license"
           fi
           if [ -n "$kc_vault" ]; then
-            /usr/bin/defaults write "${shottrDomain}" kc-vault -string "$kc_vault"
+            _shottr_defaults_write "${shottrDomain}" kc-vault -string "$kc_vault"
           fi
         fi
       '';


### PR DESCRIPTION
## Summary

- Shottr sandboxed 앱의 `defaults write` 실패가 `set -e`로 전체 HM activation을 중단시키는 문제 해결
- `_shottr_defaults_write` helper 함수로 실패를 경고로 전환
- 임시 비활성화했던 Shottr 모듈 재활성화 (commit `780704f` revert)

Closes #242

## 재현 조건

이 이슈는 **MiniPC(NixOS) → `ssh mac` → Claude Code → `nrs` 실행** 경로에서만 확인됨:

| 실행 경로 | 결과 |
|-----------|------|
| Mac 터미널에서 직접 `nrs` | ✅ 정상 |
| Mac Claude Code 세션에서 `nrs` | ✅ 정상 |
| Mac Claude Code가 직접 `nrs` 실행 | ✅ 정상 |
| **MiniPC → `ssh mac` → Claude Code → `nrs`** | ❌ 중단 |

SSH 세션에서는 macOS TCC (Transparency, Consent, and Control) 컨텍스트가 로컬 GUI 세션과 달라, sandboxed app(`cc.ffitch.shottr`)의 defaults domain에 `defaults write`가 차단되는 것으로 추정. 이 PR의 fix 적용 후 Mac 로컬 E2E 테스트에서는 Warning 없이 모든 `defaults write`가 성공함 — SSH 경유 재현 검증은 post-merge E2E로 별도 수행 예정.

## 기존 불편했던 점

SSH 경유 `nrs` 실행 시 `applyShottrCoreSettings` 단계에서 HM activation이 중단되어, Shottr 모듈 전체를 주석 처리해야 했음. 그 동안 Shottr 설정(저장 경로, 단축키, 라이센스)이 Nix로 관리되지 않는 상태.

## CIR (Change Intent Record)

이 수정은 **best-effort 완화책**이다:
- macOS TCC 제한으로 SSH 세션에서 sandboxed app container에 `defaults write` 불가 (OS 레벨 제한)
- 로컬 GUI 세션에서는 문제없이 동작하므로, 실패 시 경고만 출력하고 activation을 계속하는 것이 합리적
- **대안 검토**: stderr 파싱 기반 분류 → 기각 (macOS 에러 메시지 포맷에 의존, fragile)
- **선택한 방법**: 모든 `defaults write` 실패를 경고로 전환
- 모듈 비활성화(현재 main)보다 best-effort 적용이 strictly better

## ADR (Architecture Decision Record)

- **helper 함수 패턴 선택**: `|| true`보다 진단 정보(key 이름) 제공 — 실패 시 어떤 설정이 적용 안 됐는지 확인 가능
- **Nix `let` 바인딩으로 중복 제거**: 두 activation block(`applyShottrCoreSettings`, `applyShottrLicenseFromSecret`)에서 동일 helper 사용 (DA 피드백 반영, drift 방지)
- **`2>/dev/null`로 stderr 억제**: 깔끔한 `nrs` 출력 유지
- **진단 가이드 라인 미포함**: 복잡한 JSON 값 재현 불가, secret 키의 shell history 노출 위험

## Reference

- Issue #242: https://github.com/greenheadHQ/nixos-config/issues/242
- 임시 비활성화 커밋: `780704f`
- macOS `defaults(1)` man page: sandbox domain 동작 참조

## Human Test 가이드

### Pre-merge: worktree에서 `nrs` 실행

```bash
nrs
```

**기대 동작**:
1. `Activating applyShottrCoreSettings` 단계 통과
2. `Activating applyShottrLicenseFromSecret` 단계 통과
3. Sandbox 제한 시 `Warning: defaults write <key> failed (sandbox restriction?). Skipping.` 출력
4. `darwin-rebuild switch` exit code 0
5. `nrs` 정상 완료

**실패 시**:
- Warning 없이 중단 → helper가 올바르게 삽입되지 않았을 가능성
- `nrs` 출력 전문 확인, 특히 `applyShottrCoreSettings` 전후 메시지