### PR TITLE
fix(awesome-anki,tests): pull 재시도 및 darwin nrs 테스트 수정

### DIFF
--- a/modules/nixos/programs/docker/awesome-anki.nix
+++ b/modules/nixos/programs/docker/awesome-anki.nix
@@ -53,13 +53,17 @@ let
       # 마커 파일: 실패 에피소드당 1회만 알림 (5분 주기 스팸 방지)
       PULL_FAIL_MARKER="/run/awesome-anki-pull-failed"
       if ! podman pull "$IMAGE_NAME" >/dev/null 2>&1; then
-        echo "awesome-anki: pull failed (network error)"
-        if [ ! -f "$PULL_FAIL_MARKER" ]; then
-          send_notification "awesome-anki Deploy" \
-            "이미지 pull 실패 (네트워크 오류). 다음 주기에 재시도." "-1"
-          touch "$PULL_FAIL_MARKER"
+        echo "awesome-anki: pull failed, retrying in 5s..."
+        sleep 5
+        if ! podman pull "$IMAGE_NAME" >/dev/null 2>&1; then
+          echo "awesome-anki: pull failed (network error)"
+          if [ ! -f "$PULL_FAIL_MARKER" ]; then
+            send_notification "awesome-anki Deploy" \
+              "이미지 pull 실패 (네트워크 오류). 다음 주기에 재시도." "-1"
+            touch "$PULL_FAIL_MARKER"
+          fi
+          exit 0
         fi
-        exit 0
       fi
       rm -f "$PULL_FAIL_MARKER"
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -949,13 +949,15 @@ EOF
 set -euo pipefail
 exit 0
 EOF
-  cat > "$stub_dir/readlink" <<'EOF'
+  local real_readlink
+  real_readlink="$(command -v readlink)"
+  cat > "$stub_dir/readlink" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "/run/current-system" ]]; then
-  printf '%s\n' "${DARWIN_CURRENT_SYSTEM:?}"
+if [[ "\${1:-}" == "/run/current-system" ]]; then
+  printf '%s\n' "\${DARWIN_CURRENT_SYSTEM:?}"
 else
-  /usr/bin/readlink "$@"
+  "$real_readlink" "\$@"
 fi
 EOF
   cat > "$home_dir/.local/bin/nrs-relink" <<'EOF'
@@ -997,7 +999,7 @@ test_darwin_nrs_no_changes_releases_worktree_lock() {
   install_deployed_layout "$sandbox" "$repo_root"
   install_platform_nrs_entrypoint "$sandbox" darwin
 
-  mkdir -p "$stub_dir" "$home_dir/.local/bin"
+  mkdir -p "$stub_dir" "$home_dir/.local/bin" "$home_dir/Library/LaunchAgents"
   current_target="$sandbox/current-system"
   mkdir -p "$current_target"
   lock_file="$sandbox/nrs-state"
@@ -1029,13 +1031,15 @@ EOF
 set -euo pipefail
 echo "stub nvd diff"
 EOF
-  cat > "$stub_dir/readlink" <<'EOF'
+  local real_readlink
+  real_readlink="$(command -v readlink)"
+  cat > "$stub_dir/readlink" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "/run/current-system" ]]; then
-  printf '%s\n' "${DARWIN_CURRENT_SYSTEM:?}"
+if [[ "\${1:-}" == "/run/current-system" ]]; then
+  printf '%s\n' "\${DARWIN_CURRENT_SYSTEM:?}"
 else
-  /usr/bin/readlink "$@"
+  "$real_readlink" "\$@"
 fi
 EOF
   cat > "$home_dir/.local/bin/nrs-relink" <<'EOF'


### PR DESCRIPTION
## Summary

- awesome-anki auto-update의 이미지 pull 실패 시 5초 대기 후 1회 재시도를 추가하여, Tailscale MagicDNS의 간헐적 DNS 해석 실패로 인한 불필요한 Pushover 알림을 방지한다.
- darwin nrs 테스트의 `LaunchAgents` 디렉토리 누락 및 `readlink` stub의 NixOS 비호환 문제를 수정한다.

## 기존 문제/배경

### 1. awesome-anki 알림 스팸

awesome-anki auto-update 타이머(5분 주기)가 `ghcr.io`에서 이미지를 pull할 때, Tailscale MagicDNS 프록시의 간헐적 DNS 해석 실패(`lookup ghcr.io: no such host`)로 Pushover 알림이 반복 수신되었다.

**발생 패턴**: 최근 7일간 4회 발생. 성공 286회 대비 실패 2회(어제 기준)로, 대부분 일시적 네트워크 문제이며 5분 후 자동 복구됨.

### 2. shell-script-tests 실패

`test_darwin_nrs_no_changes_releases_worktree_lock` 테스트에서 `$home_dir/Library/LaunchAgents` 디렉토리 미생성 → nrs의 `cleanup_launchd_agents`에서 `find`가 `pipefail`로 exit 1 → 테스트 전체 조용히 실패 (exit 1이지만 에러 메시지 없음). 추가로 readlink stub이 `/usr/bin/readlink`를 폴백으로 사용하나 NixOS에는 해당 경로가 없었음.

