### PR TITLE
fix(codex): heredoc + codex exec 체이닝 stdin hang 방지 문서화

### DIFF
--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -138,7 +138,7 @@ error: the argument '--base <BRANCH>' cannot be used with '--uncommitted'
 | stdin 파이프 | `cat prompt.md \| codex exec --full-auto -o result.md` |
 | stdin 마커 | `codex exec review - --full-auto` (stdin에서 읽음) |
 | 파일 리다이렉트 | `codex exec --full-auto < prompt.md -o result.md` |
-| here-doc | `codex exec --full-auto <<'EOF' ... EOF` ⚠️ heredoc으로 파일 생성 후 같은 Bash 호출에서 codex exec를 이어 실행하면 `run_in_background`에서 hang ([§11](references/known-issues.md)) |
+| here-doc | `codex exec --full-auto <<'EOF' ... EOF` |
 
 ## 표준 실행 절차
 

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -347,7 +347,7 @@ echo "PID: $!"
 
 #### heredoc + codex exec 체이닝 시 hang (run_in_background 환경)
 
-**심각도**: 높음 — `run_in_background: true`로 실행하는 모든 codex exec 호출에 적용
+**심각도**: 높음 — `run_in_background: true`에서 heredoc으로 파일 생성 후 같은 Bash 호출에서 codex exec를 이어 실행하는 경우에 적용
 
 **증상**: `run_in_background: true`로 실행한 Bash 호출에서 heredoc으로 파일을 생성한 뒤 같은 호출에서 codex exec를 실행하면, codex가 무한 대기.
 
@@ -357,29 +357,31 @@ echo "PID: $!"
 
 HANG — heredoc 체이닝 (같은 Bash 호출):
 ```bash
-cat > /tmp/test-prompt.md <<'EOF'
+(umask 077; TDIR=$(mktemp -d /tmp/test-XXXXXX) && cat > "$TDIR/prompt.md" <<'EOF'
 테스트 프롬프트
 EOF
-codex exec --full-auto --ephemeral -o /tmp/test-result.md "$(cat /tmp/test-prompt.md)"
+codex exec --full-auto --ephemeral -o "$TDIR/result.md" "$(cat "$TDIR/prompt.md")")
 # → 무한 대기
 ```
 
 OK — 별도 Bash 호출로 분리:
 
-**1. Bash tool 호출 1**: 프롬프트 파일 생성
+**1. Bash tool 호출 1**: 프롬프트 파일 생성 (경로 출력)
 ```bash
-cat > /tmp/test-prompt.md <<'EOF'
+TDIR=$(mktemp -d /tmp/test-XXXXXX) && cat > "$TDIR/prompt.md" <<'EOF'
 테스트 프롬프트
 EOF
+echo "$TDIR"
+# → /tmp/test-a1b2c3 (이 경로를 다음 호출에서 사용)
 ```
 
-**2. Bash tool 호출 2**: codex exec 실행
+**2. Bash tool 호출 2**: codex exec 실행 (경로 직접 지정)
 ```bash
-codex exec --full-auto --ephemeral -o /tmp/test-result.md "$(cat /tmp/test-prompt.md)"
+codex exec --full-auto --ephemeral \
+  -o /tmp/test-a1b2c3/result.md \
+  "$(cat /tmp/test-a1b2c3/prompt.md)"
 ```
 
-**올바른 패턴**: 프롬프트 파일 생성과 codex exec를 별도 Bash tool 호출로 분리한다. §11 본문의 "올바른 패턴"과 동일 원리. 호출 간 상태 공유는 파일 경로를 통해서만 한다 (셸 변수는 호출 간 유지되지 않음).
+**올바른 패턴**: 프롬프트 파일 생성과 codex exec를 별도 Bash tool 호출로 분리한다. §11 본문의 "올바른 패턴"과 동일 원리. 호출 간 상태 공유는 파일 경로를 통해서만 한다 (셸 변수는 호출 간 유지되지 않으므로, 1단계에서 출력한 경로를 2단계에서 직접 사용).
 
 **§11 본문과의 관계**: §11은 `& + wait` shell-level 병렬과 다수 stdin pipe 경합의 제약이고, 이 항목은 heredoc 체이닝의 stdin 관련 문제이다. 원인은 다르지만 해결 패턴(별도 Bash tool 호출 분리)은 동일하다.
