### PR TITLE
feat(claude): Cache TTL 1시간 대응 + 캐시 히트/미스 표시 (#451)

### DIFF
--- a/modules/shared/programs/claude/files/docs/cache-guide.md
+++ b/modules/shared/programs/claude/files/docs/cache-guide.md
@@ -28,7 +28,7 @@
 
 **적중 시 리셋**: TTL은 캐시가 적중(hit)할 때마다 리셋된다.
 연속 대화 중에는 매 요청마다 리셋되므로 사실상 만료되지 않는다.
-`expired`는 유휴 상태에서만 발생한다.
+`expired`는 주로 유휴 상태에서 발생한다. 요청 중단(Escape/Ctrl+C) 시에도 표시될 수 있다.
 
 ### 히트율 (✓ / △ / ✗)
 
@@ -75,7 +75,7 @@
 
 ### Bug 1: Sentinel Replacement
 
-Claude Code standalone binary(228MB ELF)에 billing sentinel(`cch=00000`) 교체 로직이 존재.
+Claude Code standalone binary에 billing sentinel(`cch=00000`) 교체 로직이 존재.
 대화 내용에 sentinel 문자열이 포함되면 `messages[]`의 sentinel이 먼저 교체되어
 **매 요청마다 캐시 prefix가 변경** → 캐시 full rebuild.
 
@@ -83,14 +83,14 @@ Claude Code standalone binary(228MB ELF)에 billing sentinel(`cch=00000`) 교체
 - **감지**: statusline에서 매 턴 ✗ (red) 표시
 - **회피**: `npx @anthropic-ai/claude-code`로 실행 (standalone 대신 npm 패키지)
 
-### Bug 2: --resume Cache Miss (v2.1.69~)
+### Bug 2: --resume Cache Miss (v2.1.69~v2.1.96, **수정됨**)
 
 `--resume` 시 `deferred_tools_delta`가 `messages[N]`(끝)에 추가되어
 `messages[0]`의 내용이 달라짐 → 캐시 prefix 불일치 → resume 첫 요청에서 full cache miss.
 
 - **영향**: resume마다 ~$0.15 일회성 비용 (500K 컨텍스트)
 - **감지**: resume 직후 ✗, 이후 ✓로 회복
-- **회피**: 없음 (v2.1.68 핀닝 외)
+- **수정**: [v2.1.97](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md#2197)에서 수정됨
 
 ## Max 구독자 특이사항
 

--- a/modules/shared/programs/claude/files/docs/cache-guide.md
+++ b/modules/shared/programs/claude/files/docs/cache-guide.md
@@ -104,8 +104,8 @@ Max 구독자는 1시간 캐시 TTL이 적용된다. Claude Code 소스의 `shou
 
 ### TTL 감지 방법
 
-statusline은 transcript JSONL에서 `cache_creation.ephemeral_1h_input_tokens` 필드를 파싱하여
-1시간 TTL 적용 여부를 감지한다. 한번 감지되면 세션 내에서 유지 (sticky).
+statusline은 transcript JSONL에서 가장 최근 `cache_creation` 필드의 TTL 타입을 파싱하여
+1시간/5분 TTL을 동적으로 감지한다. Extra Usage 진입 시 5분으로 자동 복귀한다.
 
 `CLAUDE_CACHE_TTL` 환경변수로 수동 override 가능:
 ```bash

--- a/modules/shared/programs/claude/files/docs/cache-guide.md
+++ b/modules/shared/programs/claude/files/docs/cache-guide.md
@@ -1,0 +1,130 @@
+# Claude Code Prompt Cache Guide
+
+## Statusline 표시
+
+```
+⏱️ 54:32 ✓98%     ← TTL 카운트다운 + 캐시 히트율
+💤 expired ✓98%   ← TTL 만료 + 마지막 히트율
+```
+
+### TTL 카운트다운
+
+프롬프트 캐시의 남은 유효 시간. 마지막 API 응답(Stop) 이후 경과 시간 기준.
+
+| 구독 플랜 | TTL | 카운트다운 |
+|----------|-----|----------|
+| Pro | 5분 | 5:00 → 0:00 |
+| **Max** | **1시간** | **60:00 → 0:00** |
+| API | 5분 | 5:00 → 0:00 |
+
+**색상 의미** (TTL에 비례):
+
+| 색상 | 5분 TTL | 1시간 TTL | 의미 |
+|------|---------|----------|------|
+| Green | ≥2분 | ≥24분 | 여유 있음 |
+| Yellow | 1~2분 | 12~24분 | 곧 만료 |
+| Red | <1분 | <12분 | 임박 |
+| Muted | expired | expired | 만료됨 |
+
+**적중 시 리셋**: TTL은 캐시가 적중(hit)할 때마다 리셋된다.
+연속 대화 중에는 매 요청마다 리셋되므로 사실상 만료되지 않는다.
+`expired`는 유휴 상태에서만 발생한다.
+
+### 히트율 (✓ / △ / ✗)
+
+현재 턴의 캐시 효율. `cache_read_input_tokens`와 `cache_creation_input_tokens`로 계산.
+
+```
+히트율 = cache_read / (cache_read + cache_creation) × 100%
+```
+
+| 표시 | 히트율 | 의미 |
+|------|--------|------|
+| ✓98% (green) | ≥80% | 정상 — 대부분의 컨텍스트가 캐시에서 로드됨 |
+| △72% (yellow) | 50~79% | 주의 — 캐시 일부 재생성. 컨텍스트 변경이 있었을 수 있음 |
+| ✗12% (red) | <50% | 문제 — 캐시 대부분 재생성. 아래 원인 확인 필요 |
+
+## 건강상태 판단
+
+### 정상 세션의 기대치
+
+- **일반적 세션**: 95~99% (연속 대화 시)
+- **세션 초반 (cold start)**: 첫 1~3턴은 캐시 미스 정상 (캐시 빌드 중)
+- **컨텍스트 compaction 직후**: 일시적으로 낮아질 수 있음 (곧 회복)
+
+### 히트율이 낮은 원인
+
+| 증상 | 원인 | 대응 |
+|------|------|------|
+| 매 턴마다 ✗ 표시 | Sentinel replacement bug | npm 패키지로 전환 |
+| --resume 직후 ✗ | Resume cache miss bug | 알려진 이슈, 첫 턴만 영향 |
+| 갑자기 ✗ 전환 | 대규모 컨텍스트 변경 | 정상 동작, 다음 턴에 회복 |
+| 항상 ✗ | Extra Usage 다운그레이드 | 플랜 확인 (5분 TTL로 변경됨) |
+
+### 비용 영향
+
+캐시 미스 시 추가 비용 (500K 컨텍스트 기준):
+
+| 상황 | 추가 비용 | 빈도 |
+|------|----------|------|
+| Sentinel bug 활성 | ~$0.04/요청 | 매 요청 |
+| Resume 캐시 미스 | ~$0.15 | Resume 1회 |
+| 정상 cold start | ~$0.15 | 세션 시작 1회 |
+
+## 알려진 캐시 버그
+
+### Bug 1: Sentinel Replacement
+
+Claude Code standalone binary(228MB ELF)에 billing sentinel(`cch=00000`) 교체 로직이 존재.
+대화 내용에 sentinel 문자열이 포함되면 `messages[]`의 sentinel이 먼저 교체되어
+**매 요청마다 캐시 prefix가 변경** → 캐시 full rebuild.
+
+- **영향**: 매 요청 ~$0.04 추가 (500K 컨텍스트 기준)
+- **감지**: statusline에서 매 턴 ✗ (red) 표시
+- **회피**: `npx @anthropic-ai/claude-code`로 실행 (standalone 대신 npm 패키지)
+
+### Bug 2: --resume Cache Miss (v2.1.69~)
+
+`--resume` 시 `deferred_tools_delta`가 `messages[N]`(끝)에 추가되어
+`messages[0]`의 내용이 달라짐 → 캐시 prefix 불일치 → resume 첫 요청에서 full cache miss.
+
+- **영향**: resume마다 ~$0.15 일회성 비용 (500K 컨텍스트)
+- **감지**: resume 직후 ✗, 이후 ✓로 회복
+- **회피**: 없음 (v2.1.68 핀닝 외)
+
+## Max 구독자 특이사항
+
+### 1시간 TTL
+
+Max 구독자는 1시간 캐시 TTL이 적용된다. Claude Code 소스의 `should1hCacheTTL()` 함수에서
+`isClaudeAISubscriber() && !currentLimits.isUsingOverage` 조건으로 판단.
+
+**Extra Usage 시 다운그레이드**: 5시간/7일 사용량 초과로 Extra Usage에 진입하면
+1시간 → 5분 TTL로 자동 다운그레이드된다.
+
+### TTL 감지 방법
+
+statusline은 transcript JSONL에서 `cache_creation.ephemeral_1h_input_tokens` 필드를 파싱하여
+1시간 TTL 적용 여부를 감지한다. 한번 감지되면 세션 내에서 유지 (sticky).
+
+`CLAUDE_CACHE_TTL` 환경변수로 수동 override 가능:
+```bash
+export CLAUDE_CACHE_TTL=300   # 5분 TTL 강제
+export CLAUDE_CACHE_TTL=3600  # 1시간 TTL 강제
+```
+
+## 최적화 팁
+
+1. **연속 대화 유지**: 유휴 시간을 TTL 내로 유지하면 캐시가 리셋되어 계속 유효
+2. **npm 패키지 사용**: `npx @anthropic-ai/claude-code`로 sentinel bug 회피
+3. **resume 최소화**: 가능하면 기존 세션 유지 (resume마다 캐시 미스 1회)
+4. **Extra Usage 모니터링**: rate limits 진행률 바 확인 (statusline 하단)
+
+## 레퍼런스
+
+- [Anthropic Docs: Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
+- [Reddit: Claude Code Cache Bugs (역공학 분석)](https://www.reddit.com/r/ClaudeCode/comments/1s7mitf/)
+- [GitHub: Cache TTL downgrades from 1h to 5m](https://github.com/anthropics/claude-code/issues/43566)
+- [GitHub: Sentinel replacement bug](https://github.com/anthropics/claude-code/issues/40524)
+- [GitHub: --resume cache miss](https://github.com/anthropics/claude-code/issues/34629)
+- [cc-diag: Cache test script](https://gitlab.com/treetank/cc-diag/-/raw/c126a7890f2ee12f76d91bfb1cc92612ae95284e/test_cache.py)

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -205,8 +205,12 @@ fi
 #   grep 대신 jq: user 메시지에 포함된 필드명 텍스트 오탐 방지 (DA Regression-F2).
 #   sticky: 이전 heavy에서 감지한 CACHE_TTL을 vars에서 복원.
 #     pure cache hit(cache_creation 없음)에서는 이전 값을 유지한다.
+#     실측: 매 턴 새 메시지 추가로 cache_creation > 0 (최솟값 ~120 tokens),
+#     ephemeral 상세도 항상 존재하므로 pure hit에 의한 stale은 발생하지 않음.
 #     cache_creation이 있는 가장 최근 메시지의 TTL 타입으로 업데이트한다.
 #   다운그레이드 감지: 마지막 cache_creation이 5m이면 300으로 복귀.
+#     Extra Usage 진입 후에도 기존 1h 캐시는 유효하므로 3600 유지가 정확하고,
+#     캐시 만료 시 새 creation(5m 타입)이 발생하면 자동 감지한다.
 # 우선순위: CLAUDE_CACHE_TTL env > transcript 감지 > vars 캐시 > 기본값 300
 CACHE_TTL=300
 if [ -f "${HEAVY_STATE}.vars" ]; then

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -42,6 +42,10 @@ fi
 IS_SSH=false
 [ -n "$SSH_CONNECTION" ] && IS_SSH=true
 
+# 캐시 가이드 URL (TTL + 히트율 아이콘 클릭 시 브라우저에서 열림)
+CACHE_GUIDE_URL="https://github.com/greenheadHQ/nixos-config/blob/main/modules/shared/programs/claude/files/docs/cache-guide.md"
+$IS_SSH && CACHE_GUIDE_URL=""
+
 # 256-color 고정 그레이 — 터미널 팔레트 의존 \e[90m 대신 사용
 # Termius 등 bright black을 검정으로 렌더링하는 터미널에서 가시성 확보
 MUTED="38;5;242"   # #6c6c6c
@@ -203,9 +207,10 @@ fi
 #   sticky: 한번 3600 감지 후 재감지 skip (pure cache hit에서 ephemeral_1h=0 대응, DA Correctness-F1).
 #   다운그레이드(1h→5m) 감지는 별도 이슈로 분리.
 if [ "${CACHE_TTL:-300}" -ne 3600 ] && [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
-  _1h=$(tac "$TRANSCRIPT" \
-    | jq -r 'select(.message.usage.cache_creation.ephemeral_1h_input_tokens > 0) | "1"' 2>/dev/null \
-    | head -1)
+  # 정순 파싱 + tail -1로 마지막 매칭을 취함 (tac 의존성 제거, DA Correctness-F1).
+  # jq만 필요 (이미 보장됨). macOS/Linux 모두 동작.
+  _1h=$(jq -r 'select(.message.usage.cache_creation.ephemeral_1h_input_tokens > 0) | "1"' \
+    "$TRANSCRIPT" 2>/dev/null | tail -1)
   [ "$_1h" = "1" ] && CACHE_TTL=3600
 fi
 
@@ -324,7 +329,7 @@ _render_cache_hit() {
 render_cache_ttl() {
   local remaining=$1
   if [ "$remaining" -le 0 ]; then
-    print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
+    print_icon "$MUTED" "$CACHE_GUIDE_URL" "\xf0\x9f\x92\xa4" "expired"
     _render_cache_hit
     return
   fi
@@ -339,7 +344,7 @@ render_cache_ttl() {
   elif [ "$remaining" -ge "$yellow_th" ]; then cache_color="33"
   else cache_color="31"
   fi
-  print_icon "$cache_color" "" "\xe2\x8f\xb1\xef\xb8\x8f" "$cache_label"
+  print_icon "$cache_color" "$CACHE_GUIDE_URL" "\xe2\x8f\xb1\xef\xb8\x8f" "$cache_label"
   _render_cache_hit
 }
 

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -25,7 +25,6 @@ mkdir -p "$HEAVY_CACHE_DIR"
 HEAVY_STATE="${HEAVY_CACHE_DIR}/heavy-${SESSION_ID}"
 HEAVY_INTERVAL=10
 DO_HEAVY=true
-CACHE_TTL=300  # 기본값 (5분). 우선순위: CLAUDE_CACHE_TTL env > transcript 감지 > 기본값
 
 if [ -f "$HEAVY_STATE" ]; then
   last_heavy=$(head -1 "$HEAVY_STATE" 2>/dev/null || echo 0)
@@ -204,8 +203,14 @@ fi
 # v2 (이번): Max 구독자 1시간 TTL 대응. transcript에서 assistant usage의
 #   cache_creation.ephemeral_1h_input_tokens를 jq로 파싱하여 감지.
 #   grep 대신 jq: user 메시지에 포함된 필드명 텍스트 오탐 방지 (DA Regression-F2).
-#   sticky: 한번 3600 감지 후 재감지 skip (pure cache hit에서 ephemeral_1h=0 대응, DA Correctness-F1).
+#   sticky: 이전 heavy에서 감지한 CACHE_TTL을 vars에서 복원하여 3600이면 재스캔 skip.
+#     이렇게 하면 1h 세션에서 10초마다 불필요한 전체 transcript 스캔을 방지한다.
 #   다운그레이드(1h→5m) 감지는 별도 이슈로 분리.
+# 우선순위: CLAUDE_CACHE_TTL env > transcript 감지 > vars 캐시 > 기본값 300
+CACHE_TTL=300
+if [ -f "${HEAVY_STATE}.vars" ]; then
+  eval "$(grep '^CACHE_TTL=' "${HEAVY_STATE}.vars" 2>/dev/null)" 2>/dev/null || true
+fi
 if [ "${CACHE_TTL:-300}" -ne 3600 ] && [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
   # 정순 파싱 + tail -1로 마지막 매칭을 취함 (tac 의존성 제거, DA Correctness-F1).
   # jq만 필요 (이미 보장됨). macOS/Linux 모두 동작.

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -25,6 +25,7 @@ mkdir -p "$HEAVY_CACHE_DIR"
 HEAVY_STATE="${HEAVY_CACHE_DIR}/heavy-${SESSION_ID}"
 HEAVY_INTERVAL=10
 DO_HEAVY=true
+CACHE_TTL=300  # 기본값 (5분). 우선순위: CLAUDE_CACHE_TTL env > transcript 감지 > 기본값
 
 if [ -f "$HEAVY_STATE" ]; then
   last_heavy=$(head -1 "$HEAVY_STATE" 2>/dev/null || echo 0)
@@ -193,15 +194,39 @@ if [ -n "$TRANSCRIPT" ]; then
   fi
 fi
 
+# -- Cache TTL 동적 감지 --
+# === Change Intent Record ===
+# v1 (PR #444): CACHE_TTL=300 하드코딩 (5분 전용).
+# v2 (이번): Max 구독자 1시간 TTL 대응. transcript에서 assistant usage의
+#   cache_creation.ephemeral_1h_input_tokens를 jq로 파싱하여 감지.
+#   grep 대신 jq: user 메시지에 포함된 필드명 텍스트 오탐 방지 (DA Regression-F2).
+#   sticky: 한번 3600 감지 후 재감지 skip (pure cache hit에서 ephemeral_1h=0 대응, DA Correctness-F1).
+#   다운그레이드(1h→5m) 감지는 별도 이슈로 분리.
+if [ "${CACHE_TTL:-300}" -ne 3600 ] && [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  _1h=$(tac "$TRANSCRIPT" \
+    | jq -r 'select(.message.usage.cache_creation.ephemeral_1h_input_tokens > 0) | "1"' 2>/dev/null \
+    | head -1)
+  [ "$_1h" = "1" ] && CACHE_TTL=3600
+fi
+
 # -- Heavy 결과 저장 --
-printf 'PLAN_FILE=%q\nMEMORY_LINK=%q\nMEMORY_LABEL=%q\n' \
-  "$PLAN_FILE" "$MEMORY_LINK" "$MEMORY_LABEL" > "${HEAVY_STATE}.vars"
+printf 'PLAN_FILE=%q\nMEMORY_LINK=%q\nMEMORY_LABEL=%q\nCACHE_TTL=%q\n' \
+  "$PLAN_FILE" "$MEMORY_LINK" "$MEMORY_LABEL" "$CACHE_TTL" > "${HEAVY_STATE}.vars"
 echo "$NOW" > "$HEAVY_STATE"
 
 else
   # -- Light run: 캐시된 변수 복원 --
   # shellcheck source=/dev/null
   source "${HEAVY_STATE}.vars" 2>/dev/null || true
+fi
+
+# --- CACHE_TTL 환경변수 override ---
+# CLAUDE_CACHE_TTL이 설정되면 transcript 감지/캐시 값을 덮어씀.
+# Pro/API 사용자 대응 및 디버깅 용도.
+# source 이후에 적용하여 light run 캐시 복원을 확실히 덮어씀 (DA Regression-F3).
+# 숫자 검증: -gt 0 비교가 비숫자를 자동 거부 (DA Correctness-F2).
+if [ -n "${CLAUDE_CACHE_TTL:-}" ] && [ "$CLAUDE_CACHE_TTL" -gt 0 ] 2>/dev/null; then
+  CACHE_TTL=$CLAUDE_CACHE_TTL
 fi
 
 # --- Status icons 읽기 ---
@@ -239,8 +264,17 @@ if command -v jq >/dev/null 2>&1; then
     @sh "RATE_5H=\(.rate_limits.five_hour.used_percentage // "")",
     @sh "RATE_5H_RESET=\(.rate_limits.five_hour.resets_at // "")",
     @sh "RATE_7D=\(.rate_limits.seven_day.used_percentage // "")",
-    @sh "RATE_7D_RESET=\(.rate_limits.seven_day.resets_at // "")"
+    @sh "RATE_7D_RESET=\(.rate_limits.seven_day.resets_at // "")",
+    @sh "CACHE_READ=\(.context_window.current_usage.cache_read_input_tokens // 0)",
+    @sh "CACHE_CREATE=\(.context_window.current_usage.cache_creation_input_tokens // 0)"
   ' 2>/dev/null)" 2>/dev/null || true
+fi
+
+# --- 캐시 히트율 계산 ---
+CACHE_HIT_PCT=""
+_cache_total=$((${CACHE_READ:-0} + ${CACHE_CREATE:-0}))
+if [ "$_cache_total" -gt 0 ] 2>/dev/null; then
+  CACHE_HIT_PCT=$((${CACHE_READ:-0} * 100 / _cache_total))
 fi
 
 # --- 출력 ---
@@ -266,24 +300,47 @@ print_icon() {
   HAS_OUTPUT=true
 }
 
+# _render_cache_hit: 캐시 히트율 suffix 출력 (render_cache_ttl 내부에서 호출)
+# CACHE_HIT_PCT 전역 변수 참조. 비어있으면 아무것도 출력하지 않음.
+_render_cache_hit() {
+  [ -z "$CACHE_HIT_PCT" ] && return
+  local sym color
+  if [ "$CACHE_HIT_PCT" -ge 80 ] 2>/dev/null; then
+    sym=$'\xe2\x9c\x93'; color="32"      # ✓ green
+  elif [ "$CACHE_HIT_PCT" -ge 50 ] 2>/dev/null; then
+    sym=$'\xe2\x96\xb3'; color="33"      # △ yellow
+  else
+    sym=$'\xe2\x9c\x97'; color="31"      # ✗ red
+  fi
+  printf ' %b' "\e[${color}m${sym}"
+  printf '%s%%' "$CACHE_HIT_PCT"
+  printf '%b' "\e[0m"
+}
+
 # render_cache_ttl: 캐시 TTL 남은 시간을 색상 + 아이콘으로 출력
-# $1=remaining_seconds → green(≥2min) / yellow(1-2min) / red(<1min) / muted(expired)
+# $1=remaining_seconds. 색상 임계값은 CACHE_TTL에 비례 (DA 합의).
+# 5분 TTL: green≥2m, yellow≥1m, red<1m (기존과 동일)
+# 1시간 TTL: green≥24m, yellow≥12m, red<12m
 render_cache_ttl() {
   local remaining=$1
   if [ "$remaining" -le 0 ]; then
     print_icon "$MUTED" "" "\xf0\x9f\x92\xa4" "expired"
+    _render_cache_hit
     return
   fi
   local minutes=$((remaining / 60))
   local seconds=$((remaining % 60))
   local cache_label
   cache_label=$(printf '%d:%02d' "$minutes" "$seconds")
+  local green_th=$((CACHE_TTL * 40 / 100))
+  local yellow_th=$((CACHE_TTL * 20 / 100))
   local cache_color
-  if [ "$remaining" -ge 120 ]; then cache_color="32"
-  elif [ "$remaining" -ge 60 ]; then cache_color="33"
+  if [ "$remaining" -ge "$green_th" ]; then cache_color="32"
+  elif [ "$remaining" -ge "$yellow_th" ]; then cache_color="33"
   else cache_color="31"
   fi
   print_icon "$cache_color" "" "\xe2\x8f\xb1\xef\xb8\x8f" "$cache_label"
+  _render_cache_hit
 }
 
 # rate_color: 사용률에 따른 ANSI 색상 코드 반환
@@ -404,8 +461,6 @@ if [ -n "$SESSION_ID" ]; then
 else
   LAST_STOP_FILE="${CACHE_TTL_DIR}/last-stop"
 fi
-CACHE_TTL=300  # 5분
-
 if [ -f "$LAST_STOP_FILE" ]; then
   last_stop=$(cat "$LAST_STOP_FILE" 2>/dev/null)
   if [ -n "$last_stop" ] 2>/dev/null; then

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -203,20 +203,25 @@ fi
 # v2 (이번): Max 구독자 1시간 TTL 대응. transcript에서 assistant usage의
 #   cache_creation.ephemeral_1h_input_tokens를 jq로 파싱하여 감지.
 #   grep 대신 jq: user 메시지에 포함된 필드명 텍스트 오탐 방지 (DA Regression-F2).
-#   sticky: 이전 heavy에서 감지한 CACHE_TTL을 vars에서 복원하여 3600이면 재스캔 skip.
-#     이렇게 하면 1h 세션에서 10초마다 불필요한 전체 transcript 스캔을 방지한다.
-#   다운그레이드(1h→5m) 감지는 별도 이슈로 분리.
+#   sticky: 이전 heavy에서 감지한 CACHE_TTL을 vars에서 복원.
+#     pure cache hit(cache_creation 없음)에서는 이전 값을 유지한다.
+#     cache_creation이 있는 가장 최근 메시지의 TTL 타입으로 업데이트한다.
+#   다운그레이드 감지: 마지막 cache_creation이 5m이면 300으로 복귀.
 # 우선순위: CLAUDE_CACHE_TTL env > transcript 감지 > vars 캐시 > 기본값 300
 CACHE_TTL=300
 if [ -f "${HEAVY_STATE}.vars" ]; then
   eval "$(grep '^CACHE_TTL=' "${HEAVY_STATE}.vars" 2>/dev/null)" 2>/dev/null || true
 fi
-if [ "${CACHE_TTL:-300}" -ne 3600 ] && [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
-  # 정순 파싱 + tail -1로 마지막 매칭을 취함 (tac 의존성 제거, DA Correctness-F1).
-  # jq만 필요 (이미 보장됨). macOS/Linux 모두 동작.
-  _1h=$(jq -r 'select(.message.usage.cache_creation.ephemeral_1h_input_tokens > 0) | "1"' \
-    "$TRANSCRIPT" 2>/dev/null | tail -1)
-  [ "$_1h" = "1" ] && CACHE_TTL=3600
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  # 가장 최근 cache_creation의 TTL 타입을 감지 (jq, macOS/Linux 모두 동작).
+  # 1h → 3600, 5m → 300, cache_creation 없음(pure hit) → empty(이전 값 유지).
+  _detected=$(jq -r '
+    select(.message.usage.cache_creation)
+    | if .message.usage.cache_creation.ephemeral_1h_input_tokens > 0 then "3600"
+      elif .message.usage.cache_creation.ephemeral_5m_input_tokens > 0 then "300"
+      else empty end
+  ' "$TRANSCRIPT" 2>/dev/null | tail -1)
+  [ -n "$_detected" ] && CACHE_TTL="$_detected"
 fi
 
 # -- Heavy 결과 저장 --


### PR DESCRIPTION
## Summary

- Max 구독자의 1시간 TTL을 transcript 파싱으로 동적 감지하여 거짓 expired 제거
- 캐시 히트/미스 비율(✓/△/✗)을 TTL 카운트다운 옆에 실시간 표시
- 아이콘 클릭 시 GitHub의 포괄적 캐시 가이드 문서를 브라우저에서 열기

Closes #451

## 기존 문제/배경

`CACHE_TTL=300` (5분) 하드코딩으로 Max 구독자(1시간 TTL)가 5분 후 거짓 `expired`를 표시.
실제 캐시는 55분 더 유효한데 statusline이 만료로 오표시하여 사용자가 캐시 상태를 오판.

또한 `cache_read_input_tokens`와 `cache_creation_input_tokens`가 statusline stdin에 이미 포함되어 있지만 활용되지 않아, 알려진 캐시 버그(sentinel replacement, resume cache miss) 발생 시 사용자가 인지할 수 없었음.

## CIR (Change Intent Record)

- **발견 경위**: 이슈 #451에서 Max 구독자 실측 데이터로 1시간 TTL 확인. `ephemeral_1h_input_tokens` 필드가 transcript에 존재하지만 statusline stdin에는 미포함 → transcript 파싱 필요.
- **DA for_plan에서 주요 방향 전환**:
  - `tail -20 | grep` 초안 → `tac + jq` → 최종 `jq + tail -1` (portability)
  - pure cache hit에서 `ephemeral_1h=0` → sticky 감지 도입
  - env override 숫자 검증 + source 이후 적용 (precedence 보장)
- **전수조사에서 발견**: heavy run의 `CACHE_TTL=300` 리셋으로 sticky guard가 매번 전체 transcript 재스캔 → vars 선행 복원으로 수정

## ADR (Architecture Decision Record)

### TTL 감지 방법

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `tail -20 \| grep` | 마지막 20줄에서 grep | 빠름, 단순 | 윈도우 밀림, user 메시지 오탐 | ❌ |
| `tac \| jq \| head -1` | 역순 파싱 | 정확한 JSON 필터링 | GNU tac 의존 (macOS 미보장) | ❌ |
| **`jq \| tail -1`** | 정순 파싱 + 마지막 매칭 | jq만 필요, 크로스 플랫폼 | tac과 동일 IO | ✅ |
| env override | `CLAUDE_CACHE_TTL` | 수동 제어, 디버깅 | 자동 감지 불가 | ✅ (보조) |

### 색상 임계값

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 고정 (2m/1m) | 현재 방식 유지 | 단순 | 1시간 TTL에서 96%가 green | ❌ |
| **TTL 비례 (40%/20%)** | TTL에 비례한 임계값 | 5분/1시간 모두 자연스러운 색상 전환 | 계산 추가 (미미) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `statusline.sh` | 수정 (+75/-10) | TTL 동적 감지, 히트율 표시, 비례 색상, OSC 8 링크 |
| `cache-guide.md` | 신규 (+130) | 캐시 TTL/히트율 포괄 가이드 |

### 핵심 코드

**TTL 감지 (sticky + vars 선행 복원)**:
```bash
CACHE_TTL=300
if [ -f "${HEAVY_STATE}.vars" ]; then
  eval "$(grep '^CACHE_TTL=' "${HEAVY_STATE}.vars" 2>/dev/null)" 2>/dev/null || true
fi
if [ "${CACHE_TTL:-300}" -ne 3600 ] && [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
  _1h=$(jq -r 'select(.message.usage.cache_creation.ephemeral_1h_input_tokens > 0) | "1"' \
    "$TRANSCRIPT" 2>/dev/null | tail -1)
  [ "$_1h" = "1" ] && CACHE_TTL=3600
fi
```

**히트율 (분모 0 가드)**:
```bash
CACHE_HIT_PCT=""
_cache_total=$((${CACHE_READ:-0} + ${CACHE_CREATE:-0}))
if [ "$_cache_total" -gt 0 ] 2>/dev/null; then
  CACHE_HIT_PCT=$((${CACHE_READ:-0} * 100 / _cache_total))
fi
```

## 참고 레퍼런스

- `144633b` — fix(claude): Cache TTL "0" sentinel의 5:00→expired 전환 수정 (#449, #450)
- `0050262` — feat(claude): statusline에 프롬프트 캐시 TTL 카운트다운 추가 (#444)
- [Reddit: PSA: Claude Code has two cache bugs](https://www.reddit.com/r/ClaudeCode/comments/1s7mitf/) — standalone binary 역공학으로 발견한 2개 캐시 버그
- [GitHub #43566](https://github.com/anthropics/claude-code/issues/43566) — Cache TTL downgrades from 1h to 5m
- [Anthropic Docs: Prompt Caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)

## Human Test Plan

### 1. TTL 카운트다운 확인
- Claude Code Max 구독 세션에서 프롬프트 전송 후 응답 대기
- **기대**: `⏱️ 59:XX` (1시간 카운트다운), green 색상
- **실패 시**: `CLAUDE_CACHE_TTL=3600` 환경변수로 강제 설정 후 재확인

### 2. 히트율 표시 확인
- 연속 대화에서 히트율 표시 확인
- **기대**: `✓95%` 이상 (green), 세션 초반 1-3턴은 낮을 수 있음
- **실패 시**: transcript에서 `cache_read_input_tokens` 값 확인

### 3. 아이콘 클릭 → 가이드 문서
- TTL 아이콘 클릭 (OSC 8 지원 터미널)
- **기대**: 브라우저에서 GitHub cache-guide.md 열림
- **실패 시**: OSC 8 미지원 터미널 확인 (SSH에서는 링크 비활성)

### 4. ENV override 테스트
- `CLAUDE_CACHE_TTL=300` 설정 후 세션 시작
- **기대**: 5분 TTL 카운트다운으로 전환
- `CLAUDE_CACHE_TTL=abc` 설정 시 무시되는지 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 배포 파일 존재 확인
ls ~/.claude/scripts/statusline.sh
# CACHE_TTL 하드코딩 제거 확인
grep -c 'CACHE_TTL=300  # 5분' ~/.claude/scripts/statusline.sh  # 기대: 0
# jq + tail -1 방식 확인 (tac 미사용)
grep -c 'tac ' ~/.claude/scripts/statusline.sh  # 기대: 0
# 히트율 계산 존재 확인
grep -c 'CACHE_HIT_PCT' ~/.claude/scripts/statusline.sh  # 기대: 5+
# GitHub URL 확인
grep -c 'CACHE_GUIDE_URL' ~/.claude/scripts/statusline.sh  # 기대: 4+
# cache-guide.md 존재 확인
test -f modules/shared/programs/claude/files/docs/cache-guide.md && echo "EXISTS"
```

### Phase 1: TTL 감지 검증

```bash
SESSION_ID="<현재 세션>"
TRANSCRIPT="<현재 transcript 경로>"
HEAVY_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/claude-statusline"
# heavy 캐시 초기화
rm -f "$HEAVY_DIR/heavy-${SESSION_ID}" "$HEAVY_DIR/heavy-${SESSION_ID}.vars"
# statusline 실행
echo '{"transcript_path":"'$TRANSCRIPT'","context_window":{"current_usage":{"cache_read_input_tokens":100,"cache_creation_input_tokens":0}}}' | ~/.claude/scripts/statusline.sh
# vars에서 CACHE_TTL 확인
grep CACHE_TTL "$HEAVY_DIR/heavy-${SESSION_ID}.vars"
# 기대: Max → CACHE_TTL=3600, Pro/API → CACHE_TTL=300
```

### Phase 2: Regression 검증

```bash
# 기존 아이콘 정상 표시 확인 (Plan, Memory, Rate Limits)
# nrs 빌드 성공 확인
nrs --force
# shellcheck 통과 확인
shellcheck ~/.claude/scripts/statusline.sh
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive cache guide covering status display, TTL interpretation, hit-rate calculations, health ranges, troubleshooting, and cost impacts.

* **New Features**
  * Enhanced cache status display with visual hit-rate indicators (✓/△/✗) and color-coded health signals.
  * Implemented dynamic TTL detection based on cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->