### PR TITLE
feat(claude-code): system bash 3.2 가드 hook + shebang 마이그레이션

### DIFF
--- a/.claude/scripts/detect-empty-commit.sh
+++ b/.claude/scripts/detect-empty-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PostToolUse hook: git commit 후 빈 커밋 감지
 # tree hash 비교로 staging area 초기화 버그 감지 (Issue #125)
 set -euo pipefail

--- a/.claude/scripts/wrap-git-with-nix-develop.sh
+++ b/.claude/scripts/wrap-git-with-nix-develop.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PreToolUse hook: git 명령어를 nix develop 환경에서 실행
 # 이 프로젝트는 lefthook (gitleaks, shellcheck 등)을 사용하므로
 # nix develop 환경에서 git 명령어를 실행해야 함

--- a/modules/darwin/programs/folder-actions/files/scripts/compress-rar.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/compress-rar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Folder Action: RAR 압축 + 체크섬 가이드 생성
 # 감시 폴더: ~/FolderActions/compress-rar/
 # 결과물: ~/Downloads/<파일명>/<파일명>.rar + 데이터_무결성_검증방법.txt

--- a/modules/darwin/programs/folder-actions/files/scripts/compress-video.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/compress-video.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Folder Action: 비디오 H.265 압축
 # 감시 폴더: ~/FolderActions/compress-video/
 # 결과물: ~/Downloads/<타임스탬프>.mp4

--- a/modules/darwin/programs/folder-actions/files/scripts/convert-video-to-gif.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/convert-video-to-gif.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Folder Action: 비디오를 GIF로 변환
 # 감시 폴더: ~/FolderActions/convert-video-to-gif/
 # 결과물: ~/Downloads/<타임스탬프>.gif

--- a/modules/darwin/programs/folder-actions/files/scripts/rename-asset.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/rename-asset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Folder Action: 파일 이름을 타임스탬프로 변경
 # 감시 폴더: ~/FolderActions/rename-asset/
 # 결과물: ~/Downloads/<타임스탬프>.<확장자>

--- a/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Folder Action: Immich 자동 업로드
 # 감시 폴더: $WATCH_DIR (기본값: ~/FolderActions/upload-immich/)
 # 미디어 파일 → Immich 서버 업로드 → Pushover 알림 → 원본 삭제

--- a/modules/nixos/lib/generic-version-check.sh
+++ b/modules/nixos/lib/generic-version-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 서비스 버전 체크 및 Pushover 알림 (공통)
 # 매일 GitHub Releases API로 최신 버전을 확인하고, 새 버전 발견 시 알림 전송
 # 이미지에 버전 레이블이 없으므로 GitHub latest 추적 방식 사용

--- a/modules/nixos/lib/service-lib.sh
+++ b/modules/nixos/lib/service-lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # 홈서버 서비스 공통 셸 라이브러리
 # 각 서비스의 version-check, update-script, cleanup에서 source하여 사용
 # 주의: set -euo pipefail은 호출 스크립트가 선언 (라이브러리에서 선언하지 않음)

--- a/modules/nixos/programs/copyparty-update/files/update-script.sh
+++ b/modules/nixos/programs/copyparty-update/files/update-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyparty 수동 업데이트 스크립트
 # 이미지 pull → digest 비교 → 컨테이너 재시작 → 헬스체크 → 결과 알림
 # 백업 불필요 (설정은 Nix 관리, 데이터는 HDD 볼륨)

--- a/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh
+++ b/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Karakeep 웹훅 → Pushover 브리지
 # socat EXEC: 핸들러로 실행됨 (stdin=HTTP 요청, stdout=HTTP 응답)
 set -uo pipefail

--- a/modules/nixos/programs/immich-cleanup/files/cleanup-script.sh
+++ b/modules/nixos/programs/immich-cleanup/files/cleanup-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Immich 임시 앨범 자동 정리 스크립트
 # "Claude Code Temp" 앨범의 모든 이미지를 삭제
 set -euo pipefail

--- a/modules/nixos/programs/immich-update/files/update-script.sh
+++ b/modules/nixos/programs/immich-update/files/update-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Immich 수동 업데이트 스크립트
 # DB 백업 → 이미지 pull → 컨테이너 재시작 → 헬스체크 → 결과 알림
 set -euo pipefail

