### PR TITLE
feat(claude): CLAUDE.md에 extended thinking 한국어 사고 지시 추가

### DIFF
--- a/modules/shared/programs/claude/files/CLAUDE.md
+++ b/modules/shared/programs/claude/files/CLAUDE.md
@@ -1,5 +1,11 @@
 # User-scope Instructions
 
+## 사고 언어
+
+내부 사고(thinking)를 항상 한국어로 수행하라. 영어로 사고하지 마라.
+
+> 배경: Opus 4.6의 영어 thinking 기본 동작을 한국어로 유도. 공식 `thinking_language` 설정이 추가되면 이 섹션을 제거한다. (#345)
+
 ## skill-creator 스크립트 Override
 
 skill-creator 플러그인의 Python 스크립트를 직접 호출하지 마라. 아래 셸 스크립트 대체물을 사용하라.


### PR DESCRIPTION
## Summary

- CLAUDE.md에 `## 사고 언어` 섹션을 추가하여 Opus 4.6의 extended thinking을 한국어로 유도한다.
- 보장이 아닌 유도: CLAUDE.md는 context이지 enforced config가 아니다. 실패 시 즉시 제거 가능한 저비용 실험.

Closes #345

## 기존 문제/배경

Opus 4.6은 기본적으로 thinking을 영어로 강제한다 (Opus 4.5 대비 regression). 한국어로 작업하면서 thinking만 영어로 출력되면 영어↔한국어 코드 스위칭으로 인지 부하가 증가한다. 공식 `thinking_language` 설정이 존재하지 않으므로 CLAUDE.md 지시가 유일한 workaround이다.

실 세션(2026-03-29)에서 한국어 thinking 화제 자체가 맥락으로 작용하여 전환이 일어남을 확인. CLAUDE.md 지시는 매 턴 시스템 프롬프트에 포함되므로, context compaction 후에도 유지되는 장점이 있다.

**영향 범위:**

| 영향 대상 | 경로 | 실질 영향 |
|-----------|------|-----------|
| Claude Code 대화형 | `~/.claude/CLAUDE.md` | **의도된 대상** — 한국어 thinking 유도 |
| Codex CLI | `~/.codex/AGENTS.md` (동일 소스 공유) | 무시됨 — GPT 기반, thinking 지시 무의미 |
| `claude -p` 자동화 | trigger-eval.sh, run-loop.sh 등 | 토큰 소모 ~2.4x 증가 (인지/수용) |

## CIR (Change Intent Record)

해당 없음 — 단순 변경. `## 사고 언어` 섹션 1개 추가.

**trade-off**: 토큰 소모 ~2.4x 증가 (한국어 토큰 효율), 추론 성능 thinking 언어 자체 영향 ~1% ([ICLR 2025](https://arxiv.org/html/2501.02448v1)). 효과 불확실 시 섹션 삭제로 즉시 롤백 가능.

**검증 한계**: `showThinkingSummaries: true` 상태에서 visible thinking은 summarized thinking이며 다른 모델이 생성한다. 한국어 thinking이 보여도 internal thinking 언어의 직접 증명은 아니다.

## ADR

해당 없음 — 대안 없음. `thinking_language` API 파라미터가 존재하지 않아 CLAUDE.md 지시가 유일한 방법.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/CLAUDE.md` | 추가 | `## 사고 언어` 섹션 (헤더 + 지시문 + 배경 주석) |

```markdown
## 사고 언어

내부 사고(thinking)를 항상 한국어로 수행하라. 영어로 사고하지 마라.

> 배경: Opus 4.6의 영어 thinking 기본 동작을 한국어로 유도. 공식 `thinking_language` 설정이 추가되면 이 섹션을 제거한다. (#345)
```

**적용 메커니즘**: `~/.claude/CLAUDE.md`는 mkOutOfStoreSymlink 3-hop 체인으로 소스 파일을 직접 가리킨다. 소스 편집 즉시 반영되며, `nrs`는 적용 게이트가 아니다.

## 참고 레퍼런스

- `86f2f57` — feat(claude): CLAUDE.md에 extended thinking 한국어 사고 지시 추가
- Issue #345 — extended thinking 한국어 고정 요청 + 사이드이펙트 분석
- [anthropics/claude-code#27051](https://github.com/anthropics/claude-code/issues/27051) — `thinking_language` 파라미터 요청 (Closed/stale)
- [anthropics/claude-code#15817](https://github.com/anthropics/claude-code/issues/15817) — Thinking 톤/스타일 제어 요청 (Closed/not planned)
- [ICLR 2025 "Understand, Solve and Translate"](https://arxiv.org/html/2501.02448v1) — thinking 언어 자체 영향 ~1%
- [Anthropic "Tracing the Thoughts"](https://www.anthropic.com/research/tracing-thoughts-language-model) — "English is mechanistically privileged"

## Human Test Plan

### 정상 동작 검증

1. merge 후 `grep "사고 언어" ~/.claude/CLAUDE.md`로 내용 확인.
   - **기대**: `## 사고 언어` 출력.
   - **실패 시**: `realpath ~/.claude/CLAUDE.md`로 symlink 최종 대상 확인. main repo 소스에 변경이 반영되었는지 확인.

2. 새 Claude Code 세션에서 간단한 질문을 보내고 thinking 블록 확인.
   - **기대**: thinking이 한국어로 출력.
   - **실패 시**: workaround가 Opus 4.6에서 무효. 지시 문구 강화 또는 이슈에 기록 후 섹션 제거.

### 롤백

3. `## 사고 언어` 섹션 삭제 → 소스 파일 저장 즉시 반영 (mkOutOfStoreSymlink, nrs 불필요).

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 사고 언어 섹션 존재
grep -q "사고 언어" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0

# 2. 지시문 존재
grep -q "내부 사고.*한국어" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0

# 3. 배경 주석 존재 (제거 조건 명시)
grep -q "#345" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0

# 4. 기존 섹션 미손상 — Negative 검증
grep -q "skill-creator 스크립트 Override" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0
```

### Phase 1: 구조 검증

> "새 섹션이 올바른 위치에 삽입되었는지 확인"

```bash
# 사고 언어가 skill-creator 앞에 위치하는지
head -10 modules/shared/programs/claude/files/CLAUDE.md | grep -q "사고 언어"
# 기대: exit 0 (상위 10줄 내에 존재)
```

- **기대**: `## 사고 언어`가 파일 상단(line 3)에 위치.
- **실패 시**: Edit 순서 확인 — `# User-scope Instructions` 바로 아래에 삽입되었는지 확인.

### Phase 2: Regression

> "기존 CLAUDE.md 섹션이 손상되지 않았는지 확인"

```bash
# Superpowers 라우팅 섹션 유지
grep -q "Superpowers 플러그인 라우팅" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0

# CLI 레퍼런스 섹션 유지
grep -q "CLI 레퍼런스" modules/shared/programs/claude/files/CLAUDE.md
# 기대: exit 0
```