### PR TITLE
refactor(skills): plan-with-questions /parallel-audit 매직넘버 제거

### DIFF
--- a/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
@@ -151,7 +151,7 @@ DA for_plan 결과에서 유효한 지적을 반영한다.
 
 1. 변경사항 커밋
 2. `/run-da for_pr` — 코드 DA 피드백 루프
-3. `/parallel-audit 10` — 전수조사
+3. `/parallel-audit` — 전수조사
 4. `/create-pr` — main 브랜치 대상 PR 생성
 
 사용자가 명시적으로 특정 단계를 생략하라고 지시한 경우에만 해당 단계를 건너뛴다.


### PR DESCRIPTION
## Summary
- plan-with-questions Post-Implementation에서 `/parallel-audit 10`의 하드코딩된 에이전트 수를 제거하고, parallel-audit의 기본값(10)에 위임한다.

## 기존 문제/배경

run-da에 Review Intensity (SKIP/LITE/FULL) 정책이 추가된 후 (#364, `c992d23`), 비슷한 스케일링 정책을 plan-with-questions와 parallel-audit에도 적용하려는 시도에서 출발.

**문제**: plan-with-questions의 Post-Implementation에서 `/parallel-audit 10`으로 에이전트 수를 하드코딩하여, parallel-audit의 기본값이 바뀌면 호출부와 스킬 정의가 어긋남 (매직넘버).

## CIR (Change Intent Record)

| # | 시점 | 내용 | 참조 |
|---|------|------|------|
| v1 | DA R1 | parallel-audit에 Audit Intensity (SKIP/LITE/FULL) 직접 추가 시도 | DA R1 28건 발견 |
| v2 | DA R1→R2 전환 | R1 결과: 전수조사 계약 파괴 + DRY 위반 → 호출자 계층에서 판단으로 전환 | NGMI CRITICAL, YAGNI HIGH 등 |
| v3 | DA R2 | plan-with-questions에 변경 유형 분류표 추가 시도 | DA R2 22건 발견 |
| v4 | DA R2→R3 전환 | R2 결과: 분류표 재서술 = DRY 위반 → run-da Review Intensity 결과 참조로 단순화 | CLEAN_CODE HIGH, YAGNI HIGH |
| v5 | DA R3 | run-da SKIP 시 parallel-audit 생략 연동 시도 | DA R3 19건 발견 |
| v6 | DA R3 3회 반복 | R3 결과: 승인 범위 불일치 (DA 생략 ≠ 전수조사 생략) + run-da 내부 판단의 외부 노출 — 3회 반복 규칙 발동 | NGMI CRITICAL, SIDE_EFFECT HIGH |
| **v7** | **최종** | **모든 축소 접근이 기존 계약과 충돌 → 매직넘버 10 제거만 반영** | `0d700c0` |

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| parallel-audit에 Audit Intensity 복제 | run-da의 SKIP/LITE/FULL을 parallel-audit에 그대로 추가 | 스킬 자체가 판단 | 전수조사 계약 파괴, DRY 위반, agent-count 의미 변경 | ❌ |
| 호출자에서 분류표 | plan-with-questions에 변경 유형별 분류표 추가 | parallel-audit 변경 없음 | DRY 위반 (run-da 규칙 재서술), 과설계 | ❌ |
| run-da SKIP 연동 | run-da SKIP 시 parallel-audit도 생략 | DRY 유지, 단순 | 승인 범위 불일치 (DA 생략 ≠ 전수조사 생략), 숨은 결합 | ❌ |
| **매직넘버 제거만** | `/parallel-audit 10` → `/parallel-audit` | DA 위반 0, 기존 계약 유지, 최소 변경 | 소규모 변경에서의 에이전트 축소 없음 | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md` | L154: `/parallel-audit 10` → `/parallel-audit` |

```diff
-3. `/parallel-audit 10` — 전수조사
+3. `/parallel-audit` — 전수조사
```

## 참고 레퍼런스

- `c992d23` — feat(skills): run-da Review Intensity — 경중 기반 DA 스케일링 (#364)
- DA for_plan 3라운드 (R1: 28건, R2: 22건, R3: 19건) → 3회 반복 규칙으로 사용자 위임
- DA for_pr 1라운드 (CLEAR 5/8, 기각 6건 — 모두 기존 설계의 사전 문제)

## Human Test Plan

1. `nrs`로 rebuild하여 스킬 파일이 `~/.claude/skills/plan-with-questions/SKILL.md`에 반영되는지 확인
2. 반영된 파일에서 `/parallel-audit` 호출에 숫자 인자가 없는지 확인
3. parallel-audit의 기본값(10)이 여전히 적용되는지 `parallel-audit/SKILL.md:19` 확인

실패 시: worktree symlink relink 여부 확인 (`readlink ~/.claude/skills/plan-with-questions/SKILL.md`)

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 변경 반영 확인
grep -n 'parallel-audit' modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
# 기대: `/parallel-audit` (숫자 없음)

# old 값 부재 확인
grep -c 'parallel-audit 10' modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
# 기대: 0

# parallel-audit 기본값 유지 확인
grep 'basic.*10\|기본값 10' modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
# 기대: "비어있으면 기본값 10 사용" 존재
```

### Phase 1: 기능 검증

변경이 1줄 매직넘버 제거이므로, 기능 검증은 Phase 0의 정적 검증으로 충분하다.

### Phase 2: Regression

```bash
# plan-with-questions Post-Implementation 구조 보존 확인
grep -A3 'Post-Implementation' modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md | grep -c '/run-da\|/parallel-audit\|/create-pr'
# 기대: 3 (3개 스킬 호출 모두 존재)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to remove a numeric parameter from the parallel audit command during the post-implementation phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->