### PR TITLE
feat(statusline): SSH 환경 아이콘 최적화 + rate limits 유효 폭 이원화

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -290,30 +290,21 @@ fi
 # stale state file은 [ -f "$PLAN_FILE" ]에 의해 아이콘 미표시,
 # 새 plan 생성 시 자연 덮어쓰기로 갱신됨
 if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ]; then
-  if $IS_SSH; then
-    print_icon "36" "" "\xf0\x9f\x93\x9d" "Plan"
-  else
-    print_icon "36" "file://${PLAN_FILE}" "\xf0\x9f\x93\x9d" "Plan"
-  fi
+  PLAN_URL="file://${PLAN_FILE}"; $IS_SSH && PLAN_URL=""
+  print_icon "36" "$PLAN_URL" "\xf0\x9f\x93\x9d" "Plan"
 fi
 
 # Memo: green — 📓 (SSH에서는 링크 없이 텍스트만 표시)
 if [ -n "$MEMO_PATH" ] && [ -f "$MEMO_PATH" ]; then
-  if $IS_SSH; then
-    print_icon "32" "" "\xf0\x9f\x93\x93" "${MEMO_LABEL:-Memo}"
-  else
-    print_icon "32" "file://${MEMO_PATH}" "\xf0\x9f\x93\x93" "${MEMO_LABEL:-Memo}"
-  fi
+  MEMO_URL="file://${MEMO_PATH}"; $IS_SSH && MEMO_URL=""
+  print_icon "32" "$MEMO_URL" "\xf0\x9f\x93\x93" "${MEMO_LABEL:-Memo}"
 fi
 
 # Memory: blue — 🧠 (SSH에서는 링크 없이 텍스트만 표시)
 # statusline에서 직접 감지 (Plan과 동일한 방식, 상태 파일 불필요)
 if [ -n "$MEMORY_LINK" ]; then
-  if $IS_SSH; then
-    print_icon "34" "" "\xf0\x9f\xa7\xa0" "$MEMORY_LABEL"
-  else
-    print_icon "34" "$MEMORY_LINK" "\xf0\x9f\xa7\xa0" "$MEMORY_LABEL"
-  fi
+  MEMORY_URL="$MEMORY_LINK"; $IS_SSH && MEMORY_URL=""
+  print_icon "34" "$MEMORY_URL" "\xf0\x9f\xa7\xa0" "$MEMORY_LABEL"
 fi
 
 # 아이콘이 하나라도 있으면 최종 개행
@@ -343,10 +334,10 @@ if [ -n "$RATE_5H" ] || [ -n "$RATE_7D" ]; then
   # 콘텐츠 너비 기반 임계값:
   #   detail 4 = bar(11) + "100% 5h → 99d23h (12/31 23:59)"(~30) × 2 + sep(3) ≈ 최대 85자 → 임계값 88
   #   detail 3 = bar(11) + "100% 5h → 99d23h"(~16) × 2 + sep(3) ≈ 최대 55자 → 임계값 58
-  #   detail 2 = bar(11) + "100% 5h"(~8) × 2 + sep(3) ≈ 최대 41자 → 임계값 42
+  #   detail 2 = bar(11) + "100% 5h"(7) × 2 + sep(3) = 최대 39자 → 임계값 40
   if   [ "$EFF_COLS" -ge 88 ]; then RATE_DETAIL=4
   elif [ "$EFF_COLS" -ge 58 ]; then RATE_DETAIL=3
-  elif [ "$EFF_COLS" -ge 42 ]; then RATE_DETAIL=2
+  elif [ "$EFF_COLS" -ge 40 ]; then RATE_DETAIL=2
   else RATE_DETAIL=1
   fi
 


### PR DESCRIPTION
## Summary

- SSH 환경에서 클릭 불가한 OSC 8 하이퍼링크 아이콘을 조건부 처리하여 불필요한 링크 표시를 제거한다.
- 좁은 터미널(iPhone Termius ~50 cols)에서 줄바꿈 시 rate limits가 전체 폭을 사용할 수 있도록 유효 폭 이원화를 도입한다.

## 기존 문제/배경

iPhone 14 Pro Max에서 Termius로 MiniPC에 SSH 접속 후 Claude Code를 실행하면 statusline에서 두 가지 UX 문제가 발생:

