### PR TITLE
fix(claude): Cache TTL "0" sentinel의 5:00→expired 갑작스러운 전환 수정 (#449)

### DIFF
--- a/modules/shared/programs/claude/files/hooks/record-last-stop.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-stop.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 # record-last-stop.sh — 프롬프트 캐시 TTL 추적용 타임스탬프 기록
 # statusline.sh가 세션별 파일을 읽어 캐시 남은 시간을 계산한다.
+# 주의: settings.json의 Stop 훅 배열에서 첫 번째로 실행되어야 한다.
+# 다른 Stop 훅(collect-pain-points.sh 등)보다 먼저 타임스탬프를 기록하여
+# statusline 카운트다운의 레이스 컨디션을 최소화한다.
 
 # stdin에서 세션 정보 읽기 (agent_id 가드 + session_id 파싱 공용)
 INPUT=""

--- a/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
+++ b/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# record-prompt-submit.sh — 프롬프트 전송 시 캐시 TTL을 "활성" 상태로 전환
-# "0"을 기록하면 statusline.sh가 5:00 고정 표시 (API 호출 중 = 캐시 갱신 중)
+# record-prompt-submit.sh — 프롬프트 전송 시 캐시 TTL을 "in-flight" 상태로 전환
+# "0"을 기록하면 statusline.sh가 mtime 기준 카운트다운 표시 (Stop 미기록 상태)
 
 # stdin에서 세션 정보 읽기 (agent_id 가드 + session_id 파싱 공용)
 INPUT=""

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -266,6 +266,26 @@ print_icon() {
   HAS_OUTPUT=true
 }
 
+# render_cache_ttl: 캐시 TTL 남은 시간을 색상 + 아이콘으로 출력
+# $1=remaining_seconds → green(≥2min) / yellow(1-2min) / red(<1min) / muted(expired)
+render_cache_ttl() {
+  local remaining=$1
+  if [ "$remaining" -le 0 ]; then
+    print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
+    return
+  fi
+  local minutes=$((remaining / 60))
+  local seconds=$((remaining % 60))
+  local cache_label
+  cache_label=$(printf '%d:%02d' "$minutes" "$seconds")
+  local cache_color
+  if [ "$remaining" -ge 120 ]; then cache_color="32"
+  elif [ "$remaining" -ge 60 ]; then cache_color="33"
+  else cache_color="31"
+  fi
+  print_icon "$cache_color" "" "\xe2\x8f\xb1\xef\xb8\x8f" "$cache_label"
+}
+
 # rate_color: 사용률에 따른 ANSI 색상 코드 반환
 # $1=percentage → 32(green <50%) / 33(yellow 50-79%) / 31(red ≥80%)
 rate_color() {
@@ -372,9 +392,11 @@ if [ -n "$MEMORY_LINK" ]; then
 fi
 
 # Cache TTL: 프롬프트 캐시 남은 시간 표시
-# 값 "0" = API 호출 중 (UserPromptSubmit → Stop 사이) → 5:00 고정 표시
+# 값 "0" = Stop 미기록 상태 (UserPromptSubmit → Stop 사이) → mtime 기준 카운트다운
+#   정상 API 호출 중에는 Stop에서 타임스탬프가 곧 기록되어 리셋됨
+#   중단(Escape/Ctrl+C) 시에는 자연스럽게 0까지 감소 후 expired
 # 값 >0  = Unix epoch (Stop 시점) → 카운트다운
-# green(≥2min) / yellow(1-2min) / red(<1min) / muted(expired)
+# 공통 렌더링: render_cache_ttl 함수 사용
 # 세션별 파일 우선, 글로벌 fallback
 CACHE_TTL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/claude-hooks"
 if [ -n "$SESSION_ID" ]; then
@@ -388,30 +410,15 @@ if [ -f "$LAST_STOP_FILE" ]; then
   last_stop=$(cat "$LAST_STOP_FILE" 2>/dev/null)
   if [ -n "$last_stop" ] 2>/dev/null; then
     if [ "$last_stop" = "0" ]; then
-      # API 호출 중 — 캐시가 활발히 갱신되므로 5:00 고정
-      # 안전장치: 프로세스 kill 등으로 Stop 미발동 시 "0"이 영구 지속되는 것을 방지
-      # 파일 수정 시각이 CACHE_TTL을 초과하면 expired로 전환
+      # "0" = Stop 미기록 상태의 in-flight sentinel (mtime 기준 카운트다운)
       file_mtime=$(stat -c %Y "$LAST_STOP_FILE" 2>/dev/null || stat -f %m "$LAST_STOP_FILE" 2>/dev/null || echo 0)
-      if [ "$((NOW - file_mtime))" -ge "$CACHE_TTL" ]; then
-        print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
-      else
-        print_icon "36" "" "\xe2\x8f\xb1\xef\xb8\x8f" "5:00"
-      fi
+      elapsed=$((NOW - file_mtime))
+      remaining=$((CACHE_TTL - elapsed))
+      render_cache_ttl "$remaining"
     elif [ "$last_stop" -gt 0 ] 2>/dev/null; then
       elapsed=$((NOW - last_stop))
       remaining=$((CACHE_TTL - elapsed))
-      if [ "$remaining" -gt 0 ]; then
-        minutes=$((remaining / 60))
-        seconds=$((remaining % 60))
-        CACHE_LABEL=$(printf '%d:%02d' "$minutes" "$seconds")
-        if [ "$remaining" -ge 120 ]; then CACHE_COLOR="32"
-        elif [ "$remaining" -ge 60 ]; then CACHE_COLOR="33"
-        else CACHE_COLOR="31"
-        fi
-        print_icon "$CACHE_COLOR" "" "\xe2\x8f\xb1\xef\xb8\x8f" "$CACHE_LABEL"
-      else
-        print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
-      fi
+      render_cache_ttl "$remaining"
     fi
   fi
 fi

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -94,6 +94,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "~/.claude/hooks/record-last-stop.sh"
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/stop-notification.sh"
           },
           {
@@ -103,10 +107,6 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/collect-pain-points.sh"
-          },
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/record-last-stop.sh"
           }
         ]
       }
