### PR TITLE
feat(claude): statusline에 프롬프트 캐시 TTL 카운트다운 추가

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -164,6 +164,12 @@ in
     ".claude/hooks/auto-archive.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/auto-archive.sh";
 
+    # Cache TTL tracking hooks
+    ".claude/hooks/record-last-stop.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-last-stop.sh";
+    ".claude/hooks/record-prompt-submit.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-prompt-submit.sh";
+
     # Pain point collection hooks
     ".claude/hooks/detect-pain-point.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/detect-pain-point.sh";

--- a/modules/shared/programs/claude/files/hooks/record-last-stop.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-stop.sh
@@ -23,6 +23,7 @@ mkdir -p "$DATADIR"
 
 if [ -n "$SESSION_ID" ]; then
   date +%s > "$DATADIR/last-stop-${SESSION_ID}"
+else
+  # 글로벌 fallback (SESSION_ID 없는 환경용)
+  date +%s > "$DATADIR/last-stop"
 fi
-# 글로벌 fallback (SESSION_ID 없는 환경용)
-date +%s > "$DATADIR/last-stop"

--- a/modules/shared/programs/claude/files/hooks/record-last-stop.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-stop.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# record-last-stop.sh — 프롬프트 캐시 TTL 추적용 타임스탬프 기록
+# statusline.sh가 세션별 파일을 읽어 캐시 남은 시간을 계산한다.
+
+# stdin에서 세션 정보 읽기 (agent_id 가드 + session_id 파싱 공용)
+INPUT=""
+[ ! -t 0 ] && INPUT=$(cat)
+
+if [ -n "$INPUT" ]; then
+  # 서브에이전트 내부 Stop은 무시 (메인 턴 완료만 추적)
+  AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
+  [ -n "$AGENT_ID" ] && exit 0
+  # stdin JSON에서 session_id 파싱 (env var보다 신뢰성 높음)
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+
+# fallback: env var → 빈 문자열
+[ -z "${SESSION_ID:-}" ] && SESSION_ID="${CLAUDE_SESSION_ID:-}"
+
+DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}/claude-hooks"
+mkdir -p "$DATADIR"
+
+if [ -n "$SESSION_ID" ]; then
+  date +%s > "$DATADIR/last-stop-${SESSION_ID}"
+fi
+# 글로벌 fallback (SESSION_ID 없는 환경용)
+date +%s > "$DATADIR/last-stop"

--- a/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
+++ b/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
@@ -23,6 +23,7 @@ mkdir -p "$DATADIR"
 
 if [ -n "$SESSION_ID" ]; then
   echo 0 > "$DATADIR/last-stop-${SESSION_ID}"
+else
+  # 글로벌 fallback (SESSION_ID 없는 환경용)
+  echo 0 > "$DATADIR/last-stop"
 fi
-# 글로벌 fallback (SESSION_ID 없는 환경용)
-echo 0 > "$DATADIR/last-stop"

--- a/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
+++ b/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# record-prompt-submit.sh — 프롬프트 전송 시 캐시 TTL을 "활성" 상태로 전환
+# "0"을 기록하면 statusline.sh가 5:00 고정 표시 (API 호출 중 = 캐시 갱신 중)
+
+# stdin에서 세션 정보 읽기 (agent_id 가드 + session_id 파싱 공용)
+INPUT=""
+[ ! -t 0 ] && INPUT=$(cat)
+
+if [ -n "$INPUT" ]; then
+  # 서브에이전트 내부 UserPromptSubmit은 무시 (메인 턴만 추적)
+  AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
+  [ -n "$AGENT_ID" ] && exit 0
+  # stdin JSON에서 session_id 파싱 (env var보다 신뢰성 높음)
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+
+# fallback: env var → 빈 문자열
+[ -z "${SESSION_ID:-}" ] && SESSION_ID="${CLAUDE_SESSION_ID:-}"
+
+DATADIR="${XDG_DATA_HOME:-$HOME/.local/share}/claude-hooks"
+mkdir -p "$DATADIR"
+
+if [ -n "$SESSION_ID" ]; then
+  echo 0 > "$DATADIR/last-stop-${SESSION_ID}"
+fi
+# 글로벌 fallback (SESSION_ID 없는 환경용)
+echo 0 > "$DATADIR/last-stop"

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -20,7 +20,9 @@ SESSION_ID=$(basename "$TRANSCRIPT" .jsonl)
 # refreshInterval=1(매초)에서 Plan/Memory 감지(grep/git/find)를 매초 실행하면 비효율적.
 # 캐시 TTL만 매초 갱신하고, heavy 연산은 HEAVY_INTERVAL 간격으로만 실행한다.
 NOW=$(date +%s)
