### PR TITLE
fix(caddy): nixpkgs 업데이트로 Go 버전 불일치 해소

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772963539,
-        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- nixpkgs를 `9dcb002`(2026-03-08) → `46db2e0`(2026-03-24)으로 업데이트하여 Caddy `withPlugins` 빌드 실패를 해소한다.
- 근본 원인: nixpkgs의 Go 1.25.7과 Caddy 2.11.2의 go.mod 요구사항(Go >= 1.26.1) 간 버전 불일치.

## 기존 문제/배경

`nrs` 실행 시 Caddy 2.11.2 `withPlugins` 빌드가 실패한다:

```
go: go.mod requires go >= 1.26.1 (running go 1.25.7; GOTOOLCHAIN=local)
```

일반 `pkgs.caddy`는 바이너리 캐시(`cache.nixos.org`)에서 fetch되어 문제가 숨겨지지만, `withPlugins`는 커스텀 플러그인 조합이므로 반드시 로컬 빌드가 필요하다. 로컬 빌드 시 flake.lock에 고정된 nixpkgs의 Go 1.25.7이 사용되어 빌드 실패가 발생한다.

## CIR (Change Intent Record)

- **발견 경위**: `nrs` 실행 시 Caddy 빌드 에러 발생. `nix derivation show`로 Caddy derivation의 Go 입력이 1.25.7임을 확인.
- **원인 분석**: `nix eval`로 flake의 Go 버전(1.25.7)과 최신 nixpkgs-unstable의 Go 버전(1.26.1)을 대조하여 flake.lock 고정 시점의 일시적 불일치임을 확인.
- **재발 가능성 판단**: nixpkgs-unstable에서 Go/Caddy 간 일시적 버전 불일치는 구조적으로 재발 가능하나, 빈도가 낮고 `withPlugins` 사용자만 영향받음. overlay 추가는 유지보수 부담이 더 크므로 flake update만으로 대응.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `nix flake update nixpkgs` | nixpkgs를 최신 unstable로 업데이트 | 즉시 해결, 추가 코드 없음 | 다음 불일치 시 재수행 필요 | ✅ |
| Go pinning overlay | caddy의 Go를 명시적으로 고정 | 재발 방지 | nixpkgs 구조 변경에 brittle, `plugins.nix` 내부 `callPackage` 오버라이드 필요 | ❌ |
| 빌드 검증 스크립트 추가 | flake update 후 withPlugins 빌드 smoke test | 조기 감지 | 문제 자체를 예방하지 않음, 추가 유지보수 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `flake.lock` | 수정 | nixpkgs `9dcb002` → `46db2e0` (Go 1.25.7 → 1.26.1) |

### 핵심 변경

```diff
-        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
```

`withPlugins`의 FOD hash(`caddy.nix`)는 변경 불필요 — 동일 플러그인 버전이므로 hash 유지.

## 참고 레퍼런스

- `e68628d` — 이번 변경 커밋
- `modules/nixos/programs/caddy.nix:18-21` — `withPlugins` 사용 위치
- nixpkgs `plugins.nix` — `callPackage`에서 `pkgs.go`를 받아 FOD 빌드에 사용하는 구조가 불일치의 근본 원인

## Human Test Plan

1. MiniPC에서 `nrs`를 실행한다.
   - **기대**: 빌드 성공, Caddy withPlugins 포함 전체 시스템 빌드 완료.
   - **실패 시**: `nix log`로 Caddy derivation 빌드 로그를 확인하고, Go 버전을 `nix eval '.#nixosConfigurations."greenhead-minipc".pkgs.go.version'`으로 점검.

2. Caddy 서비스가 정상 동작하는지 확인한다.
   - **기대**: `systemctl status caddy`가 active.
   - **실패 시**: `journalctl -u caddy -n 50`으로 로그 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. nixpkgs 커밋이 업데이트되었는지 확인
grep -q "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9" flake.lock
# 기대: exit 0

# 2. 이전 nixpkgs 커밋이 없는지 확인
! grep -q "9dcb002ca1690658be4a04645215baea8b95f31d" flake.lock
# 기대: exit 0

# 3. Go 버전 확인
nix eval '.#nixosConfigurations."greenhead-minipc".pkgs.go.version' 2>/dev/null | grep -q "1.26"
# 기대: exit 0
```

### Phase 1: 빌드 검증

```bash
# withPlugins 포함 전체 시스템 빌드
nix build '.#nixosConfigurations."greenhead-minipc".config.system.build.toplevel' --dry-run
# 기대: 에러 없이 완료
```

- **실패 시**: `nix log`로 실패한 derivation의 빌드 로그를 확인한다.