--- a/modules/nixos/programs/immich-update/files/version-check.sh
+++ b/modules/nixos/programs/immich-update/files/version-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Immich 버전 체크 및 Pushover 알림
 # 매일 GitHub Releases API로 최신 버전을 확인하고, 새 버전 발견 시 알림 전송
 set -euo pipefail

--- a/modules/nixos/programs/karakeep-update/files/update-script.sh
+++ b/modules/nixos/programs/karakeep-update/files/update-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Karakeep 수동 업데이트 스크립트
 # 이미지 pull → digest 비교 → 컨테이너 재시작 → 헬스체크 → 결과 알림
 set -euo pipefail

--- a/modules/nixos/programs/temp-monitor/files/check-temp.sh
+++ b/modules/nixos/programs/temp-monitor/files/check-temp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # writeShellApplication이 set -euo pipefail + shebang 자동 적용
 
 # 환경변수 검증

--- a/modules/nixos/programs/uptime-kuma-update/files/update-script.sh
+++ b/modules/nixos/programs/uptime-kuma-update/files/update-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Uptime Kuma 수동 업데이트 스크립트
 # 이미지 pull → digest 비교 → backup → 컨테이너 재시작 → 헬스체크 → 결과 알림
 set -euo pipefail

--- a/modules/nixos/programs/vaultwarden-update/files/update-script.sh
+++ b/modules/nixos/programs/vaultwarden-update/files/update-script.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Vaultwarden 수동 업데이트 스크립트
 # pinned tag 이미지 pull → digest 비교 → 안전 백업 → 재시작 → 헬스체크 → 결과 알림
 set -euo pipefail

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -161,6 +161,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/log-skill.sh";
     ".claude/hooks/fragile-hardcoding-guard.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/fragile-hardcoding-guard.sh";
+    ".claude/hooks/system-bash-guard.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/system-bash-guard.sh";
     # Cache TTL tracking hooks
     ".claude/hooks/record-last-stop.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-last-stop.sh";

--- a/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
@@ -123,7 +123,7 @@ fi
 
 [ -z "$WARNINGS" ] && exit 0
 
-# Claude Code PreToolUse hook 차단 형식: {decision: "block", reason: "..."}
+# Claude Code PreToolUse hook 차단 형식: hookSpecificOutput.permissionDecision (공식 최신 스펙)
 jq -n --arg reason "[Fragile hardcoding] ${WARNINGS}코드에서 동적 확인 가능한 정보입니다. 하드코딩 대신 확인 방법을 기술하세요." \
-  '{decision: "block", reason: $reason}'
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
 exit 0

--- a/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# PreToolUse Hook: 시스템 bash 3.2 강제 호출 차단
+# [WHY] macOS /bin/bash는 Apple의 GPLv3 회피로 3.2.x에 고정되어
+# `declare -A` 등 bash 4+ 기능이 `invalid option`으로 실패. Nix bash 5.x가
+# PATH 최상단에 있으므로 `/bin/bash` 절대경로 호출과 `#!/bin/bash` shebang을
+# 차단해 PATH-resolved bash로 유도한다.
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+
+_deny() {
+  # [WHY] 공식 최신 PreToolUse 스펙: hookSpecificOutput.permissionDecision
+  # (top-level {decision:"block"}은 legacy). permissionDecisionReason은 "deny"에서
+  # Claude에 전달되어 다음 시도를 교정한다.
+  jq -n --arg reason "$1" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+  exit 0
+}
+
+case "$TOOL_NAME" in
+  Bash)
+    CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+    # [WHY] 명령 세그먼트 시작(라인 시작, `;`, `&&`, `||`, `|`, `(`) 뒤에서
+    # `/bin/bash`가 실행되는 케이스만 매치. `grep /bin/bash README`나
+    # `test -x /bin/bash` 같은 문자열 언급은 통과.
+    # Trade-off: quoted path(`"/bin/bash"`), 변수 치환, `sudo /bin/bash`는 MISS —
+    # 주 방어선은 shebang 마이그레이션이며 여기서는 heredoc 등 주 호출 패턴 차단이 목적.
+    if printf '%s' "$CMD" | grep -Eq '(^|[;&|(])[[:space:]]*/bin/bash([[:space:]<>]|$)'; then
+      _deny "[system-bash-guard] Bash command에서 /bin/bash 절대경로 호출이 감지되었습니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 'declare -A' 등 bash 4+ 기능이 실패합니다. 대안: \`bash <<'EOF'\` (PATH-resolved). PATH 최상단의 Nix bash 5.x가 자동 선택됩니다."
+    fi
+    ;;
+  Write)
+    CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
+    if printf '%s' "$CONTENT" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
+      _deny "[system-bash-guard] Write content의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash. PATH 최상단의 Nix bash 5.x가 자동 선택됩니다."
+    fi
+    ;;
+  Edit)
+    NEW_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
+    if printf '%s' "$NEW_STR" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
+      _deny "[system-bash-guard] Edit new_string의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash. PATH 최상단의 Nix bash 5.x가 자동 선택됩니다."
+    fi
+    ;;
+esac
+
+exit 0

