### PR TITLE
fix(nrs): main rebuild 시 stale 워크트리 심링크 자동 제거

### DIFF
--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -640,28 +640,33 @@ maybe_relink_or_restore() {
         done < <(find "$HOME/.claude" "$HOME/.codex" -maxdepth 3 -type l -print0 2>/dev/null)
         if [[ $_wt_cleaned -gt 0 ]]; then
             log_info "🧹 Removed $_wt_cleaned stale worktree symlink(s)"
-        fi
-
-        # Phase 2: 기존 엔트리 nix store 체인 복원
-        # NO_CHANGES 경로에서는 rebuild가 스킵되어 HM activation이 실행되지 않고,
-        # --force rebuild에서도 동일 generation이면 HM이 심링크를 재생성하지 않으므로
-        # 명시적 복원이 필요
-        # 다중 probe: sed -i 등으로 대표 파일이 일반 파일로 바뀌거나,
-        # relink skip으로 partial mismatch가 발생한 경우를 방어
-        local _needs_restore=false
-        local _p
-        for _p in "$HOME/.claude/settings.json" "$HOME/.claude/mcp.json" "$HOME/.codex/config.toml"; do
-            [[ ! -L "$_p" ]] && continue
-            local _target
-            _target=$(readlink "$_p" 2>/dev/null) || continue
-            if [[ "$_target" != /nix/store/* ]]; then
-                _needs_restore=true
-                break
-            fi
-        done
-        if [[ "$_needs_restore" == true ]]; then
+            # Phase 1이 probe 파일(settings.json 등)을 삭제하면 Phase 2의 probe 탐지가
+            # 실패하여 restore를 건너뛸 수 있음. NO_CHANGES 경로에서는 HM activation이
+            # 실행되지 않아 심링크가 영구 유실됨. Phase 1이 작동했으면 무조건 restore 실행.
             log_info "🔗 Restoring symlinks to nix store chain..."
             "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
+        else
+            # Phase 2: 기존 엔트리 nix store 체인 복원 (Phase 1 미작동 시 fallback)
+            # NO_CHANGES 경로에서는 rebuild가 스킵되어 HM activation이 실행되지 않고,
+            # --force rebuild에서도 동일 generation이면 HM이 심링크를 재생성하지 않으므로
+            # 명시적 복원이 필요
+            # 다중 probe: sed -i 등으로 대표 파일이 일반 파일로 바뀌거나,
+            # relink skip으로 partial mismatch가 발생한 경우를 방어
+            local _needs_restore=false
+            local _p
+            for _p in "$HOME/.claude/settings.json" "$HOME/.claude/mcp.json" "$HOME/.codex/config.toml"; do
+                [[ ! -L "$_p" ]] && continue
+                local _target
+                _target=$(readlink "$_p" 2>/dev/null) || continue
+                if [[ "$_target" != /nix/store/* ]]; then
+                    _needs_restore=true
+                    break
+                fi
+            done
+            if [[ "$_needs_restore" == true ]]; then
+                log_info "🔗 Restoring symlinks to nix store chain..."
+                "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
+            fi
         fi
     fi
 }


### PR DESCRIPTION
## Summary

- 워크트리에서 새 `mkOutOfStoreSymlink` 엔트리(스킬 등)를 개발하고 `nrs`를 실행한 뒤 main으로 돌아오면, Home Manager의 `checkLinkTargets`가 해당 경로에 non-HM 심링크를 발견하여 `"would be clobbered"` 에러로 `nrs`가 실패하는 버그를 수정
- `maybe_relink_or_restore`에 Phase 1(워크트리 타깃 심링크 스캔/제거)을 추가하여, main rebuild 전에 `~/.claude`, `~/.codex` 하위의 워크트리 경로를 가리키는 심링크를 자동 제거

## Change Intent Record

### 문제 발생 경로

1. 워크트리(`feat_245`)에서 새 스킬(`using-claude-p`) 추가 + `nrs` 실행 → `~/.claude/skills/using-claude-p`가 워크트리 경로를 가리키는 심링크로 생성됨
2. PR 머지 후 main으로 복귀
3. main에서 `nrs` 실행 → 실패

### 기존 복원 로직의 맹점 (2가지)

1. **Probe 커버리지 부족**: pre-rebuild 복원 판단이 3개 probe 파일(`settings.json`, `mcp.json`, `config.toml`)만 검사. 이 3개가 정상이면 `nrs-relink restore`를 건너뛰므로, 스킬 디렉토리 등의 stale 심링크를 놓침.
2. **새 엔트리 인식 불가**: `nrs-relink restore`는 **현재 HMF**(Home Manager Files) 기반으로 엔트리를 발견. 워크트리에서 새로 추가된 엔트리는 아직 현재 HMF에 없으므로, restore가 실행되어도 새 엔트리를 복원하지 못함.

### 검토한 대안

| 대안 | 거부 이유 |
|------|----------|
| (a) probe 목록 확장 | 새 엔트리가 추가될 때마다 수동 관리 필요, 근본 해결 아님 |
| (b) `./result`의 새 HMF 참조 | 플랫폼별 경로 해석 복잡 (darwin/nixos 분기, system config 구조 차이) |
| (c) dangling 심링크만 제거 | 워크트리가 아직 살아있으면 dangling이 아니라 탐지 실패 |
| **(d) 워크트리 경로 패턴 매칭으로 직접 제거** | **채택** |

### trade-off

`.claude/worktrees/` 외부에 수동 생성된 워크트리는 탐지 불가하지만, `wt` 스크립트와 Claude Code Agent가 `.claude/worktrees/`에만 워크트리를 생성하므로 실용적으로 충분.

### 참조

- PR #239 (`8694700`): worktree 심링크 자동 전환/복원 시스템 최초 도입
- Issue #244: 관련 이슈 (SSH 경유 worktree nrs 시 HM 심링크 충돌 — 별도 시나리오)

## Test plan

### 1. 재현 검증 (이미 완료)

- [x] 실제 발생한 에러 환경에서 stale 심링크(`~/.claude/skills/using-claude-p` → worktree 경로) 제거 후 `nrs` 성공 확인
- [x] `nrs` 빌드 + 적용 정상 완료 (39s)

### 2. 정상 동작 검증

- [x] main에서 `nrs` 실행 시 stale 워크트리 심링크 없으면 Phase 1이 아무것도 하지 않음 (로그에 `🧹` 미출력)
- [x] shellcheck, eval-tests, gitleaks 등 pre-commit 훅 통과

### 3. 회귀 테스트 시나리오

향후 동일 시나리오 재현 시:

1. 워크트리에서 새 `mkOutOfStoreSymlink` 엔트리 추가
2. 워크트리에서 `nrs` 실행 (심링크가 워크트리 경로를 가리키게 됨)
3. main으로 복귀 후 `nrs` 실행
4. **기대**: Phase 1이 stale 심링크를 자동 제거하고 `🧹 Removed N stale worktree symlink(s)` 로그 출력 → rebuild 정상 완료

### 실패 시 가이드

Phase 1 이후에도 clobber 에러가 발생하면:
1. 에러 메시지에서 충돌 경로 확인 (예: `Existing file '/Users/green/.config/something'`)
2. 해당 경로가 `~/.claude`, `~/.codex` **외부**인 경우, `find` 명령에 디렉토리를 추가하면 됨 (CIR 대안 (a)의 범위 확장 버전)
3. 긴급 우회: `rm <충돌 심링크>` 후 `nrs` 재실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved rebuild script to more reliably clean up stale worktree links and restore system entries using a two-phase approach (direct cleanup first, probe-based fallback).
  * Added clearer logging around cleanup and restoration steps to make outcomes more transparent during rebuild.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->