### PR TITLE
refactor(hooks): fragile-hardcoding-guard Write/Edit 비대칭 해소 + false positive 제거

### DIFF
--- a/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
@@ -5,6 +5,23 @@
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+# [WHY] fence strip을 document 모드의 SCAN_INPUT과 delta 검사의 OLD_STRIPPED
+# 양쪽에서 사용하므로 함수로 추출. Markdown spec 기준 0-3칸 들여쓰기 + 3개 이상 backtick.
+_strip_fences() {
+  awk '
+    BEGIN { depth = 0; fence_len = 0 }
+    {
+      s = $0; sub(/^[ ]{0,3}/, "", s); ticks = 0
+      while (substr(s, ticks+1, 1) == "`") ticks++
+      if (ticks >= 3) {
+        tail = substr(s, ticks+1); gsub(/[ \t\r]/, "", tail)
+        if (depth == 0) { depth = 1; fence_len = ticks; next }
+        if (ticks >= fence_len && tail == "") { depth = 0; fence_len = 0; next }
+      }
+      if (depth == 0) print
+    }'
+}
+
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 
@@ -60,76 +77,48 @@ fi
 # [WHY] fence strip은 전체 문서(document 모드)에서만 적용.
 # fragment 모드에서 미완결 fence(opening만 있고 closing 없음)를 strip하면
 # 이후 라인이 모두 제거되어 false negative 발생.
-# awk fence parser: Markdown spec 기준 0-3칸 들여쓰기 + 3개 이상 backtick.
-#   depth=fence 내부 여부, fence_len=opening backtick 수.
-#   닫힘 조건: backtick 수 >= opening 길이 && 뒤에 텍스트 없음.
 if [ "$SCAN_MODE" = "document" ]; then
-  SCAN_INPUT=$(printf '%s' "$CONTENT" | awk '
-    BEGIN { depth = 0; fence_len = 0 }
-    {
-      s = $0; sub(/^[ ]{0,3}/, "", s); ticks = 0
-      while (substr(s, ticks+1, 1) == "`") ticks++
-      if (ticks >= 3) {
-        tail = substr(s, ticks+1); gsub(/[ \t\r]/, "", tail)
-        if (depth == 0) { depth = 1; fence_len = ticks; next }
-        if (ticks >= fence_len && tail == "") { depth = 0; fence_len = 0; next }
-      }
-      if (depth == 0) print
-    }')
+  SCAN_INPUT=$(printf '%s' "$CONTENT" | _strip_fences)
 else
   SCAN_INPUT="$CONTENT"
 fi
 
 # [WHY] Edit + document 모드에서 post-edit 전체 문서를 검사하면
 # 원본에 이미 있던 하드코딩도 차단됨 (이번 Edit과 무관한 회귀).
-# 원본에 대해서도 동일한 fence strip + 패턴 검사를 수행하고,
-# 원본에도 있는 경고는 이번 Edit이 도입한 것이 아니므로 제외.
-OLD_HAS_LINE="" OLD_HAS_FILE="" OLD_HAS_PATH=""
+# 원본과 post-edit의 매치 수를 비교하여 새로 추가된 매치만 차단.
+# 카테고리 단위 boolean이 아닌 count 비교로 정밀 판정.
+OLD_LINE_COUNT=0 OLD_FILE_COUNT=0 OLD_PATH_COUNT=0
 if [ "$TOOL_NAME" = "Edit" ] && [ "$SCAN_MODE" = "document" ]; then
-  OLD_STRIPPED=$(awk '
-    BEGIN { depth = 0; fence_len = 0 }
-    {
-      s = $0; sub(/^[ ]{0,3}/, "", s); ticks = 0
-      while (substr(s, ticks+1, 1) == "`") ticks++
-      if (ticks >= 3) {
-        tail = substr(s, ticks+1); gsub(/[ \t\r]/, "", tail)
-        if (depth == 0) { depth = 1; fence_len = ticks; next }
-        if (ticks >= fence_len && tail == "") { depth = 0; fence_len = 0; next }
-      }
-      if (depth == 0) print
-    }' "$FILE_PATH")
-  printf '%s' "$OLD_STRIPPED" | grep -E '[0-9]+줄|[0-9]+ lines' | \
-    grep -qvE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)' && OLD_HAS_LINE=1
-  printf '%s' "$OLD_STRIPPED" | grep -E '[0-9]+개 파일|[0-9]+곳' | \
-    grep -qvE '[1-9]-[1-9]개 파일' && OLD_HAS_FILE=1
-  OLD_PATH_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -oE '\.claude/skills/[a-z0-9_-]+' | sort -u | wc -l)
-  [ "$OLD_PATH_COUNT" -ge 3 ] && OLD_HAS_PATH=1
+  OLD_STRIPPED=$(_strip_fences < "$FILE_PATH")
+  # [WHY_EXCLUDE] exclusion 패턴은 SCAN_INPUT 검사와 동일하게 적용하여 일관성 유지
+  OLD_LINE_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -E '[0-9]+줄|[0-9]+ lines' | \
+    grep -vE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)' | grep -c '.' || true)
+  OLD_FILE_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -E '[0-9]+개 파일|[0-9]+곳' | \
+    grep -vE '[1-9]-[1-9]개 파일' | grep -c '.' || true)
+  OLD_PATH_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -oE '\.claude/skills/[a-z0-9_-]+' | sort -u | wc -l | tr -d ' ')
 fi
 
 WARNINGS=""
 
 # [WHY] 줄 수는 코드 수정 시 즉시 변경됨 → wc -l로 동적 확인 가능
 # [WHY_EXCLUDE] "N줄 이내/이하/설명" 등은 작성 규칙 표현이지 코드 상태 하드코딩이 아님