--- a/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
@@ -38,9 +38,29 @@ case "$TOOL_NAME" in
     fi
     ;;
   Edit)
+    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+    OLD_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.old_string // empty' 2>/dev/null)
     NEW_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
-    if printf '%s' "$NEW_STR" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
-      _deny "[system-bash-guard] Edit new_string의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash (호출 환경 PATH를 통해 bash가 해석됨; launchd/systemd처럼 PATH가 통제된 컨텍스트에서는 해당 agent의 PATH에 Nix bash 경로가 포함되는지 별도 확인 필요)."
+    # [WHY] new_string만 검사하면 partial 치환(예: old="/usr/bin/env bash",
+    # new="/bin/bash")이 post-edit shebang을 #!/bin/bash로 만들어도 우회된다.
+    # old_string을 new_string으로 치환한 전체 결과에서 검사하여 bypass를 차단.
+    # fragile-hardcoding-guard.sh:52-74의 awk 재구성 패턴을 따른다.
+    POST_EDIT=""
+    if [ -n "$OLD_STR" ] && [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ]; then
+      POST_EDIT=$(OLD_STR="$OLD_STR" NEW_STR="$NEW_STR" awk '
+        BEGIN { RS="\0"; ORS="" }
+        {
+          old = ENVIRON["OLD_STR"]; new = ENVIRON["NEW_STR"]
+          idx = index($0, old)
+          if (idx > 0) { print substr($0, 1, idx-1) new substr($0, idx+length(old)); exit 0 }
+          else { exit 1 }
+        }' "$FILE_PATH" 2>/dev/null)
+      [ -z "$POST_EDIT" ] && POST_EDIT="$NEW_STR"
+    else
+      POST_EDIT="$NEW_STR"
+    fi
+    if printf '%s' "$POST_EDIT" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
+      _deny "[system-bash-guard] Edit 결과 파일의 shebang이 #!/bin/bash입니다 (post-edit 재구성 검사). macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash (호출 환경 PATH를 통해 bash가 해석됨; launchd/systemd처럼 PATH가 통제된 컨텍스트에서는 해당 agent의 PATH에 Nix bash 경로가 포함되는지 별도 확인 필요)."
     fi
     ;;
 esac

--- a/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
@@ -28,19 +28,19 @@ case "$TOOL_NAME" in
     # Trade-off: quoted path(`"/bin/bash"`), 변수 치환, `sudo /bin/bash`는 MISS —
     # 주 방어선은 shebang 마이그레이션이며 여기서는 heredoc 등 주 호출 패턴 차단이 목적.
     if printf '%s' "$CMD" | grep -Eq '(^|[;&|(])[[:space:]]*/bin/bash([[:space:]<>]|$)'; then
-      _deny "[system-bash-guard] Bash command에서 /bin/bash 절대경로 호출이 감지되었습니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 'declare -A' 등 bash 4+ 기능이 실패합니다. 대안: \`bash <<'EOF'\` (PATH-resolved). PATH 최상단의 Nix bash 5.x가 자동 선택됩니다."
+      _deny "[system-bash-guard] Bash command에서 /bin/bash 절대경로 호출이 감지되었습니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 'declare -A' 등 bash 4+ 기능이 실패합니다. 대안: \`bash <<'EOF'\` (PATH 기반 해석; Claude Code 세션 PATH에 있는 Nix bash 5.x가 선택됨)."
     fi
     ;;
   Write)
     CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
     if printf '%s' "$CONTENT" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