@@ -186,5 +186,6 @@
   "voiceEnabled": true,
   "autoMemoryEnabled": false,
   "showThinkingSummaries": true,
-  "skipDangerousModePermissionPrompt": true
+  "skipDangerousModePermissionPrompt": true,
+  "advisorModel": "opus"
 }

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -186,6 +186,5 @@
   "voiceEnabled": true,
   "autoMemoryEnabled": false,
   "showThinkingSummaries": true,
-  "skipDangerousModePermissionPrompt": true,
-  "advisorModel": "opus"
+  "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary

- Cache TTL statusline의 "0" sentinel 상태에서 5:00 고정 표시 대신 **mtime 기반 카운트다운**을 적용하여, 중단(Escape/Ctrl+C) 시에도 자연스럽게 0까지 감소 후 expired로 전환
- Stop 훅 순서를 변경하여 `record-last-stop.sh`가 가장 먼저 실행되도록 하고, 레이스 컨디션을 최소화

Closes #449

## 기존 문제/배경

`UserPromptSubmit`이 "0"을 `last-stop-{SESSION_ID}` 파일에 기록하면, statusline이 ⏱️ 5:00으로 **고정** 표시한다. 이후 `Stop` 이벤트에서 타임스탬프를 기록하면 카운트다운으로 전환된다.

**문제**: Escape/Ctrl+C로 LLM 응답을 중단하거나 세션을 종료하면 Stop 이벤트가 발생하지 않아 "0"이 파일에 잔류한다. "0" 상태에는 5분 mtime 안전장치가 있어서, **카운트다운 없이 5:00에서 바로 expired로 점프**한다.

종료된 세션 데이터에서 50%가 "0" 잔류 — Stop 미발생이 빈번함을 확인.

## 🔍 foreground 도구 실행 중 카운트다운 동작

> 이 섹션은 수정의 핵심 동작을 설명합니다. 헷갈리기 쉬운 부분이니 주의해서 읽어주세요.

### Stop 이벤트는 언제 발생하는가?

Stop 이벤트는 **LLM의 최종 응답이 완료될 때** 발생한다. foreground Bash(codex exec, 빌드 명령 등)가 실행 중일 때는 도구 실행이 아직 진행 중이므로 **Stop 훅이 호출되지 않는다.**