-
-**TODO**: run-da/SKILL.md와 arbiter-scaling.md의 코드 예시에도 동일 패턴 적용 필요 (별도 이슈).

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
@@ -185,7 +185,7 @@ Ignore style-only issues.
 PROMPT
 ```
 
-**⚠️ `run_in_background` 환경**: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. DA 루프는 인라인 인자를 사용한다 (run-da 스킬과 일관성).
+**⚠️ `run_in_background` 환경**: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. DA 루프에서는 인라인 인자(`"$(cat file)"`)를 사용한다.
 
 ```bash
 codex exec --full-auto -o /tmp/da-round1-result.md \


### PR DESCRIPTION
## Summary

- `run_in_background` 환경에서 heredoc과 codex exec를 같은 Bash 호출에 체이닝하면 stdin hang이 발생하는 문제를 문서화하고, 스킬 예시를 안전한 패턴으로 교체
- known-issues.md §11 하위에 재현/원인/해결 패턴을 추가하고, SKILL.md/patterns.md의 코드 블록을 물리적으로 분리

Closes #389

## 기존 문제/배경

`using-codex-exec` 스킬의 SKILL.md와 patterns.md 예시가 heredoc(프롬프트 파일 생성)과 codex exec(실행)를 같은 코드 블록에 체이닝하는 패턴을 사용하고 있었다. 이 패턴은 일반 터미널에서는 정상 작동하지만, Claude Code Bash tool의 `run_in_background: true` 환경에서는 codex가 무한 대기하는 hang을 유발한다 (codex-cli v0.118.0에서 재현 확인).

## CIR (Change Intent Record)

- **v1** (`f85893c`): 이행 가이드 원안대로 모든 `cat | codex exec`를 `"$(cat)"` 인라인 인자로 전면 교체 시도
- **DA for_plan 피드백**: NGMI-1(ARG_MAX 한계), NGMI-2(일반/특수 경계 무너짐), SIDE_EFFECT-3(patterns.md "세션 안팎 공통" 계약 변경) 등 6건 CONFIRMED → 접근 전환
- **v2** (최종): "코드 블록 물리적 분리" 방식 채택. 일반 예시의 stdin pipe 유지, 대형 payload는 file redirect, DA 루프는 인라인 인자. 기존 계약 보존
- **DA for_pr R1** (`cad6523`): `$TDIR` 변수 호출 간 공유 불가 버그 + 원인 서술 과도 단정 수정
- **DA for_pr R2** (`f97ba83`): 영향 범위 축소(heredoc 체이닝 패턴으로 한정) + mktemp 복원

**trade-off**: run-da/arbiter-scaling.md의 코드 예시에도 동일 패턴 적용이 필요하나, 이번 이슈 범위를 넘어가므로 별도 이슈로 분리.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 인라인 인자 전면 교체 | 모든 `cat \| codex exec` → `"$(cat)"` | 단순, 일관적 | ARG_MAX 2MB 한계, "세션 안팎 공통" 계약 무너짐 | ❌ |
| 코드 블록 물리적 분리 | heredoc과 codex exec를 별도 코드 블록으로 분리 + 맥락별 입력 방법 | 기존 계약 보존, ARG_MAX 안전 | 경고 문구 반복 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 줄 수 |
|------|------|------|
| `using-codex-exec/references/known-issues.md` | §11 하위에 heredoc 체이닝 hang 항목 추가 + 금지 패턴 추가 + 스모크 테스트 코드 블록 분리 | +46 |
| `using-codex-exec/references/patterns.md` | 패턴 1/4/5/6/8 코드 블록 분리 + 맥락별 입력 방법 (stdin pipe/file redirect/인라인 인자) | +38/-7 |
| `using-codex-exec/SKILL.md` | 표준 실행 절차 코드 블록 분리 | +4 |

