### PR TITLE
feat(nrs): worktree_symlink_guard() 역방향 검사 추가

### DIFF
--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -173,8 +173,20 @@ worktree_symlink_guard() {
     # ── 역방향 검사: worktree-only entry 탐지 (정보성) ──────────────────
     # worktree에만 추가된 mkOutOfStoreSymlink entry를 감지하여 사용자에게 알린다.
     # _remove_worktree_symlinks()가 pre-rebuild에서 자동 처리하므로 차단하지 않는다.
-    # missing_count와 독립적으로 실행: 정보성 검사이므로 정방향 결과에 게이트하지 않는다.
     # merge_base..HEAD: worktree 브랜치에서 변경된 .nix 파일 (정방향의 merge_base..main과 반대)
+    #
+    # === Change Intent Record ===
+    # v1 (6039360, PR #223): worktree_symlink_guard() 최초 도입 — 정방향 검사만
+    # v2 (543acd7, PR #291): _remove_worktree_symlinks() 도입 — worktree-only 자동 제거
+    # v3 (PR #293 초기): 역방향 검사를 missing_count==0 블록 내부에 배치
+    #    → 설계 전제: "정방향 dirty면 역방향 정보는 noise"
+    # v4 (PR #293): early return(L118/L128) 제거 — 빈 changed_nix_files에서도 역방향 도달
+    # v5 (PR #293 최종): hoisting — 역방향을 missing_count 블록 밖으로 이동
+    #    → v3 전제 기각: --force 시 자동 정리 대상의 가시성 확보 불가,
+    #      차단 검사가 정보성 검사를 게이트하는 semantic coupling,
+    #      "No drift" 직후 역방향 발견의 인지 부조화
+    #    trade-off: missing_count>0일 때도 역방향 git diff 추가 실행되나,
+    #              로컬 git 명령 1회로 무시 가능한 비용
     local wt_changed_nix_files
     wt_changed_nix_files=$(git -C "$FLAKE_PATH" diff --name-only "$merge_base" HEAD -- '*.nix' 2>/dev/null) || {
         log_warn "⚠️  symlink guard (reverse): git diff failed. Skipping."


### PR DESCRIPTION
## Summary

- `worktree_symlink_guard()`에 역방향 검사를 추가하여, worktree에만 존재하고 main에 없는 `mkOutOfStoreSymlink` entry를 rebuild 전에 사용자에게 알린다.
- 역방향 검사는 `missing_count`와 독립적으로 항상 실행되며, `--force` 시에도 자동 정리 대상의 사전 가시성을 제공한다.
- `_remove_worktree_symlinks()`가 pre-rebuild에서 자동 처리하므로 차단하지 않는 정보성(`log_info`) 메시지이다.

Closes #292

## 기존 문제/배경

현재 `worktree_symlink_guard()`는 **정방향** 검사만 수행한다 — main에 있고 worktree에 없는 entry를 감지하여 차단(또는 `--force`로 우회). 그러나 **역방향**(worktree에만 있는 entry)은 탐지하지 않아, 사용자는 `_remove_worktree_symlinks()`가 어떤 entry를 정리하는지 사전에 인지할 수 없었다.

`_remove_worktree_symlinks()`는 제거 건수만 사후 보고(`Removed N symlink(s)`)하며, 개별 entry가 어떤 `.nix` 파일에서 유래했는지는 알려주지 않는다.

## CIR (Change Intent Record)

### 버전 이력

| 버전 | 참조 | 변경 | 결과 |
|------|------|------|------|
| v1 | `6039360`, PR #223 | `worktree_symlink_guard()` 최초 도입 | 정방향 검사만 |
| v2 | `543acd7`, PR #291 | `_remove_worktree_symlinks()` 도입 | worktree-only 자동 제거 |
| v3 | PR #293 (`a9ee75c`) | 역방향을 `missing_count==0` 내부에 배치 | 정방향 clean일 때만 역방향 실행 |
| v4 | PR #293 (`7d7bbf4`) | L118/L128 early return 제거 | 빈 `changed_nix_files`에서도 역방향 도달 |
| v5 | PR #293 (`d96396d`) | hoisting — `missing_count` 블록 밖으로 이동 | **역방향이 항상 실행** |

### v3 → v5 설계 전환

**v3 설계 (기각됨)**: "정방향 dirty면 역방향 정보는 noise" — 역방향을 `missing_count==0` 내부에 배치

**v3의 4가지 문제** (CodeRabbit 지적 + DA 에이전트 평가):

1. **`--force` 가시성 상실**: `--force`로 정방향 우회 시 `_remove_worktree_symlinks()`가 자동 정리하는데, 사용자는 정리 대상을 모른 채 rebuild 진행. 역방향 검사의 "사전 가시성"이 정작 필요한 순간에 미작동.
2. **semantic coupling**: 차단 검사의 결과 변수(`missing_count`)가 독립적 정보성 검사의 실행 여부를 결정하는 의미적 결합.
3. **"No drift" 인지 부조화**: "✓ No drift" 직후 "ℹ️ worktree-only detected" 출력 시 사용자 혼란.
4. **early return 문제**: L118/L128 early return이 main에 `.nix` 변경 없는 경우(가장 흔한 케이스) 역방향을 완전히 건너뜀.

**v5 설계 (채택)**: "순수 정보성 검사에 게이트 불필요. 정보는 항상 유용하다."
- 흐름: 정방향 루프 → 역방향 검사(항상) → 정방향 결과 처리
- trade-off: `missing_count>0`일 때도 역방향 git diff 실행되나, 로컬 명령 1회로 무시 가능

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| missing_count==0 내부 (v3) | 정방향 clean일 때만 역방향 실행 | 정방향 dirty 시 출력 간결 | --force 가시성 상실, semantic coupling, early return 문제 | ❌ |
| hoisting (v5) | 역방향을 missing_count 처리 전에 배치 | --force에서도 가시성, semantic decoupling, 자연스러운 메시지 순서 | missing_count>0에서도 git diff 1회 추가 | ✅ |
| 별도 함수 추출 | `_detect_worktree_only_entries()` 분리 | 스코프 격리, 함수 길이 감소 | 단일 호출 사이트에 YAGNI, 인자 전달 간접성 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/rebuild-common.sh` | 수정 (+59/-3) | L118/L128 early return 제거, 역방향 검사 hoisting, 인라인 CIR 추가 |

### 최종 흐름

```
worktree_symlink_guard():
1. merge_base 계산, platform_filter 설정
2. 정방향 검사: merge_base..main 변경 .nix 파일 순회
   → main에 있고 worktree에 없는 entry 누적 (missing_count)
3. 역방향 검사: merge_base..HEAD 변경 .nix 파일 순회
   → worktree에만 있고 main에 없는 entry 탐지 → log_info
4. missing_count == 0 → "✓ No drift" + return 0
5. --force → 경고 + return 0
6. else → 에러 + exit 1
```

### DA 피드백 반영

- CONSISTENCY: `git diff` 에러 핸들링을 `|| { log_warn; var="" }` 패턴으로 통일
- READABILITY: `comm -23` 사용 지점에 방향 설명 주석 추가, diff 방향 주석 추가

## 참고 레퍼런스

- Issue #292 — worktree-only entry 역방향 탐지 요청 (LLM 이행 가이드 포함)
- PR #291 (`543acd7`) — `_remove_worktree_symlinks()` 도입
- PR #288 (`7c2eefb`) — worktree pre-rebuild restore 추가
- PR #223 (`6039360`) — `worktree_symlink_guard()` 최초 도입

## Human Test Plan

### 정상 동작 검증

1. Worktree에서 새 `mkOutOfStoreSymlink` entry를 추가한 `.nix` 파일을 커밋 후 `nrs` 실행.
   - **기대**: `"ℹ️  1 worktree-only mkOutOfStoreSymlink entry(s) detected:"` 표시 후 `"✓ No drift"`.
   - **실패 시**: `wt_changed_nix_files` 결과 확인 — `git diff --name-only "$merge_base" HEAD -- '*.nix'`.

2. Worktree에서 entry를 추가하지 않고 `nrs` 실행.
   - **기대**: `"✓ No mkOutOfStoreSymlink drift."` 만 출력, 역방향 메시지 없음.

### --force 시나리오

3. Main에서 새 entry 추가 후 merge하지 않은 worktree에서 `nrs --force` 실행.
   - **기대**: 역방향 정보(`ℹ️ worktree-only`) 표시 후 정방향 `--force` 경고 표시.
   - **실패 시**: 역방향 검사가 `missing_count` 블록 내부에 있는지 확인.

### 엣지 케이스

4. Main과 worktree 모두 `.nix` 변경 없이 `nrs` 실행 (worktree, non-nix 변경만).
   - **기대**: `"✓ No mkOutOfStoreSymlink drift."` 만 출력.

5. 정방향 차단 상태 (merge 필요)에서 worktree에도 entry가 있는 경우.
   - **기대**: 역방향 정보 표시 후 정방향 `"❌ Worktree would remove"` 차단.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 역방향 검사 로직 존재
grep -q 'worktree-only mkOutOfStoreSymlink' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0

# 2. log_info 수준 확인
grep 'worktree-only mkOutOfStoreSymlink' modules/shared/scripts/rebuild-common.sh | grep -q 'log_info'
# 기대: exit 0

# 3. 정방향 차단 메시지 유지
grep -q 'Worktree would remove' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0

# 4. CIR 인라인 주석 존재
grep -q 'Change Intent Record' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0

# 5. early return 부재 확인 (Negative)
! grep -q 'No mkOutOfStoreSymlink drift.*return 0' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0
```

### Phase 1: hoisting 검증

> "역방향 검사가 missing_count 블록 밖에 위치하는지 확인"

```bash
# 역방향 검사 후 정방향 결과 처리 순서 확인
grep -n '역방향 검사\|정방향 결과 처리' modules/shared/scripts/rebuild-common.sh
# 기대: 역방향 검사 줄 번호 < 정방향 결과 처리 줄 번호
```
- **기대**: 역방향 검사가 정방향 결과 처리보다 먼저 나타난다.
- **실패 시**: 역방향 블록이 `if [[ $missing_count` 내부에 있는지 확인.

### Phase 2: 패턴 검증

> "역방향이 정방향과 동일한 3-way 비교 패턴을 사용하는지 확인"

```bash
# extract_oos_entries 6회 이상 (정방향 3 + 역방향 3)
test $(grep -c 'extract_oos_entries' modules/shared/scripts/rebuild-common.sh) -ge 6
# 기대: exit 0

# comm -23 4회 이상 (정방향 2 + 역방향 2)
test $(grep -c 'comm -23' modules/shared/scripts/rebuild-common.sh) -ge 4
# 기대: exit 0
```

### Phase 3: Regression

> "정방향 검사(차단/--force)가 이번 변경에 의해 깨지지 않았는지 확인"

```bash
# --force 경고 유지
grep -q 'missing vs main (--force, proceeding)' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0

# exit 1 경로 유지
grep -q 'exit 1' modules/shared/scripts/rebuild-common.sh
# 기대: exit 0
```

---

**DA Feedback**: 3 rounds, ALL CLEAR (R1: 6건→3해결+3기각, R2: 4건→4기각, R3: 1건→1기각)
**전수조사**: 2회 실행 (v3: 10에이전트 ALL SAFE, v5: 10에이전트 ALL SAFE)