### PR TITLE
feat(darwin): manage cmux declaratively

### DIFF
--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -68,6 +68,7 @@
         ./programs/zed
         ./programs/folder-actions
         ./programs/ghostty
+        ./programs/cmux
         ./programs/shottr
         ./programs/keybindings
         ./programs/ssh

--- a/modules/darwin/programs/cmux/default.nix
+++ b/modules/darwin/programs/cmux/default.nix
@@ -1,0 +1,8 @@
+# cmux 설정 (macOS 전용)
+{ ... }:
+
+{
+  xdg.configFile."cmux/cmux.json".text = builtins.toJSON {
+    commands = [ ];
+  };
+}

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -24,9 +24,12 @@
       #      공통 cask인 이유: Zed 설정 모듈(./programs/zed)이 모든 darwin host에 적용되므로
       #      설치도 공통이어야 scope 일치. 업데이트: personal은 brew upgrade + Zed 자체,
       #      work는 Zed 자체 업데이터에만 의존 (onActivation.upgrade가 personal 전용).
+      # cmux: Homebrew core cask로 제공되므로 별도 tap 불필요.
+      #       사용자 설정은 ./programs/cmux에서 ~/.config/cmux/cmux.json으로 관리.
       casks = [
         "ghostty"
         "zed"
+        "cmux"
       ];
     }
 


### PR DESCRIPTION
## Summary
- Add `cmux` to the shared Darwin Homebrew cask set so both macOS hosts get the app declaratively.
- Add a macOS-only Home Manager module that materializes `~/.config/cmux/cmux.json` as a global empty command scaffold.
- Keep scope intentionally narrow: no Claude hook rewiring, no project-local `cmux.json`, and no NixOS packaging changes.

## 기존 문제/배경

`cmux`를 쓰려면 macOS에서 앱 설치와 글로벌 `cmux.json` 구성을 수동으로 해야 했다. 이 저장소는 Darwin GUI 앱을 `homebrew.casks`로, 사용자 설정 파일을 Home Manager `xdg.configFile`/`home.file`로 선언적으로 관리하고 있는데 `cmux`만 그 흐름 밖에 있었다.

그 결과 새 Mac 셋업이나 work/personal 호스트 간 동기화 시 `cmux` 설치 여부와 기본 명령 팔레트 파일 상태가 보장되지 않았다. 특히 `cmux` 문서는 글로벌 설정 파일 위치를 `~/.config/cmux/cmux.json`으로 규정하지만, 기존 코드베이스에는 해당 파일을 생성하는 모듈이 없었다.

## CIR (Change Intent Record)

- **탐색 단계**: `nixpkgs`에 `cmux` 패키지가 있는지 확인했지만 현재 flake 입력 기준 `cmux` derivation은 제공되지 않았다.
- **업스트림 비교**: `cmux` 문서는 DMG + Sparkle 자동 업데이트를 권장하지만, 이 저장소의 Darwin GUI 앱은 이미 `modules/darwin/programs/homebrew.nix`의 Homebrew cask 경로로 일관 관리되고 있다.
- **최종 선택** (`a0eea7d`): 앱 배포는 Homebrew cask로, 사용자 기본 설정은 Home Manager `xdg.configFile`로 분리 관리한다.

