### PR TITLE
fix(nix): download-buffer-size 256 MiB — 병렬 다운로드 정체 해소

### DIFF
--- a/.claude/skills/understanding-nix/SKILL.md
+++ b/.claude/skills/understanding-nix/SKILL.md
@@ -48,6 +48,7 @@ nix flake check --no-build --all-systems  # flake 평가 오류 검사
 | 오프라인 빌드 | `nrs --offline` | 네트워크 요청 없음 (~10초, 18배 빠름) |
 | 병렬 다운로드 | `max-substitution-jobs = 128` | 동시 128개 다운로드 (기본 16) |
 | HTTP 연결 | `http-connections = 50` | 동시 50 연결 (기본 25) |
+| 다운로드 버퍼 | `download-buffer-size = 256 * 1024 * 1024` | 기본 64 MiB → 256 MiB |
 | GitHub 토큰 | `access-tokens = github.com=...` | rate limit 해제 |
 
 ### 에러 디버깅

--- a/.claude/skills/understanding-nix/references/features.md
+++ b/.claude/skills/understanding-nix/references/features.md
@@ -375,21 +375,24 @@ nrs --offline  # 네트워크 요청 없이 빠르게 빌드
 nix.settings = {
   max-substitution-jobs = 128;  # 동시 다운로드 수 (기본값: 16)
   http-connections = 50;        # 동시 HTTP 연결 수 (기본값: 25)
+  download-buffer-size = 256 * 1024 * 1024; # 다운로드 버퍼 (기본값: 64 MiB)
 };
 ```
 
 **효과:**
 
-| 설정                    | 기본값 | 현재값 | 효과                         |
-| ----------------------- | ------ | ------ | ---------------------------- |
-| `max-substitution-jobs` | 16     | 128    | 동시에 128개 패키지 다운로드 |
-| `http-connections`      | 25     | 50     | HTTP 연결 2배 증가           |
+| 설정                    | 기본값 | 현재값  | 효과                            |
+| ----------------------- | ------ | ------- | ------------------------------- |
+| `max-substitution-jobs` | 16     | 128     | 동시에 128개 패키지 다운로드    |
+| `http-connections`      | 25     | 50      | HTTP 연결 2배 증가              |
+| `download-buffer-size`  | 64 MiB | 256 MiB | 버퍼 부족 시 다운로드 정체 방지 |
 
 **확인 방법:**
 
 ```bash
-nix config show | grep -E "(max-substitution|http-connections)"
+nix config show | grep -E "(max-substitution|http-connections|download-buffer)"
 # 출력:
+# download-buffer-size = 268435456
 # http-connections = 50
 # max-substitution-jobs = 128
 ```

--- a/.claude/skills/understanding-nix/references/troubleshooting.md
+++ b/.claude/skills/understanding-nix/references/troubleshooting.md
@@ -172,6 +172,7 @@ nrs --offline
 nix.settings = {
   max-substitution-jobs = 128;  # 기본값 16
   http-connections = 50;        # 기본값 25
+  download-buffer-size = 256 * 1024 * 1024; # 기본값 64 MiB
 };
 ```
 

--- a/modules/shared/configuration.nix
+++ b/modules/shared/configuration.nix
@@ -12,8 +12,10 @@
       warn-dirty = false;
 
       # 병렬 다운로드 최적화
+      # 높은 동시성(128 substitution + 50 HTTP)에서 버퍼 부족 시 다운로드 정체 방지
       max-substitution-jobs = 128; # 기본값 16 → 128
       http-connections = 50; # 기본값 25 → 50
+      download-buffer-size = 256 * 1024 * 1024; # 기본값 64 MiB → 256 MiB
     };
 
     # 스토어 최적화 (auto-optimise-store 대신 사용)


### PR DESCRIPTION
## Summary

- 높은 동시성(128 substitution + 50 HTTP)에서 기본 download-buffer-size(64 MiB) 부족으로 인한 다운로드 정체를 256 MiB 버퍼로 해소한다.
- understanding-nix 스킬 문서 3개를 코드와 동기화한다.

## 기존 문제/배경

MiniPC에서 `nrs` 실행 시 `warning: download buffer is full; consider increasing the 'download-buffer-size' setting` 경고가 발생하고 3분 이상 빌드가 진행되지 않고 정체되었다.

기존 설정에서 `max-substitution-jobs = 128`, `http-connections = 50`으로 공격적인 병렬 다운로드를 설정했지만, `download-buffer-size`는 Nix 기본값(64 MiB)이어서 backpressure/stall이 발생한 것으로 추정된다.

## CIR (Change Intent Record)

- **v1** (이번 변경): MiniPC에서 `nrs` 정체 현상 조사 → `nix show-config`로 `download-buffer-size = 67108864` (64 MiB) 기본값 확인 → 256 MiB로 증가 결정
- DA for_plan에서 shared vs minipc 배치 논의 → 기존 `max-substitution-jobs`/`http-connections`가 이미 shared에 있으므로 **일관성 유지를 위해 shared 유지** 결정