## CIR (Change Intent Record)

### awesome-anki

- **발견 경위**: 사용자가 Pushover 에러 알림 스크린샷으로 문제 보고
- **원인 분석**: journalctl 로그 분석 → DNS 해석 실패 확인 → resolv.conf 확인 → MagicDNS 프록시 간헐적 장애
- **DNS fallback 조사**: Tailscale admin console에 이미 global nameserver(8.8.8.8, 1.1.1.1 등) 설정 확인. NixOS의 networking.nameservers는 Tailscale이 resolv.conf를 덮어쓰므로 무효. DNS 설정 변경 불필요.
- **최종 결정**: 스크립트 레벨에서 pull 재시도를 추가하여 일시적 DNS 문제를 자체 흡수

### shell-script-tests

- **발견 경위**: awesome-anki PR push 시 pre-push hook에서 shell-script-tests exit 1 발생
- **원인 분석**: main 브랜치에서도 동일 실패 확인 → 기존 버그
- **최종 결정**: 디렉토리 생성 추가 + readlink stub에서 실제 경로를 캡처하여 heredoc 변수 치환으로 주입

## ADR

### awesome-anki

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Pull 재시도 | 실패 시 5초 대기 후 1회 재시도 | 일시적 문제 자체 흡수, 기존 로직 보존 | 실패 시 +5초 지연 | ✅ |
| 타임스탬프 쿨다운 | 마커 파일에 타임스탬프, N시간 내 재알림 방지 | 간헐적 실패 대응 | 마커 파일 형식 변경, 진짜 장애도 묻힐 수 있음 | ❌ |
| DNS fallback 추가 | NixOS nameservers 설정 | 근본 원인 해결 | Tailscale이 resolv.conf 덮어써서 무효 (이미 admin console에 설정됨) | ❌ |

### readlink stub

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| command readlink | PATH에서 검색 | 플랫폼 무관 | stub 자기 자신을 재귀 호출하여 hang | ❌ |
| 실제 경로 캡처 + heredoc 치환 | stub 생성 전 command -v readlink 캡처 | 재귀 방지, NixOS/macOS 모두 호환 | heredoc이 unquoted로 변경 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/docker/awesome-anki.nix` | 수정 | pull 실패 블록에 5초 대기 + 재시도 래핑 추가 |
| `tests/shell-script-tests.sh` | 수정 | LaunchAgents 디렉토리 생성 추가 + readlink stub 경로 수정 |

## 참고 레퍼런스

- `f773e16` — awesome-anki pull 재시도 로직 추가
- `3f1bbfa` — shell-script-tests LaunchAgents 디렉토리 누락 + readlink stub 수정
- `67b6b54` — 변경 전 awesome-anki.nix
- `.claude/skills/managing-ssh/references/troubleshooting.md:314` — 2026-02-13 Tailscale DNS 장애 기록

## Human Test Plan

### awesome-anki 정상 동작 검증

1. `nrs`로 변경 배포 후, `sudo systemctl start awesome-anki-auto-update`로 수동 실행
   - **기대**: 정상 pull 시 기존과 동일하게 동작 (재시도 로그 없음)
   - **실패 시**: `journalctl -u awesome-anki-auto-update --since '1 min ago'` 확인

### shell-script-tests 검증

2. `bash tests/shell-script-tests.sh` 실행
   - **기대**: 모든 19개 테스트 통과, EXIT: 0
   - **실패 시**: 실패 테스트 이름 직전/직후 출력 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 재시도 로직 존재 확인
grep -q "retrying in 5s" modules/nixos/programs/docker/awesome-anki.nix

# 2. 기존 마커 파일 로직 보존 확인
grep -q "PULL_FAIL_MARKER" modules/nixos/programs/docker/awesome-anki.nix

# 3. /usr/bin/readlink 부재 확인
! grep -q '/usr/bin/readlink' tests/shell-script-tests.sh

# 4. real_readlink 캡처 패턴 확인
grep -q 'real_readlink="$(command -v readlink)"' tests/shell-script-tests.sh
```

### Phase 1: 셸 스크립트 테스트 검증

> "전체 셸 스크립트 테스트가 통과하는지 확인"

```bash
bash tests/shell-script-tests.sh
```
- **기대**: 19개 테스트 모두 통과, exit 0
- **실패 시**: 마지막 `==> ...` 출력 이후 테스트 함수에서 실패 원인 추적

### Phase 2: Regression

> "기존 기능이 보존되었는지 확인"

```bash
# awesome-anki 기존 로직 보존
grep -q "get_image_digest" modules/nixos/programs/docker/awesome-anki.nix
grep -q "http_health_check" modules/nixos/programs/docker/awesome-anki.nix
grep -q "새 이미지 배포 완료" modules/nixos/programs/docker/awesome-anki.nix
```
