### PR TITLE
fix(pain): long_session 제거 + 야 키워드 + 빈 context 필터링

### DIFF
--- a/modules/shared/programs/claude/files/hooks/collect-pain-points.sh
+++ b/modules/shared/programs/claude/files/hooks/collect-pain-points.sh
@@ -25,7 +25,6 @@ fi
 AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
 [ -n "$AGENT_ID" ] && exit 0
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)
 
 [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ] || exit 0
@@ -33,8 +32,6 @@ TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/de
 # --- 설정 ---
 PAIN_FILE="${PAIN_POINTS_FILE:-$HOME/.claude/pain-points.jsonl}"
 ARCHIVE_FILE="${PAIN_ARCHIVE_FILE:-$HOME/.claude/pain-points.archive.jsonl}"
-TURN_THRESHOLD=30
-
 # --- Transcript 안정화 대기 (stop-notification.sh와 동일 패턴) ---
 wait_for_stable_transcript() {
   local file="$1"
@@ -54,65 +51,9 @@ wait_for_stable_transcript "$TRANSCRIPT_PATH"
 # --- Git 정보 (worktree 보정) ---
 REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)
 REPO="${REPO:-unknown}"
-BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
 if [ -n "$COMMON_DIR" ] && [ "$COMMON_DIR" != ".git" ]; then
   REPO=$(basename "$(cd "$COMMON_DIR/.." 2>/dev/null && pwd)" 2>/dev/null || echo "$REPO")
