### PR TITLE
fix(statusline): Termius 호환 — muted color를 256-color 고정 그레이로 교체

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -24,6 +24,10 @@ SESSION_ID=$(basename "$TRANSCRIPT" .jsonl)
 IS_SSH=false
 [ -n "$SSH_CONNECTION" ] && IS_SSH=true
 
+# 256-color 고정 그레이 — 터미널 팔레트 의존 \e[90m 대신 사용
+# Termius 등 bright black을 검정으로 렌더링하는 터미널에서 가시성 확보
+MUTED="38;5;242"   # #6c6c6c
+
 # --- Plan 파일 감지 ---
 # 현재 세션의 transcript에서 plan 파일 Read/Write 기록을 추출한다.
 # ※ 이전 ls -t 방식은 세션과 무관하게 가장 최근 파일을 반환하여
@@ -245,7 +249,7 @@ render_rate_window() {
     local i bar_filled="" bar_empty=""
     for ((i=0; i<filled; i++)); do bar_filled+="█"; done
     for ((i=0; i<empty; i++)); do bar_empty+="░"; done
-    printf '%b%s%b%s%b ' "\e[${color}m" "$bar_filled" "\e[90m" "$bar_empty" "\e[0m"
+    printf '%b%s%b%s%b ' "\e[${color}m" "$bar_filled" "\e[${MUTED}m" "$bar_empty" "\e[0m"
   fi
 
   # Percentage + window (always)
@@ -256,7 +260,7 @@ render_rate_window() {
     if [ "$detail" -ge 3 ]; then
       local remaining=$((resets_at - now))
       if [ "$remaining" -gt 0 ]; then
-        printf ' %b%s%b %s' "\e[90m" "→" "\e[0m" "$(format_remaining $remaining)"
+        printf ' %b%s%b %s' "\e[${MUTED}m" "→" "\e[0m" "$(format_remaining $remaining)"
       fi
     fi
     # (reset_date) (detail ≥ 4)
@@ -264,7 +268,7 @@ render_rate_window() {
       local reset_fmt
       reset_fmt=$(date -r "$resets_at" "+%m/%d %H:%M" 2>/dev/null \
                || date -d "@$resets_at" "+%m/%d %H:%M" 2>/dev/null)
-      [ -n "$reset_fmt" ] && printf ' %b(%s)%b' "\e[90m" "$reset_fmt" "\e[0m"
+      [ -n "$reset_fmt" ] && printf ' %b(%s)%b' "\e[${MUTED}m" "$reset_fmt" "\e[0m"
     fi
   fi
 }
@@ -346,7 +350,7 @@ if [ -n "$RATE_5H" ] || [ -n "$RATE_7D" ]; then
     render_rate_window "$RATE_5H" "5h" "$RATE_5H_RESET" "$NOW" "$RATE_DETAIL"
   fi
   if [ -n "$RATE_5H" ] && [ -n "$RATE_7D" ]; then
-    printf ' %b%s%b ' "\e[90m" "|" "\e[0m"
+    printf ' %b%s%b ' "\e[${MUTED}m" "|" "\e[0m"
   fi
   if [ -n "$RATE_7D" ]; then
     render_rate_window "$RATE_7D" "7d" "$RATE_7D_RESET" "$NOW" "$RATE_DETAIL"


### PR DESCRIPTION
## Summary

- Termius (iOS SSH 클라이언트)에서 rate limits의 화살표(`→`), 구분선(`|`), 빈 진행바(`░`), 리셋 시각이 배경에 묻혀 보이지 않는 문제를 해결한다.
- `\e[90m` (ANSI bright black, 터미널 팔레트 의존) → `\e[38;5;242m` (256-color 고정 그레이 #6c6c6c)로 교체하여 모든 터미널에서 일관된 회색으로 표시한다.

## 기존 문제/배경

statusline.sh의 muted 요소(화살표, 구분선, 빈 진행바, 리셋 시각)는 `\e[90m` (ANSI bright black)을 사용한다. 이 색상은 터미널의 16색 팔레트 매핑에 의존하여, 팔레트 설정에 따라 실제 렌더링 색상이 달라진다.

| 터미널 | `\e[90m` 렌더링 | 결과 |
|--------|-----------------|------|
| Ghostty (macOS) | 밝은 회색 | 정상 가시성 |
| Echo (iOS, libghostty) | 밝은 회색 | 정상 가시성 |
| **Termius (iOS SSH)** | **거의 검정** | **배경에 묻혀 안 보임** |

iPhone에서 Termius로 MiniPC SSH 접속 시 rate limits 화살표와 구분선이 완전히 보이지 않아 가시성이 매우 떨어지는 문제가 있었다.

## CIR (Change Intent Record)

- **v1** (`3d6375d`): rate limits progress bar 최초 구현 — `\e[90m`을 muted 색상으로 채택
- **v2** (`2186b21`): SSH 환경 아이콘 최적화 — SSH 감지 추가, 유효 폭 이원화. 색상은 변경 없음
- **v3** (이번 변경): Termius에서 bright black이 검정으로 렌더링되는 문제 발견 → 터미널 팔레트 의존 없는 256-color 고정 그레이로 교체

**trade-off**: 256-color 미지원 극구형 터미널(16색 전용)에서는 색상이 무시되거나 기본색으로 fallback되지만, 프로젝트가 이미 256-color를 전제로 사용(`pane-helpers.sh`, `wt.sh`)하므로 실질적 제약 없음.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 256-color 고정 그레이 | `\e[38;5;242m` (#6c6c6c) 전역 사용 | 간단, 터미널 무관 일관성, 프로젝트 선례 있음 | 극구형 16색 터미널 미지원 | ✅ |
| 터미널 감지 분기 | COLORTERM/TERM 체크로 true color/256/16 분기 | 최적 렌더링 | 분기 로직 복잡, 서브프로세스에서 tput 부정확 | ❌ |
| SSH 환경에서만 변경 | IS_SSH=true일 때만 다른 색상 | 로컬 환경 무변경 | SSH 클라이언트별 차이 여전, 근본 해결 아님 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | 수정 | MUTED 변수 추가 + 4곳 교체 |

### 핵심 코드

```bash
# L29: 변수 정의
MUTED="38;5;242"   # #6c6c6c

# L252, L263, L271, L353: 사용 (4곳 동일 패턴)
# BEFORE:
printf '%b%s%b' "\e[90m" "→" "\e[0m"
# AFTER:
printf '%b%s%b' "\e[${MUTED}m" "→" "\e[0m"
```

## 참고 레퍼런스

- PR #314 (`2186b21`) — SSH 환경 아이콘 최적화 + rate limits 유효 폭 이원화
- PR #284 (`3d6375d`) — rate limits progress bar 최초 구현 (`\e[90m` 도입)
- [xterm 256-color chart](https://www.ditig.com/256-colors-cheat-sheet) — index 242 = #6c6c6c 참조

## Human Test Plan

### 정상 동작 검증

1. `nrs` 실행하여 symlink 반영한다.
   - **기대**: 에러 없이 완료.
   - **실패 시**: `modules/shared/programs/claude/default.nix`의 statusline.sh symlink 설정 확인.

2. MiniPC 로컬에서 Claude Code 세션을 열어 rate limits 표시를 확인한다.
   - **기대**: 화살표(`→`), 구분선(`|`), 빈 진행바(`░`), 리셋 시각이 회색으로 표시.
   - **실패 시**: `~/.claude/scripts/statusline.sh` 내용이 최신인지 확인.

3. iPhone Termius로 MiniPC에 SSH 접속하여 Claude Code 세션을 확인한다.
   - **기대**: 이전에 검정으로 보이던 `→`, `|`, `░`가 회색으로 정상 표시.
   - **실패 시**: `echo -e "\e[38;5;242mtest\e[0m"`로 Termius의 256-color 지원 확인.

### 엣지 케이스

4. macOS Ghostty에서 Claude Code 세션을 열어 기존 가시성이 유지되는지 확인한다.
   - **기대**: 기존과 동일하거나 매우 유사한 회색 톤.
   - **실패 시**: Ghostty의 bright black 팔레트 색상과 #6c6c6c를 비교.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. MUTED 변수 존재 확인
grep -q 'MUTED="38;5;242"' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 2. old \e[90m 부재 확인 (주석 제외)
! grep -v '^#' modules/shared/programs/claude/files/scripts/statusline.sh | grep -q '\\e\[90m'
# 기대: exit 0 (코드에서 \e[90m이 없어야 성공)

# 3. MUTED 사용처 4곳 확인
[ "$(grep -c '${MUTED}' modules/shared/programs/claude/files/scripts/statusline.sh)" -eq 4 ]
# 기대: exit 0
```

### Phase 1: ANSI escape sequence 생성 검증

> "MUTED 변수가 올바른 256-color escape sequence를 생성하는지 확인"

```bash
MUTED="38;5;242"
output=$(printf '%b' "\e[${MUTED}m" | od -An -tx1 | tr -d ' \n')
[ "$output" = "1b5b33383b353b3234326d" ]
# 기대: exit 0 — ESC [ 3 8 ; 5 ; 2 4 2 m
```

- **기대**: 바이트 시퀀스가 `\x1b[38;5;242m`과 일치.
- **실패 시**: MUTED 변수값과 printf %b의 escape 처리 확인.

### Phase 2: Regression

> "rate limits 외 아이콘 영역이 MUTED 변경에 영향받지 않는지 확인"

```bash
# print_icon 함수가 MUTED를 사용하지 않는지 확인
! sed -n '/^print_icon/,/^}/p' modules/shared/programs/claude/files/scripts/statusline.sh | grep -q 'MUTED'
# 기대: exit 0 (print_icon 내에 MUTED 참조 없음)
```

- **기대**: print_icon 함수는 기존 ANSI 색상(31-36)만 사용.
- **실패 시**: MUTED가 의도치 않게 아이콘 영역에 침투했는지 확인.

---

### DA Feedback Summary

| Round | Discovered | Resolved | Rejected | Deferred |
|-------|-----------|----------|----------|----------|
| R1    | 5         | 0        | 5        | 0        |
| R2    | 0         | 0        | 0        | 0        |

**Result**: ALL CLEAR after 2 rounds

<details>
<summary>Round details</summary>

### Round 1
- YAGNI: CLEAR
- NGMI: CLEAR
- HALLUCINATION: CLEAR
- SECURITY: CLEAR
- SIDE_EFFECT: 1건 (256-color fallback) → 기각 (VERIFIED_FALSE_POSITIVE: 프로젝트가 이미 256-color 전제)
- CONSISTENCY: 1건 (MUTED만 256-color 형식) → 기각 (DESIGN_TRADEOFF: 기본 8색은 전환 불필요)
- READABILITY: CLEAR
- CLEAN_CODE: 3건 (기존 매직넘버) → 기각 (SCOPE_DEFERRAL: 이번 변경과 무관한 기존 코드)

### Round 2
- SIDE_EFFECT: CLEAR
- CONSISTENCY: CLEAR
- CLEAN_CODE: CLEAR

</details>

### Parallel Audit Summary

전수조사 완료: SAFE — 10개 관점 모두 사이드이펙트/회귀 발견 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined status line visual presentation with an updated color scheme for improved terminal displays. Rate-limit information including progress bars, remaining time indicators, reset dates, and visual separators now render in muted gray tones. This provides better visual clarity, improved readability, and enhanced visual distinction between different status line elements and states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->