-HEAVY_STATE="${TMPDIR:-/tmp}/.statusline-heavy-${SESSION_ID}"
+HEAVY_CACHE_DIR="${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/claude-statusline}"
+mkdir -p "$HEAVY_CACHE_DIR"
+HEAVY_STATE="${HEAVY_CACHE_DIR}/heavy-${SESSION_ID}"
 HEAVY_INTERVAL=10
 DO_HEAVY=true
 
@@ -375,8 +377,11 @@ fi
 # green(≥2min) / yellow(1-2min) / red(<1min) / muted(expired)
 # 세션별 파일 우선, 글로벌 fallback
 CACHE_TTL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/claude-hooks"
-LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop-${SESSION_ID}"
-[ -f "$LAST_STOP_FILE" ] || LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop"
+if [ -n "$SESSION_ID" ]; then
+  LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop-${SESSION_ID}"
+else
+  LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop"
+fi
 CACHE_TTL=300  # 5분
 
 if [ -f "$LAST_STOP_FILE" ]; then

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -16,6 +16,21 @@ fi
 # statusline stdin에는 session_id 필드가 없으므로 transcript 파일명에서 유도한다.
 SESSION_ID=$(basename "$TRANSCRIPT" .jsonl)
 
+# --- Heavy 연산 분기 ---
+# refreshInterval=1(매초)에서 Plan/Memory 감지(grep/git/find)를 매초 실행하면 비효율적.
+# 캐시 TTL만 매초 갱신하고, heavy 연산은 HEAVY_INTERVAL 간격으로만 실행한다.
+NOW=$(date +%s)
+HEAVY_STATE="${TMPDIR:-/tmp}/.statusline-heavy-${SESSION_ID}"
+HEAVY_INTERVAL=10
+DO_HEAVY=true
+
+if [ -f "$HEAVY_STATE" ]; then
+  last_heavy=$(head -1 "$HEAVY_STATE" 2>/dev/null || echo 0)
+  if [ "$((NOW - last_heavy))" -lt "$HEAVY_INTERVAL" ]; then
+    DO_HEAVY=false
+  fi
+fi
+
 # --- SSH 환경 감지 ---
 # SSH 세션에서는 OSC 8 하이퍼링크가 클릭 불가하므로,
 # 외부 링크(Jira/Slack/Figma)는 숨기고 로컬 상태(Plan/Memo/Memory)는 텍스트만 표시.
@@ -28,11 +43,19 @@ IS_SSH=false
 # Termius 등 bright black을 검정으로 렌더링하는 터미널에서 가시성 확보
 MUTED="38;5;242"   # #6c6c6c
 
-# --- Plan 파일 감지 ---
+# --- Plan 파일 감지 + Memory 디렉토리 감지 (Heavy 연산) ---
+# DO_HEAVY=true일 때만 실행하고, 결과를 파일로 캐시.
+# DO_HEAVY=false일 때는 캐시된 변수를 복원하여 렌더링에 사용.
+PLAN_FILE=""
+MEMORY_LINK=""
+MEMORY_LABEL=""
+
+if $DO_HEAVY; then
+
+# -- Plan 파일 감지 --
 # 현재 세션의 transcript에서 plan 파일 Read/Write 기록을 추출한다.
 # ※ 이전 ls -t 방식은 세션과 무관하게 가장 최근 파일을 반환하여
 #   다른 세션의 plan을 오표시하는 버그가 있었음 (worktree fallback 포함).
-PLAN_FILE=""
 PLAN_STATE_FILE=""
 
 if [ -n "$TRANSCRIPT" ]; then
