### PR TITLE
feat(nvim): snacks explorer 'o' 키로 파일을 Zed에서 열기

### DIFF
--- a/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
+++ b/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
@@ -150,17 +150,25 @@ return {
             actions = {
               -- macOS 일반 파일은 Zed로 열고, 그 외(디렉토리/non-mac/nil item)는
               -- upstream explorer_open에 위임해 snacks 업데이트 시 구현 변경을 자동 반영한다.
-              -- vararg 전달로 dispatcher가 추가 인자를 넘겨도 호환 유지.
-              explorer_open = function(...)
-                local _, item = ...
+              -- Zed launch 실패(미설치/앱명 불일치) 시 upstream으로 fallback.
+              explorer_open = function(picker, item, action)
+                local upstream = require("snacks.explorer.actions").actions.explorer_open
                 if vim.fn.has("mac") == 1 and item and not item.dir then
-                  local _, err = vim.ui.open(item.file, { cmd = { "open", "-a", "Zed" } })
-                  if err then
-                    Snacks.notify.error("Failed to open `" .. item.file .. "`:\n- " .. err)
-                  end
+                  vim.system(
+                    { "open", "-a", "Zed", item.file },
+                    { text = true },
+                    vim.schedule_wrap(function(res)
+                      if res.code ~= 0 then
+                        Snacks.notify.error(
+                          "Failed to open `" .. item.file .. "` with Zed:\n- " .. (res.stderr or "")
+                        )
+                        upstream(picker, item, action)
+                      end
+                    end)
+                  )
                   return
                 end
-                require("snacks.explorer.actions").actions.explorer_open(...)
+                upstream(picker, item, action)
               end,
             },
           },

--- a/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
+++ b/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
@@ -148,17 +148,19 @@ return {
               },
             },
             actions = {
-              -- macOS 파일은 Zed로 열고, 디렉토리/non-mac은 upstream explorer_open에 위임한다.
-              -- 위임으로 snacks 업데이트 시 upstream 구현 변경을 자동 반영한다.
-              explorer_open = function(picker, item)
-                if vim.fn.has("mac") == 1 and item and item.file and not item.dir then
+              -- macOS 일반 파일은 Zed로 열고, 그 외(디렉토리/non-mac/nil item)는
+              -- upstream explorer_open에 위임해 snacks 업데이트 시 구현 변경을 자동 반영한다.
+              -- vararg 전달로 dispatcher가 추가 인자를 넘겨도 호환 유지.
+              explorer_open = function(...)
+                local _, item = ...
+                if vim.fn.has("mac") == 1 and item and not item.dir then
                   local _, err = vim.ui.open(item.file, { cmd = { "open", "-a", "Zed" } })
                   if err then
-                    Snacks.notify.error(err)
+                    Snacks.notify.error("Failed to open `" .. item.file .. "`:\n- " .. err)
                   end
                   return
                 end
-                require("snacks.explorer.actions").actions.explorer_open(picker, item)
+                require("snacks.explorer.actions").actions.explorer_open(...)
               end,
             },
           },

--- a/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
+++ b/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
@@ -147,6 +147,21 @@ return {
                 },
               },
             },
