### PR TITLE
fix(nrs): worktree pre-rebuild에서 worktree-only entry 직접 제거

### DIFF
--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -143,12 +143,18 @@ main() {
     # HM activation의 checkLinkTargets가 non-HMF 심링크(worktree 타깃)를
     # "would be clobbered"로 거부하므로, rebuild 전에 먼저 복원한다.
     # - main: maybe_relink_or_restore() → stale worktree symlink 제거 + nix store 복원
-    # - worktree: nrs-relink restore → worktree symlink를 nix store 체인으로 복원
+    # - worktree: worktree 심링크 직접 제거 + nrs-relink restore로 기존 entry 복원
     #   (activation 성공 후 maybe_relink_or_restore()가 다시 worktree로 relink)
     if [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]]; then
         maybe_relink_or_restore
     else
-        log_info "🔗 Restoring symlinks before rebuild..."
+        # Worktree pre-rebuild: worktree 경로를 가리키는 심링크를 제거하여
+        # HM activation의 checkLinkTargets가 정상 생성할 수 있도록 한다.
+        # nrs-relink restore는 현재 HMF(gcroot) 기반이라 worktree-only entry를 모르므로,
+        # _remove_worktree_symlinks()로 먼저 제거한 뒤 restore를 실행한다.
+        log_info "🔗 Removing worktree symlinks before rebuild..."
+        _remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
+        # 기존 entry를 nix store chain으로 복원 (rebuild 실패 시에도 안전)
         "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     fi
     run_darwin_rebuild

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -67,7 +67,13 @@ main() {
        && [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
         maybe_relink_or_restore
     elif [[ "$FLAKE_PATH" != "$MAIN_FLAKE_PATH" ]]; then
-        log_info "🔗 Restoring symlinks before rebuild..."
+        # Worktree pre-rebuild: worktree 경로를 가리키는 심링크를 제거하여
+        # HM activation의 checkLinkTargets가 정상 생성할 수 있도록 한다.
+        # nrs-relink restore는 현재 HMF(gcroot) 기반이라 worktree-only entry를 모르므로,
+        # _remove_worktree_symlinks()로 먼저 제거한 뒤 restore를 실행한다.
+        log_info "🔗 Removing worktree symlinks before rebuild..."
+        _remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
+        # 기존 entry를 nix store chain으로 복원 (rebuild 실패 시에도 안전)
         "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     fi
     run_nixos_rebuild

--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -652,6 +652,28 @@ preflight_cask_conflict_check() {
 }
 
 #───────────────────────────────────────────────────────────────────────────────
+# Worktree 심링크 제거: 지정 패턴에 매칭되는 심링크를 $HOME/.claude, .codex에서 제거
+# 사용처: maybe_relink_or_restore() (main: stale 제거), nrs.sh (worktree: pre-rebuild 제거)
+#───────────────────────────────────────────────────────────────────────────────
+_remove_worktree_symlinks() {
+    local pattern="$1" label="${2:-worktree}"
+    local _wt_cleaned=0
+    while IFS= read -r -d '' _link; do
+        local _lt
+        _lt=$(readlink "$_link" 2>/dev/null) || continue
+        if [[ "$_lt" == "$pattern"* ]]; then
+            rm -f "$_link"
+            ((++_wt_cleaned))
+        fi
+    done < <(find "$HOME/.claude" "$HOME/.codex" -maxdepth 3 -type l -print0 2>/dev/null)
+    if [[ $_wt_cleaned -gt 0 ]]; then
+        log_info "  ✓ Removed $_wt_cleaned ${label} symlink(s)"
+        return 0  # 제거 발생
+    fi
+    return 1  # 제거 없음
+}
+
+#───────────────────────────────────────────────────────────────────────────────
 # Worktree 심링크 전환/복원: worktree에서는 relink, main에서는 잔존 심링크 복원
 # nrs.sh의 NO_CHANGES 및 rebuild 경로 양쪽에서 호출
 #───────────────────────────────────────────────────────────────────────────────
@@ -678,21 +700,10 @@ maybe_relink_or_restore() {
         #    (d) 워크트리 경로 패턴 매칭으로 직접 제거 → 채택
         #    trade-off: .claude/worktrees/ 외부에 수동 생성된 워크트리는 탐지 불가하지만,
         #              wt 스크립트가 .claude/worktrees/에만 생성하므로 실용적으로 충분.
-        local _wt_cleaned=0
-        local _wt_pattern="$MAIN_FLAKE_PATH/.claude/worktrees/"
-        while IFS= read -r -d '' _link; do
-            local _lt
-            _lt=$(readlink "$_link" 2>/dev/null) || continue
-            if [[ "$_lt" == "$_wt_pattern"* ]]; then
-                rm -f "$_link"
-                ((++_wt_cleaned))
-            fi
-        done < <(find "$HOME/.claude" "$HOME/.codex" -maxdepth 3 -type l -print0 2>/dev/null)
-        if [[ $_wt_cleaned -gt 0 ]]; then
-            log_info "🧹 Removed $_wt_cleaned stale worktree symlink(s)"
-            # Phase 1이 probe 파일(settings.json 등)을 삭제하면 Phase 2의 probe 탐지가
-            # 실패하여 restore를 건너뛸 수 있음. NO_CHANGES 경로에서는 HM activation이
-            # 실행되지 않아 심링크가 영구 유실됨. Phase 1이 작동했으면 무조건 restore 실행.
+        if _remove_worktree_symlinks "$MAIN_FLAKE_PATH/.claude/worktrees/" "stale worktree"; then
+            # stale worktree 심링크가 제거되면 probe 파일(settings.json 등)도 사라져
+            # Phase 2의 probe 탐지가 실패할 수 있음. NO_CHANGES 경로에서는 HM activation이
+            # 실행되지 않아 심링크가 영구 유실됨 → 무조건 restore 실행.
             log_info "🔗 Restoring symlinks to nix store chain..."
             "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
         else


### PR DESCRIPTION
## Summary

- worktree에서 새 `mkOutOfStoreSymlink` entry를 추가한 뒤 main에서 `nrs`를 실행하면, 이후 worktree `nrs` 재실행 시 HM activation이 "would be clobbered"로 실패하는 문제를 해결한다.
- worktree pre-rebuild에서 `$FLAKE_PATH/*` 패턴 매칭으로 worktree symlink를 직접 제거한 뒤, `nrs-relink restore`로 기존 entry를 안전하게 복원한다.
- 3곳에 중복된 find+readlink+rm 루프를 `_remove_worktree_symlinks()` 함수로 추출한다.

Closes #289

## 기존 문제/배경

`nrs-relink restore`는 현재 HMF(gcroot)를 참조하여 out-of-store symlink entry 목록을 구한다. worktree에서 새 `mkOutOfStoreSymlink` entry Y를 추가하고 `nrs`를 실행하면 Y가 worktree symlink로 전환된다. 이후 main에서 `nrs`를 실행하면 gcroot가 main generation(Y 없음)으로 이동한다.

이 상태에서 worktree `nrs`를 재실행하면:
1. `nrs-relink restore`가 main generation의 HMF를 참조 → Y를 발견하지 못함
2. Y의 worktree symlink가 그대로 잔존
3. HM activation의 `checkLinkTargets`가 Y를 "would be clobbered"로 거부 → rebuild 실패

PR #288이 기존 entry(main/worktree 공통)의 clobber는 해결했으나, worktree-only entry는 커버하지 못하는 한계가 남아있었다.

## CIR (Change Intent Record)

- **v1** (`461a8d4`, PR #240): `maybe_relink_or_restore()` 최초 도입. main-only 시나리오만 대상.
- **v2** (`0f9ade8`, PR #258): stale worktree symlink 자동 제거 (Phase 1 패턴 매칭). worktree 경로(`$MAIN_FLAKE_PATH/.claude/worktrees/*`)를 가리키는 symlink을 직접 rm하여 HMF 의존 한계를 우회. `./result` 기반 접근은 플랫폼별 경로 해석 복잡으로 기각.
- **v3** (`6fc2c1e`, PR #288): worktree pre-rebuild restore 추가. 기존 entry(main/worktree 공통)의 clobber 해결. 단, worktree-only entry는 HMF에 없어 restore 불가.
- **v4** (이번 변경): v2의 Phase 1 접근(패턴 매칭 직접 제거)을 worktree pre-rebuild에도 적용. `$FLAKE_PATH/*` 패턴으로 현재 worktree의 symlink를 제거한 뒤, `nrs-relink restore`로 기존 entry를 nix store chain으로 복원. DA R1에서 3곳 DRY 중복 지적 → `_remove_worktree_symlinks()` 함수 추출.

**trade-off**: find 범위가 `$HOME/.claude`와 `$HOME/.codex`에 한정되어 VSCode(`Library/Application Support/Code/User/`)와 neovim(`.config/nvim`)의 mkOutOfStoreSymlink entry는 커버하지 않음. Phase 1과 동일한 의도적 트레이드오프 — worktree-only로 이 경로에 entry가 추가될 가능성은 극히 낮음.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| worktree 경로 패턴 매칭으로 직접 제거 | `$FLAKE_PATH/*` symlink을 find+rm | HMF 의존 없음, 확실한 제거 | `.claude/.codex` 외 경로 미커버 | ✅ |
| `./result`의 새 HMF 참조 | rebuild preview의 result에서 HMF 추출 | 정확한 entry 목록 | 플랫폼별 경로 해석 복잡 (PR #258 CIR에서 기각) | ❌ |
| `nrs-relink restore`에 worktree 인자 전달 | restore가 worktree 경로 기반으로 제거 | nrs-relink 내부 통합 | 인터페이스 변경, 기존 호출처 영향 | ❌ |
| rm -f만 (restore 미실행) | symlink 제거 후 HM이 새로 생성 | 단순 | rebuild 실패 시 기존 entry symlink 유실 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/rebuild-common.sh` | 추가 | `_remove_worktree_symlinks(pattern, label)` 함수 추출 |
| `modules/shared/scripts/rebuild-common.sh` | 수정 | Phase 1 인라인 코드를 함수 호출로 대체 |
| `modules/darwin/scripts/nrs.sh` | 수정 | worktree else 분기: 함수 호출 + restore 병행 |
| `modules/nixos/scripts/nrs.sh` | 수정 | worktree elif 분기: 함수 호출 + restore 병행 |

### 핵심 코드

```bash
# rebuild-common.sh — 공통 함수 (3곳에서 호출)
_remove_worktree_symlinks() {
    local pattern="$1" label="${2:-worktree}"
    local _wt_cleaned=0
    while IFS= read -r -d '' _link; do
        local _lt
        _lt=$(readlink "$_link" 2>/dev/null) || continue
        if [[ "$_lt" == "$pattern"* ]]; then
            rm -f "$_link"
            ((++_wt_cleaned))
        fi
    done < <(find "$HOME/.claude" "$HOME/.codex" -maxdepth 3 -type l -print0 2>/dev/null)
    if [[ $_wt_cleaned -gt 0 ]]; then
        log_info "  ✓ Removed $_wt_cleaned ${label} symlink(s)"
        return 0
    fi
    return 1
}

# nrs.sh (darwin/nixos) — worktree pre-rebuild
_remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
"$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
```

## 참고 레퍼런스

- PR #240 (`461a8d4`) — `maybe_relink_or_restore()` 최초 도입
- PR #258 (`0f9ade8`) — stale worktree symlink 자동 제거 (Phase 1 패턴 매칭)
- PR #288 (`6fc2c1e`) — worktree pre-rebuild restore 추가 (기존 entry 대상)
- Issue #289 — worktree-only mkOutOfStoreSymlink entry가 main nrs 후 clobber 잔존

## Human Test Plan

### 정상 동작 검증

1. worktree에서 새 `mkOutOfStoreSymlink` entry를 추가하고 `nrs`를 실행한다.
   - **기대**: 성공. entry가 worktree symlink로 전환된다.
   - **실패 시**: `nrs-relink status`로 symlink 상태를 확인한다.

2. main에서 `nrs`를 실행한다 (gcroot가 main generation으로 이동).
   - **기대**: 성공. stale worktree symlink이 Phase 1에서 제거된다.
   - **실패 시**: `_remove_worktree_symlinks` 로그 출력을 확인한다.

3. worktree에서 `nrs`를 재실행한다.
   - **기대**: "Removing worktree symlinks before rebuild..." 로그 출력 후 성공. "would be clobbered" 에러 없음.
   - **실패 시**: `readlink` 결과와 `$FLAKE_PATH` 패턴 매칭을 수동 확인한다.

### 실패 복구 검증

4. worktree에서 `nrs` 실행 중 rebuild가 실패하도록 유도한다 (예: 문법 에러).
   - **기대**: 기존 entry(.claude/settings.json 등)가 nix store chain 상태로 안전하게 유지. worktree-only entry만 부재.
   - **실패 시**: `nrs-relink status`와 `ls -la ~/.claude/settings.json`으로 symlink 상태를 확인한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. _remove_worktree_symlinks 함수 정의 존재 확인
grep -q '_remove_worktree_symlinks()' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0

# 2. darwin nrs.sh에서 함수 호출 확인
grep -q '_remove_worktree_symlinks.*FLAKE_PATH' modules/darwin/scripts/nrs.sh
# 기대: exit 0

# 3. nixos nrs.sh에서 함수 호출 확인
grep -q '_remove_worktree_symlinks.*FLAKE_PATH' modules/nixos/scripts/nrs.sh
# 기대: exit 0

# 4. nrs-relink restore가 두 파일 모두에 존재 (rm + restore 병행)
grep -c 'nrs-relink.*restore' modules/darwin/scripts/nrs.sh  # ≥1
grep -c 'nrs-relink.*restore' modules/nixos/scripts/nrs.sh   # ≥1
# 기대: 각각 1 이상

# 5. old 인라인 코드 부재 확인 (Negative)
! grep -q 'local _wt_pattern=' modules/darwin/scripts/nrs.sh
! grep -q 'local _wt_pattern=' modules/nixos/scripts/nrs.sh
# 기대: exit 0 (인라인 패턴 변수가 없어야 성공)
```

### Phase 1: 함수 추출 검증

> "Phase 1 인라인 코드가 함수 호출로 올바르게 대체되었는지 확인"

```bash
# maybe_relink_or_restore()에서 _remove_worktree_symlinks 호출 확인
grep -A1 '_remove_worktree_symlinks.*MAIN_FLAKE_PATH' modules/shared/scripts/rebuild-common.sh
```
- **기대**: `if _remove_worktree_symlinks "$MAIN_FLAKE_PATH/.claude/worktrees/" "stale worktree"; then` 출력
- **실패 시**: `maybe_relink_or_restore()` 함수 내부에서 인라인 코드가 잔존하는지 확인

### Phase 2: set -e 안전성 검증

> "return 1이 set -e에서 스크립트를 중단시키지 않는지 확인"

```bash
# nrs.sh에서 || true로 보호되는지 확인
grep '_remove_worktree_symlinks.*|| true' modules/darwin/scripts/nrs.sh
grep '_remove_worktree_symlinks.*|| true' modules/nixos/scripts/nrs.sh
```
- **기대**: 두 파일 모두 `|| true` 패턴 출력
- **실패 시**: `set -e` 환경에서 return 1이 script exit을 유발할 수 있음

### Phase 3: Regression

> "기존 maybe_relink_or_restore()의 Phase 2(probe 기반 fallback)가 영향받지 않았는지 확인"

```bash
# Phase 2 probe 로직이 여전히 존재하는지 확인
grep -q 'needs_restore=false' modules/shared/scripts/rebuild-common.sh
grep -q 'settings.json.*mcp.json.*config.toml' modules/shared/scripts/rebuild-common.sh
```
- **기대**: 두 grep 모두 exit 0
- **실패 시**: `maybe_relink_or_restore()`의 else 분기(Phase 2)가 리팩터링 과정에서 삭제되었을 수 있음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symlink cleanup and restoration during system rebuild operations for enhanced stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->