@@ -90,7 +113,7 @@ elif [ -z "$PLAN_FILE" ] && [ -f "$PROJECT_PLAN_STATE" ]; then
   fi
 fi
 
-# --- Memory 디렉토리 감지 ---
+# -- Memory 디렉토리 감지 --
 #
 # === Change Intent Record ===
 # v1 (PR #264): dirname(transcript_path)/memory/로 경로 유도.
@@ -113,8 +136,6 @@ fi
 #              양쪽 분수 표시(5/7) → label 과도, 자동 등록/삭제 → 데이터 손실 위험.
 #    trade-off: ⚠ 의미를 사용자가 알아야 하지만, 평소엔 깔끔하고
 #              orphan 존재 시에만 시각적 신호를 제공.
-MEMORY_LINK=""
-MEMORY_LABEL=""
 
 if [ -n "$TRANSCRIPT" ]; then
   PROJECT_MEMORY_DIR="$(dirname "$TRANSCRIPT")/memory"
@@ -168,6 +189,17 @@ if [ -n "$TRANSCRIPT" ]; then
     MEMORY_LINK="file://$(dirname "$MEMORY_INDEX")"
     MEMORY_LABEL="Memory (${MEMORY_COUNT}${MEMORY_WARN})"
   fi
+fi
+
+# -- Heavy 결과 저장 --
+printf 'PLAN_FILE=%q\nMEMORY_LINK=%q\nMEMORY_LABEL=%q\n' \
+  "$PLAN_FILE" "$MEMORY_LINK" "$MEMORY_LABEL" > "${HEAVY_STATE}.vars"
+echo "$NOW" > "$HEAVY_STATE"
+
+else
+  # -- Light run: 캐시된 변수 복원 --
+  # shellcheck source=/dev/null
+  source "${HEAVY_STATE}.vars" 2>/dev/null || true
 fi
 
 # --- Status icons 읽기 ---
@@ -337,6 +369,41 @@ if [ -n "$MEMORY_LINK" ]; then
   print_icon "34" "$MEMORY_URL" "\xf0\x9f\xa7\xa0" "$MEMORY_LABEL"
 fi
 
+# Cache TTL: 프롬프트 캐시 남은 시간 표시
+# 값 "0" = API 호출 중 (UserPromptSubmit → Stop 사이) → 5:00 고정 표시
+# 값 >0  = Unix epoch (Stop 시점) → 카운트다운
+# green(≥2min) / yellow(1-2min) / red(<1min) / muted(expired)
+# 세션별 파일 우선, 글로벌 fallback
+CACHE_TTL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/claude-hooks"
+LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop-${SESSION_ID}"
+[ -f "$LAST_STOP_FILE" ] || LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop"
+CACHE_TTL=300  # 5분
+
+if [ -f "$LAST_STOP_FILE" ]; then
+  last_stop=$(cat "$LAST_STOP_FILE" 2>/dev/null)
+  if [ -n "$last_stop" ] 2>/dev/null; then
+    if [ "$last_stop" = "0" ]; then
+      # API 호출 중 — 캐시가 활발히 갱신되므로 5:00 고정
+      print_icon "36" "" "\xe2\x8f\xb1\xef\xb8\x8f" "5:00"
+    elif [ "$last_stop" -gt 0 ] 2>/dev/null; then
+      elapsed=$((NOW - last_stop))
+      remaining=$((CACHE_TTL - elapsed))
+      if [ "$remaining" -gt 0 ]; then
+        minutes=$((remaining / 60))
+        seconds=$((remaining % 60))
+        CACHE_LABEL=$(printf '%d:%02d' "$minutes" "$seconds")
+        if [ "$remaining" -ge 120 ]; then CACHE_COLOR="32"
+        elif [ "$remaining" -ge 60 ]; then CACHE_COLOR="33"
+        else CACHE_COLOR="31"
+        fi
+        print_icon "$CACHE_COLOR" "" "\xe2\x8f\xb1\xef\xb8\x8f" "$CACHE_LABEL"
+      else
+        print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
+      fi
+    fi
+  fi
+fi
+
 # 아이콘이 하나라도 있으면 최종 개행
 if $HAS_OUTPUT; then printf '\n'; fi
 