+            actions = {
+              -- macOS 파일은 Zed, 디렉토리/non-mac은 기본 동작(Finder/xdg-open).
+              -- upstream explorer_open 동작은 유지하고 macOS 파일만 Zed로 우회한다.
+              explorer_open = function(_, item)
+                if not item then return end
+                local opts
+                if vim.fn.has("mac") == 1 and not item.dir then
+                  opts = { cmd = { "open", "-a", "Zed" } }
+                end
+                local _, err = vim.ui.open(item.file, opts)
+                if err then
+                  Snacks.notify.error(err)
+                end
+              end,
+            },
           },
           grep = {
             case_sens = false,

--- a/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
+++ b/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
@@ -148,18 +148,17 @@ return {
               },
             },
             actions = {
-              -- macOS 파일은 Zed, 디렉토리/non-mac은 기본 동작(Finder/xdg-open).
-              -- upstream explorer_open 동작은 유지하고 macOS 파일만 Zed로 우회한다.
-              explorer_open = function(_, item)
-                if not item then return end
-                local opts
-                if vim.fn.has("mac") == 1 and not item.dir then
-                  opts = { cmd = { "open", "-a", "Zed" } }
+              -- macOS 파일은 Zed로 열고, 디렉토리/non-mac은 upstream explorer_open에 위임한다.
+              -- 위임으로 snacks 업데이트 시 upstream 구현 변경을 자동 반영한다.
+              explorer_open = function(picker, item)
+                if vim.fn.has("mac") == 1 and item and item.file and not item.dir then
+                  local _, err = vim.ui.open(item.file, { cmd = { "open", "-a", "Zed" } })
+                  if err then
+                    Snacks.notify.error(err)
+                  end
+                  return
                 end
-                local _, err = vim.ui.open(item.file, opts)
-                if err then
-                  Snacks.notify.error(err)
-                end
+                require("snacks.explorer.actions").actions.explorer_open(picker, item)
               end,
             },
           },