-      _deny "[system-bash-guard] Write content의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash. PATH 최상단의 Nix bash 5.x가 자동 선택됩니다."
+      _deny "[system-bash-guard] Write content의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash (호출 환경 PATH를 통해 bash가 해석됨; launchd/systemd처럼 PATH가 통제된 컨텍스트에서는 해당 agent의 PATH에 Nix bash 경로가 포함되는지 별도 확인 필요)."
     fi
     ;;
   Edit)
     NEW_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
     if printf '%s' "$NEW_STR" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
-      _deny "[system-bash-guard] Edit new_string의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash. PATH 최상단의 Nix bash 5.x가 자동 선택됩니다."
+      _deny "[system-bash-guard] Edit new_string의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash (호출 환경 PATH를 통해 bash가 해석됨; launchd/systemd처럼 PATH가 통제된 컨텍스트에서는 해당 agent의 PATH에 Nix bash 경로가 포함되는지 별도 확인 필요)."
     fi
     ;;
 esac

--- a/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
@@ -55,7 +55,7 @@ if _is_main_repo_path "$FILE_PATH" || _is_main_repo_path "$RESOLVED"; then
   REL="${local_resolved#"$MAIN_REPO"/}"
   SUGGESTED="$WORKTREE_ROOT/$REL"
   jq -n --arg reason "main repo 파일을 직접 수정할 수 없습니다 (worktree에서 실행 중). worktree 경로를 사용하세요: $SUGGESTED" \
-    '{decision: "block", reason: $reason}'
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
   exit 0
 fi
 

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -71,6 +71,24 @@
             "command": "~/.claude/hooks/fragile-hardcoding-guard.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/system-bash-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/system-bash-guard.sh"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/modules/shared/programs/claude/files/skills/playwright-cli/references/session-management.md
+++ b/modules/shared/programs/claude/files/skills/playwright-cli/references/session-management.md
@@ -63,7 +63,7 @@ playwright-cli open example.com  # Uses "mysession" automatically
 ### Concurrent Scraping
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # Scrape multiple sites concurrently
 
 # Start all browsers

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/harness-testing.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/harness-testing.md
@@ -13,7 +13,7 @@
 **비용**: ~$0.07 | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T1: Harness Inventory Check
 RESULT=$(echo "ok" | claude -p --output-format json 2>/dev/null)
 
@@ -61,7 +61,7 @@ $PASS && echo "T1: PASS" || echo "T1: FAIL"
 **비용**: ~$0.07 (T1과 동일 init 이벤트 재사용 가능) | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T2: Skill Trigger Spot Check
 RESULT=$(echo "ok" | claude -p --output-format json 2>/dev/null)
 
@@ -102,7 +102,7 @@ $PASS && echo "T2: PASS" || echo "T2: FAIL"
 **비용**: $0 (파일 시스템 검사만) | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T3: Hooks File Verification
 SETTINGS="$HOME/.claude/settings.json"
 PASS=true
@@ -158,7 +158,7 @@ $PASS && echo "T3: PASS" || echo "T3: FAIL"
 **비용**: ~$0.07 (T1과 동일 init 이벤트 재사용 가능) | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T4: MCP Server Verification
 RESULT=$(echo "ok" | claude -p --output-format json 2>/dev/null)
 
@@ -205,7 +205,7 @@ $PASS && echo "T4: PASS" || echo "T4: FAIL"
 **비용**: ~$0.14 (2회 호출) | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T5: Permission Model Check
 PASS=true
 
@@ -255,7 +255,7 @@ $PASS && echo "T5: PASS" || echo "T5: FAIL"
 **비용**: ~$0.07 | **위치**: 크로스머신 (Mac -> MiniPC 또는 반대)
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T6: SSH Cross-Machine Execution
 # 현재 머신에 따라 원격 대상 결정
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -288,7 +288,7 @@ fi
 **비용**: ~$0.14 (2회 호출) | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T7: Session Chaining
 SECRET="T7_$(date +%s)"
 
