### PR TITLE
fix(flake): 전체 input 업데이트로 atuin migration 불일치 해결

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773025010,
-        "narHash": "sha256-khlHllTsovXgT2GZ0WxT4+RvuMjNeR5OW0UYeEHPYQo=",
+        "lastModified": 1773889306,
+        "narHash": "sha256-PAqwnsBSI9SVC2QugvQ3xeYCB0otOwCacB1ueQj2tgw=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "7b9f7f88ab3b339f8142dc246445abb3c370d3d3",
+        "rev": "5ad85c82cc52264f4beddc934ba57f3789f28347",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773179137,
-        "narHash": "sha256-EdW2bwzlfme0vbMOcStnNmKlOAA05Bp6su2O8VLGT0k=",
+        "lastModified": 1774584114,
+        "narHash": "sha256-uWR9fC+4NykFJVn4GN4Ini9LX+w8Llj7BnWKKp0N6bw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3f98e2bbc661ec0aaf558d8a283d6955f05f1d09",
+        "rev": "4b1be5c38be350ee9452a4847945ce71d950dc31",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773196667,
-        "narHash": "sha256-jFlVopQCfQumeZ6iXTJR/jrFvuS408ReTeLfggNiLLM=",
+        "lastModified": 1774580365,
+        "narHash": "sha256-IsFhvJ0GC42GGP8ldTGNU5bdxz42JPQANPgeRD8Igxk=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "931b0da906b0bf70162d84074c5085934e64750d",
+        "rev": "68f00afe80f7c424fb311d698d7c6b64cdd27572",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772963539,
-        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/programs/caddy.nix
+++ b/modules/nixos/programs/caddy.nix
@@ -17,7 +17,7 @@ let
 
   caddyWithPlugins = pkgs.caddy.withPlugins {
     plugins = [ "github.com/caddy-dns/cloudflare@v0.2.2" ];
-    hash = "sha256-Gb1nC5fZfj7IodQmKmEPGygIHNYhKWV1L0JJiqnVtbs=";
+    hash = "sha256-7DGnojZvcQBZ6LEjT0e5O9gZgsvEeHlQP9aKaJIs/Zg=";
   };
 
   envFilePath = "/run/caddy/env";


### PR DESCRIPTION
## Summary

- atuin v18.13.0 migration `20260224000100`이 Mac DB에 적용된 상태에서 nixpkgs lock(3/8)의 atuin v18.12.1이 해당 migration을 인식하지 못해 `atuin history` 명령 실패
- `nix flake update`로 전체 input 업데이트 → atuin 18.12.1 → 18.13.3
- Caddy cloudflare 플러그인 vendor hash 동시 갱신 (nixpkgs 연동)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `flake.lock` | nixpkgs 9dcb002(3/8) → 46db2e0(3/24) 외 전체 input 갱신 |
| `modules/nixos/programs/caddy.nix` | `withPlugins` vendor hash 갱신 |

## 검증

- [x] Mac: `atuin --version` → 18.13.3, `atuin history list` 정상
- [x] MiniPC: `atuin --version` → 18.13.3, `nrs` rebuild 성공
- [x] `nix flake check --no-build --all-systems` 통과 (pre-push hook)

## DA Feedback Summary (Codex 8-agent)

| Agent | Result | Note |
|-------|--------|------|
| YAGNI/Scope | ISSUE (기각) | 전체 input 업데이트는 사용자 명시 선택 |
| Side Effects | PASS | rebuild 성공이 최강 호환성 신호 |
| Security | PASS | 해시 절차 정당, 알려진 취약점 없음 |
| Rollback | ISSUE (정보성) | 롤백 시 flake.lock + caddy.nix 묶음 필요, atuin DB 비가역 |
| Plan vs Impl | ISSUE (정보성) | caddy.nix 수정은 빌드 에러 후 발견된 필수 수정 |
| Caddy | PASS | 해시 정당, nfu.sh FOD 수리 패턴과 일치 |
| Migration | PASS | 18.13.3이 migration 포함, MiniPC 자동 적용 확인 |
| Completeness | PASS | 문제 해결됨, syncing-atuin 스킬 문서 업데이트 권장 |

## Parallel Audit Summary (Codex 10-agent)

| Audit | Result |
|-------|--------|
| Breaking Changes | PASS |
| Nix Eval 정합성 | PASS |
| Service Health | PASS |
| Atuin Compat | PASS |
| Home Manager | PASS |
| Darwin Compat | PASS |
| Secrets | PASS |
| Network/Tailscale | PASS |
| Shell 환경 | PASS |
| Commit Hygiene | ISSUE (반영) → 2커밋을 1커밋으로 squash |

## Test plan

- [x] Mac `nrs` rebuild 성공 (93s)
- [x] MiniPC `nrs` rebuild 성공 (239s)
- [x] atuin 18.13.3 양쪽 확인
- [x] `atuin history list` 에러 없이 출력
- [x] MiniPC Podman 서비스 정상 (healthcheck 일시 경고만)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Caddy package integrity verification for Cloudflare DNS plugin support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->