### PR TITLE
fix(wt): restore plugin-aware codex sync for worktrees

### DIFF
--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -23,6 +23,10 @@ in
     source = "${sharedScriptsDir}/wt.sh";
     executable = true;
   };
+  home.file.".local/bin/codex-sync" = {
+    source = "${sharedScriptsDir}/codex-sync.sh";
+    executable = true;
+  };
   home.file.".local/bin/nfu" = {
     source = pkgs.replaceVars "${sharedScriptsDir}/nfu.sh" {
       flakePath = nixosConfigDefaultPath;

--- a/modules/shared/scripts/codex-sync.sh
+++ b/modules/shared/scripts/codex-sync.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# codex-sync: Claude Code 하니스를 Codex CLI 구조로 재투영
+# 사용법:
+#   codex-sync [project-root]
+
+set -euo pipefail
+
+_die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+_warn() {
+  echo "warning: $*" >&2
+}
+
+_usage() {
+  cat <<'EOF'
+사용법:
+  codex-sync [project-root]
+
+인자:
+  project-root  동기화 대상 프로젝트 루트 (기본값: 현재 작업 디렉토리)
+EOF
+}
+
+_resolve_sync_sh() {
+  local candidates=(
+    "$HOME/.claude/skills/syncing-codex-harness/references/sync.sh"
+    "$HOME/.codex/skills/syncing-codex-harness/references/sync.sh"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+_canonical_project_root() {
+  local input="${1:-$PWD}"
+  [[ -d "$input" ]] || _die "프로젝트 디렉토리가 없습니다: $input"
+  (cd "$input" && pwd -P)
+}
+
+main() {
+  if (( $# > 1 )); then
+    _die "인자는 최대 1개만 허용됩니다"
+  fi
+
+  case "${1:-}" in
+    -h|--help)
+      _usage
+      exit 0
+      ;;
+  esac
+
+  local project_root sync_sh
+  project_root=$(_canonical_project_root "${1:-$PWD}")
+  sync_sh=$(_resolve_sync_sh) || _die "sync.sh를 찾을 수 없습니다 (~/.claude 또는 ~/.codex)"
+
+  local -a args=()
+
+  if [[ -d "$project_root/.claude/skills" ]]; then
+    args+=(--local-skills-dir=.claude/skills)
+  fi
+
+  if [[ -f "$HOME/.claude/mcp.json" ]]; then
+    args+=(--user-mcp="$HOME/.claude/mcp.json")
+  else
+    _warn "$HOME/.claude/mcp.json 이 없어 user-scope MCP sync를 건너뜁니다"
+  fi
+
+  local plugin_lines
+  plugin_lines="$(
+    PROJECT_ROOT="$project_root" python3 <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def load_json(path: Path):
+    try:
+        with path.open() as f:
+            return json.load(f)
+    except Exception as exc:
+        print(f"warning: JSON parse failed: {path}: {exc}", file=sys.stderr)
+        return None
+
+
+def enabled_plugins(payload):
+    if not isinstance(payload, dict):
+        return []
+    plugins = payload.get("enabledPlugins", {})
+    if not isinstance(plugins, dict):
+        return []
+    return [key for key, value in plugins.items() if value]
+
+
+project_root = Path(os.environ["PROJECT_ROOT"]).resolve()
+home = Path.home()
+
+plugin_keys = []
+local_settings = project_root / ".claude" / "settings.local.json"
+if local_settings.is_file():
+    payload = load_json(local_settings)
+    plugin_keys = enabled_plugins(payload)
+
+if not plugin_keys:
+    user_settings = home / ".claude" / "settings.json"
+    if user_settings.is_file():
+        payload = load_json(user_settings)
+        plugin_keys = enabled_plugins(payload)
+
+manifest_path = home / ".claude" / "plugins" / "installed_plugins.json"
+manifest = load_json(manifest_path) if manifest_path.is_file() else None
+plugins = manifest.get("plugins", {}) if isinstance(manifest, dict) else {}
+
+plugin_claude_md = None
+for plugin_key in plugin_keys:
+    entries = plugins.get(plugin_key, [])
+    if not isinstance(entries, list):
+        continue
+
+    local_path = None
+    user_path = None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        install_path = entry.get("installPath")
+        if not install_path:
+            continue
+
+        scope = entry.get("scope", "")
+        if scope == "local":
+            project_path = entry.get("projectPath", "")
+            try:
+                if project_path and Path(project_path).resolve() == project_root:
+                    local_path = install_path
+            except OSError:
+                pass
+        elif scope == "user" and user_path is None:
+            user_path = install_path
+
+    resolved = local_path or user_path
+    if not resolved:
+        print(f"warning: installPath 해석 실패: {plugin_key}", file=sys.stderr)
+        continue
+
+    resolved_path = Path(resolved)
+    if not resolved_path.is_dir():
+        print(f"warning: plugin path not found: {resolved_path}", file=sys.stderr)
+        continue
+
+    plugin_name = plugin_key.split("@", 1)[0]
+    print(f"PLUGIN\t{resolved_path}\t{plugin_name}")
+
+    plugin_md = resolved_path / "CLAUDE.md"
+    if plugin_claude_md is None and not (project_root / "CLAUDE.md").exists() and plugin_md.is_file():
+        plugin_claude_md = plugin_md
+
+if plugin_claude_md is not None:
+    print(f"CLAUDE_MD\t{plugin_claude_md}")
+PY
+  )"
+
+  if [[ -n "$plugin_lines" ]]; then
+    while IFS=$'\t' read -r kind first second; do
+      [[ -n "$kind" ]] || continue
+      case "$kind" in
+        PLUGIN)
+          args+=(--plugin-install-path="${first}:${second}")
+          ;;
+        CLAUDE_MD)
+          args+=(--plugin-claude-md="${first}")
+          ;;
+      esac
+    done <<< "$plugin_lines"
+  fi
+
+  (
+    cd "$project_root"
+    bash "$sync_sh" all "$project_root" "${args[@]}"
+  )
+}
+
+main "$@"

--- a/modules/shared/scripts/wt.sh
+++ b/modules/shared/scripts/wt.sh
@@ -85,6 +85,10 @@ _info() {
   printf '\033[38;5;179m› \033[38;5;245m%s\033[0m\n' "$*" >&2
 }
 
+_warn() {
+  printf '\033[38;5;215m! \033[38;5;245m%s\033[0m\n' "$*" >&2
+}
+
 # y/N 확인 프롬프트 (gum confirm 대체)
 _confirm() {
   local msg="$1"
@@ -461,6 +465,17 @@ _bootstrap_worktree() {
 
   # .claude/plans/ 제거 (worktree에서는 불필요)
   rm -rf "$wt_path/.claude/plans"
+
+  # Claude → Codex projection 재실행 (plugin-aware worktree bootstrap 복구)
+  local codex_sync_sh
+  codex_sync_sh="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codex-sync.sh"
+  if [[ -f "$codex_sync_sh" ]]; then
+    if ! bash "$codex_sync_sh" "$wt_path"; then
+      _warn "codex-sync 실패 — 수동으로 'codex-sync $wt_path'를 실행하세요"
+    fi
+  else
+    _warn "codex-sync 스크립트를 찾지 못해 Codex projection을 건너뜁니다"
+  fi
 }
 
 # ── worktree 열기 (tmux 또는 stdout) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `wt`가 새 worktree bootstrap 시 Claude -> Codex 하니스를 다시 동기화해, plugin 기반 스킬/에이전트/규칙이 worktree에서도 즉시 보이게 한다.
- 수동 복구와 자동 bootstrap이 같은 코드 경로를 타도록 `codex-sync` 커맨드를 추가하고, `~/.claude` 우선 / `~/.codex` fallback 해석을 넣는다.
- 실제 `wt` E2E 기준으로 user-settings fallback, local-settings precedence, recreate, missing MCP preserve, sync fallback, degraded best-effort까지 검증한다.

Closes #394

## 기존 문제/배경

현재 `wt` bootstrap은 worktree 안에 `.claude/settings.local.json`과 `.codex/`만 복사하고 끝난다. 반면 실제 Claude -> Codex projection 로직은 `modules/shared/programs/codex/default.nix` activation과 `sync.sh all` 안에 들어 있어, worktree 생성 경로에서는 재실행되지 않았다.

그 결과 새 worktree에서는 project-local `.agents/skills`만 남고, Claude plugin이 제공하는 스킬/agents/AGENTS.override 보강이 빠진다. 이슈 #394 코멘트에서 추가로 적은 것처럼, bootstrap 실패 후 사용자가 긴 `sync.sh` 경로를 매번 직접 입력해야 하는 운영성 문제도 있었다.

## CIR (Change Intent Record)

- `5ef4e67` — Claude -> Codex compatibility projection tooling을 도입했지만, 현재 `wt` bootstrap 경로까지 연결되지는 않았다.
- `07e82e5` — Codex activation에서 `.agents/skills` 디렉토리 심링크 투영을 안정화했지만, 이 경로는 `nrs` 시점에만 실행된다.
- `39af947` — `wt.sh` 안에 projection 인자 조립을 다시 복붙하지 않고, 공용 `codex-sync` 래퍼를 신설해 bootstrap과 수동 복구를 동일 경로로 합쳤다.

trade-off:
worktree 생성 시 추가 sync가 한 번 더 실행되고, `~/.claude/mcp.json`이 있으면 user-scope Codex trust/MCP도 같이 갱신된다. 대신 자동 복구와 수동 복구가 완전히 같은 동작을 하게 되어 drift가 줄고, fallback/경고 정책도 한곳에서 관리된다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `wt.sh`에 plugin 해석 로직 직접 복붙 | `sync.sh all` 인자를 `wt.sh`가 직접 구성 | 파일 수 최소 | detection 로직 이중화, manual path와 drift | ❌ |
| `wt.sh`가 `sync.sh all`을 직접 호출 | bootstrap은 고치지만 수동 복구 경로는 별도 구현 필요 | 구현 단순 | 수동 복구 UX(`codex-sync`) 해결 안 됨 | ❌ |
| 공용 `codex-sync` 래퍼 추가 후 `wt`가 재사용 | bootstrap/수동 복구 모두 동일 래퍼 사용 | 단일 진실원, fallback/경고 정책 공유, 수동 복구 UX 개선 | 스크립트 1개 추가 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/codex-sync.sh` | 추가 | `sync.sh` 경로 해석, project root canonicalize, local/user plugin 설정 fallback, user MCP 조건부 전달, `sync.sh all` 호출 |
| `modules/shared/scripts/wt.sh` | 수정 | `_bootstrap_worktree()` 마지막에 `codex-sync`를 best-effort로 실행하고 실패 시 경고만 남김 |
| `modules/shared/programs/shell/default.nix` | 수정 | `~/.local/bin/codex-sync` 노출 |

### 핵심 코드

```bash
# codex-sync: local settings가 비어 있으면 user settings로 fallback
local_settings = project_root / ".claude" / "settings.local.json"
if local_settings.is_file():
    payload = load_json(local_settings)
    plugin_keys = enabled_plugins(payload)

if not plugin_keys:
    user_settings = home / ".claude" / "settings.json"
```

```bash
# wt bootstrap: copy-only에서 projection 재실행까지 확장
codex_sync_sh="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codex-sync.sh"
if [[ -f "$codex_sync_sh" ]]; then
  if ! bash "$codex_sync_sh" "$wt_path"; then
    _warn "codex-sync 실패 — 수동으로 'codex-sync $wt_path'를 실행하세요"
  fi
fi
```

실행 검증으로는 다음 6개 케이스를 실제 `wt` E2E로 통과시켰다.
- baseline user-settings fallback + manual `codex-sync` 재실행 idempotence
- existing worktree `재생성` 경로
- repo-root `.claude/settings.local.json` precedence
- missing `~/.claude/mcp.json` 시 기존 `~/.codex/config.toml` 보존
- `sync.sh`가 `~/.codex/...`에만 있을 때 fallback
- `sync.sh`가 전혀 없을 때 warning 후 worktree 생성 지속

## 참고 레퍼런스

- Issue #394 — `wt` worktree에서 Claude plugin -> Codex 하네스 자동 투영 회귀 복구 요구 + `codex-sync` 수동 경로 추가 범위
- `5ef4e67` — Add Claude-to-Codex compatibility projection tooling
- `07e82e5` — refactor(codex): 스킬 투영을 디렉토리 심링크로 전환하여 sync drift 제거 (#38)
- `39af947` — fix(wt): restore codex harness sync in worktrees

## Human Test Plan

### 정상 동작 검증

1. `nrs` 후 새 셸에서 `type codex-sync`를 실행한다.
   - **기대**: `codex-sync`가 `~/.local/bin/codex-sync`로 해석된다.
   - **실패 시**: `modules/shared/programs/shell/default.nix`의 `home.file.".local/bin/codex-sync"` 항목과 Home Manager 적용 상태를 확인한다.

2. repo root에서 `wt tmp/pr-394-user-fallback`를 실행한다.
   - **기대**: 생성된 worktree의 `.agents/skills/brainstorming`, `.agents/skills/skill-creator`가 존재한다.
   - **실패 시**: 생성된 worktree의 `.agents/skills` 내용, `~/.claude/settings.json`, `~/.claude/plugins/installed_plugins.json`, stderr warning을 확인한다.

3. repo root에 `.claude/settings.local.json`을 두고 `skill-creator`만 enable한 뒤 `wt tmp/pr-394-local-only`를 실행한다.
   - **기대**: 생성된 worktree에는 `.agents/skills/skill-creator`만 추가되고 `brainstorming`은 없어야 한다.
   - **실패 시**: copied `.claude/settings.local.json` 내용과 `codex-sync.sh`의 local/user fallback 순서를 확인한다.

4. `~/.claude/mcp.json`을 임시로 치우고, 기존 `~/.codex/config.toml`에 임의 MCP 섹션을 넣은 뒤 `wt tmp/pr-394-no-mcp`를 실행한다.
   - **기대**: warning은 출력되지만 기존 MCP 섹션은 유지되고 trust 섹션만 추가된다.
   - **실패 시**: `codex-sync.sh`가 `--user-mcp`를 조건부로만 넘기는지와 최종 `~/.codex/config.toml` 내용을 확인한다.

### 엣지 케이스

5. `~/.claude/skills/.../sync.sh`를 숨기고 `~/.codex/skills/.../sync.sh`만 남긴 상태에서 `wt tmp/pr-394-codex-fallback`를 실행한다.
   - **기대**: fallback 경로로 정상 동작하며 plugin 스킬이 투영된다.
   - **실패 시**: `codex-sync.sh`의 `_resolve_sync_sh()` 순서를 확인한다.

6. `sync.sh`를 양쪽에서 모두 숨기고 `wt tmp/pr-394-no-sync-sh`를 실행한다.
   - **기대**: worktree 생성은 계속되고 warning만 출력되며, plugin 투영은 생략된다.
   - **실패 시**: `modules/shared/scripts/wt.sh`의 best-effort warning 분기를 확인한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
rg -n 'home.file."\.local/bin/codex-sync"' modules/shared/programs/shell/default.nix
rg -n 'bash "\$codex_sync_sh" "\$wt_path"' modules/shared/scripts/wt.sh
! rg -n '~/.claude/skills/syncing-codex-harness/references/sync.sh' modules/shared/scripts/wt.sh
```

### Phase 1: User Settings Fallback

> "repo local settings가 없을 때 user settings 기반 plugin projection이 worktree bootstrap에서 자동으로 적용되는지 확인"

```bash
TMP_HOME=$(mktemp -d)
mkdir -p "$TMP_HOME/.claude/plugins" "$TMP_HOME/.codex" "$TMP_HOME/.claude/skills/syncing-codex-harness/references"
ln -s "$PWD/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh" "$TMP_HOME/.claude/skills/syncing-codex-harness/references/sync.sh"
python3 - <<'PY' "$TMP_HOME"
import json, sys
from pathlib import Path
home = Path(sys.argv[1])
(home/'.claude/settings.json').write_text(json.dumps({'enabledPlugins': {
  'skill-creator@claude-plugins-official': True,
  'superpowers@claude-plugins-official': True,
}}, indent=2))
PY
cp ~/.claude/plugins/installed_plugins.json "$TMP_HOME/.claude/plugins/installed_plugins.json"
echo '{"mcpServers":{"user_dummy":{"command":"echo","args":["user-mcp"]}}}' > "$TMP_HOME/.claude/mcp.json"
HOME="$TMP_HOME" bash modules/shared/scripts/wt.sh tmp/pr394-phase1 > /tmp/pr394-phase1.out 2> /tmp/pr394-phase1.err
WT_PATH=$(cat /tmp/pr394-phase1.out)
test -e "$WT_PATH/.agents/skills/brainstorming"
test -e "$WT_PATH/.agents/skills/skill-creator"
```

- **기대**: 두 plugin skill이 모두 보인다.
- **실패 시**: temp home의 `settings.json`, `installed_plugins.json`, stderr warning을 확인한다.

### Phase 2: Local Settings Precedence

> "repo-root `.claude/settings.local.json`이 있으면 user settings보다 우선 적용되는지 확인"

```bash
mkdir -p .claude
cat > .claude/settings.local.json <<'EOF'
{"enabledPlugins":{"skill-creator@claude-plugins-official":true}}
EOF
HOME="$TMP_HOME" bash modules/shared/scripts/wt.sh tmp/pr394-phase2 > /tmp/pr394-phase2.out 2> /tmp/pr394-phase2.err
WT_PATH=$(cat /tmp/pr394-phase2.out)
test -e "$WT_PATH/.agents/skills/skill-creator"
! test -e "$WT_PATH/.agents/skills/brainstorming"
rm -f .claude/settings.local.json
```

- **기대**: `skill-creator`만 있고 `brainstorming`은 없어야 한다.
- **실패 시**: copied local settings 파일과 projected skill 목록을 비교한다.

### Phase 3: Missing User MCP Preservation

> "`~/.claude/mcp.json`이 없을 때 기존 user Codex config를 지우지 않고 유지하는지 확인"

```bash
rm -f "$TMP_HOME/.claude/mcp.json"
cat > "$TMP_HOME/.codex/config.toml" <<'EOF'
[mcp_servers.keep_me]
command = "echo"
args = ["keep"]
EOF
HOME="$TMP_HOME" bash modules/shared/scripts/wt.sh tmp/pr394-phase3 > /tmp/pr394-phase3.out 2> /tmp/pr394-phase3.err
rg -n '\[mcp_servers.keep_me\]' "$TMP_HOME/.codex/config.toml"
```

- **기대**: `keep_me` 섹션이 남아 있고 stderr에는 skip warning만 있다.
- **실패 시**: `codex-sync.sh`의 `--user-mcp` 조건부 추가 분기를 확인한다.

### Phase 4: Regression

> "기존 worktree 재생성 경로에서도 새 bootstrap sync가 유지되는지 확인"

```bash
WT_PATH=$(cat /tmp/pr394-phase1.out)
touch "$WT_PATH/recreate-marker.txt"
printf '2\ny\n' | HOME="$TMP_HOME" PATH='/usr/bin:/bin:/usr/sbin:/sbin' bash modules/shared/scripts/wt.sh tmp/pr394-phase1 > /tmp/pr394-phase4.out 2> /tmp/pr394-phase4.err
! test -e "$WT_PATH/recreate-marker.txt"
test -e "$WT_PATH/.agents/skills/brainstorming"
```

- **기대**: old marker는 사라지고 recreated worktree에서도 plugin projection이 유지된다.
- **실패 시**: `wt.sh`의 existing-worktree 재생성 경로와 confirm 입력 흐름을 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `codex-sync` CLI command to resync projects into Codex CLI structure with plugin support.
  * Automatic project synchronization now executes during worktree bootstrap.
  * Enhanced warning system for clearer diagnostics during setup and configuration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->