### PR TITLE
feat(recall): add session_id-based dedup for live/archive

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774937393,
-        "narHash": "sha256-p9svbw7xnfBRMuaTHWzKagrlYQwQkTKdNzLBfuromk4=",
+        "lastModified": 1775288855,
+        "narHash": "sha256-uUIgCUXO+1upPo+FEBGjAHZ8MwOMbk0GXtkpb8BFITA=",
         "owner": "greenheadHQ",
         "repo": "recall",
-        "rev": "3db8b58f8b33434c58b89e8dd6cb5a48a26f80e0",
+        "rev": "2c21916dc58f0b3085e2d13e1a5dc27609a8d5b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- recall 포크에 session_id(UUID) 기반 중복 제거를 추가하여, 같은 세션이 live와 archive에 공존할 때 한 번만 표시되도록 한다.
- DA에서 발견한 `ClaudeParser::can_parse()` archive 경로 미매칭 CRITICAL 버그를 함께 수정한다.

Closes #427

## 기존 문제/배경

`cleanupPeriodDays=99999` + SessionEnd 자동 아카이빙으로 같은 세션이 `~/.claude/projects/`(live)와 `~/.claude/archive/`(archive) 양쪽에 존재한다.
recall의 `discover_session_files()`는 파일 경로 기반 인덱싱이므로 같은 UUID가 두 경로에 있으면 별도 문서로 색인되어 검색/목록에서 중복 표시된다.

추가로, `ClaudeParser::can_parse()`가 `.claude/projects`만 매칭하여 archive 파일이 파싱되지 않는 기존 버그가 있었다 (commit `3db8b58`에서 archive discover를 추가했지만 `can_parse()`를 수정하지 않음).

## CIR (Change Intent Record)

- **v1** (`3db8b58`): recall 포크에 archive 디렉터리 스캔 추가. 하지만 `can_parse()`가 archive 경로를 거부하여 파싱 실패.
- **v2** (이번 변경, `2c21916`): dedup + can_parse 수정 + GC를 한 번에 해결.

**발견 경위**: #395 하드닝 중 recall에 dedup이 없음을 확인 → #427 이슈 등록 → DA for_plan에서 `can_parse()` CRITICAL 버그 발견.

**trade-off**: `HashMap<String, PathBuf>`으로 파일 발견 순서의 비결정성이 도입되지만, 호출자 `discover_and_sort_files()`가 mtime 정렬을 수행하므로 실질적 영향 없음.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 스캔 순서 변경 + HashMap `or_insert` | archive를 먼저 스캔, first-write-wins | 의도 명확, archive 우선 자연스러움 | diff가 큼, 블록 순서가 암묵적 계약 | ✅ |
| 현재 순서 유지 + 후처리 dedup | 마지막에 file_stem 기준 dedup pass | 기존 코드 변경 최소 | archive 우선 판단 로직 별도 필요 | ❌ |

## 구현 상세

| 파일 (recall 포크) | 변경 | 내용 |
|------|------|------|
| `src/parser/claude.rs` | 수정 | `can_parse()`에 `.claude/archive` 매칭 추가 |
| `src/parser/mod.rs` | 수정 | HashMap dedup + `scan_jsonl_dir` 헬퍼 추출 + why 주석 + 단위 테스트 4개 |
| `src/index/indexer.rs` | 수정 | `gc_stale_entries()` 추가 — evicted 경로의 tantivy 문서 정리 |
| `src/index/mod.rs` | 수정 | `gc_stale_entries` public export |
| `src/index/sync.rs` | 수정 | gc 호출 삽입 (CLI 경로) |
| `src/app.rs` | 수정 | gc 호출 삽입 (TUI 경로) |

| 파일 (nixos-config) | 변경 | 내용 |
|------|------|------|
| `flake.lock` | 수정 | recall rev `3db8b58` → `2c21916` |

### 핵심 코드

```rust
// Archive MUST be scanned before live sessions: or_insert keeps the
// first-seen path per session UUID, so archive (canonical copy) wins
// over live (may be truncated or stale).
let archive_dir = home.join(".claude/archive");
scan_jsonl_dir(&archive_dir, true, &mut seen);
```

## 참고 레퍼런스

- Issue #395 — archive/recall session flow 하드닝 (발견 경위)
- PR #426 (`2c13a78`) — harden archive/recall session flow
- recall `3db8b58` — archive 디렉터리 스캔 추가 (현재 pinned rev)
- recall `2c21916` — session dedup + can_parse fix + GC (이번 변경)

## Human Test Plan

### 정상 동작 검증

1. `recall list`를 실행한다.
   - **기대**: 아카이빙된 세션이 1번만 표시된다 (이전에는 live+archive로 2번 표시).
   - **실패 시**: `recall list 2>&1 | jq '.sessions | group_by(.session_id) | map(select(length > 1))'`로 중복 확인.

2. `recall search "키워드"`로 아카이빙된 세션을 검색한다.
   - **기대**: archive 경로의 세션이 정상 검색된다 (이전에는 파싱 실패로 인덱싱 안 됨).
   - **실패 시**: `~/.local/share/recall/` 인덱스를 삭제하고 재시도.

### 엣지 케이스

3. archive에만 있는 세션 (live에 없는)이 정상 표시되는지 확인.
4. `nrs` 빌드가 성공하는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. recall rev 갱신 확인
jq -r '.nodes.recall.locked.rev' flake.lock | grep -q '2c21916'
# 기대: exit 0

# 2. old rev 부재 확인
! jq -r '.nodes.recall.locked.rev' flake.lock | grep -q '3db8b58'
# 기대: exit 0
```

### Phase 1: 빌드 검증

```bash
# nrs 또는 darwin-rebuild로 빌드 성공 확인
nrs
# 기대: 빌드 성공, recall-0.5.0 derivation 빌드됨
```

### Phase 2: 기능 검증

```bash
# recall이 정상 실행되는지 확인
recall --help
# 기대: 도움말 출력

# 중복 세션 없는지 확인
recall list 2>&1 | jq '[.sessions[].session_id] | group_by(.) | map(select(length > 1)) | length'
# 기대: 0
```

### Phase 3: Regression

```bash
# recall search가 정상 동작하는지
recall search "test" 2>&1 | jq '.results | length'
# 기대: 0 이상의 정수 (에러 아님)
```