<details>
<summary>근거: Claude Code 소스 코드</summary>

**Stop hooks 호출 위치** — `src/query.ts:1267`:
```typescript
const stopHookResult = yield* handleStopHooks(
  messagesForQuery, assistantMessages, systemPrompt,
  userContext, systemContext, toolUseContext,
  querySource, stopHookActive,
)
```

**실행 순서**: `query_api_streaming_end` 체크포인트 (줄 864) → Post-sampling hooks (줄 999) → **Stop hooks** (줄 1267)

**foreground 도구 등록** — `src/tools/BashTool/BashTool.tsx`:
```typescript
foregroundTaskId = registerForeground({...})
```
도구가 `registerForeground()`로 전경 작업을 등록하면, 도구 완료 전까지 Stop hooks가 호출되지 않는다.

**Escape/Ctrl+C 중단** — `src/query/stopHooks.ts:282-294`:
```typescript
if (toolUseContext.abortController.signal.aborted) {
  logEvent('tengu_pre_stop_hooks_cancelled', {...})
  yield createUserInterruptionMessage({ toolUse: false })
  return { blockingErrors: [], preventContinuation: true }
}
```
abort signal 감지 시 Stop hooks가 즉시 중단되어, record-last-stop.sh가 실행되지 않는다.

`src/utils/hooks.ts:215-217`:
```typescript
// A hard cancel (Escape) WILL kill the hook via the abort handler,
// which is the desired behavior.
```
</details>

따라서 LLM이 도구를 실행하는 동안에는:
1. `UserPromptSubmit`이 기록한 `"0"`이 파일에 계속 남아있음
2. Stop 이벤트가 없으므로 타임스탬프로 덮어쓰이지 않음

### 수정 전 동작

| 시간 | 상태 | statusline |
|------|------|------------|
| T+0s | UserPromptSubmit → "0" 기록 | ⏱️ 5:00 (고정) |
| T+1min | LLM이 도구 실행 중 | ⏱️ 5:00 (고정) |
| T+5min | mtime 안전장치 도달 | 💤 expired (갑작스런 전환!) |
| T+5min+N | 도구 완료 → Stop → 타임스탬프 | ⏱️ 5:00 (리셋) |

→ **5:00에서 바로 expired로 점프** — 카운트다운 없음

### 수정 후 동작

| 시간 | 상태 | statusline |
|------|------|------------|
| T+0s | UserPromptSubmit → "0" 기록 | ⏱️ 5:00 (카운트다운 시작) |
| T+1min | LLM이 도구 실행 중 | ⏱️ 4:00 (자연 감소) |
| T+3min | 여전히 도구 실행 중 | ⏱️ 2:00 (yellow) |
| T+4min30s | 도구 거의 완료 | ⏱️ 0:30 (red) |
| T+5min | mtime 5분 경과 | 💤 expired (자연 도달) |
| T+5min+N | 도구 완료 → Stop → 타임스탬프 | ⏱️ 5:00 (리셋) |

→ **카운트다운이 자연스럽게 감소** — 갑작스런 전환 없음

### 왜 이것이 오히려 더 정확한가?

서버 측 프롬프트 캐시 TTL은 **마지막 API 호출 완료 시점**부터 5분이다. foreground Bash가 5분 이상 실행되면 서버 측 캐시도 실제로 만료된다.

<details>
<summary>근거: 5분 TTL 출처</summary>

**Claude Code 소스** — `src/services/api/promptCacheBreakDetection.ts:122-126`:
```typescript
// Anthropic's server-side prompt cache TTL thresholds to test.
// Cache breaks after these durations are likely due to TTL expiration
// rather than client-side changes.
const CACHE_TTL_5MIN_MS = 5 * 60 * 1000
export const CACHE_TTL_1HOUR_MS = 60 * 60 * 1000
```

**캐시 브레이크 감지** — 같은 파일 줄 565-571:
```typescript
const lastAssistantMsgOver5minAgo =
  timeSinceLastAssistantMsg !== null &&
  timeSinceLastAssistantMsg > CACHE_TTL_5MIN_MS
```
마지막 어시스턴트 메시지로부터 5분 이상 경과하면 "possible 5min TTL expiry"로 판정한다.

