### PR TITLE
feat(zed): VSCode 누락 키맵 3종 추가 — 패널 크기, 패인 이동, 탭 복원

### DIFF
--- a/modules/darwin/programs/zed/files/keymap.json
+++ b/modules/darwin/programs/zed/files/keymap.json
@@ -179,6 +179,46 @@
   },
 
   // ============================================================================
+  // 패널(독) 크기 조절
+  // Ctrl+Alt+Cmd+방향키 → 포커스된 패널의 크기 증가/감소
+  // VSCode의 increaseViewSize/decreaseViewSize 대응.
+  // CIR: Zed 기본 ctrl-alt-=/-는 Rectangle이 Ctrl+Alt prefix를 글로벌 점유하여 사용 불가.
+  //   Ctrl+Alt+Cmd+Down은 기존 editor::GoToDefinitionSplit을 덮어씀
+  //   (Cmd+B로 정의 이동 후 Cmd+K L로 수동 스플릿 대체 가능).
+  // ============================================================================
+  {
+    "bindings": {
+      "ctrl-alt-cmd-up": ["workspace::IncreaseActiveDockSize", { "px": 0 }],
+      "ctrl-alt-cmd-right": ["workspace::IncreaseActiveDockSize", { "px": 0 }],
+      "ctrl-alt-cmd-down": ["workspace::DecreaseActiveDockSize", { "px": 0 }],
+      "ctrl-alt-cmd-left": ["workspace::DecreaseActiveDockSize", { "px": 0 }]
+    }
+  },
+
+  // ============================================================================
+  // 에디터를 다른 패인으로 이동
+  // Ctrl+Alt+]/[ → 현재 탭을 우측/좌측 패인으로 이동
+  // VSCode의 moveEditorToNextGroup/moveEditorToPreviousGroup 대응.
+  // ============================================================================
+  {
+    "bindings": {
+      "ctrl-alt-]": ["workspace::MoveItemToPaneInDirection", { "direction": "right" }],
+      "ctrl-alt-[": ["workspace::MoveItemToPaneInDirection", { "direction": "left" }]
+    }
+  },
+
+  // ============================================================================
+  // 닫힌 탭 다시 열기
+  // Shift+Cmd+T → 마지막으로 닫은 탭 복원
+  // Zed 기본에 있으나 JetBrains keymap이 덮어쓸 수 있으므로 명시적 override.
+  // ============================================================================
+  {
+    "bindings": {
+      "shift-cmd-t": "pane::ReopenClosedItem"
+    }
+  },
+
+  // ============================================================================
   // Untitled Buffer (Scratchpad 대체)
   // Shift+Cmd+N → 새 untitled 버퍼 (언어 변경: Ctrl+Cmd+M)
   // CIR: action::Sequence로 NewFile + language_selector::Toggle 시도했으나


### PR DESCRIPTION
## Summary

- VSCode → Zed 마이그레이션 전수조사에서 발견된 누락 키바인딩 3종을 추가한다.
- Rectangle의 `Ctrl+Alt` 글로벌 점유를 우회하여 `Ctrl+Alt+Cmd+방향키`로 패널 크기 조절을 구현한다.

Related to #337

## 기존 문제/배경

VSCode에서 사용하던 다음 키맵이 Zed 마이그레이션에서 누락됨:

| 기능 | VSCode 키맵 | 문제 |
|------|-----------|------|
| 패널(사이드바/터미널) 크기 조절 | `Ctrl+Alt+Cmd+방향키` | Zed 기본 `ctrl-alt-=/-`는 Rectangle이 `Ctrl+Alt` prefix를 글로벌 점유하여 사용 불가 |
| 에디터를 다른 패인으로 이동 | `Ctrl+Alt+[/]` | Zed에 미바인딩 |
| 닫힌 탭 다시 열기 | `Shift+Cmd+T` | Zed 기본에 있으나 JetBrains keymap이 덮어쓸 수 있음 |

## CIR (Change Intent Record)

- **독 크기 조절 키 선정**: Zed 기본 `ctrl-alt-=/-`(macOS)와 `shift-alt-=/-`(Linux) 모두 사용 불가 확인.
  `ctrl-alt-*`는 Rectangle 글로벌 점유, `shift-alt-=`는 macOS Option 키 특수문자(`±`) 생성으로 Zed가 키 이벤트를 수신하지 못함.
  `Ctrl+Alt+Cmd+방향키`는 Rectangle 충돌 없음(확인 완료), VSCode 근육 기억 유지 가능.
- **GoToDefinitionSplit 덮어씀**: `Ctrl+Alt+Cmd+Down`이 기존 `editor::GoToDefinitionSplit`을 덮어씀.
  `Cmd+B`(정의 이동) + `Cmd+K L`(수동 스플릿)로 대체 가능하므로 수용.
- **macOS Option 키 특수문자 비활성화**는 별도 이슈 #337에서 추적 중 (커스텀 `.keylayout` 파일 필요).