@@ -371,7 +438,7 @@ if [ -n "$RATE_5H" ] || [ -n "$RATE_7D" ]; then
   else RATE_DETAIL=1
   fi
 
-  NOW=$(date +%s)
+  # NOW는 스크립트 상단에서 이미 계산됨
   if [ -n "$RATE_5H" ]; then
     render_rate_window "$RATE_5H" "5h" "$RATE_5H_RESET" "$NOW" "$RATE_DETAIL"
   fi

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -384,7 +384,14 @@ if [ -f "$LAST_STOP_FILE" ]; then
   if [ -n "$last_stop" ] 2>/dev/null; then
     if [ "$last_stop" = "0" ]; then
       # API 호출 중 — 캐시가 활발히 갱신되므로 5:00 고정
-      print_icon "36" "" "\xe2\x8f\xb1\xef\xb8\x8f" "5:00"
+      # 안전장치: 프로세스 kill 등으로 Stop 미발동 시 "0"이 영구 지속되는 것을 방지
+      # 파일 수정 시각이 CACHE_TTL을 초과하면 expired로 전환
+      file_mtime=$(stat -c %Y "$LAST_STOP_FILE" 2>/dev/null || stat -f %m "$LAST_STOP_FILE" 2>/dev/null || echo 0)
+      if [ "$((NOW - file_mtime))" -ge "$CACHE_TTL" ]; then
+        print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
+      else
+        print_icon "36" "" "\xe2\x8f\xb1\xef\xb8\x8f" "5:00"
+      fi
     elif [ "$last_stop" -gt 0 ] 2>/dev/null; then
       elapsed=$((NOW - last_stop))
       remaining=$((CACHE_TTL - elapsed))

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -80,6 +80,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/detect-pain-point.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/record-prompt-submit.sh"
           }
         ]
       }
@@ -99,6 +103,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/collect-pain-points.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/record-last-stop.sh"
           }
         ]
       }
