### PR TITLE
fix(zed): Cmd+- zoom 복원 — JetBrains fold 충돌 해소

### DIFF
--- a/modules/darwin/programs/zed/files/keymap.json
+++ b/modules/darwin/programs/zed/files/keymap.json
@@ -179,6 +179,22 @@
   },
 
   // ============================================================================
+  // 확대/축소 + 코드 접기
+  // JetBrains keymap이 Cmd+-/+를 fold/unfold로 덮어쓰므로 zoom으로 복원.
+  // fold/unfold는 VSCode 기본키인 Alt+Cmd+[/]로 재배치.
+  // persist: false → 세션 간 폰트 크기 변경을 settings.json에 저장하지 않음.
+  // ============================================================================
+  {
+    "context": "Editor",
+    "bindings": {
+      "cmd--": ["zed::DecreaseBufferFontSize", { "persist": false }],
+      "cmd-+": ["zed::IncreaseBufferFontSize", { "persist": false }],
+      "alt-cmd-[": "editor::Fold",
+      "alt-cmd-]": "editor::UnfoldLines"
+    }
+  },
+
+  // ============================================================================
   // 패널(독) 크기 조절
   // Ctrl+Alt+Cmd+방향키 → 포커스된 패널의 크기 증가/감소
   // VSCode의 increaseViewSize/decreaseViewSize 대응.


### PR DESCRIPTION
## Summary

- JetBrains base_keymap이 `Cmd+-/+`를 fold/unfold로 덮어쓰는 문제를 해소하여 macOS 표준 zoom을 복원한다.
- fold/unfold를 VSCode 기본키(`Alt+Cmd+[/]`)로 재배치한다.

## 기존 문제/배경

`settings.json`의 `base_keymap: "JetBrains"` 설정에 의해 Zed의 [JetBrains 키맵](https://github.com/zed-industries/zed/blob/main/assets/keymaps/macos/jetbrains.json)이 적용된다. 이 키맵은:

- `cmd--` → `editor::Fold` (코드 접기)
- `cmd-+` → `editor::UnfoldLines` (코드 펼치기)

로 바인딩하여 macOS 기본 zoom out(`Cmd+-`)을 덮어쓴다. `Cmd+=`(Shift 없이)는 JetBrains 키맵에서 override하지 않아 zoom in이 유지되지만, `Cmd+-`는 zoom out 대신 코드 접기가 동작하는 비대칭 상태였다.

## CIR (Change Intent Record)

- **VSCode 이전 설정 확인** (`605bab4`): VSCode keybindings.json에 fold/unfold 커스텀 바인딩이 없었음을 확인. VSCode 기본값(`Cmd+Opt+[/]`)을 사용했으므로 동일 키로 재배치.
- **JetBrains 키맵 소스 확인**: Zed GitHub에서 `assets/keymaps/macos/jetbrains.json`의 `cmd--`/`cmd-+` 바인딩 확인.
- **충돌 검사**: `alt-cmd-[`/`alt-cmd-]`가 JetBrains 키맵, Zed 기본 macOS 키맵, 현재 keymap.json 모두에서 미사용임을 확인.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| zoom 복원 + fold 재배치 | `cmd--/+`를 zoom으로 복원, fold/unfold를 `alt-cmd-[/]`로 이동 | macOS 표준 동작 복원, VSCode 습관 유지 | JetBrains 키맵의 fold 키를 잃음 | ✅ |
| fold만 다른 키로 이동 | `cmd--`만 zoom으로 복원, `cmd-+`는 unfold 유지 | 최소 변경 | zoom in/out과 fold/unfold 키가 비대칭 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/programs/zed/files/keymap.json` | 추가 | Editor 컨텍스트에 zoom + fold 바인딩 4개 추가 |

### 핵심 코드

```json
{
  "context": "Editor",
  "bindings": {
    "cmd--": ["zed::DecreaseBufferFontSize", { "persist": false }],
    "cmd-+": ["zed::IncreaseBufferFontSize", { "persist": false }],
    "alt-cmd-[": "editor::Fold",
    "alt-cmd-]": "editor::UnfoldLines"
  }
}
```

`persist: false`: Zed 기본 키맵과 동일. 세션 간 폰트 크기 변경을 `settings.json`에 저장하지 않음.

## 참고 레퍼런스

- `605bab4` — feat(editor): VSCode → Zed 마이그레이션 (VSCode keybindings.json 삭제 포함)
- `0ffb406` — feat(zed): VSCode 누락 키맵 3종 추가 (직전 키맵 작업)
- [Zed JetBrains keymap](https://github.com/zed-industries/zed/blob/main/assets/keymaps/macos/jetbrains.json) — `cmd--`/`cmd-+` fold/unfold 바인딩 원본

## Human Test Plan

### 정상 동작 검증

1. Zed를 재시작한다.
2. 에디터에서 `Cmd+-`를 누른다.
   - **기대**: 폰트 크기가 축소된다 (zoom out).
   - **실패 시**: keymap.json이 Zed에 반영되었는지 확인 (`~/.config/zed/keymap.json` 심링크 대상 확인).
3. `Cmd+=`를 누른다.
   - **기대**: 폰트 크기가 확대된다 (zoom in, 기존 동작 유지).
4. 코드 블록에서 `Alt+Cmd+[`를 누른다.
   - **기대**: 해당 코드 블록이 접힌다.
   - **실패 시**: Editor 컨텍스트에서 동작하는지 확인 (터미널 등 다른 패널에서는 미동작 정상).
5. `Alt+Cmd+]`를 누른다.
   - **기대**: 접힌 코드 블록이 펼쳐진다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 바인딩 존재 확인
grep -q '"cmd--"' modules/darwin/programs/zed/files/keymap.json
# 기대: exit 0

# 2. DecreaseBufferFontSize 액션 확인
grep -q 'DecreaseBufferFontSize' modules/darwin/programs/zed/files/keymap.json
# 기대: exit 0

# 3. fold 재배치 확인
grep -q '"alt-cmd-\[": "editor::Fold"' modules/darwin/programs/zed/files/keymap.json
# 기대: exit 0

# 4. unfold 재배치 확인
grep -q '"alt-cmd-\]": "editor::UnfoldLines"' modules/darwin/programs/zed/files/keymap.json
# 기대: exit 0
```

### Phase 1: 구조 검증

- keymap.json이 유효한 JSON(주석 포함 JSONC)인지 확인한다.
- Editor 컨텍스트 블록 안에 4개 바인딩이 모두 포함되어 있는지 확인한다.

### Phase 2: Regression

- 기존 바인딩(`f12`, `cmd-b`, `cmd-\\`, `cmd-9`, `cmd-g` 등)이 변경되지 않았는지 diff로 확인한다.
- `git diff main...HEAD`에서 변경이 keymap.json 1개 파일, 신규 섹션 추가만인지 확인한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for adjusting editor font size (cmd--, cmd-+)
  * Added keyboard shortcuts for code folding and unfolding (alt-cmd-[, alt-cmd-])
  * Font size adjustments are temporary and do not persist across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->