**공식 문서**: [Anthropic Docs: Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) — 5분 TTL 명시.
</details>

따라서:

- **수정 전**: 캐시가 이미 만료되었는데 "5:00"으로 거짓말
- **수정 후**: 캐시 만료 상태를 정직하게 반영

도구 실행이 완료되면 다시 API 호출이 이루어지고, Stop 이벤트에서 새 타임스탬프가 기록되어 카운트다운이 리셋된다.

## 🧠 thinking/extended thinking 중 카운트다운 동작

Thinking(extended thinking 포함)은 **API 스트리밍의 일부**다. 스트리밍이 완전히 끝난 후에야 Stop hooks가 호출되므로, thinking 중에도 Stop은 발생하지 않는다.

<details>
<summary>근거: thinking과 스트리밍의 관계</summary>

**thinking 규칙** — `src/query.ts:152-160`:
```typescript
* The rules of thinking are lengthy and fortuitous. They require plenty of thinking
* 1. A message that contains a thinking or redacted_thinking block
*    must be part of a query whose max_thinking_length > 0
* 2. A thinking block may not be the last message in a block
```

**스트리밍 완료 체크포인트** — `src/query.ts:864`:
```typescript
queryCheckpoint('query_api_streaming_end')
```
이 체크포인트는 API 스트리밍이 완전히 끝난 후 실행된다. Thinking 중에는 여전히 스트리밍이 진행 중이므로, Stop hooks는 스트리밍 완료 후에만 호출된다.
</details>

| 관점 | 동작 |
|------|------|
| Stop 이벤트 | 아직 미발생 (응답 미완료) |
| last-stop 파일 | UserPromptSubmit이 기록한 "0" 유지 |
| statusline (수정 후) | mtime 기반 카운트다운 (4:59 → 4:19 → ...) |
| 서버 측 캐시 | API 요청 시작됨 → 아직 완료 전 |

### 시나리오: 5분 넘는 extended thinking

```
T+0s     UserPromptSubmit → "0" 기록
T+1s     statusline: ⏱️ 4:59 (카운트다운 시작)
         ... Thinking 진행 중 ...
T+4min   statusline: ⏱️ 1:00 (yellow)
T+5min   statusline: 💤 expired
T+5min+  Thinking 완료 → Stop → 타임스탬프 → ⏱️ 5:00 리셋
```

5분 넘는 thinking에서 statusline이 expired를 표시하더라도, **이것은 이전 턴의 서버 캐시가 실제로 만료된 상태를 정직하게 반영한 것**이다. 현재 진행 중인 API 호출이 완료되면 새 캐시가 생성되어 자동으로 리셋된다.

> **참고**: Opus extended thinking이 활성화되면 thinking 시간이 길어질 수 있다. 이 경우 statusline이 expired를 보여도, 이는 서버 캐시의 실제 상태 반영이지 오작동이 아니다. 마지막 API 호출 완료는 Bash 도구 시작 직전이므로, 도구/thinking이 5분+ 걸리면 서버 측 캐시도 실제로 만료되기 때문이다.

## ⏱️ 카운트다운이 "불안정"해 보이는 이유 (정상 동작)

수정 후 타이머가 기존보다 역동적으로 움직여서 불안정해 보일 수 있다. **모두 의도된 동작**이다. 기존에는 "5:00 고정"이라 변화가 없었지만, 이제는 실시간 카운트다운이므로 움직임이 눈에 보이는 것이다.

### 현상 1: 갑자기 2-3초씩 줄어듦

`refreshInterval: 1`이 매초 호출을 보장하지만, statusline.sh 자체 실행 시간(heavy 연산 포함 시)이나 시스템 부하로 인해 호출 간격이 정확히 1초가 아닐 수 있다. `date +%s`가 정수 단위이므로, 타이밍에 따라 2초씩 점프하는 것도 자연스럽다.

### 현상 2: 카운트다운이 멈추기도 함