1. **OSC 8 링크 무용**: SSH 세션에서는 `file://` URL이나 외부 URL 모두 클릭 불가. Jira/Slack/Figma 아이콘이 표시되지만 아무 기능도 하지 않음.
2. **Rate limits 축소 과잉**: 터미널 폭 ~50 cols에서 줄바꿈이 발생하여 rate limits가 별도 행을 차지하는데, 코드는 항상 우측 ~40자를 감안하여 detail 1(progress bar 없음)로 표시. 공간이 충분한데도 정보가 불필요하게 축소됨.

## CIR (Change Intent Record)

- **v1** (`4598f18`): SSH_CONNECTION 기반 SSH 감지 + print_icon_text 별도 함수 + COLS 임계값 42
- **DA for_plan 반영**: print_icon_text → print_icon 내부 URL 빈값 분기로 통합 (YAGNI/DRY), EFF → EFF_COLS (CONSISTENCY), 매직넘버 산출 근거 주석 추가 (READABILITY)
- **v2** (`3376c52`): DA for_pr에서 COLS=80 회귀 발견 (EFF_COLS=40 < 42 → detail 1). 임계값 42→40 수정 (detail 2 최대 콘텐츠 39자 < 40). Plan/Memo/Memory SSH 분기를 URL 조건부 비움으로 단순화.

trade-off:
- COLS 79/80 경계에서 EFF_COLS 불연속 (79→79, 80→40) — 두 레이아웃 모드의 자연적 결과, 실사용에서 경계 왕복 거의 없음.
- SSH 감지가 tmux reattach 시 stale할 수 있음 — SSH_CONNECTION 기반 감지의 표준적 한계.

## ADR (Architecture Decision Record)

### SSH 아이콘 처리

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| print_icon 내부 URL 분기 | URL 빈값이면 OSC 8 생략 | DRY 유지, HAS_OUTPUT 자동 보존 | 없음 | ✅ |
| print_icon_text 별도 함수 | OSC 8 없는 별도 출력 함수 | 분기 명확 | DRY 위반, 동기화 부담 | ❌ |
| 모든 아이콘 숨김 | SSH에서 아이콘 행 전체 제거 | 단순 | Plan/Memory 상태 정보 손실 | ❌ |

### Rate limits 유효 폭

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 유효 폭 이원화 | COLS<80 → 전체 폭, ≥80 → COLS-40 | 줄바꿈 시 정확한 유효 폭 | COLS 79/80 경계 불연속 | ✅ |
| 단순 임계값 하향 | detail 2 임계값만 80→40 | 단순 | detail 3/4 과도하게 보수적 유지 | ❌ |

## 구현 상세

| 파일 | 변경 | 줄 |
|------|------|-----|
| `statusline.sh` | SSH 감지 플래그 추가 | +8줄 (19-25) |
| `statusline.sh` | print_icon URL 빈값 분기 | +5줄 (187-203) |
| `statusline.sh` | 아이콘 호출부 SSH 조건 | +12/-13줄 (274-307) |
| `statusline.sh` | EFF_COLS 유효 폭 계산 | +15/-4줄 (327-351) |

## 참고 레퍼런스