**의도적 미반영:**
| 기능 | 이유 |
|------|------|
| 패인 크기 비율 조절 (`Shift+Alt+[/]`) | `vim::ResizePane*`는 Vim 전용. non-vim 액션 미존재 ([Issue #23334](https://github.com/zed-industries/zed/issues/23334)). 마우스 드래그 수용 |
| Emmet removeTag (`Alt+Cmd+K`) | Zed에 동등 액션 없음 |
| 키맵 설정 열기 (`Cmd+R Cmd+S`) | `Cmd+R`이 Replace chord prefix 충돌. Zed 기본 `Cmd+K Cmd+S` 사용 |

## ADR (Architecture Decision Record)

### 패널 크기 조절 키 조합

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Zed 기본 `ctrl-alt-=/-` | macOS 기본 바인딩 | 설정 불필요 | Rectangle이 `Ctrl+Alt` 글로벌 점유 | ❌ |
| `shift-alt-=/-` | Linux 기본 바인딩 | 설정 불필요 | macOS Option 키가 특수문자(`±`) 생성 | ❌ |
| `ctrl-alt-cmd-방향키` | VSCode 패턴 유지 | Rectangle 충돌 없음, 근육 기억 유지 | Down만 GoToDefinitionSplit 충돌 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/programs/zed/files/keymap.json` | 수정 | 3개 바인딩 블록 추가 (40줄) |

### 추가된 바인딩

```jsonc
// 패널(독) 크기 조절
"ctrl-alt-cmd-up": ["workspace::IncreaseActiveDockSize", { "px": 0 }],
"ctrl-alt-cmd-right": ["workspace::IncreaseActiveDockSize", { "px": 0 }],
"ctrl-alt-cmd-down": ["workspace::DecreaseActiveDockSize", { "px": 0 }],
"ctrl-alt-cmd-left": ["workspace::DecreaseActiveDockSize", { "px": 0 }]

// 에디터를 다른 패인으로 이동
"ctrl-alt-]": ["workspace::MoveItemToPaneInDirection", { "direction": "right" }],
"ctrl-alt-[": ["workspace::MoveItemToPaneInDirection", { "direction": "left" }]

// 닫힌 탭 다시 열기
"shift-cmd-t": "pane::ReopenClosedItem"
```

## 참고 레퍼런스

- `33cff69` — refactor(zed): nixpkgs → Homebrew cask 전환 (Zed 설치 방식 변경)
- #337 — feat(macos): Option+bracket 특수문자 생성 비활성화 (macOS Option 키 근본 해결)
- [PR #31366](https://github.com/zed-industries/zed/pull/31366) — Zed에 `IncreaseActiveDockSize` 액션 추가 (2025-07-02 머지)
- [Issue #23334](https://github.com/zed-industries/zed/issues/23334) — non-vim 패인 리사이즈 액션 요청 (오픈 중)

## Human Test Plan

### 1. 패널 크기 조절
1. Zed에서 사이드바(Project Panel)를 열고 **포커스**를 준다
2. `Ctrl+Alt+Cmd+Right` → 사이드바 너비 증가 확인
3. `Ctrl+Alt+Cmd+Left` → 사이드바 너비 감소 확인
4. 터미널 패널을 열고 포커스를 준다
5. `Ctrl+Alt+Cmd+Up` → 터미널 높이 증가 확인
6. `Ctrl+Alt+Cmd+Down` → 터미널 높이 감소 확인

**실패 시**: Command Palette에서 "Increase Active Dock Size" 검색하여 액션 존재 여부 확인. 없으면 Zed 버전이 PR #31366 이전일 수 있음.

### 2. 에디터 패인 이동
1. 에디터를 좌우로 분할 (`Cmd+K L`)
2. 왼쪽 패인에서 파일을 열고 `Ctrl+Alt+]` → 해당 탭이 오른쪽 패인으로 이동 확인
3. 오른쪽 패인에서 `Ctrl+Alt+[` → 해당 탭이 왼쪽 패인으로 이동 확인

**실패 시**: Rectangle이 `Ctrl+Alt+[/]`를 가로채는지 확인. Rectangle 설정에서 해당 키 해제 필요.

### 3. 닫힌 탭 복원
1. 파일 탭을 닫는다 (`Cmd+W`)
2. `Shift+Cmd+T` → 방금 닫은 탭이 복원되는지 확인

**실패 시**: Command Palette에서 "Reopen Closed Item" 검색하여 실행.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 바인딩 존재 확인
grep -c "IncreaseActiveDockSize" modules/darwin/programs/zed/files/keymap.json
# 기대: 2

grep -c "DecreaseActiveDockSize" modules/darwin/programs/zed/files/keymap.json
# 기대: 2

grep -c "MoveItemToPaneInDirection" modules/darwin/programs/zed/files/keymap.json
# 기대: 2

grep -c "ReopenClosedItem" modules/darwin/programs/zed/files/keymap.json
# 기대: 1

# JSONC 유효성 확인
sed 's|//.*||' modules/darwin/programs/zed/files/keymap.json | python3 -c "import json,sys; json.load(sys.stdin); print('VALID')"
# 기대: VALID
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New keyboard shortcuts added for dynamic adjustment of editor panel and dock sizes to customize workspace layout
  * New keyboard shortcuts added for moving editors between different panes to accommodate various workflow preferences
  * New keyboard shortcut added to reopen tabs you have recently closed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->