@@ -327,7 +327,7 @@ fi
 **비용**: ~$0.14 (2회 동시 호출) | **위치**: 로컬
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 # T8: Concurrent Execution
 TMPDIR=$(mktemp -d)
 

--- a/modules/shared/scripts/validate-skills.sh
+++ b/modules/shared/scripts/validate-skills.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # validate-skills.sh - Claude Code 스킬 유효성 검사 도구
 #
 # 용도: .claude/skills/*/SKILL.md 파일들의 YAML 프론트매터를 검증


### PR DESCRIPTION
## Summary

- macOS `/bin/bash` 3.2가 Claude의 `/bin/bash` 절대경로 호출 또는 `#!/bin/bash` shebang 작성으로 강제 호출되는 문제를 PreToolUse `system-bash-guard.sh` hook으로 선제 차단.
- 기존 `#!/bin/bash` 스크립트 21개를 `#!/usr/bin/env bash`로 일괄 마이그레이션.
- 기존 PreToolUse hook 2개(`fragile-hardcoding-guard.sh`, `worktree-path-guard.sh`)의 응답 형식을 공식 최신 스펙(`hookSpecificOutput.permissionDecision`)으로 정렬.

Closes #492

## 기존 문제 / 배경

- **Pain**: `which bash` = `/nix/store/.../bash-5.3p9/bin/bash`로 Nix bash 5.x가 PATH 최상단인데도, Claude가 `/bin/bash <<'OUTER' … OUTER` 같이 절대경로로 heredoc을 실행하면 macOS 번들 `/bin/bash` 3.2.57이 돌면서 `declare -A` 등 bash 4+ 기능이 `invalid option`으로 즉시 실패.
- **로컬 재현**: `/bin/bash -c 'declare -A m'` → `/bin/bash: line 0: declare: -A: invalid option`.
- **CLAUDE.md 지침만으로는 한계**: 기존에도 지침으로 `#!/usr/bin/env bash` 사용을 안내했으나, `/bin/bash` 절대경로 호출은 PATH 자체를 무력화해 지침 우회 발생. 코드 가드(PreToolUse hook)가 필요.
- **추가 정리**: 기존 PreToolUse blocker 두 hook이 legacy top-level `{decision:"block"}` envelope을 쓰고 있었음. 공식 최신 docs([code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks))는 PreToolUse에서 `hookSpecificOutput.permissionDecision`을 쓰도록 명시. 같은 이슈에서 정렬.

## CIR (Change Intent Record)

**발견 경위**: 이슈 #492 본문에서 `/bin/bash` 절대경로 호출 패턴이 관측된 것이 계기.

**DA for_plan Round 1 사용자 결정** (4건):
1. **Hook 차단 방식**: `exit 0` + JSON `hookSpecificOutput.permissionDecision:"deny"` (공식 최신 스펙). 사용자 요청으로 Claude Code hooks 공식 문서를 직접 확인한 뒤 `exit 2 + stderr` 대신 JSON 방식 채택.
2. **Bash regex 전략**: 명령 세그먼트 시작(`^`/`;`/`&&`/`||`/`|`/`(`) 위치만 매칭. quoted path/sudo/env 우회는 의도적 trade-off로 수용 (주 방어선은 shebang 마이그레이션).
3. **커밋 분리**: 3개 커밋(+ 수정 2개)으로 분리하여 독립 revert 가능.
4. **차단 메시지 내용**: 근본 원인 + 구체적 대안 + PATH 기반 해석 힌트.

**DA for_plan Round 1 CONFIRMED_ISSUE 반영**:
- `/bin/sh` 범위 제거 (이슈 원본 범위 밖).
- 기존 hook 2개를 같은 이슈에서 permissionDecision envelope로 마이그레이션 (프로젝트 일관성).