Claude Code가 바쁠 때 (API 스트리밍, 도구 실행 등) statusline 갱신 자체가 지연될 수 있다. 갱신이 재개되면 `date +%s` 기준으로 올바른 남은 시간을 다시 계산하므로, 멈춘 시간만큼 한번에 줄어드는 것처럼 보인다.

### 현상 3: 갑자기 5분으로 점프 — 이것이 핵심

**Stop 이벤트가 발생하면 타임스탬프가 갱신되어 카운트다운이 ~5:00으로 리셋된다.**

이 세션에서 매번 이런 일이 발생하고 있었지만 — LLM 응답이 완료될 때마다 Stop → 타임스탬프 기록 → ~5:00 리셋이 일어난다. 기존에는 이 리셋이 "5:00 고정 → 5:00 고정"이라 눈에 보이지 않았지만, 이제는 **"3:42 → 5:00"처럼 점프가 보이는 것**이다.

### 정상 사이클 요약

```
카운트다운 감소 (5:00 → 4:30 → 4:00 → ...)
       ↓
  Stop 이벤트 발생 (LLM 응답 완료)
       ↓
  카운트다운 리셋 (~5:00)
       ↓
카운트다운 다시 감소 (5:00 → 4:50 → ...)
       ↓
  또 Stop 이벤트 발생
       ↓
       ... (반복)
```

> **한 줄 요약**: 카운트다운이 줄어들다가 → Stop에서 리셋 → 다시 줄어들다가 → 또 Stop에서 리셋... 이 사이클이 정상이다. 기존에는 항상 "5:00"이라 이 사이클이 안 보였을 뿐이다.

## CIR (Change Intent Record)

- **v1** (`0050262`): 캐시 TTL 카운트다운 최초 구현. "0" sentinel = API 호출 중 5:00 고정.
- **v2** (이번 변경): "0" sentinel 상태에서 5:00→expired 갑작스런 전환 버그 발견. "0"도 mtime 기반 카운트다운으로 변경.

**DA for_plan 피드백 반영**:
- CORR-1: stale 파일 GC를 heavy 블록에 넣으면 `CACHE_TTL_DIR` 미정의 → 변경 제거
- DESIGN-1 (YAGNI): stale GC는 이번 패치 범위 밖 → 변경 제거
- REG-1: "0" 계약 변경 → 주석 갱신으로 문서화
- REG-2: Stop 훅 순서 변경 → ordering contract 주석 추가
- MAINT-2: 카운트다운 렌더링 중복 → `render_cache_ttl` 공통 함수 추출

**trade-off**: 정상 API 호출 중에도 카운트다운이 살짝 줄어드는 것이 보이지만 (5:00→4:50), Stop 완료 시 리셋되므로 실질적 영향 없음. 중단 시 "거짓 5:00" 대신 정직한 카운트다운이 훨씬 나은 UX.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| mtime 기반 카운트다운 | "0" 상태에서도 파일 수정 시각으로 남은 시간 계산 | 갑작스런 전환 없음, 서버 캐시 상태를 정직하게 반영 | 정상 API 호출 중에도 카운트다운 진행 | ✅ |
| API 호출 중 별도 아이콘 | 🔄 calling 표시 + mtime 30분 안전장치 | "0"의 의미가 명확 | 중단 후 30분 동안 "calling" 고착, 거짓 정보 | ❌ |
| "0" sentinel 제거 | Stop 타임스탬프만 사용 | 가장 단순 | API 호출 중 피드백 없음 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `statusline.sh` | 함수 추가 | `render_cache_ttl` — 카운트다운 렌더링 공통 함수 |
| `statusline.sh` | 로직 수정 | "0" 분기에서 5:00 고정 → mtime 기반 카운트다운 |
| `statusline.sh` | 주석 갱신 | "0" sentinel 의미 변경 반영 |
| `settings.json` | 순서 변경 | `record-last-stop.sh`를 Stop 훅 맨 앞으로 이동 |
| `record-last-stop.sh` | 주석 추가 | ordering contract 문서화 |
| `record-prompt-submit.sh` | 주석 갱신 | "0" sentinel 의미 변경 반영 |

<details>
<summary>핵심 코드 diff</summary>

