### PR TITLE
feat(statusline): rate_limits progress bar 추가 (v2.1.80)

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -214,6 +214,9 @@ format_remaining() {
 # detail: 4=full, 3=no date, 2=no remaining, 1=no bar
 render_rate_window() {
   local pct=${1:-0} window=$2 resets_at=$3 now=$4 detail=${5:-4}
+  # 소수점 truncate (bash 산술은 정수만 지원, e.g. "37.5" → "37")
+  pct=${pct%%.*}
+  pct=${pct:-0}
   # pct를 0-100으로 clamp (음수/초과값 방어)
   [ "$pct" -lt 0 ] 2>/dev/null && pct=0
   [ "$pct" -gt 100 ] 2>/dev/null && pct=100


### PR DESCRIPTION
## Summary

<img width="1439" height="110" alt="Pasted Graphic 53" src="https://github.com/user-attachments/assets/822641c2-a0e7-4e04-b13a-be0426808020" />

> 1단계

<img width="989" height="112" alt="Pasted Graphic 54" src="https://github.com/user-attachments/assets/34f4970a-f99f-4e67-899d-d8d71ec2ddb7" />

> 2단계

<img width="715" height="116" alt="Pasted Graphic 55" src="https://github.com/user-attachments/assets/6c0a8617-eee1-4e92-ab79-0627fc72a950" />

> 3단계

<img width="596" height="148" alt="Pasted Graphic 56" src="https://github.com/user-attachments/assets/1521d5c0-1a7c-4a1e-9c24-b757098e07c5" />

> 4단계

- Claude Code v2.1.80에서 추가된 `rate_limits` statusline 필드를 활용하여 5시간/7일 사용량을 progress bar로 시각화
- 터미널 폭에 따라 4단계 progressive disclosure로 좁은 화면에서도 깔끔하게 표시
- `stty size </dev/tty`로 실시간 터미널 폭 감지 (서브프로세스에서 `tput cols`가 80 고정되는 문제 해결)

## 기존 문제/배경

Claude Code v2.1.80 이전에는 rate limit 사용량을 확인하려면 `/usage` 명령을 수동 실행해야 했다. 응답 중에는 사용 불가하고, 서브에이전트/훅의 백그라운드 소비량도 파악할 수 없었다. v2.1.80에서 `rate_limits` 필드가 statusline JSON 페이로드에 추가되었으나, 우리 statusline.sh에는 이를 표시하는 기능이 없었다.

## CIR (Change Intent Record)

- **v1**: 기본 텍스트 `⏱ 5h:1% 7d:97%` 형태로 아이콘 줄에 인라인 표시 → 좁은 화면에서 아이콘과 겹침
- **v2**: 별도 줄 분리 → 잘 동작하나 progress bar/잔여 시간 없이 정보 부족
- **v3**: progress bar + 잔여 시간 + 리셋 시각 추가 → 좁은 화면에서 우측 Claude Code 콘텐츠(토큰 수, 버전)와 겹침
- **v4**: `tput cols`로 동적 대응 시도 → 서브프로세스에서 항상 80 반환하여 실패
- **v5** (최종): `stty size </dev/tty`로 실제 폭 감지 + 보수적 브레이크포인트(우측 ~40자 여유) 적용

**trade-off**: `stty size </dev/tty`는 매 호출마다 syscall 1회 추가. 하지만 statusline 실행 빈도(응답당 1회, 300ms debounce)에서 무시할 수 있는 수준이며, 정확한 폭 감지가 UX에 더 중요.

**필드명 발견**: CHANGELOG/이슈에서는 `session`/`weekly`로 기술되었으나, 실제 JSON에서는 `five_hour`/`seven_day`임을 디버그 덤프로 확인.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `tput cols` | ncurses terminfo 기반 터미널 폭 조회 | 표준적, 크로스 플랫폼 | 서브프로세스에서 항상 80 고정 | ❌ |
| `$COLUMNS` 쉘 변수 | 쉘이 설정하는 터미널 폭 변수 | 빠름 | 서브프로세스에 미전달 (unset) | ❌ |
| `stty size </dev/tty` | controlling terminal에 직접 ioctl 조회 | 실시간 정확한 폭, 서브프로세스에서도 동작 | macOS/Linux에서만 동작 (이 프로젝트 대상) | ✅ |
| 고정 브레이크포인트 (동적 감지 없음) | 항상 같은 detail level 표시 | 구현 단순 | 화면 폭 변화 대응 불가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | 수정 | rate_limits 파싱, progress bar 렌더링, progressive disclosure 추가 (+106/-1) |

### 핵심 코드

```bash
# 실시간 터미널 폭 감지 (tput cols는 서브프로세스에서 80 고정)
COLS=$(stty size </dev/tty 2>/dev/null | awk '{print $2}')
[ "${COLS:-0}" -gt 0 ] 2>/dev/null || COLS=80

# 우측 Claude Code 콘텐츠(~40자) 여유 확보한 브레이크포인트
if   [ "$COLS" -ge 130 ]; then RATE_DETAIL=4  # bar + pct + remaining + date
elif [ "$COLS" -ge 100 ]; then RATE_DETAIL=3  # bar + pct + remaining
elif [ "$COLS" -ge 80 ];  then RATE_DETAIL=2  # bar + pct
else RATE_DETAIL=1                             # pct only
fi
```

```bash
# render_rate_window: 색상 코딩된 progress bar
rate_color() {  # green(<50%) / yellow(50-79%) / red(≥80%)
  if [ "${1:-0}" -ge 80 ] 2>/dev/null; then echo "31"
  elif [ "${1:-0}" -ge 50 ] 2>/dev/null; then echo "33"
  else echo "32"
  fi
}
```

## 참고 레퍼런스

- Claude Code v2.1.80 CHANGELOG — `rate_limits` 필드 추가
- [Issue #32257](https://github.com/anthropics/claude-code/issues/32257) — rate limit usage data in statusline JSON (COMPLETED)
- [Issue #27915](https://github.com/anthropics/claude-code/issues/27915) — Expose rate-limit / plan quota usage in statusLine JSON input
- `2aff51a` — 본 PR 최종 squash 커밋

## Human Test Plan

### 정상 동작 검증

1. Claude Code를 리로드한다 (v2.1.80 이상).
   - **기대**: statusline 하단에 rate limits progress bar가 표시된다 (`██░░░░░░░░ 2% 5h → Xh ...`).
   - **실패 시**: `/tmp/statusline-debug-*.txt`에 디버그 덤프를 추가하여 `rate_limits` JSON 필드 존재 여부를 확인한다.

2. 터미널 창을 넓히고 (≥130 cols) 아무 메시지를 보낸다.
   - **기대**: detail 4 — progress bar + 퍼센트 + 잔여 시간 + 리셋 날짜가 모두 표시된다.
   - **실패 시**: `stty size </dev/tty`의 반환값을 확인한다.

3. 터미널 창을 좁히고 (<80 cols) 아무 메시지를 보낸다.
   - **기대**: detail 1 — 퍼센트와 윈도우명만 표시된다 (`2% 5h | 97% 7d`).
   - **실패 시**: 브레이크포인트 값과 실제 `stty size` 출력을 비교한다.

### 엣지 케이스

4. API 키 사용자(rate_limits 없음)로 실행한다.
   - **기대**: rate limits 줄이 표시되지 않고, 기존 아이콘만 정상 표시된다.

5. Link icons(Jira, Slack 등)이 설정된 상태에서 확인한다.
   - **기대**: link icons가 1줄에 표시되고, rate limits는 그 아래 별도 줄에 표시된다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. rate_limits 파싱 코드 존재 확인
grep -q 'five_hour.used_percentage' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 2. seven_day 파싱 코드 존재 확인
grep -q 'seven_day.used_percentage' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 3. stty size 사용 확인 (tput cols가 아님)
grep -q 'stty size </dev/tty' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 4. old tput cols 미사용 확인
! grep -q 'tput cols' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 5. rate_color 함수 존재 확인
grep -q 'rate_color()' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 6. SC2155 위반 없음 확인 (local var=$(cmd) 패턴 부재)
! grep -P 'local \w+=\$\(' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0
```

### Phase 1: rate_limits JSON 파싱 검증

> "five_hour/seven_day 필드를 올바르게 파싱하는지 확인"

```bash
echo '{"transcript_path":"/tmp/test.jsonl","rate_limits":{"five_hour":{"used_percentage":42,"resets_at":1774000000},"seven_day":{"used_percentage":78,"resets_at":1774500000}}}' \
  | bash modules/shared/programs/claude/files/scripts/statusline.sh 2>/dev/null \
  | grep -q '42%'
# 기대: exit 0 — 42% 표시 확인
```

- **기대**: 5h:42%, 7d:78%가 출력에 포함된다.
- **실패 시**: jq 파싱 쿼리의 필드명(`five_hour`/`seven_day`)이 올바른지 확인한다.

### Phase 2: rate_limits 미존재 시 graceful skip

> "rate_limits 필드가 없을 때 에러 없이 건너뛰는지 확인"

```bash
echo '{"transcript_path":"/tmp/test.jsonl"}' \
  | bash modules/shared/programs/claude/files/scripts/statusline.sh 2>/dev/null
# 기대: exit 0, rate limit 관련 출력 없음
```

- **기대**: 에러 없이 종료, rate limit 줄 미표시.
- **실패 시**: jq `// ""` fallback이 올바르게 작동하는지 확인한다.

### Phase 3: progressive disclosure 브레이크포인트 검증

> "브레이크포인트 값이 우측 콘텐츠 여유를 확보하는지 확인"

```bash
grep -oP 'COLS" -ge \K\d+' modules/shared/programs/claude/files/scripts/statusline.sh | sort -n
# 기대: 80 100 130 (보수적 브레이크포인트)
```

- **기대**: 80, 100, 130 세 값이 출력된다.
- **실패 시**: 브레이크포인트가 이전 값(60, 80, 110)으로 남아있는지 확인한다.

### Phase 4: Regression — 기존 아이콘 기능 보존

> "rate_limits 추가가 기존 link icons/memory 표시에 영향을 주지 않는지 확인"

```bash
# print_icon 함수 존재 확인
grep -q 'print_icon()' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# Memory orphan 감지 로직 존재 확인
grep -q 'MEMORY_WARN' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# Plan 상태 파일 관리 로직 존재 확인
grep -q 'PLAN_STATE_FILE' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0
```

- **기대**: 기존 아이콘 관련 코드가 모두 보존되어 있다.
- **실패 시**: git diff에서 삭제된 기존 코드가 있는지 확인한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limit display to the status line showing 5-hour and 7-day usage with colored percentage and visual progress indicators.
  * Display adapts to terminal width, progressively revealing progress bar, remaining time, and reset timestamp for optimal readability; multiple windows are separated for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->