### PR TITLE
fix(skills): LLM bash 배열 문법 오류 재발 방지 — zsh 환경 명시 + 코드 예시 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Environment 섹션의 `Platform` 값으로 현재 환경을 판별한다.
 
 ## Bash tool 환경
 
-Bash tool의 inline 스크립트는 zsh에서 실행된다. `${!arr[@]}` 등 bash 전용 간접 확장을 사용하지 않는다 (상세: [known-issues.md §11](modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md)).
+Bash tool의 inline 스크립트는 zsh에서 실행된다. `${!arr[@]}` 등 bash 전용 간접 확장을 사용하지 않는다.
 
 ## 상수
 

--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -188,7 +188,9 @@ Round N 요약 (LITE: 선택 M개/전체 N개): DA 발견 X건
      # Bash call 1: 임시 디렉토리 + 선택된 도메인별 프롬프트 파일 생성
      DA_DIR=$(mktemp -d /tmp/da-plan-XXXXXX)
 
-     # 예시: SECURITY 도메인 (나머지 선택 도메인도 동일 패턴으로 조립)
+     # 각 선택 도메인마다 cat(프롬프트 생성) + codex exec(실행)를 반복한다.
+     # 반복은 shell loop가 아닌 tool-level 병렬 호출로 처리한다.
+     # 예시: SECURITY 도메인
      cat > "$DA_DIR/SECURITY.md" <<'PROMPT'
      당신은 SECURITY 전문 Devil's Advocate이다. 오직 SECURITY 관점에서만 리뷰한다.
      "공격자가 악용할 수 있는 경로"를 식별하라.

--- a/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
@@ -41,7 +41,7 @@ DA 영역의 집중 관점과 에이전트 프롬프트 구성을 정의한다. 
 `{DOMAIN}`, `{FOCUS_QUESTION}`, `{FOCUS_TARGETS}`, `{OTHER_DOMAINS}`를 영역별로 치환한다.
 
 > **⚠️ 이 플레이스홀더는 셸 변수가 아니다.** 조립 절차는 [run-da/SKILL.md](../SKILL.md)를 참조한다.
