### PR TITLE
fix(hook): worktree에서 plan 생성 시 worktree-path-guard 차단 해소

### DIFF
--- a/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
@@ -25,6 +25,23 @@ MAIN_REPO=$(cd "$COMMON_DIR/.." 2>/dev/null && pwd) || exit 0
 # 대상 파일의 실제 경로 확인 (심링크 해석)
 RESOLVED=$(readlink -f "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
 
+# main repo guard 예외: Claude plan 파일 허용
+# claude --worktree의 main session에서 plan write가 $MAIN_REPO/.claude/plans/로 나가는
+# 사례가 관측되어 예외 허용 (Claude Code 2.x, plansDirectory를 main repo 기준으로 해석)
+_is_main_repo_plan_path() {
+  local p="$1"
+  [[ "$p" == *".."* ]] && return 1  # path traversal 방어
+  local dir base
+  dir=$(dirname "$p")
+  base=$(basename "$p")
+  [[ "$dir" == "$MAIN_REPO/.claude/plans" ]] && [[ "$base" == *.md ]] && return 0
+  return 1
+}
+
+if _is_main_repo_plan_path "$RESOLVED"; then
+  exit 0
+fi
+
 # main repo 경로이면서 현재 worktree 하위가 아닌 경우 차단
 _is_main_repo_path() {
   local p="$1"


### PR DESCRIPTION
## Summary

- `claude --worktree`로 생성한 워크트리에서 plan 생성 시 `worktree-path-guard.sh` PreToolUse hook이 main repo의 `.claude/plans/` 경로 쓰기를 차단하는 버그 수정
- Claude Code의 plan 시스템이 `plansDirectory`를 main repo 기준으로 해석하여 `$MAIN_REPO/.claude/plans/`에 쓰려 하지만, hook이 이를 "main repo 파일 수정"으로 판단하여 차단했음
- `_is_main_repo_plan_path()` 함수를 추가하여 예외 처리

## Changes

`modules/shared/programs/claude/files/hooks/worktree-path-guard.sh` (+17 lines)

- `_is_main_repo_plan_path()` 함수 추가: RESOLVED(canonical) 경로 기준으로 `$MAIN_REPO/.claude/plans/` 직계 `.md` 파일만 허용
- Path traversal 방어: `..` 포함 경로 거부
- `dirname`/`basename` 분리: 서브디렉토리 매칭 차단

## Root Cause

"wt" (EnterWorktree) 워크트리에서는 plan이 워크트리 진입 전(main repo 컨텍스트)에 생성되므로 문제 없었음. `claude --worktree`는 세션 시작부터 워크트리에 있으므로 hook이 발동.

## DA Review

3 rounds for_plan + 1 round for_pr (codex exec 병렬 8-agent).

수용된 개선:
- Path traversal 방어 (`..` 체크)
- RESOLVED 경로만 검사 (symlink raw path 우회 방어)
- `.md` 확장자 제한
- 서브디렉토리 매칭 차단 (`dirname`/`basename`)

사용자 기각 확정:
- Plan 경로 공용 resolver 도입 (YAGNI — Claude Code upstream workaround)

## Test plan

- [x] 정상 plan .md 경로 → 통과
- [x] Plan 비-.md 파일 → 차단
- [x] Path traversal (`../..`) → 차단
- [x] 서브디렉토리 plan .md → 차단
- [x] Main repo 코드 파일 → 차단
- [x] Worktree 내부 파일 → 통과
- [x] pre-commit hooks 통과 (shellcheck, gitleaks, eval-tests)
- [x] flake-check 통과