### PR TITLE
feat(hosting): 호스팅 서비스 일괄 업데이트 (5개 서비스)

### DIFF
--- a/modules/nixos/programs/docker/vaultwarden.nix
+++ b/modules/nixos/programs/docker/vaultwarden.nix
@@ -65,7 +65,7 @@ in
     # Vaultwarden 컨테이너
     # ═══════════════════════════════════════════════════════════════
     virtualisation.oci-containers.containers.vaultwarden = {
-      image = "vaultwarden/server:1.35.2";
+      image = "vaultwarden/server:1.35.4";
       autoStart = true;
       ports = [ "127.0.0.1:${toString cfg.port}:80" ];
       volumes = [


### PR DESCRIPTION
## Summary

- 전체 호스팅 서비스를 최신 stable 버전으로 일괄 업데이트한다 (Vaultwarden 보안 패치 포함 5개 서비스).
- 데이터 마이그레이션이 필요한 2개 작업은 별도 이슈로 분리 등록하였다.

Closes #303 관련, Closes #304 관련

## 기존 문제/배경

전체 호스팅 서비스의 버전 점검 결과, 5개 서비스에서 업데이트가 가용한 상태였다:

| 서비스 | 이전 버전 | 최신 버전 | 차이 |
|--------|----------|----------|------|
| **Vaultwarden** | 1.35.2 | 1.35.4 | 보안 패치 3건 (cipher access, collection 권한) |
| **Immich** | v2.5.6 | v2.6.1 | rolling tag 업데이트 |
| **Uptime Kuma** | 2.1.3 | 2.2.1 | rolling tag 업데이트 |
| **Copyparty** | v1.20.7 | v1.20.12 | rolling tag 업데이트 |
| **Karakeep** | 0.30.0 | 0.31.0 | rolling tag 업데이트 |

특히 Vaultwarden 1.35.3~1.35.4는 인증된 공격자가 조직 내 다른 컬렉션 항목에 접근할 수 있는 보안 취약점 수정을 포함한다.

## CIR (Change Intent Record)

해당 없음 — 단순 버전 업데이트. Vaultwarden만 nix config 태그 변경이 필요하고, 나머지 4개는 기존 update 스크립트로 rolling tag pull 수행.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 서비스별 개별 PR | 서비스마다 별도 브랜치+PR | 세분화된 리뷰 | 단순 업데이트에 과도한 오버헤드 | ❌ |
| 일괄 업데이트 PR | 한 PR에서 모든 업데이트 처리 | 효율적, 전체 현황 파악 용이 | 롤백 단위가 큼 | ✅ |
| Meilisearch/Postgres 포함 | DB 마이그레이션까지 한번에 | 한번에 완료 | 데이터 손실 위험, 복잡도 증가 | ❌ |

**trade-off**: Meilisearch (DB 삭제+재인덱싱)와 Immich Postgres (pgvecto-rs→VectorChord 마이그레이션)는 데이터 위험이 있어 별도 이슈(#303, #304)로 분리.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/docker/vaultwarden.nix` | 수정 | 이미지 태그 1.35.2 → 1.35.4 |

### Nix config 변경 (Vaultwarden)

```nix
# BEFORE
image = "vaultwarden/server:1.35.2";

# AFTER
image = "vaultwarden/server:1.35.4";
```

### Rolling tag 업데이트 (운영 서버에서 실행 완료)

```bash
sudo immich-update        # v2.5.6 → v2.6.1 (DB 백업 포함)
sudo uptime-kuma-update   # 2.1.3 → 2.2.1 (DB 백업 포함)
sudo copyparty-update     # v1.20.7 → v1.20.12
sudo karakeep-update --ack-bridge-risk  # 0.30.0 → 0.31.0
```

## 참고 레퍼런스

- Issue #303 — Karakeep Meilisearch v1.13.3 → v1.37.0 업그레이드 (별도 진행)
- Issue #304 — Immich PostgreSQL pgvecto-rs → VectorChord 마이그레이션 (별도 진행)
- `82219ae` — 이 PR의 Vaultwarden 태그 변경 커밋
- [Vaultwarden 1.35.4 릴리스 노트](https://github.com/dani-garcia/vaultwarden/releases/tag/1.35.4) — 보안 수정 3건

## Human Test Plan

### 정상 동작 검증

1. Vaultwarden 웹 UI 접속 및 로그인
   - **기대**: 정상 로그인, 비밀번호 조회/생성 가능
   - **실패 시**: `sudo podman logs vaultwarden` 확인

2. Immich 웹 UI 접속
   - **기대**: 타임라인 정상 표시, 사진 검색 동작
   - **실패 시**: `sudo podman logs immich-server` 확인

3. Uptime Kuma 대시보드 확인
   - **기대**: 모니터 목록 정상 표시, 상태 업데이트 중
   - **실패 시**: `sudo podman logs uptime-kuma` 확인

4. Copyparty 파일 서버 접속
   - **기대**: 파일 목록 표시, 업로드/다운로드 가능
   - **실패 시**: `sudo podman logs copyparty` 확인

5. Karakeep 웹 UI 접속 + 검색
   - **기대**: 북마크 목록 표시, 검색 정상 동작
   - **실패 시**: bridge 서비스 확인 `systemctl status karakeep-log-monitor karakeep-singlefile-bridge`

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 Vaultwarden 태그 존재 확인
grep -q 'vaultwarden/server:1.35.4' modules/nixos/programs/docker/vaultwarden.nix
# 기대: exit 0

# 2. old 태그 부재 확인
! grep -q 'vaultwarden/server:1.35.2' modules/nixos/programs/docker/vaultwarden.nix
# 기대: exit 0
```

### Phase 1: 런타임 검증

> "모든 서비스가 업데이트된 버전으로 정상 실행 중인지 확인"

```bash
# Vaultwarden 버전 확인
sudo podman inspect vaultwarden 2>/dev/null | grep '"org.opencontainers.image.version": "1.35.4"'

# Immich 버전 확인
sudo podman inspect immich-server 2>/dev/null | grep '"org.opencontainers.image.version": "v2.6.1"'

# Karakeep 버전 확인
sudo podman inspect karakeep 2>/dev/null | grep 'SERVER_VERSION=0.31.0'
```

- **기대**: 각 서비스가 최신 버전으로 실행 중
- **실패 시**: 해당 서비스의 update 스크립트를 재실행하고 `podman logs`로 에러 확인

### Phase 2: 헬스체크

> "모든 서비스 엔드포인트가 응답하는지 확인"

```bash
# Immich (병렬 가능)
curl -sf http://127.0.0.1:2283/api/server/ping

# Uptime Kuma
curl -sf http://127.0.0.1:3002

# Copyparty
curl -sf http://127.0.0.1:3923

# Karakeep
curl -sf http://127.0.0.1:3000/api/health

# Vaultwarden
curl -sf http://127.0.0.1:8222/alive
```

- **기대**: 모든 엔드포인트가 HTTP 200 응답
- **실패 시**: `systemctl status podman-<서비스명>` + `sudo podman logs <서비스명>`으로 진단

### Phase 3: Regression

> "Karakeep bridge 서비스가 업데이트 후에도 정상 동작하는지 확인"

```bash
systemctl is-active karakeep-log-monitor
systemctl is-active karakeep-singlefile-bridge
systemctl is-active karakeep-fallback-sync.timer
```

- **기대**: 3개 모두 `active`
- **실패 시**: `sudo systemctl restart <서비스명>` 후 `journalctl -u <서비스명> -n 20` 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vaultwarden to version 1.35.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->