-if [ -z "$OLD_HAS_LINE" ]; then
-  printf '%s' "$SCAN_INPUT" | grep -E '[0-9]+줄|[0-9]+ lines' | \
-    grep -qvE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)' && \
-    WARNINGS="${WARNINGS}줄 수 하드코딩. "
-fi
+NEW_LINE_COUNT=$(printf '%s' "$SCAN_INPUT" | grep -E '[0-9]+줄|[0-9]+ lines' | \
+  grep -vE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)' | grep -c '.' || true)
+[ "$NEW_LINE_COUNT" -gt "$OLD_LINE_COUNT" ] && \
+  WARNINGS="${WARNINGS}줄 수 하드코딩. "
 
 # [WHY] 파일/참조 수는 파일 추가/삭제 시 변경됨 → grep -c로 동적 확인 가능
 # [WHY_EXCLUDE] "N-N개 파일"(예: "1-2개 파일")은 범위 지침이지 정확한 수량 아님
-if [ -z "$OLD_HAS_FILE" ]; then
-  printf '%s' "$SCAN_INPUT" | grep -E '[0-9]+개 파일|[0-9]+곳' | \
-    grep -qvE '[1-9]-[1-9]개 파일' && \
-    WARNINGS="${WARNINGS}파일/참조 수 하드코딩. "
-fi
+NEW_FILE_COUNT=$(printf '%s' "$SCAN_INPUT" | grep -E '[0-9]+개 파일|[0-9]+곳' | \
+  grep -vE '[1-9]-[1-9]개 파일' | grep -c '.' || true)
+[ "$NEW_FILE_COUNT" -gt "$OLD_FILE_COUNT" ] && \
+  WARNINGS="${WARNINGS}파일/참조 수 하드코딩. "
 
 # [WHY] 스킬 경로를 3개 이상 나열하면 스킬 추가/삭제 시 목록이 stale 됨.
 # 3개 미만은 정당한 교차 참조(예: "NOT for X, use Y")로 간주.
-if [ -z "$OLD_HAS_PATH" ]; then
-  SKILL_PATH_COUNT=$(printf '%s' "$SCAN_INPUT" | grep -oE '\.claude/skills/[a-z0-9_-]+' | sort -u | wc -l)
-  [ "$SKILL_PATH_COUNT" -ge 3 ] && \
-    WARNINGS="${WARNINGS}.claude/skills/ 경로 ${SKILL_PATH_COUNT}개 열거. "
+NEW_PATH_COUNT=$(printf '%s' "$SCAN_INPUT" | grep -oE '\.claude/skills/[a-z0-9_-]+' | sort -u | wc -l | tr -d ' ')
+if [ "$NEW_PATH_COUNT" -ge 3 ] && [ "$NEW_PATH_COUNT" -gt "$OLD_PATH_COUNT" ]; then
+  WARNINGS="${WARNINGS}.claude/skills/ 경로 ${NEW_PATH_COUNT}개 열거. "
 fi
 
 [ -z "$WARNINGS" ] && exit 0


### PR DESCRIPTION
## Summary

- Edit 경로에서 post-edit 전체 문서를 재구성하여 Write와 동일한 fence strip + 패턴 검사를 적용, Write/Edit 비대칭 해소
- document/fragment 모드 분리로 미완결 fence 오작동 방지 + delta count 비교로 원본 하드코딩과 신규 추가를 정밀 구분
- 규칙 표현("N줄 이내", "N-N개 파일") exclusion 패턴으로 전수조사 3개 false positive 해소