**MultiEdit matcher 조사** (`/codex-fan-out` 3개 에이전트 병렬 리서치):
- 최신 공식 docs([code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks), [tools-reference](https://code.claude.com/docs/en/tools-reference))는 `Edit`/`Write`만 나열, `MultiEdit` 언급 없음.
- 현재 Claude Code 세션에도 MultiEdit tool 노출 안 됨 (2.0-era 제거 정황, Reddit/블로그).
- 단 `anthropics/claude-code` repo 내 공식 플러그인(security-guidance/hookify)은 여전히 `Edit|Write|MultiEdit` matcher 사용.
- **사용자 결정**: YAGNI 원칙에 따라 `Edit|Write`만 포함.

**DA for_pr Round 1 CORRECTNESS-1 반영** (commit e8298c3):
- 차단 메시지의 "PATH 최상단의 Nix bash 5.x가 자동 선택됩니다" 단정이 launchd/systemd처럼 PATH가 통제된 컨텍스트에서는 부정확 → "호출 환경 PATH를 통해 bash가 해석됨; PATH 통제 컨텍스트는 별도 확인 필요"로 완화.

**parallel-audit F1 반영** (commit aa156d2):
- Edit의 `new_string`만 검사하는 로직은 partial 치환(예: `old_string="/usr/bin/env bash"`, `new_string="/bin/bash"`)이 post-edit 결과를 `#!/bin/bash`로 만들어도 우회됨.
- `fragile-hardcoding-guard.sh:52-74`의 awk 재구성 패턴을 차용하여 post-edit 결과 전체에서 shebang 라인 검사.

## ADR (Architecture Decision Record)

### 결정 1: PreToolUse hook 차단 메커니즘

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `exit 0` + `hookSpecificOutput.permissionDecision:"deny"` | 공식 최신 스펙 | allow/deny/ask/defer 4단 제어, 향후 호환 | 약간 verbose | ✅ |
| `exit 2` + stderr | 단순 | 공식 docs 기본 예시 | 구조 없음, 이슈 코멘트 가이드와만 일치 | ❌ |
| top-level `{decision:"block"}` | 기존 hook canonical | 내부 일관성 (기존 2개 hook 사용) | 공식 docs상 deprecated | ❌ (기존 hook도 같이 마이그레이션) |

### 결정 2: `/bin/bash` 명령 매칭 정교도

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 명령 세그먼트 시작만 매칭 | `(^\|[;&\|(])[[:space:]]*/bin/bash(...)` | false positive 최소, heredoc 주 패턴 차단 | quoted/sudo 우회 가능 | ✅ |
| 정규화 + 세그먼트 검사 | 따옴표·`$()` 치환 후 검사 | 우회 어려움 | awk 파서 복잡도 | ❌ |
| 특정 조합만 | `/bin/bash <<`, `/bin/bash -c` 등 | 가장 보수적 | 기타 우회 형태 놓침 | ❌ |

**수용된 trade-off**: quoted path(`"/bin/bash"`), 변수 치환, `sudo /bin/bash`는 MISS. 주 방어선은 shebang 마이그레이션이며 Bash hook은 heredoc 등 주 호출 패턴 차단이 목적.

### 결정 3: Edit tool 검사 전략 (parallel-audit F1 반영)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| post-edit 재구성 검사 | `old_string` 치환 후 전체 결과에서 shebang 검사 | partial 치환 bypass 차단, canonical 패턴 재사용 | 코드 복잡도 증가 | ✅ |
| new_string literal `/bin/bash` 차단 | new_string에 `/bin/bash` 있으면 차단 | 단순 | false positive 과다 | ❌ |
| 현상 유지 | new_string만 검사 | 단순 | partial 치환 bypass | ❌ |

### 결정 4: 차단 범위 (`/bin/bash` only vs `/bin/sh` 포함)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `/bin/bash` only | 이슈 원본 범위 | 이슈에 충실, POSIX sh 호환 보존 | 없음 | ✅ |
| `/bin/sh`까지 포함 | shell policy 확장 | 방어 넓음 | 이슈 범위 초과, sh 계약 훼손, 이름 mismatch | ❌ |

## 구현 상세

### 커밋 구조 (5개)

| 순서 | Hash | 주제 | 파일 수 |
|------|------|------|---------|
| 1 | `da69f26` | 기존 hook 2개 envelope 마이그레이션 | 2 |
| 2 | `a39ebfc` | system-bash-guard.sh 신규 + settings.json + default.nix | 3 |
| 3 | `04e54fd` | 21개 파일 shebang 마이그레이션 | 21 |
| 4 | `e8298c3` | 차단 메시지 완화 (DA for_pr CORRECTNESS-1) | 1 |
| 5 | `aa156d2` | Edit post-edit 재구성 검사 (audit F1) | 1 |

### 핵심 파일

| 파일 | 변경 내용 |
|------|----------|
| `modules/shared/programs/claude/files/hooks/system-bash-guard.sh` | **신규** (70줄). jq로 `tool_input` 파싱, Bash/Write/Edit 케이스별 regex, `hookSpecificOutput.permissionDecision:"deny"` 출력 |
| `modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh` | envelope `{decision:"block"}` → `hookSpecificOutput.permissionDecision:"deny"` |
| `modules/shared/programs/claude/files/hooks/worktree-path-guard.sh` | 동일 envelope 마이그레이션 |
| `modules/shared/programs/claude/files/settings.json` | `hooks.PreToolUse`에 2개 엔트리 추가 (`Bash`, `Edit\|Write` matcher) |
| `modules/shared/programs/claude/default.nix` | 신규 hook symlink 1개 추가 |
| 21개 스크립트/문서 | `#!/bin/bash` → `#!/usr/bin/env bash` |

### 핵심 로직 (system-bash-guard.sh)

```bash
# Bash: 명령 세그먼트 시작에서 /bin/bash 실행만 차단
grep -Eq '(^|[;&|(])[[:space:]]*/bin/bash([[:space:]<>]|$)'

# Edit: post-edit 재구성 후 shebang 라인 검사 (audit F1 fix)
POST_EDIT=$(awk '{ old=ENVIRON["OLD_STR"]; new=ENVIRON["NEW_STR"]
  idx=index($0, old); if(idx>0){ print substr($0,1,idx-1) new substr($0,idx+length(old)); exit 0 } else exit 1 }' "$FILE_PATH")
[ -z "$POST_EDIT" ] && POST_EDIT="$NEW_STR"
printf '%s' "$POST_EDIT" | grep -Eq '^#!/bin/bash([[:space:]]|$)' && _deny "..."
```

## 참고 레퍼런스

- #492 — 본 이슈.
- #437 `d69ec19` — `refactor(hooks): fragile-hardcoding-guard Write/Edit 비대칭 해소 + false positive 제거` (유사 hook 설계 canonical pattern 참조).
- #386 `bfb4d15` — `fix(hooks): fragile-hardcoding-guard 코드 블록 내 false positive 해소` (jq + awk 선례).
- [Claude Code hooks 공식 문서](https://code.claude.com/docs/en/hooks) — PreToolUse `hookSpecificOutput.permissionDecision` 스펙의 출처.
- [Claude Code tools reference](https://code.claude.com/docs/en/tools-reference) — MultiEdit 부재 확인.

## Human Test Plan

아래는 본 PR을 머지 후 로컬에서 수동으로 검증하는 절차.

1. **Hook 적용 확인** — 새 Claude Code 세션을 연다 (현재 세션은 settings 재로드가 보장되지 않음).
   - `ls -la ~/.claude/hooks/system-bash-guard.sh` → symlink로 워크트리의 hook을 가리키는지 확인.
2. **Bash 차단 확인** — Bash tool로 `/bin/bash <<'EOF'\ndeclare -A m\nEOF` 시도 → `[system-bash-guard]` deny 메시지 확인.
3. **Bash 통과 확인** — Bash tool로 `grep /bin/bash ~/.claude/hooks/system-bash-guard.sh` 시도 → 정상 실행(문자열 언급은 통과).
4. **Write 차단 확인** — Write tool로 `/tmp/test-bash.sh`에 `#!/bin/bash\necho test` 시도 → deny.
5. **Write 통과 확인** — 같은 파일에 `#!/usr/bin/env bash\necho test` 시도 → 정상.
6. **Edit 차단 (partial 치환)** — 기존 `#!/usr/bin/env bash` 파일에서 `old_string="/usr/bin/env bash"`, `new_string="/bin/bash"` 시도 → post-edit 재구성 결과가 `#!/bin/bash`가 되어 deny.
7. **Edit 통과 (마이그레이션)** — 기존 `#!/bin/bash` 파일에서 `old_string="#!/bin/bash"`, `new_string="#!/usr/bin/env bash"` 시도 → 정상.
8. **기존 hook 회귀** — main repo 파일을 worktree에서 직접 수정 시 `worktree-path-guard`의 deny가 `hookSpecificOutput` envelope로 표시되는지 확인.

**실패 시 진단**:
- deny 메시지 없이 그대로 실행됨 → symlink 미생성 가능성. `nrs` 재실행 후 새 세션.
- jq 에러 → `which jq` 확인 (Nix 프로필에 있어야 함).
- 무관한 차단 → `~/.claude/hooks/system-bash-guard.sh`의 regex를 직접 파싱해 locality 확인.

## Pre-Merge E2E 테스트 가이드

LLM이 이 PR을 머지 전에 직접 수행할 수 있는 자동 검증 절차.

### Phase 0: 정적 검증

```bash
# 잔여 `#!/bin/bash` 0건 확인
test "$(grep -rln '^#!/bin/bash' . 2>/dev/null | wc -l | tr -d ' ')" = "0" && echo "PASS" || echo "FAIL: remnants"

# 신규 hook 파일 존재 확인
test -x modules/shared/programs/claude/files/hooks/system-bash-guard.sh && echo "PASS" || echo "FAIL: hook missing"

# settings.json 등록 확인 (2엔트리)
jq '.hooks.PreToolUse | map(select(.hooks[].command | test("system-bash-guard"))) | length' \
  modules/shared/programs/claude/files/settings.json  # → 2

# default.nix symlink 엔트리 확인
grep -q 'system-bash-guard.sh' modules/shared/programs/claude/default.nix && echo "PASS" || echo "FAIL"

# 기존 2개 hook envelope 마이그레이션 확인 (legacy top-level decision 부재)
! grep -qE "'\{decision:\s*\"block\"" modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh && echo "PASS"
! grep -qE "'\{decision:\s*\"block\"" modules/shared/programs/claude/files/hooks/worktree-path-guard.sh && echo "PASS"
```

### Phase 1: Hook 로직 시뮬레이션 (동일 세션에서 검증 가능)

```bash
H=modules/shared/programs/claude/files/hooks/system-bash-guard.sh
# Bash /bin/bash heredoc → DENY
jq -n '{tool_name:"Bash",tool_input:{command:"/bin/bash <<EOF\necho\nEOF"}}' | "$H" | jq -r '.hookSpecificOutput.permissionDecision'  # → deny
# Bash grep mention → pass
jq -n '{tool_name:"Bash",tool_input:{command:"grep /bin/bash README"}}' | "$H"  # → empty
# Write shebang → DENY
jq -n '{tool_name:"Write",tool_input:{content:"#!/bin/bash\necho"}}' | "$H" | jq -r '.hookSpecificOutput.permissionDecision'  # → deny
# Edit partial 치환 (audit F1) → DENY
echo '#!/usr/bin/env bash' > /tmp/test.sh
jq -n --arg fp /tmp/test.sh '{tool_name:"Edit",tool_input:{file_path:$fp,old_string:"/usr/bin/env bash",new_string:"/bin/bash"}}' | "$H" | jq -r '.hookSpecificOutput.permissionDecision'  # → deny
```

### Phase 2: Regression

```bash
# 기존 hook도 permissionDecision 반환 확인 (fragile-hardcoding은 특정 조건에서만 차단하므로 envelope 유지만 확인)
grep -q 'hookSpecificOutput' modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh && echo "PASS"
grep -q 'hookSpecificOutput' modules/shared/programs/claude/files/hooks/worktree-path-guard.sh && echo "PASS"

# nrs 빌드 성공
nrs  # 성공해야 함 (49 symlinks 재링크)
```

### 기대 결과
- Phase 0: 6/6 PASS
- Phase 1: 4/4 DENY/PASS 적절
- Phase 2: 3/3 PASS

실패 시: 해당 Phase의 해당 bullet을 머지 차단자로 기록하고 재현 로그 수집.