### PR TITLE
fix(nrs): worktree에서 .nix 수정 시 pre-rebuild restore 추가

### DIFF
--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -139,11 +139,17 @@ main() {
     acquire_rebuild_lock
     preflight_cask_conflict_check
     cleanup_launchd_agents
-    # Pre-rebuild restore (darwin 전용):
+    # Pre-rebuild restore:
     # HM activation의 checkLinkTargets가 non-HMF 심링크(worktree 타깃)를
-    # "would be clobbered"로 거부하므로, main에서는 rebuild 전에 먼저 복원
+    # "would be clobbered"로 거부하므로, rebuild 전에 먼저 복원한다.
+    # - main: maybe_relink_or_restore() → stale worktree symlink 제거 + nix store 복원
+    # - worktree: nrs-relink restore → worktree symlink를 nix store 체인으로 복원
+    #   (activation 성공 후 maybe_relink_or_restore()가 다시 worktree로 relink)
     if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]]; then
         maybe_relink_or_restore
+    else
+        log_info "🔗 Restoring symlinks before rebuild..."
+        "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     fi
     run_darwin_rebuild
     # shellcheck disable=SC2034

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -58,14 +58,17 @@ main() {
     fi
     worktree_symlink_guard
     acquire_rebuild_lock
-    # Pre-rebuild restore (darwin과 같은 이유):
+    # Pre-rebuild restore:
     # HM activation의 checkLinkTargets가 non-HMF 심링크(worktree 타깃)를
-    # "would be clobbered"로 거부하므로, main에서는 rebuild 전에 먼저 복원
+    # "would be clobbered"로 거부하므로, rebuild 전에 먼저 복원한다.
     # Safety: HM gcroot가 유효할 때만 실행 — gcroot 파손 시 Phase 1(rm)만 되고
     # Phase 2(restore) 실패하여 심링크 유실 방지
     if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]] \
        && [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
         maybe_relink_or_restore
+    elif [[ "$FLAKE_PATH" != "$MAIN_FLAKE_PATH" ]]; then
+        log_info "🔗 Restoring symlinks before rebuild..."
+        "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     fi
     run_nixos_rebuild
     maybe_relink_or_restore


### PR DESCRIPTION
## Summary

- worktree에서 `.nix` 파일 수정 후 `nrs` 실행 시 HM `checkLinkTargets`의 "would be clobbered" 에러를 해결한다.
- 기존에 main repo 전용이던 pre-rebuild restore를 worktree에서도 `nrs-relink restore`로 실행하여, activation 전에 worktree symlink를 Nix store 체인으로 복원한다.

Closes #286

## 기존 문제/배경

worktree에서 `nrs`를 실행하면 `maybe_relink_or_restore()`가 symlink를 worktree 경로로 전환한다. 이후 `.nix` 파일을 수정하고 다시 `nrs`를 실행하면 새 derivation이 생성되어 HM activation이 트리거되는데, `checkLinkTargets`가 기존 worktree symlink(non-HMF 타깃)를 "would be clobbered"로 거부하여 빌드가 실패한다.

기존 pre-rebuild restore는 `FLAKE_PATH == MAIN_FLAKE_PATH` 조건으로 main repo에서만 실행되었다. worktree 시나리오는 미고려 엣지케이스였다.

## CIR (Change Intent Record)

- **v1** (`461a8d4`, PR #240): `maybe_relink_or_restore()` 최초 도입 — "main에서 worktree symlink 잔존" 시나리오만 대상
- **v2** (`01fc06b`): darwin pre-rebuild restore 추가 — main 전용
- **v3** (`0f9ade8`, PR #258): stale worktree symlink 자동 제거 (v2 패턴 매칭) — main 전용 유지
- **v4** (`4fda164`, PR #261): NixOS에도 pre-rebuild restore 추가 — 여전히 main 전용
- **v5** (이번 변경): worktree에서도 pre-rebuild `nrs-relink restore` 실행

5개 선행 커밋 모두 동일 시나리오("main에서 stale symlink 처리")만 다루었고, "worktree 자신의 symlink가 clobber"되는 시나리오는 어디에서도 검토되지 않았다.

**trade-off**: worktree에서 nrs 실행 시 restore + rebuild + relink 3단계가 되어 ~200ms 오버헤드 추가. 전체 빌드 시간(10-40s) 대비 무시 가능.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| worktree에서 `nrs-relink restore` 호출 | pre-rebuild에 else/elif 분기 추가 | 기존 패턴 재사용, 최소 변경 | worktree마다 restore 오버헤드 | ✅ |
| `maybe_relink_or_restore()` 수정 | worktree에서 relink 대신 restore 호출 | 단일 함수로 통합 | post-rebuild relink와 pre-rebuild restore가 같은 함수에서 반대 방향으로 동작 → 혼란 | ❌ |
| HM `force = true` 설정 | 모든 mkOutOfStoreSymlink에 force 적용 | 코드 변경 없음 | checkLinkTargets 보호 우회, 예기치 않은 덮어쓰기 위험 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/scripts/nrs.sh` | 수정 | pre-rebuild restore에 `else` 분기 추가 (line 148-153) |
| `modules/nixos/scripts/nrs.sh` | 수정 | pre-rebuild restore에 `elif` 분기 추가 (line 69-72) |

### 핵심 코드

```bash
# darwin: else 분기
if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]]; then
    maybe_relink_or_restore
else
    log_info "🔗 Restoring symlinks before rebuild..."
    "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
fi

# nixos: elif 분기 (gcroot 없는 main 케이스 silent fall-through 보존)
if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]] \
   && [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
    maybe_relink_or_restore
elif [[ "$FLAKE_PATH" != "$MAIN_FLAKE_PATH" ]]; then
    log_info "🔗 Restoring symlinks before rebuild..."
    "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
fi
```

### 수정 후 흐름

```
worktree nrs:
1. preview_changes → 변경 감지
2. ★ nrs-relink restore → worktree symlink를 Nix store로 복원
3. rebuild switch → HM activation 성공 (Nix store끼리 교체)
4. maybe_relink_or_restore → nrs-relink relink → 다시 worktree로 전환
```

## 참고 레퍼런스

- PR #240 (`461a8d4`) — `maybe_relink_or_restore()` 최초 도입
- PR #258 (`0f9ade8`) — stale worktree symlink 자동 제거 (v2 패턴 매칭)
- PR #261 (`4fda164`) — NixOS에도 pre-rebuild restore 추가
- PR #262 (`d40f171`) — rebuild lock serialize
- Issue #286 — worktree에서 .nix 수정 시 "would be clobbered" 에러 보고

## Human Test Plan

### 정상 동작 검증

1. worktree에서 `nrs` 실행 (1회차)
   - **기대**: 빌드 성공, symlink worktree로 relink
   - **실패 시**: `nrs-relink status`로 symlink 상태 확인

2. worktree에서 `.sh`/`.nix` 파일 수정 후 `nrs` 실행 (2회차)
   - **기대**: "🔗 Restoring symlinks before rebuild..." 로그 출력 → "would be clobbered" 없이 빌드 성공
   - **실패 시**: `journalctl -u home-manager-*.service`(NixOS) 또는 터미널 출력(macOS)에서 clobber 에러 확인

3. `nrs-relink status` 실행
   - **기대**: `[worktree]` 상태의 symlink 목록

### 기존 동작 보존

4. main repo에서 `nrs` 실행
   - **기대**: 기존과 동일하게 동작 (pre-rebuild restore에서 `maybe_relink_or_restore` 호출)

5. NO_CHANGES 상태에서 `nrs` 실행
   - **기대**: "No changes to apply" 메시지 출력, pre-rebuild restore 미실행

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. darwin nrs.sh에 worktree pre-rebuild restore 존재 확인
grep -q 'nrs-relink.*restore' modules/darwin/scripts/nrs.sh
# 기대: exit 0

# 2. nixos nrs.sh에 worktree pre-rebuild restore 존재 확인
grep -q 'nrs-relink.*restore' modules/nixos/scripts/nrs.sh
# 기대: exit 0

# 3. main 전용 조건이 제거되지 않았는지 확인 (기존 main 경로 유지)
grep -q 'MAIN_FLAKE_PATH' modules/darwin/scripts/nrs.sh
grep -q 'MAIN_FLAKE_PATH' modules/nixos/scripts/nrs.sh
# 기대: exit 0

# 4. old 주석 부재 확인 (Negative 검증)
! grep -q 'darwin 전용' modules/darwin/scripts/nrs.sh
! grep -q 'darwin과 같은 이유' modules/nixos/scripts/nrs.sh
# 기대: exit 0 (old 주석이 없어야 성공)
```

### Phase 1: macOS 빌드 검증

> "worktree에서 derivation 변경 후 nrs가 pre-rebuild restore를 실행하여 clobber 없이 성공하는지 확인"

1. worktree에서 `nrs` 1회차 실행 → 성공 + relink 확인
2. `.sh` 파일에 무해한 변경 추가 (derivation 변경 유발)
3. `nrs` 2회차 실행
   - **기대**: "🔗 Restoring symlinks before rebuild..." 로그 + "would be clobbered" 없이 성공
   - **실패 시**: `nrs-relink restore` 단독 실행 후 `nrs` 재시도

### Phase 2: NixOS 빌드 검증

> "NixOS에서도 동일한 pre-rebuild restore가 동작하는지 확인"

1. `ssh minipc`에서 worktree 생성 + 브랜치 checkout
2. Phase 1과 동일한 2회차 테스트 수행
   - **기대**: "🔗 Restoring symlinks before rebuild..." 로그 + HM service 성공
   - **실패 시**: `sudo journalctl -u home-manager-*.service`에서 clobber 에러 확인

### Phase 3: Regression

> "main repo에서의 기존 동작과 NO_CHANGES 경로가 영향받지 않았는지 확인"

```bash
# main repo에서 nrs 실행 — 기존 동작 유지
cd ~/Workspace/nixos-config && nrs
# 기대: 정상 빌드 (pre-rebuild에서 maybe_relink_or_restore 호출)

# NO_CHANGES 상태 확인
nrs
# 기대: "No changes to apply" — pre-rebuild restore 미실행
```

## DA Feedback

ALL CLEAR after 1 round each (for_plan + for_pr). 총 13건 발견, 전건 기각 (기존 코드 패턴/사전 문제).

## Parallel Audit

10개 에이전트 전수조사 완료: **ALL SAFE**. 사이드이펙트/회귀 발견 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pre-rebuild symlink restoration to properly support alternative system configurations with improved error handling that prevents build interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->