**맥락별 입력 방법 분기:**

| 패턴 | 입력 방법 | 이유 |
|------|----------|------|
| 1 (기본 exec), 8 (스모크) | stdin pipe | 일반 사용, 짧은 프롬프트 |
| 4 (커스텀 리뷰), 6 (구조화 출력) | file redirect (`< file`) | 대형 diff, ARG_MAX 안전 |
| 5 (DA 루프) | 인라인 인자 (`"$(cat)"`) | DA 특수 패턴 |

## 참고 레퍼런스

| 참조 | 설명 |
|------|------|
| `16b45d9` | fix(run-da): Arbiter for_plan 오탐 해결 (#390) — run-da heredoc 예시 이미 quoted로 수정 |
| `55ffaf6` | feat(run-da): Review Intensity 독립 에이전트 (#382) — codex exec 실행 계약 도입 |
| known-issues.md §11 | Claude Code Bash tool sandbox 제약 — 본문에 금지 패턴 항목 추가 |

## Human Test Plan

### 1. known-issues.md §11 하위 항목 확인

1. `modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md`에서 §11 끝의 `####` 하위 항목 확인
2. 재현 예시가 `mktemp -d` + `umask 077`을 사용하는지 확인
3. "OK — 별도 Bash 호출" 예시에서 셸 변수가 아닌 고정 경로를 사용하는지 확인

### 2. patterns.md 코드 블록 분리 확인

1. 패턴 1/4/5/6/8에서 heredoc과 codex exec가 별도 코드 블록으로 분리되어 있는지 확인
2. 패턴 4/6이 `< file` redirect를 사용하는지 확인
3. 패턴 5가 `"$(cat)"` 인라인 인자를 사용하는지 확인
4. 빠른 참조 표가 패턴 4의 변경을 반영하는지 확인

### 3. SKILL.md 변경 확인

1. 표준 실행 절차가 코드 블록 분리되어 있는지 확인
2. here-doc 입력 방법 표에 불필요한 경고가 없는지 확인

**실패 시**: 변경 내용이 DA for_plan에서 승인된 계획과 일치하는지 `.claude/plans/moonlit-jingling-eagle.md` 대조

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. §11 하위 항목 존재
grep -q "heredoc.*codex exec.*hang" modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
# 기대: exit 0

# 2. 금지 패턴에 heredoc 항목 추가됨
grep -q "heredoc.*codex exec.*체이닝" modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
# 기대: exit 0

# 3. SKILL.md here-doc 행에 불필요한 경고 없음
! grep -q "run_in_background.*체이닝 금지" modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
# 기대: exit 0

# 4. 패턴 4/6이 file redirect 사용
grep -q "< /tmp/" modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
# 기대: exit 0

# 5. 패턴 5가 인라인 인자 사용
grep -q '"$(cat' modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
# 기대: exit 0

# 6. run-da/SKILL.md 미변경
test -z "$(git diff main...HEAD -- modules/shared/programs/claude/files/skills/run-da/SKILL.md)"
# 기대: exit 0
```

### Phase 1: 스킬 eval 테스트

```bash
cd modules/shared/programs/claude/files/skills/using-codex-exec && \
  ~/.claude/scripts/run-eval.sh evals/queries.json
```

- **기대**: 모든 eval 통과
- **실패 시**: `evals/queries.json`의 실패 항목과 SKILL.md description 변경 여부 대조

### Phase 2: Regression — 인접 스킬 라우팅

| 쿼리 | 기대 스킬 | 영향 |
|------|----------|------|
| `codex exec review --base main` | using-codex-exec | 무영향 |
| `DA 피드백 루프` | run-da | 무영향 |
| `claude -p 사용법` | using-claude-p | 무영향 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warnings regarding potential hang scenarios in `run_in_background` environment
  * Documented known issues and provided workarounds for affected use cases
  * Updated usage examples to reflect recommended practices and patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->