### PR TITLE
refactor(skills): create-issue Step 3 E1/E2 축약 (#470 축소)

### DIFF
--- a/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
@@ -51,10 +51,10 @@ description: |
 
 ### Step 3 — Anti-hallucination 자체 검증
 
-작성된 이슈 본문에 대해 다음을 수행한다 (LLM 친화성 체크리스트 E1/E2 참조).
+작성된 이슈 본문에 체크리스트 E1/E2를 적용한다 (규칙 상세 정의와 출처는 [`../write-handoff/references/llm-friendly-checklist.md`](../write-handoff/references/llm-friendly-checklist.md) Normative E1/E2 참조).
 
-- **E1. `[UNVERIFIED]` 라벨**: 코드베이스 직접 확인 또는 출처 링크가 없는 모든 주장에 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다. 근접 근거로부터의 추론은 `[INFERRED]`, 두 출처 상충은 `[CONFLICTING]`. 출처: [Anthropic: Reduce hallucinations](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-hallucinations), [MetaFaith (EMNLP 2025)](https://aclanthology.org/2025.emnlp-main.1505/).
-- **E2. Self-verification 패스 (CoVe 경량)**: 초안의 비자명 주장을 질문으로 변환 → `Read`/`Grep`/`gh` 재실행으로 독립 확인 → 불일치 또는 근거 부재 시 `[UNVERIFIED]` 라벨 또는 삭제. 출처: [Chain-of-Verification (arXiv 2309.11495)](https://arxiv.org/abs/2309.11495).
+- **E1**: 근거 링크 또는 코드 직접 확인이 없는 주장에 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다. 근접 근거 추론은 `[INFERRED]`, 출처 상충은 `[CONFLICTING]`.
+- **E2**: 비자명 주장을 검증 질문으로 변환 → `Read`/`Grep`/`gh` 재실행으로 독립 확인 → 불일치/근거 부재 시 라벨 또는 삭제.
 
 ### Step 4 — 라벨 자동 결정
 

--- a/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
@@ -53,7 +53,7 @@ description: |
 
 작성된 이슈 본문에 체크리스트 E1/E2를 적용한다 (규칙 상세 정의와 출처는 [`../write-handoff/references/llm-friendly-checklist.md`](../write-handoff/references/llm-friendly-checklist.md) Normative E1/E2 참조).
 
-- **E1**: 근거 링크 또는 코드 직접 확인이 없는 주장에 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다. 근접 근거 추론은 `[INFERRED]`, 출처 상충은 `[CONFLICTING]`.
+- **E1**: 근거 링크 또는 코드 직접 확인이 없거나 확신이 낮은 주장에 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다. 근접 근거 추론은 `[INFERRED]`, 출처 상충은 `[CONFLICTING]`.
 - **E2**: 비자명 주장을 검증 질문으로 변환 → `Read`/`Grep`/`gh` 재실행으로 독립 확인 → 불일치/근거 부재 시 라벨 또는 삭제.
 
 ### Step 4 — 라벨 자동 결정

--- a/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
@@ -126,7 +126,7 @@ description: |
 - 이슈 본문에 시크릿/credential/API 키를 포함하지 않는다. `.age` 복호화 값, `.env` 내용은 파일 경로만 참조한다.
 - 조회(`gh issue list`), 감사(audit), 라이프사이클(close/reopen/edit), 라벨 관리(CRUD)는 이 스킬의 범위 밖이다. `gh` CLI를 직접 사용한다.
 - `gh issue create` 실행 시 본문은 **`--body-file`로 전달**한다. HEREDOC(`$(cat <<'EOF' ... EOF)`) 방식은 본문 내부에 PoC/Reproduction 섹션의 nested `cat <<'EOF'` 예시나 독립 `EOF` 라인이 포함될 때 outer heredoc가 조기 종료되어 등록이 실패하거나 본문이 잘린다. `PoC / Reproduction` 섹션(issue-template)의 shell 재현 스니펫이 기본 기능이므로 HEREDOC 전달은 금지.
-- **근거 없는 주장 금지**: 코드베이스 직접 확인 또는 출처 링크가 없는 주장은 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다 (체크리스트 E1). `<!-- 미검증 -->` HTML 주석은 DEPRECATED.
+- **근거 없거나 확신 없는 주장 금지**: 코드베이스 직접 확인 또는 출처 링크가 없거나 확신이 낮은 주장은 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다 (체크리스트 E1). `<!-- 미검증 -->` HTML 주석은 DEPRECATED.
 
 ## 참조 자료
 


### PR DESCRIPTION
## Summary

- `create-issue` Step 3의 E1/E2 서술을 축약하고 출처 URL 중복을 제거하여, 규칙 정의/출처는 `llm-friendly-checklist.md` 정본에만 유지.
- E1/E2 **실행 규칙 bullet 2개는 로컬에 유지** — Arbiter 판정("Step 3만 읽어도 수행 가능" 요구) 반영.
- 이슈 #470 원안(sibling 의존 그래프 정리)은 DA Round 2에서 fragility가 드러나 YAGNI 판정으로 축소. Closes #470.

## 기존 문제/배경

PR #462 리뷰에서 "외부 의존성 과다" 피드백이 나왔고, #467 tracking 이슈가 이를 3개 atomic sub (#468/#469/#470)로 분해했다. #468/#469는 이미 CLOSED, #470이 마지막 sub.

#470 원안은 sibling skill 4개(`create-issue`, `plan-with-questions`, `write-handoff`, `using-claude-p`)의 의존 그래프를 신규 `dependency-graph.md`로 정리하는 것이었다. 그러나 계획 구현 후 for_pr DA Round 2에서 다음 문제가 드러났다:

- Drift 수정 대상 인벤토리의 라인 번호가 만든 순간부터 stale 위험. 실측 결과 `issue-template.md`, `write-handoff/SKILL.md` 일부 라인이 이미 문서 작성 시점부터 부정확.
- 동일 정보를 `rg -n 'llm-friendly-checklist' modules/shared/programs/claude/files/skills` 한 줄로 실시간 획득 가능. 문서화가 오히려 drift 원천.
- 참조자 4개 규모에서 메타 문서 유지 비용 > 실제 drift 비용.

순 가치가 있는 단일 변경(Step 3 E1/E2 축약)만 남기고 나머지 축소. `_shared/` 기각 근거는 이슈 #470 본문에 이미 보존되어 있다.

## CIR (Change Intent Record)

- **처음 계획**: dependency-graph.md 신규 + 정본 상단 포인터 + Step 3 축약 + patterns.md case 블록 확장 (4 파일).
- **for_plan DA (FULL)**: 5 CONFIRMED_ISSUE 모두 반영 후 사용자 승인. 자세한 판정은 계획 파일 `.claude/plans/squishy-dreaming-scroll.md`의 "DA 반영 이력" 섹션 참조.
- **1차 구현**: 계획대로 4 파일 수정, 커밋 `2ffda15`.
- **for_pr DA (FULL)**: 다시 5건 finding — Canonical Referencers "4 skills vs 5 rows" 혼동, Drift 인벤토리 stale 라인, `guide-template.md` 및 `E3` 누락, `write-handoff` 실제 참조 누락.
- **YAGNI 재평가 (사용자 피드백)**: "변경 연관성 PASS — 부정확한 인벤토리는 이번 신규 파일이 직접 도입했다"는 Arbiter 지적을 계기로 dependency-graph.md 자체의 fragility가 드러남.
- **축소 결정**: dependency-graph.md 폐기, llm-friendly-checklist.md 포인터 제거, patterns.md 복원. Step 3 축약만 유지.
- **구현 방식**: `git reset --soft HEAD~1` 후 dependency-graph.md를 `git rm`, llm-friendly-checklist.md/patterns.md는 `git checkout HEAD --`로 복원. 새 커밋 `b035915` 생성. 기존 `2ffda15`는 로컬 push 전에 버려짐.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| A. dependency-graph.md 신규 + 의존 표 + Drift 인벤토리 | 원안. 모든 참조 표면을 한 곳에 정리 | 단일 정보원, `_shared/` 기각 근거 보존 | Drift 인벤토리가 만들자마자 stale; `rg`로 실시간 대체 가능 | ❌ 기각 (fragile) |
| B. 정본 상단에 섹션으로 통합 | 별도 파일 없이 checklist 상단에 표 | 파일 수 증가 없음 | 동일한 stale 문제 | ❌ 기각 |
| **C. Step 3 E1/E2 축약만 (출처 중복 제거)** | 순 가치 있는 부분만 적용 | Fragility 없음, 영구 가치 | `_shared/` 기각 근거는 이슈 본문에만 남음 | ✅ **채택** |
| D. 전체 폐기 | 아무것도 하지 않음 | 단순 | Step 3 축약의 작은 이득 포기 | ❌ 기각 |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/skills/create-issue/SKILL.md` | Step 3 (L52-57) 4줄 수정. 출처 URL 3개 제거, E1/E2 실행 규칙 bullet 2개 유지, 체크리스트 정본 링크 추가. |

핵심 diff:

```diff
-작성된 이슈 본문에 대해 다음을 수행한다 (LLM 친화성 체크리스트 E1/E2 참조).
+작성된 이슈 본문에 체크리스트 E1/E2를 적용한다 (규칙 상세 정의와 출처는 [`../write-handoff/references/llm-friendly-checklist.md`](../write-handoff/references/llm-friendly-checklist.md) Normative E1/E2 참조).

-- **E1. `[UNVERIFIED]` 라벨**: ... 출처: [Anthropic: Reduce hallucinations](...), [MetaFaith (EMNLP 2025)](...).
-- **E2. Self-verification 패스 (CoVe 경량)**: ... 출처: [Chain-of-Verification (arXiv 2309.11495)](...).
+- **E1**: 근거 링크 또는 코드 직접 확인이 없는 주장에 `[UNVERIFIED]` 라벨을 붙이거나 삭제한다. 근접 근거 추론은 `[INFERRED]`, 출처 상충은 `[CONFLICTING]`.
+- **E2**: 비자명 주장을 검증 질문으로 변환 → `Read`/`Grep`/`gh` 재실행으로 독립 확인 → 불일치/근거 부재 시 라벨 또는 삭제.
```

## 참고 레퍼런스

- `#467` — parent tracking issue (Sub-3/3 부분 달성으로 close 예정)
- `#468` CLOSED — Sub-1 references 분리 (commit `7adca81`)
- `#469` CLOSED — Sub-2 few-shot 추가 (commit `0e06e6c`)
- `#470` — 본 PR, 축소 scope로 Closes
- `#464` — 라벨 단일 소스화 (직교, OPEN)
- `#462` — 체크리스트 도입 PR (commit `1e106f3`)
- 본 PR 커밋: `b035915` refactor(skills): create-issue Step 3 E1/E2 축약 + 출처 중복 제거 (#470 축소)
- (폐기) `2ffda15` — 축소 전 원안 커밋, 로컬에서 버려짐
- E1/E2 정의 정본: `modules/shared/programs/claude/files/skills/write-handoff/references/llm-friendly-checklist.md:42-47`

## Human Test Plan

1. **Step 3 축약 렌더링 확인**: GitHub UI에서 `modules/shared/programs/claude/files/skills/create-issue/SKILL.md` L51-59 확인. E1/E2 bullet 2줄 + 체크리스트 링크 1개가 명확히 보여야 한다. 실패 시 `git diff main...HEAD -- modules/shared/programs/claude/files/skills/create-issue/SKILL.md`.
2. **체크리스트 정본 도달성**: GitHub 렌더링에서 `llm-friendly-checklist.md` 링크 클릭 → 정본 페이지로 이동 → `E1`/`E2` rule이 존재하는지 확인.
3. **/create-issue 스킬 시나리오 (optional, 실제 이슈 생성 전)**: Step 3가 수행 규칙(E1 라벨, E2 CoVe 패스)을 실행에 필요한 만큼 제공하는지 육안으로 판단. 상세 출처가 필요하면 체크리스트 정본으로 1-hop.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```bash
cd "$(git rev-parse --show-toplevel)"
SKILL=modules/shared/programs/claude/files/skills/create-issue/SKILL.md
CHK=modules/shared/programs/claude/files/skills/write-handoff/references/llm-friendly-checklist.md

# (1) Step 3에 E1/E2 bullet 2개 유지
grep -cE '^- \*\*E[12]\*\*' "$SKILL"  # 기대: 2

# (2) Step 3에서 제거된 출처 URL 3개가 모두 사라짐
grep -cE 'Reduce hallucinations|MetaFaith|Chain-of-Verification' "$SKILL"  # 기대: 0

# (3) Step 3에서 체크리스트 정본 링크 1개 존재
grep -cE 'llm-friendly-checklist\.md\).*Normative E1/E2' "$SKILL"  # 기대: 1

# (4) 체크리스트 정본에 E1/E2 rule 여전히 존재
grep -cE '^\- \[ \] \*\*E[12]\.' "$CHK"  # 기대: 2

# (5) ai-skills-consistency / gitleaks / eval-tests 훅 통과
lefthook run pre-commit  # 기대: 모든 훅 성공
```

**성공 기준**: (1)=2, (2)=0, (3)=1, (4)=2, (5) 훅 모두 ✔️.

### Phase 1 — 기능 검증 (/create-issue 스킬 시나리오)

- 임의 이슈 아이디어로 `/create-issue`를 실행.
- **기대**: Step 1-2 수행 후 Step 3에서 E1(`[UNVERIFIED]` 라벨 부여)과 E2(CoVe 검증 패스)를 로컬 bullet으로 보고 수행 가능. 출처를 보려면 체크리스트 정본으로 1-hop.
- **실패 시 진단**: Step 3 본문이 모호하면 bullet 문구가 부족한 것 → 재축약 검토.

### Phase 2 — Regression (인접 기능)

- `/write-handoff` 스킬 실행 시 E1/E2 참조가 여전히 작동하는지 확인. 본 PR은 `write-handoff/SKILL.md`와 체크리스트의 관계를 변경하지 않음.
- **기대**: write-handoff 산출물에 `[UNVERIFIED]` 라벨 사용 규칙이 계속 적용됨.
- **실패 시**: 본 PR과 무관한 사전 드리프트. 별도 처리.

### 결과 보고

Phase 0 (1)-(5) 모두 pass → merge 가능. Phase 1-2는 실 사용 시 검증.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal skill verification guidelines for improved clarity and consistency in the verification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->