--- a/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
+++ b/modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
@@ -159,9 +159,8 @@ return {
                     { text = true },
                     vim.schedule_wrap(function(res)
                       if res.code ~= 0 then
-                        Snacks.notify.error(
-                          "Failed to open `" .. item.file .. "` with Zed:\n- " .. (res.stderr or "")
-                        )
+                        -- Zed launch 실패 시 조용히 upstream으로 fallback.
+                        -- 최종 실패는 upstream의 vim.ui.open 에러 처리가 노출한다.
                         upstream(picker, item, action)
                       end
                     end)


### PR DESCRIPTION
## Summary
- macOS에서 snacks.nvim explorer의 `o` 키로 파일을 열 때 시스템 기본 앱(VSCode) 대신 Zed로 열리도록 `sources.explorer.actions.explorer_open`을 오버라이드.
- 디렉토리와 비-macOS(Linux/MiniPC)는 기존 `vim.ui.open` 동작(Finder/xdg-open) 유지.
- 시스템 전역 LaunchServices 기본 앱 설정은 변경하지 않음 — 영향 범위를 nvim explorer의 `o` 키 하나로 한정.

## 기존 문제 / 배경
LazyVim의 snacks explorer는 `o` 키에서 `vim.ui.open(item.file)`을 호출한다 (`~/.local/share/nvim/lazy/snacks.nvim/lua/snacks/explorer/actions.lua:120-126`). macOS에서 이는 `open <path>` → LaunchServices → 등록된 기본 텍스트 앱(현 환경: VSCode)으로 이어진다. 사용자는 nvim 내부에서 `o`를 누를 때만 Zed로 열리길 원하지만 LaunchServices 전역 기본을 바꾸면 Finder 더블클릭 등 다른 경로까지 Zed로 전환되어 범위가 지나치게 넓어진다.

## CIR (Change Intent Record)
- **발견 경위**: 사용자가 File Explorer에서 `o` 입력 시 VSCode가 열리는 현상을 보고. 디렉토리는 Finder로 잘 열리지만 파일이 원치 않는 에디터로 연결됨.
- **설계 의도**: (1) 시스템 전역 기본 앱은 불변 유지, (2) nvim 내부 바인딩만 커스터마이즈, (3) 디렉토리 동작과 Linux 동작은 그대로, (4) upstream의 에러 표면화(`Snacks.notify.error`) 계약 유지.
- **대안 검토 이력**: DA for_plan 1라운드에서 3건의 CONFIRMED_ISSUE를 수용하여 초안의 `vim.system({detach=true})` + 커스텀 `open_in_zed` 액션 + `["o"]` 키 재매핑 구조를 폐기하고 `actions.explorer_open` 오버라이드 + `vim.ui.open(path, {cmd=...})` 구조로 단순화.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `actions.explorer_open` 오버라이드 + `vim.ui.open({cmd=...})` | snacks 공식 확장 포인트 사용, upstream 에러 처리 패턴 그대로 계승 | 단순/최소 변경, 에러 노티 유지, 키 바인딩 재매핑 불필요 | 없음 | ✅ |
| 커스텀 `open_in_zed` 액션 + `["o"] = "open_in_zed"` 키 재매핑 | 새 액션 이름 도입, 명시적 키 바인딩 교체 | 의도가 네이밍으로 명시됨 | 이름이 실제 분기(dir/non-mac 포함)를 설명 못함, 키 계약 추가 | ❌ (DA MAINT-2) |
| `vim.system({"open","-a","Zed",path}, {detach=true})` 직접 호출 | `vim.ui.open` 우회 | 간단 | Zed launch 실패 시 에러가 조용히 사라짐, upstream 계약 회귀 | ❌ (DA CORR-2/REGR-1) |
| 시스템 전역 LaunchServices 기본 앱을 duti로 Zed로 설정 | nix-darwin에서 `duti` 관리 | Finder 더블클릭 등 전역 일관성 | 범위 과대, 사용자 의도 초과 | ❌ (사용자 거부) |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua` | `sources.explorer` 블록에 `actions.explorer_open` 오버라이드 15줄 추가 |

핵심 코드 (editor.lua, snacks 블록 내):

```lua
sources = {
  explorer = {
    win = { list = { keys = { ["<Space>"] = false } } },
    actions = {
      -- macOS 파일은 Zed, 디렉토리/non-mac은 기본 동작(Finder/xdg-open).
      -- upstream explorer_open 동작은 유지하고 macOS 파일만 Zed로 우회한다.
      explorer_open = function(_, item)
        if not item then return end
        local opts
        if vim.fn.has("mac") == 1 and not item.dir then
          opts = { cmd = { "open", "-a", "Zed" } }
        end
        local _, err = vim.ui.open(item.file, opts)
        if err then
          Snacks.notify.error(err)
        end
      end,
    },
  },
  grep = { ... },
},
```

**동작 매트릭스**

| 플랫폼 | 항목 타입 | 실행 명령 | 결과 |
|--------|-----------|-----------|------|
| macOS | 파일 | `open -a Zed <path>` | Zed에서 파일 오픈 |
| macOS | 디렉토리 | `open <path>` | Finder에서 디렉토리 오픈 |
| Linux | 파일/디렉토리 | `xdg-open <path>` (기본) | 기존 동작 |

## 참고 레퍼런스
- Neovim `vim.ui.open(path, opt)` 공식 시그니처 — `{cmd}` 옵션 지원: `/nix/store/.../neovim-unwrapped-0.11.6/share/nvim/runtime/lua/vim/ui.lua:138-167`.
- snacks explorer upstream `explorer_open` — `vim.ui.open` + `Snacks.notify.error` 에러 표면화 패턴: `~/.local/share/nvim/lazy/snacks.nvim/lua/snacks/explorer/actions.lua:120-126`.
- snacks picker `sources.<source>.actions[name]` 확장 포인트 — built-in보다 먼저 resolve됨: `~/.local/share/nvim/lazy/snacks.nvim/lua/snacks/picker/config/init.lua:300-307`.
- snacks explorer `item.dir`/`item.file` 필드 — render 시점에 채워짐: `~/.local/share/nvim/lazy/snacks.nvim/lua/snacks/picker/source/explorer.lua:238,283,360`.

## Human Test Plan

### 사전 조건
- macOS에서 `open -a Zed /tmp` 또는 `osascript -e 'id of app "Zed"'`로 Zed가 LaunchServices에 등록되어 있는지 확인.
- 이 PR 브랜치(`feat/nvim-explorer-open-files-in-zed`)를 체크아웃한 상태.

### Step 1 — nvim 재시작 후 파일 열기 (macOS, 골든 패스)
1. nvim 재시작 (out-of-store symlink이므로 `nrs` 불필요).
2. 저장소 루트에서 `<leader>e` → snacks explorer 열기.
3. `README.md`에 커서 두고 `o` 입력.
4. **기대**: Zed가 활성화되며 `README.md`를 열어 표시.
5. **실패 시 진단**:
   - VSCode가 열리면 → `editor.lua`의 `actions.explorer_open` 블록이 반영됐는지 확인, nvim 재시작 누락 여부 체크.
   - 아무것도 안 열리면 → `:messages`에서 `Snacks.notify.error` 노티 확인, `open -a Zed /tmp` 수동 실행 테스트.

### Step 2 — 디렉토리는 Finder 유지 (엣지 케이스 1)
1. explorer에서 `modules/` 같은 디렉토리에 커서.
2. `o` 입력.
3. **기대**: Finder 창이 해당 디렉토리로 열림.
4. **실패 시 진단**: Zed가 디렉토리를 프로젝트로 열면 → `item.dir` 분기 로직 확인 (`not item.dir` 조건).

### Step 3 — Linux(MiniPC)에서 기존 동작 유지 (엣지 케이스 2)
1. MiniPC에 접속 후 nvim에서 같은 테스트.
2. **기대**: `xdg-open` 기본 동작 그대로 (Zed 호출 없음).
3. **실패 시 진단**: `vim.fn.has("mac") == 1` 가드 오작동.

### Step 4 — 에러 처리 유지 (엣지 케이스 3)
1. 존재하지 않는 심볼릭 링크나 권한 없는 경로를 explorer에 만들어 `o` 입력.
2. **기대**: `Snacks.notify.error`로 에러 노티가 우측 상단에 표시됨.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```bash
# 1) 파일에 actions.explorer_open 블록이 존재하는지
grep -n "actions = {" modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua | head
grep -n "explorer_open = function" modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua

# 2) 핵심 키워드 존재 확인
grep -n 'vim.fn.has("mac")' modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
grep -n '"open", "-a", "Zed"' modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
grep -n "Snacks.notify.error" modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua

# 3) old 코드 부재 확인: vim.system + detach 패턴이 없어야 함
! grep -n 'vim.system.*detach.*true' modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua

# 4) Lua 구문 검증
nix shell nixpkgs#lua -c luac -p modules/shared/programs/neovim/files/nvim/lua/plugins/editor.lua
```

**기대**: 1-3번 grep은 1건 이상 매칭, 3번은 no-match(exit≠0로 `!` 통해 통과), 4번은 exit 0.

### Phase 1 — 기능 검증 (macOS 수동)

Human Test Plan의 Step 1~4와 동일. UI 기반이므로 LLM이 직접 실행할 수 없고 리뷰어가 실행한다.

### Phase 2 — Regression

1. `<leader>ff`(파일 검색), `<leader>/`(grep) 등 explorer 외 picker에서 `o` 키 동작이 기존대로 유지되는지 확인 (per-source actions이므로 영향 없음을 확인).
2. `<leader>e`로 explorer를 토글 열기/닫기 반복, 필터 입력, `<Space>` 키(picker toggle_select 해제) 동작이 기존과 동일한지 확인.
3. `:Lazy reload snacks.nvim` 후에도 오버라이드가 유지되는지 확인.

## DA 판정 요약 (참고)
DA for_plan 1라운드: CONFIRMED_ISSUE 3건 수용 후 계획 단순화. 상세는 PR 코멘트 예정.

| 판정 | 건수 | 처리 |
|------|-----:|------|
| CONFIRMED_ISSUE | 3 | 계획 반영 (CORRECTNESS-2, REGRESSION-1, MAINTAINABILITY-2) |
| NOT_AN_ISSUE | 4 | 반영 불필요 |
| NEEDS_MORE_INFO | 1 | 로컬 PoC(`open -a Zed /tmp` exit 0)로 NOT_AN_ISSUE 처리 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Customized file opening in Neovim explorer: macOS users now have files open with Zed editor by default through the explorer
  * Directory navigation and non-macOS system behavior remain unchanged
  * Enhanced error handling with notifications when file opening operations encounter issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->