-fi
-
-# --- 세션 메트릭 수집 ---
-
-# 턴 수
-TURNS=$(jq -Rrs '
-  split("\n")
-  | map(select(length > 0) | fromjson?)
-  | map(select(.type == "user"))
-  | length
-' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
-
-# 세션 시간 (분)
-DURATION_MIN=$(jq -Rrs '
-  split("\n")
-  | map(select(length > 0) | fromjson?)
-  | map(.timestamp // empty | select(. != null and . != ""))
-  | if length > 1 then
-      ( (last | sub("\\.[0-9]+Z$"; "Z") | sub("\\+00:00$"; "Z") | fromdateiso8601)
-      - (first | sub("\\.[0-9]+Z$"; "Z") | sub("\\+00:00$"; "Z") | fromdateiso8601) ) / 60 | floor
-    else 0 end
-' "$TRANSCRIPT_PATH" 2>/dev/null || echo "0")
-
-# 긴 세션(31턴+, TURN_THRESHOLD 초과)이면 메트릭 레코드 기록
-# 중복 방지: 동일 session_id로 이미 기록된 long_session이 있으면 skip
-# (Stop hook은 매 턴 발동하므로 30턴 이후 매번 기록되는 것을 방지)
-if [ "$TURNS" -gt "$TURN_THRESHOLD" ]; then
-  ALREADY_RECORDED=false
-  if [ -f "$PAIN_FILE" ]; then
-    ALREADY_RECORDED=$(jq -rs --arg sid "${SESSION_ID:-unknown}" \
-      'map(select(.session_id == $sid and .signals.keyword == "long_session")) | length > 0' \
-      "$PAIN_FILE" 2>/dev/null || echo "false")
-  fi
-
-  if [ "$ALREADY_RECORDED" != "true" ]; then
-    TS=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
-    # append는 OS 레벨에서 원자적 (1줄 JSONL < PIPE_BUF)
-    jq -nc \
-      --arg ts "$TS" \
-      --arg sid "${SESSION_ID:-unknown}" \
-      --arg repo "$REPO" \
-      --arg branch "$BRANCH" \
-      --argjson turns "$TURNS" \
-      --argjson dur "$DURATION_MIN" \
-      --arg tp "${TRANSCRIPT_PATH:-}" \
-      '{
-        ts: $ts, session_id: $sid, repo: $repo, branch: $branch,
-        source: "auto", severity: "medium",
-        signals: { keyword: "long_session", turns: ($turns), duration_min: ($dur) },
-        description: ("\($turns)턴, \($dur)분 — 긴 세션"),
-        user_note: null,
-        transcript_path: (if $tp == "" then null else $tp end),
-        context: []
-      }' >> "$PAIN_FILE" 2>/dev/null || true
-  fi
 fi
 
 # --- 정제: 7일 이전 항목 처리 ---

--- a/modules/shared/programs/claude/files/hooks/detect-pain-point.sh
+++ b/modules/shared/programs/claude/files/hooks/detect-pain-point.sh
@@ -73,6 +73,9 @@ elif printf '%s' "$PROMPT" | grep -q '해야지'; then
 elif printf '%s' "$PROMPT" | grep -q '그거 말고'; then
   HAS_KEYWORD=true
   MATCHED_KEYWORD="그거 말고"
+elif printf '%s' "$PROMPT" | grep -qE '^야,|^야 '; then
+  HAS_KEYWORD=true
+  MATCHED_KEYWORD="야,"
 fi
 
 # 아무것도 감지 안 되면 exit
@@ -100,13 +103,14 @@ if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     split("\n")
     | map(select(length > 0) | fromjson?)
     | map(select(.type == "user" or .type == "assistant"))
-    | .[-4:]
     | map({type, content: (
         .message.content // ""
         | if type == "string" then .[0:300]
           elif type == "array" then ([.[] | select(type == "object" and .type == "text") | .text] | first // "") | .[0:300]
           else "" end
       )})
+    | map(select(.content | length > 0))
+    | .[-4:]
   ' "$TRANSCRIPT_PATH" 2>/dev/null || echo "[]")
 fi
 

--- a/modules/shared/programs/claude/files/scripts/show-pain-points.sh
+++ b/modules/shared/programs/claude/files/scripts/show-pain-points.sh
@@ -82,11 +82,13 @@ for entry in data:
                             if isinstance(block, dict) and block.get('type') == 'text':
                                 content = block.get('text', '')[:300]
                                 break
-                    records.append({'type': rec['type'], 'content': content})
+                    # 텍스트가 있는 턴만 수집 (tool_use만 있는 턴은 skip)
+                    if content.strip():
+                        records.append({'type': rec['type'], 'content': content})
             except (json.JSONDecodeError, KeyError):
                 continue
 
-        # pain point timestamp에 가장 가까운 4턴 추출
+        # 텍스트가 있는 최근 4턴 추출
         entry['context'] = records[-4:] if records else []
     except Exception:
         pass


### PR DESCRIPTION
## Summary

- long_session 메트릭을 pain point 수집에서 제거 (긴 세션 ≠ pain point)
- "야," 교정 키워드 추가 (medium severity)
- 대시보드 context 모달에서 (empty) 표시되는 문제 수정

Closes 사용자 피드백 (PR #352 post-merge)

## 기존 문제/배경

- long_session은 30턴 이상 세션을 자동 기록했으나, 긴 세션이 반드시 pain point는 아님
- context 모달에서 tool_use만 있는 턴이 "(empty)"로 표시되어 의미 없는 정보 노출
- "야," 같은 교정 표현이 감지되지 않음

## CIR

| 시점 | 결정 |
|------|------|
| PR #352 post-merge | 사용자가 long_session 대시보드 데이터를 보고 "구멍이 많다" 판단 → 제거 |
| PR #352 post-merge | "야," 키워드 추가 요청 |
| PR #352 post-merge | context (empty) 문제 지적 → 빈 턴 필터링 |

## ADR

해당 없음 — 사용자 명시 결정.

## 구현 상세

| 파일 | 변경 |
|------|------|
| `hooks/collect-pain-points.sh` | long_session 블록 전체 제거 (TURN_THRESHOLD, TURNS, DURATION_MIN, 중복 방지 로직), 미사용 변수(SESSION_ID, BRANCH) 정리 |
| `hooks/detect-pain-point.sh` | `^야,\|^야 ` 키워드 추가, context 추출 시 빈 content 턴 필터링 후 4턴 선택 |
| `scripts/show-pain-points.sh` | context fallback에서 `content.strip()` 빈 턴 skip |

## 참고 레퍼런스

| 참조 | 설명 |
|------|------|
| #352 | feat(pain): /show-pains 스킬 PR |
| `4610209` | fix(pain): jq -Rsc inputs 첫 줄 누락 수정 (post-merge hotfix) |

## Human Test Plan

```bash
# 빈 데이터
PAIN_POINTS_FILE=/tmp/x.jsonl PAIN_ARCHIVE_FILE=/tmp/y.jsonl ~/.claude/scripts/show-pain-points.sh
# 기대: "데이터가 없습니다"

# long_session이 더 이상 기록되지 않는지 확인
grep -c 'long_session' ~/.claude/pain-points.jsonl 2>/dev/null || echo "0 (정상)"
```

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증
```bash
# long_session 관련 코드 제거 확인
! grep -q 'long_session' modules/shared/programs/claude/files/hooks/collect-pain-points.sh && echo PASS
! grep -q 'TURN_THRESHOLD' modules/shared/programs/claude/files/hooks/collect-pain-points.sh && echo PASS

# "야," 키워드 추가 확인
grep -q '야,' modules/shared/programs/claude/files/hooks/detect-pain-point.sh && echo PASS

# shellcheck clean
shellcheck modules/shared/programs/claude/files/hooks/collect-pain-points.sh && echo PASS
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Korean language support for prompt detection.

* **Improvements**
  * Enhanced transcript content extraction to filter out empty entries, improving data quality in context processing.
  * Refined pain point analysis by excluding non-text content from context selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->