@@ -148,7 +156,7 @@
   "statusLine": {
     "type": "command",
     "command": "~/.claude/scripts/statusline.sh",
-    "refreshInterval": 10
+    "refreshInterval": 1
   },
   "enabledPlugins": {
     "plugin-dev@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

- Stop/UserPromptSubmit hook으로 프롬프트 캐시 TTL을 추적하여, statusline에 실시간 카운트다운을 표시한다.
- 세션별 상태 격리로 다중 세션 간 간섭을 방지하고, 서브에이전트 이벤트는 무시한다.
- heavy 연산(Plan/Memory 감지)은 10초 간격으로만 실행하고, 캐시 TTL은 매초 갱신하여 성능을 최적화한다.

## 기존 문제/배경

Claude Code의 프롬프트 캐시는 마지막 API 요청 후 5분(300초)이 지나면 서버 측에서 만료된다. 캐시가 유효한 상태에서 후속 프롬프트를 보내면 입력 토큰의 90% 비용 절감이 가능하지만, 현재 캐시 유효 여부를 시각적으로 확인할 방법이 없어 사용자가 비용 효율적인 타이밍을 파악하기 어렵다.

## CIR (Change Intent Record)

- **v1**: Stop hook에서 전역 `last-stop` 파일에 타임스탬프 기록 + statusline에서 카운트다운 표시. `refreshInterval`을 10→1로 변경하여 매초 갱신.
- **v2**: Codex review 피드백 반영 — 전역 파일 대신 세션별 `last-stop-${SESSION_ID}` 파일로 다중 세션 격리. `record-prompt-submit.sh`에 `agent_id` 가드 추가.
- **v3** (최종): stdin JSON에서 `session_id`를 직접 파싱하도록 변경. `CLAUDE_SESSION_ID` 환경변수 의존성 제거(fallback으로만 유지). UserPromptSubmit 시 `0`을 기록하여 API 호출 중 5:00 고정 표시(freeze) 구현.

**trade-off**: `refreshInterval=1`로 statusline.sh가 매초 실행되지만, heavy 연산(Plan/Memory 감지)을 10초 간격으로 게이팅하여 실질적 부하는 경량 파일 읽기+산술 연산으로 최소화.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 전역 last-stop 파일 | 모든 세션이 하나의 파일 공유 | 구현 단순 | 다중 세션 간 타이머 간섭 | ❌ |
| 세션별 last-stop 파일 | `last-stop-${SESSION_ID}`로 격리 + 전역 fallback | 세션 격리 완벽, 단일 세션도 정상 | 파일 수 증가 (세션별 1개) | ✅ |
| `CLAUDE_SESSION_ID` env var 의존 | env var로 세션 식별 | 구현 단순 | hook 타입별 env var 가용성 미보장 | ❌ |
| stdin JSON `session_id` 파싱 | hook stdin에서 세션 ID 직접 추출 | 모든 hook 타입에서 안정적 | jq 의존성 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `hooks/record-last-stop.sh` | 추가 | Stop hook — 세션별 타임스탬프 기록, agent_id 가드 |
| `hooks/record-prompt-submit.sh` | 추가 | UserPromptSubmit hook — "0" 기록(활성 상태), agent_id 가드 |
| `scripts/statusline.sh` | 수정 | heavy 분기 최적화 + Cache TTL 섹션 추가 |
| `settings.json` | 수정 | Stop/UserPromptSubmit hooks 등록, `refreshInterval: 10→1` |
| `default.nix` | 수정 | 새 hook 파일 mkOutOfStoreSymlink 등록 |

### 핵심 코드 — 캐시 TTL 렌더링

```bash
# 값 "0" = API 호출 중 → 5:00 고정 (cyan)
# 값 >0  = Unix epoch → 카운트다운 (green/yellow/red/muted)
if [ "$last_stop" = "0" ]; then
  print_icon "36" "" "\xe2\x8f\xb1\xef\xb8\x8f" "5:00"
elif [ "$last_stop" -gt 0 ]; then
  remaining=$((300 - (NOW - last_stop)))
  # green(≥2min) / yellow(1-2min) / red(<1min) / muted(expired)
fi
```

### 핵심 코드 — heavy 분기 최적화

```bash
NOW=$(date +%s)
HEAVY_INTERVAL=10
DO_HEAVY=true
if [ -f "$HEAVY_STATE" ]; then
  last_heavy=$(head -1 "$HEAVY_STATE" 2>/dev/null || echo 0)
  [ "$((NOW - last_heavy))" -lt "$HEAVY_INTERVAL" ] && DO_HEAVY=false
fi
# Plan/Memory 감지는 $DO_HEAVY 일 때만, 결과를 파일로 캐시
```

## 참고 레퍼런스

- `a4edc01` — refreshInterval 값을 string→number로 수정 (선행 변경)
- `e261233` — claude-code, codex 자잘한 설정 추가
- [Prompt Caching - Anthropic Docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) — 5분 TTL 사양

## Human Test Plan

### 정상 동작 검증

1. 새 Claude Code 세션을 시작하고 메시지를 전송한다.
   - **기대**: 프롬프트 전송 시 statusline에 `⏱️ 5:00` (cyan)이 고정 표시된다.
   - **실패 시**: `~/.local/share/claude-hooks/last-stop-<session_id>` 파일에 `0`이 기록되었는지 확인.

2. Claude가 응답을 완료한다(Stop 이벤트).
   - **기대**: statusline에 `⏱️ 5:00` (green)에서 카운트다운이 시작된다.
   - **실패 시**: `last-stop-<session_id>` 파일에 Unix epoch가 기록되었는지 확인.

3. 2분 이상 대기한다.
   - **기대**: 색상이 green→yellow(2분 미만)→red(1분 미만)→muted(expired)로 전환된다.

### 다중 세션 검증

4. 두 개의 Claude Code 세션을 동시에 연다.
   - **기대**: 세션 A에서 프롬프트를 보내도 세션 B의 타이머가 영향받지 않는다.
   - **실패 시**: `~/.local/share/claude-hooks/` 디렉토리에서 세션별 파일이 분리되어 있는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 hook 파일 존재 확인
ls modules/shared/programs/claude/files/hooks/record-last-stop.sh
ls modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
# 기대: exit 0

# 2. settings.json에 hook 등록 확인
grep -q "record-last-stop.sh" modules/shared/programs/claude/files/settings.json
grep -q "record-prompt-submit.sh" modules/shared/programs/claude/files/settings.json
# 기대: exit 0

# 3. refreshInterval 변경 확인
grep -q '"refreshInterval": 1' modules/shared/programs/claude/files/settings.json
! grep -q '"refreshInterval": 10' modules/shared/programs/claude/files/settings.json
# 기대: exit 0

# 4. default.nix에 symlink 등록 확인
grep -q "record-last-stop.sh" modules/shared/programs/claude/default.nix
grep -q "record-prompt-submit.sh" modules/shared/programs/claude/default.nix
# 기대: exit 0

# 5. agent_id 가드 존재 확인
grep -q "agent_id" modules/shared/programs/claude/files/hooks/record-last-stop.sh
grep -q "agent_id" modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
# 기대: exit 0

# 6. session_id stdin 파싱 확인
grep -q "session_id" modules/shared/programs/claude/files/hooks/record-last-stop.sh
grep -q "session_id" modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
# 기대: exit 0
```

### Phase 1: 세션 격리 기능 검증

> "세션별 last-stop 파일이 독립적으로 관리되는지 확인"

```bash
DATADIR=/tmp/cache-ttl-test
mkdir -p "$DATADIR"
export XDG_DATA_HOME="$DATADIR"

# 세션 A: Stop
echo '{"session_id":"sess-aaa"}' | bash modules/shared/programs/claude/files/hooks/record-last-stop.sh
A_VAL=$(cat "$DATADIR/claude-hooks/last-stop-sess-aaa")

# 세션 B: prompt (freeze)
echo '{"session_id":"sess-bbb"}' | bash modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
B_VAL=$(cat "$DATADIR/claude-hooks/last-stop-sess-bbb")

# A가 B에 의해 덮어쓰이지 않았는지 확인
A_AFTER=$(cat "$DATADIR/claude-hooks/last-stop-sess-aaa")
[ "$A_VAL" = "$A_AFTER" ] && [ "$B_VAL" = "0" ] && echo "PASS" || echo "FAIL"
rm -rf "$DATADIR/claude-hooks"
```

- **기대**: `PASS` 출력
- **실패 시**: 두 hook에서 session_id 파싱이 정상 동작하는지, `last-stop-${SESSION_ID}` 경로가 올바른지 확인.

### Phase 2: 서브에이전트 가드 검증

> "agent_id가 있는 이벤트에서 hook이 타임스탬프를 기록하지 않는지 확인"

```bash
DATADIR=/tmp/cache-ttl-test
mkdir -p "$DATADIR/claude-hooks"
export XDG_DATA_HOME="$DATADIR"

echo "12345" > "$DATADIR/claude-hooks/last-stop-sess-ccc"
echo '{"session_id":"sess-ccc","agent_id":"sub-999"}' | bash modules/shared/programs/claude/files/hooks/record-last-stop.sh
AFTER=$(cat "$DATADIR/claude-hooks/last-stop-sess-ccc")
[ "$AFTER" = "12345" ] && echo "PASS" || echo "FAIL"
rm -rf "$DATADIR/claude-hooks"
```

- **기대**: `PASS` 출력 (서브에이전트 Stop이 기존 값을 덮어쓰지 않음)
- **실패 시**: agent_id 가드의 jq 파싱이 정상 동작하는지 확인.

### Phase 3: Regression

> "기존 statusline 기능(Plan/Memory/Icons/Rate Limits)이 이번 변경에 의해 깨지지 않는지 확인"

```bash
# statusline.sh 문법 검증
bash -n modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# Nix flake check
nix flake check --no-build 2>&1 | tail -1
# 기대: 에러 없음
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt cache TTL countdown added to the status line with per-session/global fallback display.

* **Improvements**
  * Increased status line refresh frequency (10 → 1) for snappier updates.
  * Added throttling/caching for heavy Plan/Memory detection to reduce expensive work.
  * Added user-level hooks to record prompt submissions and stop events to maintain cache state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->