### PR TITLE
fix(claude): Memory 아이콘 클릭 시 디렉토리를 Finder에서 열기

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -124,7 +124,7 @@ if [ -n "$TRANSCRIPT" ]; then
     REFERENCED=$(grep -cE '^[[:space:]]*-[[:space:]]*\[.*\.md\]' "$MEMORY_INDEX" 2>/dev/null) || REFERENCED=0
     MEMORY_WARN=""
     [ "$MEMORY_COUNT" -gt "$REFERENCED" ] && MEMORY_WARN=$'\xe2\x9a\xa0'
-    MEMORY_LINK="file://${MEMORY_INDEX}"
+    MEMORY_LINK="file://${PROJECT_MEMORY_DIR}"
     MEMORY_LABEL="Memory (${MEMORY_COUNT}${MEMORY_WARN})"
   fi
 fi


### PR DESCRIPTION
## Summary

- Memory 아이콘 Cmd+Click 시 MEMORY.md 파일 대신 **memory/ 디렉토리**를 Finder에서 열도록 변경
- orphan 파일 포함 전체 메모리 파일을 한눈에 확인 가능

## 변경

```diff
- MEMORY_LINK="file://${MEMORY_INDEX}"
+ MEMORY_LINK="file://${PROJECT_MEMORY_DIR}"
```

## Test plan

- [ ] Memory 아이콘 Cmd+Click 시 Finder에서 memory/ 디렉토리가 열리는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Memory icon navigation in statusline to link to the project memory directory instead of a specific memory file, providing better access to the full memory overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->