### PR TITLE
fix(nrs): worktree-only 새 파일의 mkOutOfStoreSymlink relink 누락 수정

### DIFF
--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -150,8 +150,8 @@ main() {
     else
         # Worktree pre-rebuild: worktree 경로를 가리키는 심링크를 제거하여
         # HM activation의 checkLinkTargets가 정상 생성할 수 있도록 한다.
-        # nrs-relink restore는 현재 HMF(gcroot) 기반이라 worktree-only entry를 모르므로,
-        # _remove_worktree_symlinks()로 먼저 제거한 뒤 restore를 실행한다.
+        # _remove_worktree_symlinks()로 worktree 경로 심링크를 먼저 제거한 뒤
+        # nrs-relink restore로 nix store chain으로 복원한다.
         log_info "🔗 Removing worktree symlinks before rebuild..."
         _remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
         # 기존 entry를 nix store chain으로 복원 (rebuild 실패 시에도 안전)

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -69,8 +69,8 @@ main() {
     elif [[ "$FLAKE_PATH" != "$MAIN_FLAKE_PATH" ]]; then
         # Worktree pre-rebuild: worktree 경로를 가리키는 심링크를 제거하여
         # HM activation의 checkLinkTargets가 정상 생성할 수 있도록 한다.
-        # nrs-relink restore는 현재 HMF(gcroot) 기반이라 worktree-only entry를 모르므로,
-        # _remove_worktree_symlinks()로 먼저 제거한 뒤 restore를 실행한다.
+        # _remove_worktree_symlinks()로 worktree 경로 심링크를 먼저 제거한 뒤
+        # nrs-relink restore로 nix store chain으로 복원한다.
         log_info "🔗 Removing worktree symlinks before rebuild..."
         _remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
         # 기존 entry를 nix store chain으로 복원 (rebuild 실패 시에도 안전)

--- a/modules/shared/scripts/nrs-relink.sh
+++ b/modules/shared/scripts/nrs-relink.sh
@@ -58,7 +58,7 @@ _discover_oos_entries() {
         while [[ $hop -lt $max_hops ]]; do
             local target
             target=$(readlink "$current" 2>/dev/null) || break
-            # 각 hop은 nix store 내 절대 심링크. main_repo 패턴 첫 match가 OOS 매핑.
+            # 중간 hop은 nix store 절대 심링크. 첫 $main_repo/* match를 OOS 매핑으로 사용.
             if [[ "$target" == "$main_repo"/* ]]; then
                 final_target="$target"
                 break


### PR DESCRIPTION
## Summary

- `_discover_oos_entries`에서 `readlink -f` 대신 hop-by-hop `readlink` 루프로 변경하여, worktree-only 새 디렉토리의 파일도 relink 대상에 포함시킨다
- #332 이후 부정확해진 nrs.sh 주석 3건 수정

Closes #332

## 기존 문제/배경

`nrs-relink`의 `_discover_oos_entries`가 `readlink -f`로 심링크 체인의 최종 타겟을 추적할 때, worktree-only 새 **디렉토리**의 파일은 main repo에 부모 디렉토리가 존재하지 않아 GNU `readlink -f`가 실패(exit 1)한다. 해당 파일이 relink 대상에서 누락되어 `$HOME` 심링크가 dangling 상태가 된다.

#329 (VSCode → Zed 마이그레이션)에서 `modules/darwin/programs/zed/` 디렉토리를 새로 생성할 때 발견. merge 전 로컬 테스트가 불가능했다.

**정확한 실패 조건** (DA HALLUCINATION 검증):

| 상황 | GNU readlink -f | 발견 여부 |
|------|----------------|----------|
| 기존 파일 (main에 존재) | exit 0 | O |
| 새 파일, 기존 디렉토리에 추가 | exit 0 | O |
| **새 파일, 새 디렉토리에 추가** | **exit 1** | **X (버그)** |

## CIR (Change Intent Record)

- **v0** (`8694700`): `_discover_oos_entries` 최초 구현 — `readlink -f`로 전체 체인 해석
- **v1** (`543acd7`): worktree pre-rebuild에서 worktree-only entry 직접 제거
- **v2** (`33b6f24`): worktree 삭제 후 dangling 심링크 3중 자동 복구
- **v3** (이번 변경): `readlink -f` → hop-by-hop 루프. `readlink -f`는 부모 디렉토리 미존재 시 실패하므로 새 디렉토리 파일을 발견하지 못함

**trade-off**: readlink 호출 횟수가 OOS entry당 1회→2회로 증가하지만, 전체 92개 entry 기준 ~0.1초 추가로 nrs 빌드 대비 무의미.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| hop-by-hop readlink 루프 | 1-hop씩 readlink로 체인 추적, `$main_repo/*` 패턴 첫 match 사용 | 파일 존재 무관, 단순 구현, 하위 호환 | readlink 호출 2배 (~0.1초) | ✅ |
| manifest 기반 발견 | 빌드 시 OOS manifest 생성, 런타임에 manifest 읽기 | 체인 모양 의존 제거 | 아키텍처 재설계 필요, 범위 초과 | ❌ |
| `readlink -f` + fallback | 기존 방식 유지, 실패 시 1-hop fallback | 기존 동작 최대 유지 | 코드 복잡도 증가, 이중 경로 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/nrs-relink.sh` | 수정 | `_discover_oos_entries`: `readlink -f` → hop-by-hop 루프 |
| `modules/darwin/scripts/nrs.sh` | 수정 | stale 주석 수정 ("restore는 worktree-only entry를 모르므로" 제거) |
| `modules/nixos/scripts/nrs.sh` | 수정 | 동일 stale 주석 수정 |

### 핵심 코드

```bash
# BEFORE
final_target=$(readlink -f "$link" 2>/dev/null) || continue
[[ "$final_target" == "$main_repo"/* ]] || continue

# AFTER
local current="$link" final_target="" hop=0
local max_hops=10  # nix store 체인은 2-3 hop; 10은 안전 마진
while [[ $hop -lt $max_hops ]]; do
    local target
    target=$(readlink "$current" 2>/dev/null) || break
    if [[ "$target" == "$main_repo"/* ]]; then
        final_target="$target"
        break
    fi
    current="$target"
    ((++hop))
done
[[ -n "$final_target" ]] || continue
```

## 참고 레퍼런스

- Issue #332 — 이 버그 보고 + LLM 이행 가이드
- PR #330 (`605bab4`) — VSCode → Zed 마이그레이션 (버그 발견 계기)
- `543acd7` — worktree pre-rebuild에서 worktree-only entry 직접 제거
- `33b6f24` — worktree 삭제 후 dangling 심링크 3중 자동 복구

## Human Test Plan

### 정상 동작 검증

1. worktree에서 새 디렉토리+파일을 포함하는 모듈을 추가하고 `nrs`를 실행한다.
   - **기대**: 새 파일의 `$HOME` 심링크가 worktree 경로를 가리킨다.
   - **실패 시**: `nrs-relink status`로 DANGLING 항목을 확인한다.

2. `nrs-relink status`를 실행한다.
   - **기대**: 모든 항목이 `[worktree]` 또는 `[main]`이며 `[DANGLING]` 없음.

### 회귀 검증

3. 기존 파일(main에 존재하는 파일)의 심링크가 정상 동작하는지 확인한다.
   - `cat ~/.claude/settings.json | head -3`
   - **기대**: 파일 내용 정상 출력.

4. `nrs-relink restore` 후 `nrs-relink status`를 확인한다.
   - **기대**: 모든 항목이 `[main]`.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. readlink -f 코드(주석 제외) 부재 확인
grep -n "readlink -f" modules/shared/scripts/nrs-relink.sh | grep -v "^.*#"
# 기대: 출력 없음 (exit 1)

# 2. max_hops 명명 상수 확인
grep -q "max_hops=10" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# 3. CIR 주석 확인
grep -q "# CIR:" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# 4. stale 주석 제거 확인
! grep -q "worktree-only entry를 모르므로" modules/darwin/scripts/nrs.sh
# 기대: exit 0
! grep -q "worktree-only entry를 모르므로" modules/nixos/scripts/nrs.sh
# 기대: exit 0
```

### Phase 1: 기능 검증

> "새 hop-by-hop 루프가 OOS 엔트리를 정상 발견하는지 확인"

```bash
nrs                    # 빌드 + relink
nrs-relink status      # 전체 상태 확인
```
- **기대**: DANGLING 없이 모든 항목이 [worktree] 또는 [main]
- **실패 시**: `_discover_oos_entries` 함수의 readlink 루프 디버깅

### Phase 2: Regression

> "기존 파일(main에 존재)의 relink/restore가 여전히 정상 동작하는지 확인"

```bash
cat ~/.claude/settings.json | head -3    # 기존 파일 접근 가능
nrs-relink restore                       # nix store chain 복원
nrs-relink status                        # 모든 항목 [main]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced symlink resolution to properly handle cases with missing parent directories and worktree-only entries.

* **Documentation**
  * Updated internal documentation for symlink and restoration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->