### PR TITLE
fix(docs): LLM 오탐 방지 — nrs 워크트리 심링크 전환 문서화 (#380)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Environment 섹션의 `Platform` 값으로 현재 환경을 판별한다.
 
 ## 빌드
 
-`nrs`를 사용. `darwin-rebuild`/`nixos-rebuild` 직접 실행 금지. `nrs`는 preview를 포함하며, macOS에서는 launchd 정리와 Hammerspoon 재시작도 처리한다. **워크트리에서 `nrs` switch 성공 시 `$HOME` 아래 out-of-store symlink가 워크트리로 relink된다** (`nrs-relink`). main repo에서 `nrs` 실행 시 nix store 체인으로 복원된다.
+`nrs`를 사용. `darwin-rebuild`/`nixos-rebuild` 직접 실행 금지. `nrs`는 preview를 포함하며, macOS에서는 launchd 정리와 Hammerspoon 재시작도 처리한다. 워크트리에서 `nrs` 완료 시 `$HOME` 아래 out-of-store symlink의 워크트리 relink을 시도한다 (`nrs-relink`, non-fatal). main repo에서 `nrs` 실행 시 nix store 체인으로 복원을 시도한다.
 
 ## 상수
 

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
       #   nixosConfigPath        — 항상 메인 레포 경로. mkOutOfStoreSymlink 등 ~16곳에서 사용.
       #   nixosConfigDefaultPath — 항상 메인 레포 경로. rebuild-common.sh의 @flakePath@ 전용.
       # Worktree 빌드는 --flake <worktree> 인수로만 처리.
-      # 단, nrs post-build에서 $HOME 아래 out-of-store symlink가 워크트리로 relink될 수 있음 (nrs-relink).
+      # $HOME 아래 OOS symlink의 relink/restore는 nrs-relink이 담당 — 상세는 CLAUDE.md 참조.
 
       # macOS 호스트 설정 (확인: scutil --get LocalHostName)
       darwinHosts =


### PR DESCRIPTION
## Summary

- CLAUDE.md/flake.nix에 nrs의 워크트리 심링크 전환(nrs-relink) 동작을 문서화하여 LLM 오탐을 방지한다
- DA for_plan(22건 CONFIRMED) + DA for_pr(2라운드) + 전수조사(5에이전트 ALL SAFE) 통과
- nrs-relink trust gate 부재 보안 이슈를 별도 등록 (#384)

Closes #380

## 기존 문제/배경

#375 구현 중 LLM이 `flake.nix:77` 주석("심링크 타깃은 항상 메인 레포")만 읽고 "워크트리에서 nrs 실행해도 심링크가 안 바뀐다"고 오판했다. 실제로는 nrs의 post-build 단계에서 `nrs-relink relink`가 심링크를 워크트리로 전환하는 기능이 PR #28 이후 수십 개 PR로 구현되어 있었음.

근본 원인:
1. CLAUDE.md의 "빌드" 섹션에 워크트리 심링크 전환 기능이 미기록
2. `flake.nix` 주석이 Nix 빌드 레이어만 설명하고 post-build relink을 언급하지 않음

## CIR (Change Intent Record)

- **v1** (`1841ef7`): "switch 성공 시 relink된다"로 보장형 서술 + flake.nix에 상세 설명 포함
- **v2** (`6570d62`): DA for_pr 피드백 반영 — "완료 시 relink을 시도한다 (non-fatal)"로 best-effort 동작 반영, flake.nix는 CLAUDE.md 참조로 단일 소스화
- **DA for_plan 주요 결정**: B1/B2 feedback 메모리 제거(단일사례 과잉승격), A3 PR 이력 제거(stale 수치만 수정), 변수 불변식 "항상 메인 레포 경로" 유지

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 변수 불변식 변경 ("Nix 빌드 시 메인 레포") | nixosConfigPath 의미를 build-time으로 한정 | post-build 전환과의 대비 명확 | 16개 호출부의 계약 훼손, LLM 오해 유발 | ❌ |
| 불변식 유지 + 별도 줄로 relink 언급 | 변수 의미 보존, 후처리를 별도 설명 | 기존 계약 유지, 계층 분리 | 두 파일에 중복 서술 가능성 | ✅ |
| feedback 메모리 추가 (B1/B2) | "불가능 결론 전 git log 확인" 등 상시 규칙 | 동일 오탐 반복 방지 | 단일 사례 기반 과잉 승격, 메모리 fragile | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `CLAUDE.md` | 수정 | 빌드 섹션에 nrs-relink 동작 설명 추가 (non-fatal, best-effort) |
| `flake.nix` | 수정 | nixosConfigPath 주석에 OOS symlink relink 참조 추가 (CLAUDE.md 단일 소스) |

### 핵심 변경

```markdown
# CLAUDE.md 빌드 섹션 (추가분)
워크트리에서 `nrs` 완료 시 `$HOME` 아래 out-of-store symlink의 워크트리 relink을 시도한다
(`nrs-relink`, non-fatal). main repo에서 `nrs` 실행 시 nix store 체인으로 복원을 시도한다.
```

```nix
# flake.nix 주석 (변경분)
# Worktree 빌드는 --flake <worktree> 인수로만 처리.
# $HOME 아래 OOS symlink의 relink/restore는 nrs-relink이 담당 — 상세는 CLAUDE.md 참조.
```

### 메모리 변경 (git 미추적)

- `project_nrs_worktree_testing.md`: stale 수치 "37개" → "out-of-store symlink" (고정 수치 제거)
- `MEMORY.md` 인덱스: 동일 수치 수정

## 참고 레퍼런스

- Issue #380 — 이 PR의 원본 이슈
- Issue #384 (`6570d62`) — DA에서 발견된 nrs-relink trust gate 보안 이슈 (별도 분리)
- PR #339 (`d948e6f`) — worktree-only 새 파일의 mkOutOfStoreSymlink relink 누락 수정
- PR #294 (`33b6f24`) — worktree 삭제 후 dangling 심링크 3중 자동 복구
- `1841ef7` — 초기 문서화 커밋 (DA for_pr에서 trigger/보장 수준 수정됨)

## Human Test Plan

### 정상 동작 검증

1. worktree에서 `nrs` 실행 후 `nrs-relink status` 확인
   - **기대**: "Relinked N symlink(s) to worktree" 메시지 + status에서 worktree 경로 확인
   - **실패 시**: `nrs-relink status`의 출력과 `nrs` 로그에서 `maybe_relink_or_restore` 호출 여부 확인

2. main repo에서 `nrs` 실행 후 심링크 확인
   - **기대**: `~/.claude/hooks/` 등이 nix store 체인을 가리킴
   - **실패 시**: `ls -la ~/.claude/hooks/` 출력과 `nrs` 로그 확인

### 문서 검증

3. CLAUDE.md의 빌드 섹션에서 nrs-relink 언급 확인
   - **기대**: "non-fatal", "relink을 시도한다" 문구 존재
   - **실패 시**: `grep "nrs-relink" CLAUDE.md`

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. CLAUDE.md에 nrs-relink 언급 존재
grep -q "nrs-relink" CLAUDE.md
# 기대: exit 0

# 2. CLAUDE.md에 non-fatal 명시
grep -q "non-fatal" CLAUDE.md
# 기대: exit 0

# 3. flake.nix에 CLAUDE.md 참조 존재
grep -q "CLAUDE.md 참조" flake.nix
# 기대: exit 0

# 4. old 문구 부재 확인 — "심링크 타깃은 항상 메인 레포"
! grep -q "심링크 타깃은 항상 메인 레포" flake.nix
# 기대: exit 0

# 5. 변수 불변식 유지 확인
grep -q "항상 메인 레포 경로" flake.nix
# 기대: exit 0
```

### Phase 1: 빌드 검증

> "주석/문서 변경이 Nix 빌드에 영향을 주지 않는지 확인"

```bash
nrs
```
- **기대**: 빌드 성공, relink 정상 동작
- **실패 시**: `flake.nix` 주석이 Nix 구문을 깨뜨리지 않았는지 확인

### Phase 2: Regression

> "기존 빌드 동작과 스킬/hooks가 이번 변경에 의해 깨지지 않았는지 확인"

```bash
# pre-commit hooks 통과 확인
git diff --cached --name-only  # staged 파일 확인
# 기대: CLAUDE.md, flake.nix만 변경

# nrs-relink status 정상 확인
nrs-relink status | head -3
# 기대: Total: N entries (51 이상)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build system documentation for worktrees with new recovery behaviors for symlink management.
  * Enhanced documentation for worktree build workflows, clarifying symlink restoration and delegation procedures.
  * Added recovery behavior documentation for main repository builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->