### PR TITLE
feat(shell): ANDROID_HOME/PATH를 Home Manager 선언적 관리로 이전

### DIFF
--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -83,7 +83,7 @@ in
       # Android SDK platform-tools (adb, fastboot)
       # home.sessionPath는 PATH 앞에 prepend하므로 platform-tools의
       # sqlite3 등이 시스템 바이너리를 shadow한다. append로 우회.
-      export PATH="$PATH:$ANDROID_HOME/platform-tools"
+      [ -d "$ANDROID_HOME/platform-tools" ] && export PATH="$PATH:$ANDROID_HOME/platform-tools"
     ''
   ];
 }


### PR DESCRIPTION
## Summary

- `.zprofile`의 수동 Android SDK 환경변수(`ANDROID_HOME`, `platform-tools` PATH)를 Home Manager 선언적 관리로 이전한다.
- `home.sessionPath`(prepend)가 시스템 바이너리를 shadow하는 문제를 회피하여, `initContent`에서 append 방식으로 PATH를 추가한다.

## 기존 문제/배경

`ANDROID_HOME`과 `$ANDROID_HOME/platform-tools` PATH가 `~/.zprofile`에 수동으로 설정되어 있었다. 이 프로젝트는 macOS 환경을 nix-darwin + Home Manager로 선언적 관리하므로, repo 밖의 수동 설정은 관리 사각지대다.

사용자는 personal Mac과 work Mac 양쪽에서 React Native 개발(시뮬레이터/실기기 제어, chrome://inspect 원격 디버깅)에 ADB를 사용한다.

## CIR (Change Intent Record)

- **v1** (이전 세션): `.zprofile`에 수동으로 `ANDROID_HOME` + PATH 추가 — 즉시 동작하지만 선언적이지 않음
- **v2** (계획 단계): `home.sessionPath`로 PATH 추가 시도 → DA에서 prepend로 인한 `sqlite3` shadow 발견
- **v3** (`80bb7ac`): `home.sessionVariables` + `initContent` append 조합 채택

**trade-off**: PATH 관리가 `sessionPath`(prepend)와 `initContent`(append) 두 메커니즘으로 분산되지만, 시스템 바이너리 shadowing을 방지하는 것이 더 중요하다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `home.sessionPath` | HM 공식 PATH 관리 | 단일 메커니즘, 간결 | prepend → `sqlite3` 등 shadow | ❌ |
| `programs.zsh.profileExtra` | `.zprofile`에 추가 | login shell 전용 | HM이 `.zprofile` 관리 → Kiro/Obsidian 충돌 | ❌ |
| `initContent` append | `.zshrc`에서 PATH append | shadow 방지, `.zprofile` 비충돌 | PATH 관리 분산 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/shell/darwin.nix` | 수정 | `ANDROID_HOME` sessionVariable + platform-tools PATH append |

### 핵심 코드

```nix
# sessionVariables에 ANDROID_HOME 추가 (line 43)
ANDROID_HOME = "$HOME/Library/Android/sdk";

# initContent에서 PATH append (line 83-86)
# home.sessionPath는 PATH 앞에 prepend하므로 platform-tools의
# sqlite3 등이 시스템 바이너리를 shadow한다. append로 우회.
export PATH="$PATH:$ANDROID_HOME/platform-tools"
```

## 참고 레퍼런스

- `80bb7ac` — ANDROID_HOME/PATH를 Home Manager 선언적 관리로 이전
- `8588508` — Android PATH 주석을 자족적 설명으로 개선
- [Home Manager hm-session-vars.sh](https://github.com/nix-community/home-manager) — `sessionPath`가 prepend되는 동작 확인

## Human Test Plan

### 정상 동작 검증

1. `nrs` 실행 후 새 터미널을 연다.
   - **기대**: `echo $ANDROID_HOME` → `~/Library/Android/sdk`
   - **실패 시**: `~/.zshenv`에서 `hm-session-vars.sh`가 로드되는지 확인

2. `which adb`를 실행한다.
   - **기대**: `~/Library/Android/sdk/platform-tools/adb`
   - **실패 시**: `echo $PATH | tr ':' '\n' | grep platform` 으로 PATH 확인

3. `which sqlite3`를 실행한다.
   - **기대**: `/usr/bin/sqlite3` (Android의 sqlite3가 아님)
   - **실패 시**: PATH에서 platform-tools가 prepend되었는지 확인

### 비로그인 셸 검증

4. `zsh -c 'echo $ANDROID_HOME'`을 실행한다.
   - **기대**: `~/Library/Android/sdk` (비로그인 셸에서도 접근 가능)

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. ANDROID_HOME sessionVariable 존재 확인
grep -q 'ANDROID_HOME' modules/shared/programs/shell/darwin.nix
# 기대: exit 0

# 2. initContent에 platform-tools append 존재 확인
grep -q 'ANDROID_HOME/platform-tools' modules/shared/programs/shell/darwin.nix
# 기대: exit 0

# 3. home.sessionPath에 platform-tools가 없는지 확인 (Negative)
! grep -q 'platform-tools' <(grep -A5 'sessionPath' modules/shared/programs/shell/darwin.nix)
# 기대: exit 0 (sessionPath에는 platform-tools가 없어야 함)
```

### Phase 1: 환경변수 기능 검증

> "ANDROID_HOME이 모든 zsh 프로세스에서 접근 가능한지 확인"

```bash
zsh -c 'echo $ANDROID_HOME' | grep -q 'Library/Android/sdk'
```
- **기대**: ANDROID_HOME이 설정되어 있다.
- **실패 시**: `hm-session-vars.sh`에 ANDROID_HOME export가 포함되어 있는지 `cat $(readlink ~/.zshenv)` 로 확인.

### Phase 2: PATH shadow 방지 검증

> "platform-tools의 sqlite3가 시스템 sqlite3를 shadow하지 않는지 확인"

```bash
zsh -ic 'which sqlite3' 2>&1 | grep -q '/usr/bin/sqlite3'
```
- **기대**: `/usr/bin/sqlite3`가 반환된다.
- **실패 시**: `echo $PATH | tr ':' '\n' | head -10`으로 platform-tools가 PATH 앞에 있는지 확인.

### Phase 3: Regression

> "기존 셸 설정(Homebrew, Bun, Deno)이 이번 변경에 의해 깨지지 않았는지 확인"

```bash
# Homebrew 정상 동작
zsh -ic 'which brew' 2>&1 | grep -q '/opt/homebrew'

# Bun 정상 동작
zsh -ic 'echo $BUN_INSTALL' 2>&1 | grep -q '.bun'
```
- **기대**: 기존 설정이 모두 정상 동작한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * macOS shell now sets ANDROID_HOME and, when Android platform tools are present, exposes them on the PATH so command-line Android tools are available in terminal sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->