### PR TITLE
fix(skills): skill-creator override를 run_eval.py까지 확장 + CLI 레퍼런스 추가

### DIFF
--- a/modules/shared/programs/claude/files/CLAUDE.md
+++ b/modules/shared/programs/claude/files/CLAUDE.md
@@ -29,7 +29,7 @@ skill-creator 플러그인의 Python 스크립트를 직접 호출하지 마라.
 ### 필수 주의사항
 
 - **python3 필수**: macOS에 `python`은 없다. SKILL.md에 `python`으로 적혀 있어도 `python3`으로 실행하라.
-- **`run_loop.py`는 Override 없음**: 원본 `run_eval.py`/`improve_description.py`를 Python import로 직접 호출하므로 ANTHROPIC_API_KEY가 필요하다. `python3 -m scripts.run_loop`으로 플러그인 캐시 디렉토리에서 실행하라.
+- **`run_loop.py`는 Override 없음**: 원본 `run_eval.py`/`improve_description.py`를 Python import로 직접 호출하므로 ANTHROPIC_API_KEY가 필요하다. `python3 -m scripts.run_loop`으로 플러그인 캐시 디렉토리(`ls ~/.claude/plugins/cache/claude-plugins-official/skill-creator/`)에서 실행하라.
 - **플래그 추측 금지**: 처음 사용하는 CLI의 플래그는 반드시 `--help`로 먼저 확인하라. 추측한 플래그로 실행하면 API 호출이 낭비된다.
 
 > 배경: 캐시된 skill-creator 플러그인이 구버전(Anthropic SDK 직접 호출)이라 Override 필요. (#281)


### PR DESCRIPTION
## Summary

- skill-creator 플러그인 스크립트 override를 `improve_description.py` 단독에서 `run_eval.py` → `trigger-eval.sh` 매핑까지 확장
- CLI 레퍼런스를 명시하여 LLM의 플래그 추측 → 반복 실패 → API 낭비 패턴을 차단
- macOS `python3` 필수 주의사항 및 `--help` 사전 확인 의무화 추가

Related: #281

## 기존 문제/배경

LLM이 skill-creator 도구 사용 시 동일한 실수를 반복하는 패턴이 관찰됨:

| 실수 | 결과 | 근본 원인 |
|------|------|-----------|
| `python` 사용 | `command not found` | SKILL.md 예시가 `python`으로 기재, macOS엔 `python3`만 존재 |
| `--output` 플래그 추측 | `unrecognized arguments` | `run_eval.py` CLI가 CLAUDE.md에 미문서화 |
| `--runs` 사용 | 동일 에러 | 실제 플래그는 `--runs-per-query` |
| 백그라운드 stdout redirect | 빈 파일 (0 bytes) | stdout/stderr 분리 패턴 미인지 |

한 세션에서 이 실수들이 연쇄되면 3회 이상 재시도하게 되어 60+ claude -p API 호출이 낭비됨.

기존 CLAUDE.md override는 `improve_description.py` → `improve-description.sh` 매핑만 포함하고 있어서, `run_eval.py` 사용 시에는 아무런 가이드가 없었음. 이미 `trigger-eval.sh` 커스텀 스크립트가 배포되어 있었지만 LLM이 이를 인지하지 못함.

## CIR (Change Intent Record)

- **v1** (`3e4f31c`): `improve_description.py` override를 user-scope CLAUDE.md로 이동 — `improve_description.py`만 커버
- **v2** (`d7092e4`): `trigger-eval.sh` E2E 인프라 추가 — 그러나 CLAUDE.md에 `run_eval.py` → `trigger-eval.sh` 매핑 미등록
- **v3** (이번 변경): 실제 에러 세션 분석 후 누락된 매핑 추가 + CLI 레퍼런스 + 주의사항 보강

**trade-off**: CLAUDE.md가 11줄 → 36줄로 증가하지만, 모든 프로젝트에서 skill-creator 사용 시 반복 실수를 원천 차단.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| CLAUDE.md에 CLI 레퍼런스 포함 | override 매핑 + 플래그 문서화 | LLM이 추측 없이 바로 올바른 명령 실행 | CLAUDE.md 크기 증가 (36줄) | ✅ |
| `--help` 확인만 의무화 | "먼저 --help 실행하라" 규칙만 추가 | 최소 변경 | --help 실행 비용 발생, run_eval.py 대신 trigger-eval.sh 사용 유도 불가 | ❌ |
| skill-creator 플러그인 자체 수정 | 플러그인 캐시의 SKILL.md에서 `python` → `python3` | 근본 해결 | 캐시 파일은 업데이트 시 덮어쓰기됨, 지속 불가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/CLAUDE.md` | 수정 | override 섹션 확장 (11행 → 36행) |

### 핵심 변경

```markdown
# BEFORE: improve_description.py만 커버
## Description Optimization Override
skill description optimization 시 skill-creator 플러그인의 `improve_description.py` 대신 
`~/.claude/scripts/improve-description.sh`를 사용하라.

# AFTER: 매핑 테이블 + CLI 레퍼런스 + 주의사항
## skill-creator 스크립트 Override
| 플러그인 원본 | Override | 용도 |
| improve_description.py | improve-description.sh | description 개선 |
| run_eval.py | trigger-eval.sh | 트리거 평가 |

### CLI 레퍼런스
# trigger-eval.sh --queries <path> [--skill <name>] [--reps N] ...

### 필수 주의사항
- python3 필수 (macOS에 python 없음)
- 플래그 추측 금지 → --help로 먼저 확인
```

## 참고 레퍼런스

- Issue #281 — skill-creator 플러그인 업데이트 시 Override 제거 추적
- `3e4f31c` — Override를 user-scope(global) CLAUDE.md로 최초 이동
- `d7092e4` — trigger-eval.sh E2E 인프라 추가
- `8f2b21d` — eval 실행 시 skill-usage.log 오염 방지

## Human Test Plan

### 정상 동작 검증

1. 다른 프로젝트에서 새 Claude Code 세션을 시작한다.
   - **기대**: `~/.claude/CLAUDE.md`에 새 override 섹션이 표시된다 (`nrs` 후).
   - **실패 시**: Nix 심링크가 올바르게 생성되었는지 `ls -la ~/.claude/CLAUDE.md` 확인.

2. skill-creator의 description optimization을 요청한다.
   - **기대**: LLM이 `run_eval.py` 대신 `trigger-eval.sh`를 사용한다.
   - **기대**: `python3`을 사용하고 `python`을 사용하지 않는다.
   - **실패 시**: CLAUDE.md가 세션 컨텍스트에 로드되었는지 확인.

3. trigger-eval.sh를 올바른 플래그로 실행한다.
   - **기대**: `--queries`, `--skill`, `--reps` 등 정확한 플래그 사용.
   - **실패 시**: CLI 레퍼런스 섹션이 CLAUDE.md에 있는지 확인.

### 엣지 케이스

4. `run_loop.py`를 실행해야 하는 경우 (override 없음).
   - **기대**: `python3 -m scripts.run_loop`으로 실행하고, 플러그인 캐시 디렉토리에서 실행한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. override 매핑 테이블에 두 스크립트 모두 포함
grep -q "improve_description.py" modules/shared/programs/claude/files/CLAUDE.md
grep -q "run_eval.py" modules/shared/programs/claude/files/CLAUDE.md
grep -q "trigger-eval.sh" modules/shared/programs/claude/files/CLAUDE.md
grep -q "improve-description.sh" modules/shared/programs/claude/files/CLAUDE.md
# 기대: 모두 exit 0

# 2. CLI 레퍼런스 존재 확인
grep -q "\-\-queries" modules/shared/programs/claude/files/CLAUDE.md
grep -q "\-\-skill-path" modules/shared/programs/claude/files/CLAUDE.md
# 기대: 모두 exit 0

# 3. python3 주의사항 존재 확인
grep -q "python3 필수" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0

# 4. old 단독 override 패턴 부재 확인
! grep -q "^## Description Optimization Override" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0 (구 섹션 제목이 없어야 성공)
```

### Phase 1: Override 스크립트 존재 검증

```bash
# 두 override 스크립트가 실제로 존재하는지 확인
test -f ~/.claude/scripts/improve-description.sh && echo "OK" || echo "MISSING"
test -f ~/.claude/scripts/trigger-eval.sh && echo "OK" || echo "MISSING"
# 기대: 둘 다 "OK"

# 실행 권한 확인
test -x ~/.claude/scripts/improve-description.sh && echo "OK" || echo "NO EXEC"
test -x ~/.claude/scripts/trigger-eval.sh && echo "OK" || echo "NO EXEC"
# 기대: 둘 다 "OK"
```

### Phase 2: Regression

```bash
# 기존 CLAUDE.md 구조가 깨지지 않았는지 확인
grep -q "^# User-scope Instructions" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0

# #281 배경 주석이 유지되는지 확인
grep -q "#281" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed a documentation section and expanded override guidance to cover both description improvement and trigger evaluation workflows.
  * Added CLI reference with example commands and flags, clarified execution requirements (use Python 3 where applicable), output expectations, and operational cautions including when an API key is required.
  * Documentation-only; no code/API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->