```bash
# 새 공통 함수
render_cache_ttl() {
  local remaining=$1
  if [ "$remaining" -le 0 ]; then
    print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
    return
  fi
  local minutes=$((remaining / 60)) seconds=$((remaining % 60))
  local cache_label cache_color
  cache_label=$(printf '%d:%02d' "$minutes" "$seconds")
  if [ "$remaining" -ge 120 ]; then cache_color="32"    # green
  elif [ "$remaining" -ge 60 ]; then cache_color="33"   # yellow
  else cache_color="31"                                   # red
  fi
  print_icon "$cache_color" "" "\xe2\x8f\xb1\xef\xb8\x8f" "$cache_label"
}

# BEFORE: "0" 분기
if [ "$last_stop" = "0" ]; then
  if [ "$((NOW - file_mtime))" -ge "$CACHE_TTL" ]; then
    expired  # 갑작스런 전환!
  else
    "5:00"   # 항상 고정!
  fi

# AFTER: "0" 분기
if [ "$last_stop" = "0" ]; then
  elapsed=$((NOW - file_mtime))
  remaining=$((CACHE_TTL - elapsed))
  render_cache_ttl "$remaining"  # 자연스러운 카운트다운
```
</details>

## 참고 레퍼런스

### 관련 PR/이슈

- PR #444 (`0050262`) — statusline에 프롬프트 캐시 TTL 카운트다운 최초 추가
- Issue #449 — 이 PR이 해결하는 버그 보고
- Issue #451 — **알려진 제한: Max 구독자 1시간 TTL 미대응 + 캐시 히트/미스 표시** (후속 작업)

### 알려진 제한사항

> ⚠️ 이 PR의 `CACHE_TTL=300` (5분)은 **Max 구독자 환경에서 잘못된 값**입니다.
>
> 현재 세션 transcript에서 `ephemeral_1h_input_tokens: 1229, ephemeral_5m_input_tokens: 0`을 확인 — **1시간 TTL이 적용 중**입니다. 실제 캐시가 55분 더 유효한데 5분 후 expired를 표시하는 거짓 경보가 발생합니다.
>
> 후속 이슈 #451에서 동적 TTL 감지 및 캐시 토큰 활용을 다룹니다.

### 외부 레퍼런스

