### PR TITLE
feat(cheat): nvim/buffer cheatsheet에 종료 키맵 추가

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/nvim/buffer
+++ b/modules/shared/programs/cheat/cheatsheets/nvim/buffer
@@ -14,3 +14,9 @@ tags: [ neovim, lazyvim, buffer ]
   <C-w>s        수평 분할 (상하)
   <C-w>h/j/k/l  창 간 이동 (좌/하/상/우)
   <C-w>q        현재 창 닫기
+
+종료
+
+  :qa           모든 창 닫고 종료 (quit all)
+  :qa!          저장 안 한 변경 무시하고 강제 종료
+  <leader>qq    전체 종료 (LazyVim)


### PR DESCRIPTION
## Summary

- nvim/buffer cheatsheet에 종료 섹션 추가 (`:qa`, `:qa!`, `<leader>qq`)
- 기존 "버퍼 닫기 → 창 닫기" 흐름에 "종료"를 이어 한 파일에서 닫기/종료 계열 키맵을 모두 조회 가능

## 기존 문제/배경

Neovim에서 `:q`를 여러 번 눌러야 종료되는 상황(neo-tree + 에디터 윈도우 구조)에서,
한 번에 종료하는 키맵(`:qa`, `<leader>qq`)의 존재를 몰라 불편을 겪음.
cheatsheet에 해당 키맵이 누락되어 있어 즉시 조회가 불가능했음.

## 용어 가이드: 버퍼와 윈도우

> Vim 초보를 위한 핵심 개념 정리

**버퍼(Buffer)** — 파일을 메모리에 불러온 것. VS Code로 치면 "열린 파일" 하나하나가 버퍼다.
화면에 보이지 않아도 메모리에 남아 있을 수 있다.

**윈도우(Window)** — 버퍼를 화면에 보여주는 틀. VS Code로 치면 에디터 패널 하나에 해당한다.
화면을 분할하면 윈도우가 2개, 3개로 늘어난다.

```
┌──────────┬──────────────────────┐
│ neo-tree │   settings.json      │  ← 윈도우 2개
│ (윈도우1)  │   (윈도우2, 포커스)     │
└──────────┴──────────────────────┘
```

`:q`는 **현재 포커스된 윈도우 하나**만 닫는 명령이다. Neovim 종료 명령이 아니다.
마지막 윈도우가 닫힐 때 비로소 Neovim이 종료된다.
그래서 neo-tree + 에디터처럼 윈도우가 여러 개 열려 있으면 `:q`를 여러 번 눌러야 했던 것.

**한 번에 종료하려면**: `:qa` (quit all) 또는 `<leader>qq` (LazyVim 단축키)를 사용한다.

## CIR (Change Intent Record)

해당 없음 — 단순 cheatsheet 텍스트 추가.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 결정 |
|------|------|------|
| 기존 buffer 파일에 섹션 추가 | 버퍼/창/종료가 한 파일에 모여 맥락상 자연스러움 | ✅ |
| nvim/quit 새 파일 생성 | 독립 조회 가능하나 파일 수 증가 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/cheat/cheatsheets/nvim/buffer` | 종료 섹션 3개 키맵 추가 (+6줄) |

## 참고 레퍼런스

- `fa9f696` feat(cheat): nvim/buffer cheatsheet에 종료 키맵 추가

## Human Test Plan

1. `cheat nvim/buffer` 실행
2. 기대: 기존 "버퍼(탭)", "창 분할" 섹션 아래에 "종료" 섹션이 표시됨
3. `:qa`, `:qa!`, `<leader>qq` 3개 키맵이 설명과 함께 출력되는지 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 종료 섹션 존재 확인
grep -q ':qa' modules/shared/programs/cheat/cheatsheets/nvim/buffer && echo "PASS" || echo "FAIL"
grep -q '<leader>qq' modules/shared/programs/cheat/cheatsheets/nvim/buffer && echo "PASS" || echo "FAIL"
```

### Phase 1: 기능 검증

```bash
# cheat CLI로 정상 출력 확인
cheat nvim/buffer | grep -q '종료' && echo "PASS" || echo "FAIL"
```
