### PR TITLE
fix(skills): for_issue Step I-6 선택지 3개로 세분화

### DIFF
--- a/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
@@ -64,6 +64,9 @@ description: |
 
 ### Step 5 — LLM 이행 가이드 연계
 
+**호출 맥락 확인**: plan-with-questions에서 호출된 경우(Step I-5), 이 단계를 건너뛴다.
+(plan-with-questions Step I-6에서 통합 선택지로 제안하므로 중복 방지.)
+
 이슈 생성이 완료되면, AskUserQuestion으로 사용자에게 묻는다:
 
 "LLM 이행 가이드를 작성할까요?"

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
@@ -131,7 +131,7 @@ create-issue 호출 시 내부 write-handoff 제안을 생략한다.
 "이슈 등록이 완료되었습니다. 바로 for_action으로 전환하여 작업을 진행하시겠습니까?"
 
 - Yes → 생성된 이슈 레퍼런스로 for_action 모드를 시작한다.
-- No (/write-handoff로 마무리) → /write-handoff 스킬을 실행하여 LLM 이행 가이드를 작성한 뒤 종료한다.
+- No (/write-handoff로 마무리) → 생성된 이슈 레퍼런스를 인자로 /write-handoff 스킬을 실행하여 LLM 이행 가이드를 작성한 뒤 종료한다.
 - No (여기서 종료) → 생성된 이슈 레퍼런스를 반환하고 종료한다.
 
 ## for_action 모드 (이슈 레퍼런스 있음)


### PR DESCRIPTION
## Summary

- plan-with-questions `for_issue` 모드의 Step I-6에서 이슈 등록 후 제공하는 선택지를 Yes/No 2개에서 3개로 세분화하여 사용자 UX를 개선한다.

## 기존 문제/배경

`for_issue` 모드로 이슈를 등록한 뒤, Step I-6에서 "for_action으로 전환할까요?"라는 질문에 Yes/No만 제공되었다. "No"를 선택하면 바로 종료되므로, `/write-handoff`로 LLM 이행 가이드만 작성하고 싶은 경우 별도로 요청해야 했다.

기존 Step I-5에서는 create-issue 내부의 write-handoff 제안에 의존했으나, 이슈 등록과 후속 행동(작업 시작 / 이행 가이드 / 종료) 선택이 분리되어 있어 사용자 경험이 비직관적이었다.

## CIR (Change Intent Record)

해당 없음 — 단순 UX 개선. 사용자가 직접 요청한 선택지 구조.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| create-issue 내부 write-handoff 유지 | Step I-5에서 create-issue가 자체적으로 write-handoff 제안 | 기존 동작 유지 | Step I-6과 중복 질문, 후속 행동 선택이 분산됨 | ❌ |
| Step I-6 통합 선택지 | write-handoff 제안을 Step I-6의 3지선다로 통합 | 한 번의 질문으로 모든 후속 행동 결정 | create-issue 단독 사용 시 write-handoff 제안 영향 없음 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md` | 수정 | Step I-5 제목 및 write-handoff 위임 변경, Step I-6 선택지 3개로 확장 |

### 핵심 변경

```markdown
# Step I-5: 제목 변경
- BEFORE: "이슈 생성 + 이행 가이드"
- AFTER: "이슈 생성"

# Step I-5: write-handoff 위임 변경
- BEFORE: create-issue 내부 Step 5에서 write-handoff 제안 → 별도 호출 불필요
- AFTER: write-handoff 제안을 Step I-6에서 통합 → create-issue 호출 시 내부 제안 생략

# Step I-6: 선택지 확장
- BEFORE: Yes / No (2개)
- AFTER: Yes / No (write-handoff로 마무리) / No (여기서 종료) (3개)
```

## 참고 레퍼런스

- PR #423 (`73ffc97`) — plan-with-questions 이중 모드(for_action/for_issue) 재설계 원본

## Human Test Plan

### 정상 동작 검증

1. `/plan-with-questions for_issue` 모드로 이슈를 등록한다.
   - **기대**: Step I-6에서 3개 선택지가 AskUserQuestion으로 제시된다.
   - **실패 시**: SKILL.md의 Step I-6 섹션 내용 확인.

2. 선택지 "No (/write-handoff로 마무리)"를 선택한다.
   - **기대**: `/write-handoff` 스킬이 실행되어 LLM 이행 가이드가 작성된다.
   - **실패 시**: Step I-6의 write-handoff 호출 로직 확인.

3. 선택지 "No (여기서 종료)"를 선택한다.
   - **기대**: 이슈 레퍼런스만 반환하고 종료된다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. Step I-5 제목에서 "이행 가이드" 제거 확인
! grep -q "이슈 생성 + 이행 가이드" modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
# 기대: exit 0

# 2. Step I-6에 3개 선택지 존재 확인
grep -q "No (/write-handoff로 마무리)" modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
# 기대: exit 0

grep -q "No (여기서 종료)" modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
# 기대: exit 0

# 3. old 선택지 부재 확인
! grep -q "^- No → 생성된 이슈 레퍼런스를 반환하고 종료한다\.$" modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
# 기대: exit 0
```

### Phase 1: 라우팅 Regression

> "인접 스킬의 트리거가 이번 변경에 영향받지 않는지 확인"

| 쿼리 | 기대 스킬 | 이번 PR 영향 |
|------|----------|-------------|
| "이행 가이드 작성해줘" | write-handoff | 무영향이어야 함 |
| "이슈 등록해줘" | create-issue | 무영향이어야 함 |
| "계획 세워줘" | plan-with-questions | 무영향이어야 함 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the issue creation workflow by separating core issue creation from handoff guidance decision-making. The handoff documentation decision is now presented as a distinct step with multiple resolution paths, providing users with enhanced flexibility in managing the handoff process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->