### PR TITLE
fix(nrs): post-relink nix store OOS 체인 무결성 검증 (#338)

### DIFF
--- a/modules/shared/scripts/nrs-relink.sh
+++ b/modules/shared/scripts/nrs-relink.sh
@@ -72,7 +72,7 @@ _check_oos_chain() {
     local corrupted=0
     while IFS= read -r -d '' link; do
         local store_link
-        # readlink 실패 = 깨진 심링크 메타데이터; best-effort skip
+        # readlink 실패 = 경로 소멸 또는 읽기 불가; best-effort skip
         store_link=$(readlink "$link" 2>/dev/null) || continue
 
         # L1: HMF entry는 반드시 /nix/store/*를 가리켜야 함
@@ -86,10 +86,10 @@ _check_oos_chain() {
         # L2: mkOutOfStoreSymlink derivation만 검사 (regular file은 non-OOS이므로 skip)
         if [[ -L "$store_link" ]]; then
             local store_target
-            # readlink 실패 = derivation 자체가 손상; best-effort skip
+            # readlink 실패 = derivation 경로 소멸 또는 읽기 불가; best-effort skip
             store_target=$(readlink "$store_link" 2>/dev/null) || continue
             if [[ "$store_target" != "$main_repo"/* ]]; then
-                echo -e "${RED}  nix store corruption: $(basename "$store_link") -> $store_target${NC}" >&2
+                echo -e "${RED}  nix store corruption: ${link#"$hmf"/} -> $store_target${NC}" >&2
                 echo -e "${YELLOW}  Fix: sudo nix-store --repair-path $store_link${NC}" >&2
                 ((++corrupted))
             fi


### PR DESCRIPTION
## Summary

- worktree relink 후 nix store 내부 `mkOutOfStoreSymlink` derivation 손상을 자동 감지하는 `_check_oos_chain` 함수를 `nrs-relink.sh`에 추가한다.
- 이슈 제안의 단일 레벨(L1) 체크가 실제 손상을 감지할 수 없음을 로컬 검증으로 확인하여, L1+L2 2단계 검증으로 재설계했다.

Closes #338

## 기존 문제/배경

PR #330 (VSCode → Zed 마이그레이션) 작업 중 worktree에서 `nrs` 실행 후 `~/.config/zed/keymap.json` 심링크 체인의 nix store 내부 derivation이 `/tmp/test`를 가리키도록 손상됨.

심링크 체인 구조:
```
~/.config/zed/keymap.json
  → /nix/store/xxx-home-manager-files/.config/zed/keymap.json     (HMF, L1)
    → /nix/store/yyy-hm_keymap.json                                (mkOutOfStoreSymlink, L2)
      → /Users/green/Workspace/nixos-config/.../keymap.json        (최종 타겟)
```

손상 발생 시 자동 복구 불가 — `nix-collect-garbage -d`, `nrs --force` 모두 동일 캐시 재사용. 유일한 복구: `sudo nix-store --repair-path`. 감지 시스템이 유일한 현실적 방어선이다.

## CIR (Change Intent Record)

- **이슈 제안** (`#338`): `_verify_nix_store_integrity()` — HMF symlink L1 target만 검증하는 단일 레벨 체크
- **LLM 이행 가이드** (`#338` comment): 동일 알고리즘에 색상 출력 추가
- **이번 구현**: 로컬 검증에서 HMF 92개 symlink 전체의 L1이 `/nix/store/*`임을 확인 → 제안 체크는 항상 통과하여 실제 손상(L2: `hm_xxx → /tmp/test`) 감지 불가 → L1+L2 2단계 검증으로 재설계

**trade-off**: HMF 전체를 추가 순회하므로 relink당 ~0.5s 오버헤드 발생하나, 전체 rebuild 대비 <5%이며 nix store corruption 즉시 감지 가치가 압도한다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 이슈 제안: L1 단일 체크 | HMF entry target이 `/nix/store/*`인지만 확인 | 구현 단순 | 92/92가 항상 `/nix/store/*`이므로 손상 감지 불가 | ❌ |
| L1+L2 2단계 체크 | L1 확인 후, intermediate store symlink의 L2 target도 확인 | 실제 손상 케이스 (`hm_xxx → /tmp/test`) 감지 가능 | HMF 전체 추가 순회 (~0.5s) | ✅ |
| `_discover_oos_entries` 재사용 | 기존 OOS discovery 결과로 검증 | 추가 순회 없음 | corrupted chain은 `readlink -f` 실패로 discovery에서 invisible — 감지 불가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/nrs-relink.sh` | 수정 | `RED` 색상 상수 추가, `_check_oos_chain` 함수 추가, `cmd_relink` 마지막에 호출 |

### 핵심 코드

```bash
_check_oos_chain() {
    local hmf="$1" main_repo="$2"
    local corrupted=0
    while IFS= read -r -d '' link; do
        local store_link
        store_link=$(readlink "$link" 2>/dev/null) || continue

        # L1: HMF entry → /nix/store/* 필수
        if [[ "$store_link" != /nix/store/* ]]; then
            # HMF 자체 손상 → HMF derivation repair 안내
            ((++corrupted)); continue
        fi

        # L2: mkOutOfStoreSymlink만 검사 (regular file = non-OOS → skip)
        if [[ -L "$store_link" ]]; then
            local store_target
            store_target=$(readlink "$store_link" 2>/dev/null) || continue
            if [[ "$store_target" != "$main_repo"/* ]]; then
                # intermediate derivation 손상 → 해당 derivation repair 안내
                ((++corrupted))
            fi
        fi
    done < <(find "$hmf" -type l -print0 2>/dev/null)
    return 0  # non-blocking: 경고만 출력, nrs 중단하지 않음
}
```

**설계 결정:**
- L1은 `/nix/store/*`만 허용 (92/92 검증, `main_repo/*` 허용은 dead path)
- `-L "$store_link"` 가드로 non-OOS entries 자연 필터링 (44개 intermediate symlink 전부 OOS 확인)
- L1 repair → `$hmf`, L2 repair → `$store_link` (손상 위치별 정확한 repair 대상)

## 참고 레퍼런스

- Issue #338 — worktree relink가 nix store 심링크 손상 유발 (이 PR이 해결)
- PR #330 (`605bab4`) — VSCode → Zed 마이그레이션 (손상이 발견된 작업)
- PR #295 (`33b6f24`) — worktree 삭제 후 dangling 심링크 3중 자동 복구
- Issue #332 — worktree-only 새 파일의 relink 누락 (별개 문제)

## Human Test Plan

### 정상 동작 검증

1. worktree에서 `nrs-relink relink`를 실행한다.
   - **기대**: `Relinked N symlink(s) to worktree` 출력, corruption 경고 없음 (현재 손상 없으므로)
   - **실패 시**: `_check_oos_chain`에서 false positive 발생 여부 확인, `nrs-relink status`로 현재 상태 점검

2. `nrs-relink restore`를 실행한다.
   - **기대**: `Restored N symlink(s) to nix store chain` 출력, 검증 함수 미호출 (restore에는 추가하지 않았으므로)
   - **실패 시**: 기존 restore 로직 영향 여부 확인

### 엣지 케이스

3. main repo에서 `nrs-relink relink`를 실행한다.
   - **기대**: `Not in a worktree (main repo). Nothing to relink.` 출력, 검증 함수 미호출
   - **실패 시**: `$git_toplevel == $MAIN_REPO` 비교 로직 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. _check_oos_chain 함수 존재 확인
grep -q "_check_oos_chain()" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# 2. cmd_relink에서 호출 확인
grep -q "_check_oos_chain.*MAIN_REPO" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# 3. RED 색상 상수 존재 확인
grep -q "RED=" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# 4. 이전 함수명 부재 확인
! grep -q "_verify_nix_store_integrity" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# 5. shellcheck 통과
shellcheck modules/shared/scripts/nrs-relink.sh
# 기대: exit 0
```

### Phase 1: 2단계 체인 검증 로직

> "L1 (HMF→store) + L2 (store→main_repo) 2단계 검증이 구현되어 있는지 확인"

```bash
# L1 검사: /nix/store/* 패턴 확인
grep -q 'store_link.*!= /nix/store/\*' modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# L2 검사: main_repo 패턴 확인
grep -q 'store_target.*!= .*main_repo' modules/shared/scripts/nrs-relink.sh
# 기대: exit 0

# non-blocking: return 0 명시
grep -q "return 0" modules/shared/scripts/nrs-relink.sh
# 기대: exit 0
```
- **기대**: L1, L2 검사 패턴과 non-blocking return이 모두 존재한다.
- **실패 시**: `_check_oos_chain` 함수 본문에서 검사 조건식과 return문을 확인한다.

### Phase 2: Regression

> "기존 cmd_restore, cmd_status, cmd_fix_dangling이 영향 받지 않았는지 확인"

```bash
# cmd_restore에 _check_oos_chain 호출이 없어야 함
! grep -A5 "cmd_restore()" modules/shared/scripts/nrs-relink.sh | grep -q "_check_oos_chain"
# 기대: exit 0

# cmd_status에 _check_oos_chain 호출이 없어야 함
! grep -A20 "cmd_status()" modules/shared/scripts/nrs-relink.sh | grep -q "_check_oos_chain"
# 기대: exit 0

# flake check 통과
nix flake check --no-build --all-systems
# 기대: exit 0
```
- **기대**: 검증 함수는 cmd_relink에만 추가되었고, 다른 서브커맨드는 변경 없음.
- **실패 시**: `_check_oos_chain` 호출 위치를 `grep -n _check_oos_chain`으로 확인한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced integrity verification during relink operations to detect potential corruption issues
  * Added diagnostic warnings when system problems are discovered
  * Included suggested remediation commands in alerts for quick issue resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->