- [Reddit: PSA: Claude Code has two cache bugs](https://www.reddit.com/r/ClaudeCode/comments/1s7mitf/psa_claude_code_has_two_cache_bugs_that_can/) — Max 구독자 캐시 TTL 버그 보고
- [GitHub Issue anthropics/claude-code#43566](https://github.com/anthropics/claude-code/issues/43566) — Cache TTL silently downgrades from 1h to 5m when Extra Usage is active
- [Wentuo Blog: Claude Code Prompt Caching TTL Guide](https://blog.wentuo.ai/ko/claude-code-prompt-caching-ttl-pricing-guide-ko.html) — Max vs Pro TTL 비교, 비용 구조 분석
- [DeepWiki: Claude Code Cache TTL 분석](https://deepwiki.com/search/claude-code-ttl_3d286420-b0ba-42be-bda2-d0a5313b43cd?mode=fast) — claude-code 코드베이스 기반 LLM 분석. 5분/1시간 TTL 구조, `lastApiCompletionTimestamp` 기반 TTL 추적, `checkResponseForCacheBreak()` 감지 로직 설명.
- [Anthropic Docs: Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) — 프롬프트 캐시 공식 문서. 5분 TTL 명시.

<details>
<summary>Claude Code 소스 근거 (주장별 정리)</summary>

| 주장 | 근거 파일 | 내용 |
|------|---------|------|
| 5분 TTL | `src/services/api/promptCacheBreakDetection.ts:122-126` | `CACHE_TTL_5MIN_MS = 5 * 60 * 1000`, "Anthropic's server-side prompt cache TTL thresholds" |
| Stop = 최종 응답 완료 | `src/query.ts:864,1267` | `query_api_streaming_end` 체크포인트 후 Stop hooks 호출 |
| 도구 실행 중 Stop 없음 | `src/tools/BashTool/BashTool.tsx` | `registerForeground()` — 도구 완료 전까지 Stop 미호출 |
| Escape 시 Stop 없음 | `src/query/stopHooks.ts:282-294` | abort signal 감지 시 Stop hooks 즉시 중단 |
| Thinking 중 Stop 없음 | `src/query.ts:152-160,864` | thinking은 스트리밍의 일부, 스트리밍 완료 후에만 Stop |

> 참고: 위 파일 경로는 로컬 claude-code 코드베이스(`/Users/green/Workspace/claude-code/`)에서 확인한 것으로, 공개 GitHub 레포에서는 경로가 다를 수 있습니다.
</details>

## Human Test Plan

### 정상 동작 검증

1. 새 Claude Code 세션을 시작하고 프롬프트를 제출한다.
   - **기대**: statusline에 카운트다운이 시작됨 (5:00 고정이 아님, 초 단위로 감소)
   - **실패 시**: `cat ~/.local/share/claude-hooks/last-stop-*` 로 파일 값 확인

2. LLM 응답이 완료될 때까지 기다린다.
   - **기대**: Stop 훅이 타임스탬프를 기록하고, 카운트다운이 ~5:00으로 리셋됨
   - **실패 시**: Stop 훅 실행 여부 확인 (`ls -la ~/.local/share/claude-hooks/`)

3. 유휴 상태에서 5분 대기한다.
   - **기대**: 카운트다운이 자연스럽게 5:00→4:00→...→0:00→expired로 전환
   - **실패 시**: statusline.sh의 render_cache_ttl 함수 동작 확인

### 중단 케이스

4. 프롬프트 제출 후 즉시 Escape로 중단한다.
   - **기대**: 카운트다운이 ~5:00에서 시작하여 자연 감소 (5:00 고정 아님)
   - **실패 시**: "0" sentinel 파일의 mtime 확인

### Stop 훅 순서

5. LLM 응답 완료 후 `cat ~/.local/share/claude-hooks/last-stop-*`로 파일 확인
   - **기대**: 타임스탬프가 기록되어 있음 (Stop 직후 즉시)

## Pre-Merge E2E 테스트 가이드

<details>
<summary>Phase 0-2 상세</summary>

### Phase 0: 정적 검증

```bash
# 1. render_cache_ttl 함수 존재 확인
grep -q 'render_cache_ttl()' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 2. "0" 분기에서 render_cache_ttl 호출 확인
grep -A5 'last_stop.*=.*"0"' modules/shared/programs/claude/files/scripts/statusline.sh | grep -q 'render_cache_ttl'
# 기대: exit 0

# 3. old 5:00 고정 표시 부재 확인
! grep -q '"5:00"' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: exit 0

# 4. record-last-stop.sh가 Stop 훅 첫 번째인지 확인
python3 -c "
import json
with open('modules/shared/programs/claude/files/settings.json') as f:
    s = json.load(f)
hooks = s['hooks']['Stop'][0]['hooks']
assert hooks[0]['command'].endswith('record-last-stop.sh'), f'Expected record-last-stop.sh first, got {hooks[0][\"command\"]}'
print('OK: record-last-stop.sh is first Stop hook')
"

# 5. ordering contract 주석 존재 확인
grep -q '첫 번째로 실행되어야' modules/shared/programs/claude/files/hooks/record-last-stop.sh
# 기대: exit 0
```

### Phase 1: 기능 검증 (수동)

> statusline은 실시간 UI이므로 자동 검증이 제한적입니다. 새 세션에서 직접 확인하세요.

### Phase 2: Regression

```bash
# epoch 타임스탬프 분기도 render_cache_ttl 사용하는지 확인
grep -c 'render_cache_ttl' modules/shared/programs/claude/files/scripts/statusline.sh
# 기대: 3 이상 (정의 1 + "0" 호출 1 + epoch 호출 1 = 최소 3)

# settings.json JSON 유효성
python3 -c "import json; json.load(open('modules/shared/programs/claude/files/settings.json'))"
# 기대: exit 0

# shellcheck 통과
shellcheck modules/shared/programs/claude/files/scripts/statusline.sh modules/shared/programs/claude/files/hooks/record-last-stop.sh modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
# 기대: exit 0 또는 기존 SC 경고만
```
</details>
