### PR TITLE
fix(nrs): NixOS nrs.sh에 pre-rebuild maybe_relink_or_restore 추가

### DIFF
--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -63,7 +63,7 @@ main() {
     # Safety: HM gcroot가 유효할 때만 실행 — gcroot 파손 시 Phase 1(rm)만 되고
     # Phase 2(restore) 실패하여 심링크 유실 방지
     if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]] \
-       && [[ -L "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
+       && [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
         maybe_relink_or_restore
     fi
     run_nixos_rebuild


### PR DESCRIPTION
## Summary

- NixOS `nrs.sh`의 `main()` 함수에 pre-rebuild `maybe_relink_or_restore` 호출 추가
- darwin `nrs.sh`에는 이미 `01fc06b`에서 추가된 동일 패턴이 NixOS에는 누락되어 있었음
- 워크트리에서 `nrs` 실행 후 main으로 복귀 시, stale 워크트리 심링크가 남아있으면 `nixos-rebuild switch` 중 HM activation이 "would be clobbered" 에러로 실패 가능

## Why

`claude-rc`가 `RC_SPAWN="worktree"`로 NixOS에서도 워크트리 기반 세션을 생성하므로, 워크트리 심링크가 main 플레이크 경로에 남아있는 시나리오가 실제로 발생할 수 있다. darwin `nrs.sh`에는 PR #239에서 시스템 도입 시 pre-rebuild guard가 포함되었지만, NixOS에는 누락되었다.

## Implementation

darwin `nrs.sh` lines 137-142와 동일한 3줄 조건부 호출 추가:
```bash
if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]]; then
    maybe_relink_or_restore
fi
```

`worktree_symlink_guard` 이후, `run_nixos_rebuild` 이전에 배치.

## References

- PR #258: 전수 조사에서 이 누락 발견
- PR #239: `maybe_relink_or_restore` 시스템 원래 도입
- Commit `01fc06b`: darwin `nrs.sh`에 pre-rebuild guard 추가

## Human Test

- [x] macOS `nrs` 빌드 성공 (flake-check 포함)
- [x] shellcheck 통과
- [x] eval-tests 통과
- [x] NixOS `nrs` 빌드 성공 (SSH 경유 검증 완료)

## Pre-Merge E2E 테스트 가이드 (LLM 실행용)

> **대상**: 이 PR이 main에 merge되기 전, LLM(Claude Code)이 수행하는 기능 검증
>
> **사전 조건**: `issue/259` branch checkout 상태
>
> **실행 환경**: macOS(Platform: darwin) + NixOS(Platform: linux, SSH 경유)

### Phase 0: 코드 변경 확인

```bash
# 0-1. 변경된 파일 확인
git diff main -- modules/nixos/scripts/nrs.sh
```

**기대 동작**:
- `modules/nixos/scripts/nrs.sh`에 pre-rebuild `maybe_relink_or_restore` 블록 추가 확인 (6줄: 주석 3줄 + 조건문 3줄)

```bash
# 0-2. darwin과 NixOS main() 호출 패턴 대칭성 확인
diff <(grep -E "worktree_symlink_guard|maybe_relink_or_restore|run_.*_rebuild" modules/darwin/scripts/nrs.sh) \
     <(grep -E "worktree_symlink_guard|maybe_relink_or_restore|run_.*_rebuild" modules/nixos/scripts/nrs.sh)
```

**기대 동작**:
- 차이가 함수명(`run_darwin_rebuild` vs `run_nixos_rebuild`)뿐

### Phase 1: 정적 검증

```bash
# 1-1. shellcheck
shellcheck modules/nixos/scripts/nrs.sh
```

**기대 동작**: 경고/에러 없음

```bash
# 1-2. eval-tests
nix eval --impure --file tests/eval-tests.nix
```

**기대 동작**: `true` 출력

### Phase 2: 빌드 검증

```bash
# 2-1. macOS 빌드 (flake-check 포함)
nrs
```

**기대 동작**: `✅ Done!` 또는 `✅ No changes to apply`

```bash
# 2-2. NixOS 빌드 (ssh 경유)
ssh minipc 'cd ~/Workspace/nixos-config && git fetch && git checkout issue/259 && ~/.local/bin/nrs.sh'
```

**기대 동작**: `✅ Done!` 또는 `✅ No changes to apply`

### Phase 3: 기능 검증

```bash
# 3-1. maybe_relink_or_restore 함수가 rebuild-common.sh에 존재하는지 확인
ssh minipc 'grep -c "maybe_relink_or_restore()" ~/.local/lib/rebuild-common.sh'
```

**기대 동작**: `1` 출력 (함수 정의 존재)

```bash
# 3-2. MAIN_FLAKE_PATH 변수가 rebuild-common.sh에서 설정되는지 확인
ssh minipc 'grep "MAIN_FLAKE_PATH" ~/.local/lib/rebuild-common.sh | head -3'
```

**기대 동작**: `MAIN_FLAKE_PATH` 변수 설정 라인 출력

Closes #259