### PR TITLE
fix(scripts): all-holdout-fail 시 train score 기반 best_iteration 갱신 (#322)

### DIFF
--- a/modules/shared/programs/claude/files/scripts/run-loop.sh
+++ b/modules/shared/programs/claude/files/scripts/run-loop.sh
@@ -292,6 +292,7 @@ fi
 # --- Initialize tracking ---
 best_test_passed=-1
 best_iteration=0
+best_train_fallback=-1
 iterations_completed=0
 
 # --- Main loop ---
@@ -349,10 +350,12 @@ for ((iteration = 1; iteration <= MAX_ITERATIONS; iteration++)); do
       fi
     else
       log "  Warning: test eval failed, skipping holdout scoring"
-      # Ensure best_iteration is set even when all test evals fail.
-      # Without this, best_iteration stays 0 → serializer produces ?/?.
-      # (Codex review R2 fallback fix)
-      if (( best_iteration == 0 )); then
+      # WHY best_test_passed < 0 guard: if any test eval succeeded (best_test_passed >= 0),
+      # the test-based best is authoritative — train fallback must not override it.
+      # Without this guard, a mixed scenario (some tests pass, some fail) could replace
+      # the test-based best with a train-based one, causing best_description/best_test_score mismatch.
+      if (( best_test_passed < 0 && train_passed > best_train_fallback )); then
+        best_train_fallback=$train_passed
         best_iteration=$iteration
         cp "$work_dir/current_desc.txt" "$work_dir/best_desc.txt"
       fi


### PR DESCRIPTION
## Summary

- `run-loop.sh`에서 holdout eval이 전 iteration에서 실패할 때, `best_iteration`이 첫 iteration에 고정되던 문제를 해결한다.
- `best_train_fallback` 변수로 train score를 추적하되, test 성공이 한 번이라도 있으면 train fallback을 비활성화하여 혼합 시나리오도 안전하게 처리한다.

Closes #322

## 기존 문제/배경

PR #321에서 test eval 실패 시 graceful degradation을 도입하면서 `best_iteration == 0` fallback을 추가했다. 이 fallback은 첫 iteration에서만 트리거되어, 이후 iteration에서 train score가 개선되어도 갱신되지 않았다.

```
Iteration 1: train 8/12, test FAIL → best_iteration=1 (fallback)
Iteration 2: train 10/12, test FAIL → best_iteration=1 (변경 없음!)
Iteration 3: train 11/12, test FAIL → best_iteration=1 (변경 없음!)
→ --apply: iteration 1의 description 적용 (train 8/12)
→ 기대: iteration 3의 description 적용 (train 11/12)
```

## CIR (Change Intent Record)

- **v1** (`af5e55e`): test eval graceful degradation 도입 (`|| true` + 결과 파싱 조건부 처리)
- **v2** (`392d39e`): `best_iteration == 0` fallback 추가로 첫 iteration 최소 설정 보장 (Codex R2)
- **v3** (이번 변경): Codex R3-R5에서 3회 연속 "train score 미갱신" 지적 → 별도 이슈 #322로 분리 후 구현

**trade-off**: `best_train_fallback` 변수 1개 추가로 상태 복잡도가 미세하게 증가하지만, all-holdout-fail 시 최적 train score의 description을 선택할 수 있다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `best_iteration == 0` fallback 유지 | 첫 iteration만 설정 | 단순 | train score 개선 무시 | ❌ |
| `best_train_fallback` + `best_test_passed < 0` 가드 | train score 추적 + 혼합 시나리오 방어 | 최적 train description 선택, 혼합 시나리오 안전 | 변수 1개 추가 | ✅ |
| `best_test_passed` 재사용 (가드 없음) | train score를 `best_test_passed`에 직접 저장 | 변수 추가 없음 | `TEST_SCORE_AVAILABLE` 가드 오동작 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/scripts/run-loop.sh` | 수정 | 변수 추가 + else 블록 조건문 교체 |

### 핵심 코드

```bash
# BEFORE (run-loop.sh:355)
if (( best_iteration == 0 )); then
  best_iteration=$iteration
  cp "$work_dir/current_desc.txt" "$work_dir/best_desc.txt"
fi

# AFTER (run-loop.sh:357)
# best_test_passed < 0: test 성공이 한 번도 없을 때만 train fallback 활성화
if (( best_test_passed < 0 && train_passed > best_train_fallback )); then
  best_train_fallback=$train_passed
  best_iteration=$iteration
  cp "$work_dir/current_desc.txt" "$work_dir/best_desc.txt"
fi
```

## 참고 레퍼런스

- Issue #322 — 이 PR이 해결하는 이슈
- Issue #320 — parent issue (train/test 분리 평가 아키텍처)
- PR #321 (`392d39e`) — eval 순서 변경 + `best_iteration == 0` fallback 도입
- `75b4a25` — test_results 없는 iteration에서 — 표시 fix
- `af5e55e` — test eval graceful degradation fix
- `68127e0` — eval 순서 변경 (train → test → improve)

## Human Test Plan

### 정상 동작 검증

1. all-holdout-fail 시나리오에서 `run-loop.sh --apply`를 실행한다.
   - **기대**: 가장 높은 train score를 가진 iteration의 description이 적용된다.
   - **실패 시**: `best_train_fallback` 변수가 train_passed와 올바르게 비교되는지, `best_test_passed < 0` 가드가 활성화되는지 확인.

2. 일부 iteration에서만 test가 성공하는 혼합 시나리오에서 실행한다.
   - **기대**: test 기반 best가 유지되고 train fallback이 이를 덮어쓰지 않는다.
   - **실패 시**: `best_test_passed` 값이 0 이상으로 설정되었는지, 가드가 fallback을 비활성화하는지 확인.

### 엣지 케이스

3. holdout==0으로 실행한다.
   - **기대**: 기존 동작 유지 (train score 기반 `best_test_passed` 갱신, else 블록 미진입).
   - **실패 시**: holdout==0 경로(361-365행)가 변경되지 않았는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. best_train_fallback 변수 존재 확인
grep -q "best_train_fallback=-1" modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0

# 2. old fallback 패턴 부재 확인
! grep -q "best_iteration == 0" modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0

# 3. best_test_passed < 0 가드 존재 확인
grep -q "best_test_passed < 0 && train_passed > best_train_fallback" modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0
```

### Phase 1: 기능 검증

> "변경된 조건문이 올바르게 구성되었는지 확인"

```bash
# train_fallback 갱신 코드 존재 확인
grep -q "best_train_fallback=\$train_passed" modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0
```

- **기대**: train_passed 값이 best_train_fallback에 저장되는 코드가 존재한다.
- **실패 시**: else 블록(351-362행) 내부에서 `best_train_fallback=$train_passed` 할당이 있는지 확인.

### Phase 2: Regression

> "기존 경로(test 성공, holdout==0)가 변경되지 않았는지 확인"

```bash
# test 성공 경로 유지 확인
grep -q "test_passed > best_test_passed" modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0

# holdout==0 경로 유지 확인
grep -q "train_passed > best_test_passed" modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0

# TEST_SCORE_AVAILABLE 가드 유지 확인
grep -q 'best_test_passed -lt 0' modules/shared/programs/claude/files/scripts/run-loop.sh
# 기대: exit 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined evaluation fallback logic to improve model selection accuracy. The system now applies train-based fallback scores more intelligently—only when test evaluations have not yet produced valid results. This prevents unintended overrides of established test-based scores, ensuring more reliable model selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->