- `3d6375d` — feat(statusline): rate_limits progress bar 추가 (v2.1.80) (#284)
- `25633bd` — feat(claude): statusbar에 Jira, Slack, Figma, Memo 아이콘 추가 (#263)
- `3494bdf` — fix(claude): Memory 아이콘 worktree 호환 + orphan 경고 표시 (#265)

## Human Test Plan

### SSH 환경 (iPhone Termius → MiniPC)

1. `nrs` 실행하여 설정 적용
2. Claude Code 재시작
3. **기대동작**:
   - Jira/Slack/Figma 아이콘이 표시되지 않음
   - Plan/Memory 아이콘이 링크 없이 텍스트로 표시됨 (underline 없음)
   - Rate limits에 progress bar가 표시됨 (기존: 숫자만)
4. **실패 시**: `echo "$SSH_CONNECTION"` 확인 → 값이 비어있으면 SSH 감지 실패

### 비SSH 환경 (macOS 로컬 터미널)

1. `nrs` 실행하여 설정 적용
2. Claude Code 실행
3. **기대동작**: 기존과 완전히 동일 (OSC 8 링크, underline, detail level 모두 유지)
4. **실패 시**: `echo "$SSH_CONNECTION"` 확인 → 값이 존재하면 환경 오염

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. IS_SSH 플래그 존재 확인
grep -q 'IS_SSH=false' modules/shared/programs/claude/files/scripts/statusline.sh

# 2. 기존 COLS 직접 비교 임계값 부재 확인
! grep -q 'COLS.*-ge 130' modules/shared/programs/claude/files/scripts/statusline.sh

# 3. EFF_COLS 변수 존재 확인
grep -q 'EFF_COLS' modules/shared/programs/claude/files/scripts/statusline.sh

# 4. print_icon에 URL 빈값 분기 존재 확인
grep -q 'Without link' modules/shared/programs/claude/files/scripts/statusline.sh
```

### Phase 1: SSH 감지 동작

> "SSH_CONNECTION이 설정된 환경에서 IS_SSH=true가 되는지 확인"

```bash
# SSH 환경 시뮬레이션
SSH_CONNECTION="1.2.3.4 1234 5.6.7.8 22" bash -c '
  IS_SSH=false
  [ -n "$SSH_CONNECTION" ] && IS_SSH=true
  [ "$IS_SSH" = "true" ] && echo "PASS: IS_SSH=true" || echo "FAIL"
'

# 비SSH 환경 시뮬레이션
unset SSH_CONNECTION; bash -c '
  IS_SSH=false
  [ -n "$SSH_CONNECTION" ] && IS_SSH=true
  [ "$IS_SSH" = "false" ] && echo "PASS: IS_SSH=false" || echo "FAIL"
'
```

### Phase 2: print_icon URL 분기

> "빈 URL에서 OSC 8이 생략되고, non-empty URL에서 OSC 8이 포함되는지 확인"

```bash
# print_icon 함수 추출 + 테스트
bash -c '
HAS_OUTPUT=false
print_icon() {
  $HAS_OUTPUT && printf "  "
  if [ -n "$2" ]; then
    printf "%b" "\e[4;${1}m\e]8;;${2}\a${3} "
    printf "%s" "$4"
    printf "%b" "\e]8;;\a\e[0m"
  else
    printf "%b" "\e[${1}m${3} "
    printf "%s" "$4"
    printf "%b" "\e[0m"
  fi
  HAS_OUTPUT=true
}
# Non-empty URL: should contain OSC 8 (\e]8;;)
OUT1=$(print_icon "36" "file:///test" "T" "Plan" 2>&1)
echo "$OUT1" | grep -q "8;;" && echo "PASS: OSC 8 present with URL" || echo "FAIL"

# Empty URL: should NOT contain OSC 8
HAS_OUTPUT=false
OUT2=$(print_icon "36" "" "T" "Plan" 2>&1)
echo "$OUT2" | grep -q "8;;" && echo "FAIL: OSC 8 should not be present" || echo "PASS: OSC 8 absent without URL"
'
```

### Phase 3: EFF_COLS 경계값

> "COLS=80에서 detail 2, COLS=50에서 detail 2, COLS=130에서 detail 4가 되는지 확인"

```bash
for COLS in 50 80 100 130; do
  if [ "$COLS" -lt 80 ]; then EFF_COLS=$COLS; else EFF_COLS=$((COLS - 40)); fi
  if   [ "$EFF_COLS" -ge 88 ]; then D=4
  elif [ "$EFF_COLS" -ge 58 ]; then D=3
  elif [ "$EFF_COLS" -ge 40 ]; then D=2
  else D=1; fi
  echo "COLS=$COLS EFF=$EFF_COLS detail=$D"
done
# 기대: COLS=50 → detail 2, COLS=80 → detail 2, COLS=100 → detail 3, COLS=130 → detail 4
```

### Phase 4: Regression — 비SSH 아이콘 경로

> "IS_SSH=false일 때 외부 링크 아이콘 조건이 통과하는지 확인"

```bash
IS_SSH=false
JIRA_URL="https://jira.example.com" JIRA_LABEL="TEST-1"
if [ -n "$JIRA_URL" ] && [ -n "$JIRA_LABEL" ] && ! $IS_SSH; then
  echo "PASS: Jira icon would display"
else
  echo "FAIL: Jira icon blocked in non-SSH"
fi
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display of icons and hyperlinks in SSH terminal sessions.

* **Improvements**
  * Enhanced rate limit detail visibility with improved terminal width calculations.
  * Better handling of external resources in remote connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->