### PR TITLE
fix(hooks): fragile-hardcoding-guard 코드 블록 내 false positive 해소

### DIFF
--- a/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
@@ -41,7 +41,7 @@ if [ "$TOOL_NAME" = "Write" ]; then
       s = $0; sub(/^[ ]{0,3}/, "", s); ticks = 0
       while (substr(s, ticks+1, 1) == "`") ticks++
       if (ticks >= 3) {
-        tail = substr(s, ticks+1); gsub(/[ \t]/, "", tail)
+        tail = substr(s, ticks+1); gsub(/[ \t\r]/, "", tail)
         if (depth == 0) { depth = 1; fence_len = ticks; next }
         if (ticks >= fence_len && tail == "") { depth = 0; fence_len = 0; next }
       }


### PR DESCRIPTION
## Summary

- `fragile-hardcoding-guard.sh` hook이 markdown 코드 블록 내부의 few-shot 예시를 오탐하여 Write를 차단하던 false positive 해소
- sed 기반 단순 strip → awk fence-aware parser로 교체 (nested/indented/4-backtick fence 처리)
- Write 전용 strip + Edit는 원본 검사 분리, CRLF 줄끝 대응

Closes #377

## 기존 문제/배경

`fragile-hardcoding-guard.sh`는 SKILL.md/references 파일에서 stale해질 수 있는 하드코딩(줄 수, 파일 수, 스킬 경로 열거)을 차단하는 PreToolUse hook이다. content 전체를 대상으로 `[0-9]+줄` 등의 정규표현식을 적용하므로, markdown 코드 블록 내부의 few-shot 예시에 포함된 가상의 줄 번호(예: `caddy.nix:38줄`)도 감지되어 정당한 Write가 차단되었다.

전수조사(nixos-config 38파일 + awesome-anki 114파일): 코드 블록 내 true positive **0건** 확인.

## CIR (Change Intent Record)

**발견 경위**: `arbiter-prompt.md` 신규 작성 시 few-shot 교정 예시의 `caddy.nix:38줄` 패턴이 오탐.

**설계 의도**: 패턴 검사 전에 코드 블록을 strip하여 false positive를 제거하되, 코드 블록 밖의 진짜 하드코딩 감지는 유지.

**진화 과정**:
1. 이슈 #377의 원안: `sed '/^```/,/^```/d'` 1줄 추가 → DA for_pr R1에서 7건 CONFIRMED (nested fence 미처리, Write/Edit 비대칭 등)
2. awk fence-aware parser로 교체 + Write 전용 strip → DA R2에서 3건 CONFIRMED (변수명/주석 LOW)
3. 변수명 풀기 + SCAN_INPUT + 주석 보강 → DA R3에서 3회 반복 규칙 도달 (기존 설계 제약 → 별도 이슈 #385)
4. 전수조사에서 CRLF fence closing BUG 발견 → `\r` 제거 추가

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| sed 단순 strip | `sed '/^```/,/^```/d'` | 1줄, 극도로 단순 | nested/indented/4-backtick 미처리, CRLF 취약 | ❌ |
| awk fence parser | backtick 수 추적 + 0-3칸 들여쓰기 | CommonMark 준수, nested fence 안전 | sed보다 복잡 (15줄 awk) | ✅ |
| 외부 Markdown parser | mdast 등 AST 기반 | 완벽한 spec 준수 | hook에 외부 의존성 추가, 성능 부담 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh` | 수정 (+25/-3) | awk fence parser, Write/Edit 분기, SCAN_INPUT 변수, CRLF 대응 |

핵심 코드: Write에서만 awk fence parser로 코드 블록을 strip하여 `SCAN_INPUT`에 저장. Edit는 원본 `CONTENT`를 그대로 `SCAN_INPUT`에 할당. 이후 3개 검사(줄 수, 파일 수, 스킬 경로)는 `SCAN_INPUT`을 대상으로 실행.

## 참고 레퍼런스

- `c479077` — 초기 구현 (sed 기반)
- `635a445` — DA R1 피드백: awk parser + Write 전용
- `503a492` — DA R2 피드백: 변수명/주석
- `597e999` — 전수조사 BUG: CRLF fix
- #385 — Write/Edit 비대칭 + fenced block 의미 분류 (별도 이슈)

## Human Test Plan

| # | 단계 | 기대 동작 | 실패 시 |
|---|------|----------|---------|
| 1 | SKILL.md에 코드 블록 안 `38줄` 포함하여 Write | 통과 (빈 출력) | awk parser가 fence를 인식 못함 → `grep -n 'ticks'` 확인 |
| 2 | SKILL.md에 코드 블록 밖 `308줄` Write | 차단 (JSON block) | SCAN_INPUT 할당 확인 |
| 3 | 4-backtick wrapper 안에 3-backtick 포함 Write | 통과 | fence_len 추적 확인 |
| 4 | Edit으로 `new_string`에 fence 안 `10줄` 포함 | 차단 (Edit는 strip 안 함) | Write/Edit 분기 확인 |
| 5 | CRLF 줄끝 파일에서 fence 밖 `308줄` Write | 차단 | `\r` gsub 확인 |

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# awk fence parser 존재
grep -q 'fence_len' modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh && echo "OK"
# SCAN_INPUT 사용
grep -q 'SCAN_INPUT' modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh && echo "OK"
# CRLF 대응
grep -q '\\r' modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh && echo "OK"
```

### Phase 1: 기능 검증

```bash
# false positive 해소
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/test/.claude/skills/test/references/test.md","content":"본문\n```text\ncaddy.nix:38줄\n```\n다른 본문"}}' | bash modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# 기대: 빈 출력

# true positive 유지
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/test/.claude/skills/test/SKILL.md","content":"이 파일은 308줄이다"}}' | bash modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# 기대: {"decision":"block",...}

# CRLF 대응
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/test/.claude/skills/test/references/test.md","content":"본문\r\n```text\r\n38줄\r\n```\r\n이건 308줄이다"}}' | bash modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# 기대: {"decision":"block",...} (fence 밖 308줄 감지)
```

### Phase 2: Regression

```bash
# non-skill 파일은 무시
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/test/README.md","content":"308줄이다"}}' | bash modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# 기대: 빈 출력 (경로 불일치로 exit 0)

# Edit raw 검사 유지
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/test/.claude/skills/test/SKILL.md","old_string":"old","new_string":"```bash\necho 308줄\noutside 3곳"}}' | bash modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# 기대: {"decision":"block",...} (Edit는 strip 안 함)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection accuracy for the Write functionality by excluding content within markdown code blocks from validation checks. This reduces false positives when code examples are included in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->