**trade-off**: 업스트림 권장 경로(DMG/Sparkle)를 따르지 않고 Homebrew 업데이트 흐름에 맞춘다. 대신 기존 Darwin 앱 관리 패턴과 운영 절차(`nrs`, `brew upgrade`)를 그대로 재사용할 수 있다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Homebrew cask + Home Manager global `cmux.json` | 앱은 Darwin 공통 cask로, 설정은 `~/.config/cmux/cmux.json`으로 관리 | 기존 macOS 앱/설정 패턴과 일치, 두 호스트에 동일 적용 | 업스트림 DMG/Sparkle 권장 경로는 사용하지 않음 | ✅ |
| DMG/Sparkle 수동 설치 | upstream 권장 설치 방식 사용 | 앱 내 자동 업데이트 흐름과 일치 | 선언적 관리 불가, 호스트 간 drift 발생 | ❌ |
| `nixpkgs` 패키지로 설치 | 패키지/설정 모두 Nix로 통합 | 이상적으로 가장 순수한 선언형 | 현재 flake 입력 기준 패키지 부재 | ❌ |
| 프로젝트별 `./cmux.json`만 추가 | 이 저장소 전용 명령만 제공 | 특정 repo에 최적화 가능 | 글로벌 기본값이 없어 다른 프로젝트에서 재사용 불가, 이번 요구 범위 초과 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/programs/homebrew.nix` | 수정 | Darwin 공통 `casks`에 `cmux` 추가 및 선택 근거 주석 보강 |
| `modules/darwin/programs/cmux/default.nix` | 추가 | `~/.config/cmux/cmux.json`을 `{"commands":[]}`로 생성하는 macOS 전용 모듈 추가 |
| `modules/darwin/home.nix` | 수정 | Darwin Home Manager imports에 `./programs/cmux` 연결 |

### 핵심 코드

```nix
xdg.configFile."cmux/cmux.json".text = builtins.toJSON {
  commands = [ ];
};
```

이 구성은 `cmux` 문서의 글로벌 설정 경로와 스키마를 그대로 따르면서도, 초기 상태를 비어 있는 scaffold로 고정한다. 명령 팔레트 엔트리는 이후 별도 요구가 있을 때만 추가한다.

## 참고 레퍼런스

- `a0eea7d` — Darwin 공통 cask + `cmux.json` scaffold 추가
- https://cmux.com/docs/getting-started — Homebrew 설치 경로와 CLI 배치 방식 확인
- https://cmux.com/docs/custom-commands — 글로벌 `~/.config/cmux/cmux.json` 위치와 `commands` 스키마 확인
- 관련 GitHub issue: 해당 없음

## Human Test Plan

1. Darwin 호스트에서 `nrs`를 실행한다.
   - **기대**: Homebrew Brewfile에 `cmux`가 포함되고 Home Manager activation이 성공한다.
   - **실패 시**: `modules/darwin/programs/homebrew.nix`의 공통 `casks` 블록과 `modules/darwin/home.nix`의 import 누락 여부를 확인한다.

2. `cat ~/.config/cmux/cmux.json`을 실행한다.
   - **기대**: `{"commands":[]}`가 출력된다.
   - **실패 시**: `modules/darwin/programs/cmux/default.nix`가 import되었는지, Home Manager가 Darwin 사용자에 적용되는지 확인한다.

3. `cmux`를 실행해 앱이 정상 기동하는지 확인한다.
   - **기대**: 앱이 열리고 별도 수동 설정 없이 기본 workspace가 표시된다.
   - **실패 시**: `brew info --cask cmux` 결과와 `/Applications/cmux.app` 존재 여부를 먼저 확인한다.

4. work Mac에서도 동일하게 Brewfile evaluation을 확인한다.
   - **기대**: work host의 공통 cask 집합에도 `cmux`가 포함된다.
   - **실패 시**: `cmux`가 personal 전용 블록으로 잘못 들어갔는지 확인한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 모듈 존재 확인
ls modules/darwin/programs/cmux/default.nix
# 기대: exit 0

# 2. Darwin 공통 cask에 cmux 추가 확인
rg -n '"cmux"' modules/darwin/programs/homebrew.nix
# 기대: exit 0

# 3. cmux가 Nix package/NixOS 경로로 잘못 추가되지 않았는지 확인
! rg -n 'cmux' libraries/packages.nix modules/nixos -g '*.nix'
# 기대: exit 0 (Darwin 전용이어야 함)
```

### Phase 1: Darwin personal host cask 검증

> "personal Mac의 Homebrew cask 집합에 `cmux`가 포함되는지 확인"

```bash
nix eval --json 'path:'"$PWD"'#darwinConfigurations.greenhead-MacBookPro.config.homebrew.casks' \
  | jq -e 'map(.name) | index("cmux") != null'
```

- **기대**: `true`를 반환하고 exit 0으로 종료한다.
- **실패 시**: `modules/darwin/programs/homebrew.nix`에서 `cmux`가 personal 전용 블록이 아닌 공통 블록에 있는지 확인한다.

### Phase 2: global `cmux.json` 생성 검증

> "Home Manager가 글로벌 `cmux.json`을 빈 scaffold로 생성하는지 확인"

```bash
nix eval --raw 'path:'"$PWD"'#darwinConfigurations.greenhead-MacBookPro.config.home-manager.users.green.xdg.configFile."cmux/cmux.json".text' \
  | jq -e '.commands == []'
```

- **기대**: `true`를 반환하고 exit 0으로 종료한다.
- **실패 시**: `modules/darwin/programs/cmux/default.nix`의 JSON 스키마와 `modules/darwin/home.nix` import를 확인한다.

### Phase 3: Regression

> "기존 Darwin 공통 cask(ghostty, zed)가 유지되면서 work Mac에도 `cmux`가 함께 노출되는지 확인"

```bash
nix eval --json 'path:'"$PWD"'#darwinConfigurations.work-MacBookPro.config.homebrew.casks' \
  | jq -e 'map(.name) as $names | ($names | index("ghostty") != null) and ($names | index("zed") != null) and ($names | index("cmux") != null) and ($names | length == 3)'
```

- **기대**: `true`를 반환하고 exit 0으로 종료한다.
- **실패 시**: 공통 cask 블록이 손상되었거나 `cmux`가 잘못된 조건부 블록으로 이동했는지 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cmux application to macOS system configuration with automatic installation through Homebrew
  * User configuration for cmux is now managed through centralized configuration files
  * Configuration is automatically generated and deployed to the standard user configuration location
  * Application installation and setup is consistent across all macOS systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->