**trade-off**: 모든 호스트(darwin 2대 + nixos 1대)에 적용되지만, buffer 증가는 해가 되지 않으며(RAM의 1.56%, single shared buffer) 관련 설정 3개가 같은 블록에 있어 유지보수가 용이하다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| shared 모듈에 추가 | 기존 병렬 설정과 같은 블록 | 일관성, 유지보수 용이 | macOS에도 적용 (해 없음) | ✅ |
| 3개 모두 nixos로 이동 | 병렬 설정 전체를 NixOS 전용으로 | YAGNI 준수 | 기존 코드 대규모 변경 | ❌ |
| download-buffer-size만 minipc | 신규 설정만 호스트별 배치 | 최소 범위 | 관련 설정 분산, 비일관적 | ❌ |

## 구현 상세

| 파일 | 변경 | 설명 |
|------|------|------|
| `modules/shared/configuration.nix` | +2줄 | `download-buffer-size = 256 * 1024 * 1024` + why 주석 |
| `.claude/skills/understanding-nix/SKILL.md` | +1줄 | 빠른 참조 표에 다운로드 버퍼 행 추가 |
| `.claude/skills/understanding-nix/references/features.md` | +7줄 -5줄 | 코드 블록, 효과 표, 확인 명령 갱신 |
| `.claude/skills/understanding-nix/references/troubleshooting.md` | +1줄 | 병렬 다운로드 코드 블록에 설정 추가 |

핵심 코드:
```nix
# modules/shared/configuration.nix
# 병렬 다운로드 최적화
# 높은 동시성(128 substitution + 50 HTTP)에서 버퍼 부족 시 다운로드 정체 방지
max-substitution-jobs = 128; # 기본값 16 → 128
http-connections = 50; # 기본값 25 → 50
download-buffer-size = 256 * 1024 * 1024; # 기본값 64 MiB → 256 MiB
```

## 참고 레퍼런스

- `dac73d5` — 이번 커밋
- Nix 공식 문서: `download-buffer-size`는 curl transfer용 내부 버퍼 (단일 shared buffer, per-connection 아님)

## Human Test Plan

### 1. NixOS(MiniPC)에서 검증
```bash
# 1. main repo에서 git pull
# 2. nrs 실행
# 3. "download buffer is full" warning이 발생하지 않는지 확인
# 4. 빌드가 정체 없이 진행되는지 확인
```
- **기대**: warning 미발생, 빌드 정상 진행
- **실패 시**: `nix config show download-buffer-size`로 설정 적용 확인, 값이 268435456이 아니면 rebuild 재시도

### 2. macOS에서 검증
```bash
# 1. main repo에서 git pull
# 2. nrs 실행
# 3. 빌드가 정상 완료되는지 확인
```
- **기대**: 에러 없이 빌드 완료
- **실패 시**: `nix config show download-buffer-size`로 설정 적용 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 설정 존재 확인
grep -q "download-buffer-size" modules/shared/configuration.nix
# 기대: exit 0

# 2. 계산식 사용 확인 (매직넘버 아님)
grep -q "256 \* 1024 \* 1024" modules/shared/configuration.nix
# 기대: exit 0

# 3. why 주석 존재 확인
grep -q "버퍼 부족 시 다운로드 정체 방지" modules/shared/configuration.nix
# 기대: exit 0

# 4. 스킬 문서 동기화 확인
grep -q "download-buffer-size" .claude/skills/understanding-nix/SKILL.md
grep -q "download-buffer-size" .claude/skills/understanding-nix/references/features.md
grep -q "download-buffer-size" .claude/skills/understanding-nix/references/troubleshooting.md
# 기대: 모두 exit 0
```

### Phase 1: Nix eval 검증

> "설정이 올바르게 평가되어 268435456(256 MiB)이 되는지 확인"

```bash
nix eval .#nixosConfigurations.greenhead-minipc.config.nix.settings.download-buffer-size
```
- **기대**: `268435456`
- **실패 시**: `modules/shared/configuration.nix`의 산술 표현식 문법 확인

### Phase 2: Regression

> "기존 설정이 이번 변경에 의해 깨지지 않았는지 확인"

```bash
nix eval .#nixosConfigurations.greenhead-minipc.config.nix.settings.max-substitution-jobs
# 기대: 128

nix eval .#nixosConfigurations.greenhead-minipc.config.nix.settings.http-connections
# 기대: 50
```
- **실패 시**: `modules/shared/configuration.nix`의 nix.settings 블록 구조 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nix performance tuning documentation to include download buffer size configuration details.
  * Added configuration examples and guidance for optimizing download performance.

* **Chores**
  * Updated system configuration settings to include download buffer size parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->