-> `{OTHER_DOMAINS}`는 현재 도메인을 제외한 나머지 전체 도메인 이름의 쉼표 구분 목록이다.
+> `{OTHER_DOMAINS}`는 전체 8개 도메인 중 현재 도메인을 제외한 이름의 쉼표 구분 목록이다.
 
 ```text
 당신은 {DOMAIN} 전문 Devil's Advocate이다. 오직 {DOMAIN} 관점에서만 리뷰한다.

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
@@ -2,7 +2,7 @@
 
 각 패턴은 Claude Code 세션 안팎에서 동일하게 재현 가능한 순수 셸 명령으로 작성한다.
 
-> **⚠️ Bash tool은 zsh에서 실행됨.** bash 전용 간접 확장(`${!arr[@]}`) 사용 금지 ([known-issues.md §11](known-issues.md) 참조).
+> **⚠️ Bash tool은 zsh에서 실행됨.** bash 전용 간접 확장(`${!arr[@]}`) 사용 금지.
 
 ## 패턴 1: 기본 exec — 파일 프롬프트 → 결과 저장
 


### PR DESCRIPTION
## Summary
- LLM이 run-da DA 프롬프트 생성 시 `${!arr[@]}` 등 bash 전용 간접 확장을 사용하여 zsh 환경에서 `bad substitution` 에러가 반복 발생하던 문제를 해소한다.
- run-da 코드 예시를 도메인별 개별 조립 패턴으로 교체하고, 프로젝트 전역에 zsh 환경 규칙을 명시한다.

## 기존 문제/배경

NixOS의 Bash tool은 zsh에서 실행되는데, LLM이 run-da DA 프롬프트를 생성할 때 bash 전용 배열 간접 확장(`${!arr[@]}`)을 사용하여 `bad substitution` 에러가 **오늘만 5회 반복** 발생했다.

**근본 원인 분석 결과**:
1. `da-domains.md`의 `{FOCUS_QUESTION}` 등 플레이스홀더가 LLM에게 "셸 변수 치환" 충동을 유발
2. `run-da SKILL.md`의 코드 예시가 `... 영역별 프롬프트 ...`로 생략되어 LLM이 자체 구현하면서 bash 문법 사용
3. 실증 결과 `${!arr[@]}`만 zsh에서 에러 발생 — `declare -A`, `${arr[$i]}`는 zsh 호환

## CIR (Change Intent Record)

**발견 경위**: 동일 세션에서 run-da 실행 5회 연속 `bad substitution` 에러 후 전수조사 요청.

**설계 의도 전환 이력**:
1. 초기 계획: case문 기반 완성 예시(방식 A) + 플레이스홀더 표기 변경(방식 B) → DA for_plan에서 DRY 위반 6건 + 표기 이원화 3건 CONFIRMED
2. 수정 계획: 도메인별 개별 조립 패턴 + 플레이스홀더 표기 유지 + 전역 zsh 규칙
3. DA for_pr Round 1: 배열 금지 과도 지적 → `${!arr[@]}`만으로 한정, zsh 호환 배열 허용
4. DA for_pr Round 2: 참조 정리 + 확장 규칙 명시 + OTHER_DOMAINS 기준 명확화

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| case문 하드코딩 | SKILL.md에 8개 도메인 FOCUS_QUESTION을 case문으로 매핑 | 배열 오류 원천 차단 | DRY 위반 (da-domains.md와 이중 관리), DA 6건 CONFIRMED | ❌ |
| 플레이스홀더 표기 변경 | `{DOMAIN}` → `__DOMAIN__` | 셸 변수 혼동 방지 | 동일 스킬 내 표기 이원화, DA 3건 CONFIRMED | ❌ |
| 도메인별 개별 조립 + 전역 규칙 | 1개 예시 + tool-level 병렬 반복 + zsh 경고 | DRY 유지, da-domains.md SSoT 보존, zsh 호환 배열 허용 | 예시가 단일 도메인뿐 | ✅ |

## 구현 상세

| 파일 | 변경 | 핵심 |
|------|------|------|
| `CLAUDE.md` | +3 | Bash tool zsh 환경 규칙 추가 |
| `run-da/SKILL.md` | +18/-12 | for 루프+배열 예시 → 도메인별 개별 조립 패턴, zsh 경고, 확장 규칙 |
| `run-da/references/da-domains.md` | +3 | 플레이스홀더 주석 + OTHER_DOMAINS 산출 규칙 |
| `using-codex-exec/references/patterns.md` | +2 | zsh 환경 경고 |

## 참고 레퍼런스

- `16b45d9` — fix(run-da): Arbiter for_plan 오탐 해결 (직전 run-da 변경)
- `55ffaf6` — feat(run-da): Review Intensity 독립 에이전트 (LITE 모드 도입으로 배열 사용 빈도 증가)
- `2c4476d` — refactor(skills): run-da 실행 엔진을 codex exec 기반 병렬로 전환 (배열 예시 최초 도입)
- known-issues.md §11 — Claude Code Bash tool sandbox 제약 (배경 문서)

## Human Test Plan

| 단계 | 기대 동작 | 실패 시 진단 |
|------|----------|-------------|
| 1. run-da for_plan 실행 | DA 프롬프트 생성 시 `${!arr[@]}` 미사용 | Bash tool 출력에서 `bad substitution` 확인 |
| 2. run-da for_pr 실행 | 도메인별 개별 cat + codex exec 호출 | 프롬프트 파일 생성 여부 확인 (`ls /tmp/da-*/`) |
| 3. LITE 모드 (2-4개 도메인) | 선택 도메인만 프롬프트 생성 | 불필요한 도메인 파일이 생성되지 않는지 확인 |

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. SKILL.md에 bash 전용 간접 확장 금지 경고 존재
grep -q 'bash 전용 간접 확장' modules/shared/programs/claude/files/skills/run-da/SKILL.md && echo "PASS" || echo "FAIL"

# 2. da-domains.md에 OTHER_DOMAINS 산출 규칙 존재
grep -q '전체 8개 도메인 중' modules/shared/programs/claude/files/skills/run-da/references/da-domains.md && echo "PASS" || echo "FAIL"

# 3. CLAUDE.md에 zsh 규칙 존재
grep -q 'Bash tool.*zsh' CLAUDE.md && echo "PASS" || echo "FAIL"

# 4. patterns.md에 zsh 경고 존재
grep -q 'Bash tool.*zsh' modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md && echo "PASS" || echo "FAIL"

# 5. 이전 for 루프 패턴 부재
! grep -q 'for domain in "\${SELECTED_DOMAINS' modules/shared/programs/claude/files/skills/run-da/SKILL.md && echo "PASS" || echo "FAIL"
```

### Phase 1: zsh 호환성 검증

```bash
# SKILL.md 예시의 핵심 구문이 zsh에서 에러 없이 실행되는지
zsh -fc 'DA_DIR=$(mktemp -d /tmp/da-test-XXXXXX); cat > "$DA_DIR/SECURITY.md" <<'"'"'PROMPT'"'"'
test
PROMPT
echo "zsh OK"; rm -rf "$DA_DIR"'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Bash tool environment clarification detailing zsh execution requirements and shell syntax compatibility constraints
  * Updated domain execution workflow documentation with refined operational guidance and implementation patterns
  * Enhanced variable documentation with explicit definitions and shell compatibility guidelines for tool integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->