### PR TITLE
fix(scripts): improve-description.sh inline Python injection 수정

### DIFF
--- a/modules/shared/programs/claude/files/scripts/improve-description.sh
+++ b/modules/shared/programs/claude/files/scripts/improve-description.sh
@@ -56,18 +56,18 @@ skill_content=$(cat "$SKILL_PATH/SKILL.md")
 current_description=$(jq -r '.description' "$EVAL_RESULTS")
 
 # --- Build scores summary ---
-scores_summary=$(python3 -c "
-import json
-er = json.load(open('$EVAL_RESULTS'))
+scores_summary=$(EVAL_FILE="$EVAL_RESULTS" python3 -c "
+import json, os
+er = json.load(open(os.environ['EVAL_FILE']))
 s = er['summary']
 train = f\"{s['passed']}/{s['total']}\"
 print(f'Train: {train}')
 ")
 
 # --- Build failure analysis ---
-failure_analysis=$(python3 -c "
-import json
-er = json.load(open('$EVAL_RESULTS'))
+failure_analysis=$(EVAL_FILE="$EVAL_RESULTS" python3 -c "
+import json, os
+er = json.load(open(os.environ['EVAL_FILE']))
 lines = []
 
 failed = [r for r in er['results'] if r['should_trigger'] and not r['pass']]
@@ -95,9 +95,9 @@ print('\n'.join(lines))
 # --- Build history section ---
 history_section=""
 if [[ -n "$HISTORY" && -f "$HISTORY" ]]; then
-  history_section=$(python3 -c "
-import json
-history = json.load(open('$HISTORY'))
+  history_section=$(HISTORY_FILE="$HISTORY" python3 -c "
+import json, os
+history = json.load(open(os.environ['HISTORY_FILE']))
 lines = []
 if history:
     lines.append('PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n')
@@ -235,13 +235,13 @@ fi
 desc_tmpfile=$(mktemp)
 printf '%s' "$new_description" > "$desc_tmpfile"
 
-python3 -c "
-import json, sys
+DESC_FILE="$desc_tmpfile" EVAL_FILE="$EVAL_RESULTS" HISTORY_FILE="${HISTORY}" python3 -c "
+import json, sys, os
 
-description = open('$desc_tmpfile').read()
-eval_results = json.load(open('$EVAL_RESULTS'))
-history_file = '${HISTORY}'
-history = json.load(open(history_file)) if history_file and history_file != '' else []
+description = open(os.environ['DESC_FILE']).read()
+eval_results = json.load(open(os.environ['EVAL_FILE']))
+history_file = os.environ.get('HISTORY_FILE', '')
+history = json.load(open(history_file)) if history_file else []
 
 # Append current to history
 history.append({


### PR DESCRIPTION
## Summary

- `improve-description.sh`의 inline Python 6곳에서 shell 변수 직접 보간(`open('$VAR')`)을 환경변수 패턴(`os.environ['VAR']`)으로 전환하여 code injection 취약점 해소 (CWE-78, CWE-94)

Closes #301

## 기존 문제/배경

`improve-description.sh`의 inline Python에서 `$EVAL_RESULTS`, `$HISTORY`, `$desc_tmpfile` 등의 shell 변수가 Python single-quote 문자열로 직접 보간된다. Single quote를 포함하는 파일 경로가 전달되면 Python 코드가 의도치 않게 실행될 수 있다.

동일 파일 line 47에서는 이미 `os.environ['SKILL_FILE']` 패턴으로 이 문제를 회피하고 있으나(주석에 "avoid shell injection" 명시), 나머지 5개 inline Python 블록에는 동일 패턴이 미적용되어 있었다.

`trigger-eval.sh`는 PR #315에서 이미 환경변수 패턴으로 전환 완료. `run-loop.sh`에는 직접 보간 없음.

## CIR (Change Intent Record)

- **발견 경위**: PR #300 DA SECURITY 리뷰에서 발견, SCOPE_DEFERRAL로 이슈 #301 분리
- **설계 의도**: 기존 안전 패턴(line 47)을 나머지 블록에 일관 적용하는 단순 패턴 통일
- **대안 검토 불필요**: 이미 코드베이스에 검증된 패턴이 존재하므로 새로운 접근법 불필요

## ADR

대안 1개뿐 — 기존 `os.environ` 패턴을 일관 적용. 별도 대안 비교 불필요.

| 대안 | 설명 | 결정 |
|------|------|------|
| 환경변수 패턴 (`VAR=val python3 -c "os.environ[...]"`) | 동일 파일 line 47, trigger-eval.sh에서 이미 사용 중인 검증된 패턴 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/scripts/improve-description.sh` | 수정 | 6곳의 inline Python 변수 보간을 환경변수 패턴으로 전환 |

### 변경 위치

| Line | 변수 | 맥락 |
|------|------|------|
| 59-61 | `$EVAL_RESULTS` → `EVAL_FILE` | scores_summary 계산 |
| 68-70 | `$EVAL_RESULTS` → `EVAL_FILE` | failure_analysis 계산 |
| 98-100 | `$HISTORY` → `HISTORY_FILE` | history_section 계산 |
| 238-244 | `$desc_tmpfile`/`$EVAL_RESULTS`/`$HISTORY` → `DESC_FILE`/`EVAL_FILE`/`HISTORY_FILE` | 최종 JSON 출력 |

### 핵심 코드

```bash
# BEFORE: shell 변수 직접 보간 (injection 취약)
scores_summary=$(python3 -c "
import json
er = json.load(open('$EVAL_RESULTS'))
...")

# AFTER: 환경변수 패턴 (안전)
scores_summary=$(EVAL_FILE="$EVAL_RESULTS" python3 -c "
import json, os
er = json.load(open(os.environ['EVAL_FILE']))
...")
```

## 참고 레퍼런스

- Issue #301 — 이 PR의 대상 이슈
- PR #300 (`da38e05`) — DA SECURITY 리뷰에서 취약점 최초 발견
- PR #315 (`cea7375`) — trigger-eval.sh 환경변수 패턴 전환 (이미 완료)
- `improve-description.sh:47` (`d7092e4`) — 기존 안전 패턴 원본

## Human Test Plan

### 정상 동작 검증

1. single-quote 포함 경로에 테스트 데이터 생성 후 스크립트 실행
   - **기대**: Python 블록들이 정상 실행되어 JSON 출력 생성
   - **실패 시**: 해당 Python 블록의 `os.environ` 키 이름과 shell prefix 변수명이 일치하는지 확인

2. `--history` 미지정 상태로 실행
   - **기대**: `HISTORY_FILE=""`이 전달되어 `history = []`로 폴백
   - **실패 시**: `os.environ.get('HISTORY_FILE', '')`의 falsy 평가 확인

### 엣지 케이스

3. 백슬래시, 개행, 유니코드 포함 경로로 실행
   - **기대**: 환경변수는 shell expansion 없이 그대로 전달되므로 정상 동작
   - **실패 시**: 해당 플랫폼의 `env` 명령 동작 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 직접 보간 패턴 부재 확인
! grep -q "open('\$" modules/shared/programs/claude/files/scripts/improve-description.sh
# 기대: exit 0 (직접 보간이 없어야 성공)

# 2. 환경변수 패턴 존재 확인 (기존 line 47 포함 7곳)
test $(grep -c "os.environ" modules/shared/programs/claude/files/scripts/improve-description.sh) -eq 7
# 기대: exit 0

# 3. shell 구문 유효성
bash -n modules/shared/programs/claude/files/scripts/improve-description.sh
# 기대: exit 0
```

### Phase 1: 기능 검증 — single-quote 경로

> "single-quote 포함 경로에서 모든 inline Python 블록이 정상 동작하는지 확인"

```bash
mkdir -p "/tmp/it's a test"
cat > "/tmp/it's a test/eval.json" <<'JSON'
{"description":"test","summary":{"passed":3,"failed":1,"total":4},"results":[{"query":"q1","should_trigger":true,"pass":true,"trigger_count":1,"total_runs":1}]}
JSON

EVAL_FILE="/tmp/it's a test/eval.json" python3 -c "
import json, os
er = json.load(open(os.environ['EVAL_FILE']))
print(er['summary']['passed'])
"
```
- **기대**: `3` 출력
- **실패 시**: `EVAL_FILE` 환경변수가 올바르게 전달되는지, Python의 `os.environ` 접근이 정상인지 확인

### Phase 2: Regression — run-loop.sh 호환성

> "상위 호출부(run-loop.sh)의 인터페이스가 변경되지 않았는지 확인"

```bash
# CLI 인터페이스 불변 확인
grep -q "\-\-skill-path" modules/shared/programs/claude/files/scripts/improve-description.sh
grep -q "\-\-eval-results" modules/shared/programs/claude/files/scripts/improve-description.sh
grep -q "\-\-history" modules/shared/programs/claude/files/scripts/improve-description.sh
# 기대: 3개 모두 exit 0

# JSON 출력 구조 불변 확인 (description, history 키)
grep -q "'description'" modules/shared/programs/claude/files/scripts/improve-description.sh
grep -q "'history'" modules/shared/programs/claude/files/scripts/improve-description.sh
# 기대: 2개 모두 exit 0
```
- **실패 시**: 커밋 diff에서 CLI 파싱 또는 JSON 출력 블록의 의도치 않은 변경 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal file path handling in build scripts for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->