Closes #385

## 기존 문제/배경

`fragile-hardcoding-guard.sh` PreToolUse hook에 Write/Edit 간 검사 비대칭이 존재했다:

- **Write**: 전체 `tool_input.content` → awk fence strip → 패턴 검사
- **Edit**: `tool_input.new_string` 조각만 → fence strip 없이 패턴 검사

동일 문서를 Write로 작성하면 통과, Edit로 수정하면 차단되는 불일치가 발생. #377 DA for_pr에서 3라운드 연속 지적되어 별도 이슈로 분리됨.

추가로 전수조사 152파일 중 3개 파일(`write-handoff/SKILL.md`, `create-pr/SKILL.md`, `create-pr/references/pr-template.md`)에서 규칙/지침 표현이 false positive로 차단됨.

## CIR (Change Intent Record)

- **v1** (이행 가이드, #385 코멘트): Edit에서 원본 파일 읽기 + awk sub() 치환 제안. awk sub()의 regex 특수문자 문제를 "미검증"으로 표시.
- **v2** (`603b3f4`): awk ENVIRON + index() + substr() 기반 순수 문자열 치환 채택. regex 안전성 로컬 검증 완료. fence strip을 Write/Edit 모두 적용으로 계획.
- **DA for_plan 반영**: 7건 전부 CONFIRMED → document/fragment 모드 분리(DESIGN-1), delta 기반 검사(REGRESSION-1), 미매치 fallback(CORRECTNESS-1), exclusion 좁히기(CORRECTNESS-2) 반영.
- **v3** (`c325277`): DA for_pr R1에서 카테고리 boolean 면제 문제(CORRECTNESS-1 MEDIUM) 지적 → count 비교로 전환. fence strip awk 중복(MAINTAINABILITY-1 LOW) → `_strip_fences` 함수 추출.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Edit new_string만 검사 (현행) | 조각만 검사, fence strip 없음 | 단순, 파일 I/O 없음 | Write/Edit 비대칭, fenced block 내 false positive | ❌ |
| Post-edit 전체 문서 재구성 | 원본 + awk 치환 → fence strip | Write와 동일 정책, 비대칭 해소 | 파일 I/O 추가, 재구성 실패 처리 필요 | ✅ |
| diff 기반 검사 (pre/post) | 원본과 post-edit 모두 검사 → delta만 차단 | 원본 하드코딩 무시, 정밀 | 복잡도 증가, 파일 2회 읽기 | ✅ (count 비교로 단순화) |
| fenced block 의미 분류 | marker 기반 예시/실행 절차 구분 | 가장 정밀한 fence strip | 마이그레이션 필요, true positive 0건 | ❌ YAGNI |

## 구현 상세

| 파일 | 변경 | 줄 |
|------|------|-----|
| `modules/.../hooks/fragile-hardcoding-guard.sh` | 전체 | +78 -24 |

핵심 변경:

1. **SCAN_MODE 도입** (`document`/`fragment`): Edit 재구성 성공 → document, 실패 → fragment fallback
2. **awk ENVIRON 치환**: `index()` + `substr()`로 regex 안전한 순수 문자열 치환. exit code로 매치 여부 반환
3. **`_strip_fences()` 함수**: fence strip awk를 공유 함수로 추출 (SCAN_INPUT + OLD_STRIPPED 양쪽 사용)
4. **delta count 비교**: `OLD_*_COUNT` vs `NEW_*_COUNT` 라인 수 비교로 신규 추가만 차단
5. **exclusion 패턴**: `[0-9]+줄\s*(이내|이하|...)` + `[1-9]-[1-9]개 파일`

## 참고 레퍼런스

- `c479077` — fix(hooks): fragile-hardcoding-guard 코드 블록 내 false positive 해소
- `635a445` — fix(hooks): DA 피드백 반영 — awk fence parser + Write 전용 strip
- `bfb4d15` — fix(hooks): fragile-hardcoding-guard 코드 블록 내 false positive 해소 (#386)
- #377 — DA for_pr에서 비대칭 3라운드 지적 → #385 분리
- #385 이행 가이드 코멘트 — Phase 2/3 접근 방식 + awk sub() 미검증 주석

## Human Test Plan

1. **Write + fenced block 내 줄수** → 통과 확인
   ```
   printf '{"tool_name":"Write",...,"content":"본문\n```text\n38줄 예시\n```\n끝"}' | bash hook.sh
   ```
   기대: 빈 출력. 실패 시: fence strip 미작동 → `_strip_fences` 함수 확인.

2. **Edit + fenced block 내 줄수** → 통과 확인 (재구성 성공 시 document 모드)
   임시 파일에 fenced block + 본문 작성 → Edit으로 본문만 수정 → 빈 출력.
   실패 시: SCAN_MODE가 fragment로 떨어짐 → awk 치환 exit code 확인.

3. **Edit + 신규 하드코딩 추가** → 차단 확인
   임시 파일에 깨끗한 본문 → Edit으로 "308줄" 추가 → JSON block 출력.

4. **Edit + 원본에 기존 하드코딩 (무관 수정)** → 통과 확인 (delta)
   임시 파일에 "10줄" 포함 → Edit으로 무관한 부분 수정 → 빈 출력.

5. **Edit + 원본에 기존 + 신규 추가** → 차단 확인 (count 증가)
   임시 파일에 "10줄" → Edit으로 "20줄" 추가 → JSON block 출력.

6. **false positive 해소** → "3줄 이내", "1줄 설명", "1-2개 파일" 모두 통과 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# hook 파일 존재 + 실행 권한
ls -la modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# _strip_fences 함수 정의 확인
grep -c '_strip_fences' modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# SCAN_MODE 변수 사용 확인
grep -c 'SCAN_MODE' modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
# settings.json hook 등록 확인
grep 'fragile-hardcoding-guard' modules/shared/programs/claude/files/settings.json
```

기대: 파일 존재, `_strip_fences` 3회 이상, `SCAN_MODE` 5회 이상, settings.json에 등록됨.

### Phase 1: Write/Edit 비대칭 해소

```bash
H=modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
mkdir -p /tmp/pe/.claude/skills/t
cat > /tmp/pe/.claude/skills/t/SKILL.md << 'TESTEOF'
# Test
```text
caddy.nix:38줄 예시
```
여기는 본문입니다.
TESTEOF

# Write: fenced block 내 줄수 → 통과
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/pe/.claude/skills/t/SKILL.md","content":"본문\n```text\ncaddy.nix:38줄\n```\n끝"}}' | bash $H
# 기대: 빈 출력

# Edit: fenced block 내 줄수 (document 모드) → 통과
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/pe/.claude/skills/t/SKILL.md","old_string":"여기는 본문입니다.","new_string":"수정된 본문."}}' | bash $H
# 기대: 빈 출력
```

### Phase 2: delta count 검증

```bash
cat > /tmp/pe/.claude/skills/t/SKILL.md << 'TESTEOF'
# Test
이 파일은 10줄이다.
여기는 본문입니다.
TESTEOF

# 원본 하드코딩 유지 + 무관 수정 → 통과
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/pe/.claude/skills/t/SKILL.md","old_string":"여기는 본문입니다.","new_string":"수정됨."}}' | bash $H
# 기대: 빈 출력

# 원본 하드코딩 + 신규 추가 → 차단
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/pe/.claude/skills/t/SKILL.md","old_string":"여기는 본문입니다.","new_string":"새로 추가된 20줄."}}' | bash $H
# 기대: JSON block 출력
```

### Phase 3: false positive / true positive

```bash
# false positive → 통과
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/pe/.claude/skills/t/SKILL.md","content":"3줄 이내.\n1줄 설명.\n1-2개 파일"}}' | bash $H
# 기대: 빈 출력

# true positive → 차단
printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/tmp/pe/.claude/skills/t/SKILL.md","content":"308줄.\n152개 파일."}}' | bash $H
# 기대: JSON block 출력
```

### Phase 4: Regression — fragment fallback

```bash
# 파일 없음 → fragment 모드 → 하드코딩 차단 유지
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/nonexistent/.claude/skills/t/SKILL.md","old_string":"x","new_string":"308줄"}}' | bash $H
# 기대: JSON block 출력

# fragment 내 미완결 fence → fence strip 미적용 → 차단 유지
printf '%s' '{"tool_name":"Edit","tool_input":{"file_path":"/nonexistent/.claude/skills/t/SKILL.md","old_string":"x","new_string":"```bash\n42줄"}}' | bash $H
# 기대: JSON block 출력
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardcoding detection accuracy by comparing against baseline metrics rather than fixed thresholds, reducing false positives.
  * Enhanced handling of code edits to prevent unrelated pre-existing issues from triggering false warnings.

* **Improvements**
  * Refined scan logic to better distinguish between new hardcoding instances and existing code patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->