### PR TITLE
feat(shared): yazi TUI 파일 매니저 통합 (#496)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ macOS와 NixOS 개발 환경을 **nix-darwin/NixOS + Home Manager**로 선언적
 
 **공유 설정** (`modules/shared/`):
 - 쉘 환경 (zsh, starship, atuin, fzf, zoxide)
-- 개발 도구 (git, tmux, neovim (LazyVim), lazygit, direnv)
+- 개발 도구 (git, tmux, neovim (LazyVim), lazygit, direnv, yazi)
 - AI 도구 (Claude Code, Codex CLI)
 - 시크릿 관리 (agenix)
 
@@ -34,7 +34,7 @@ flake.nix                          # 진입점: mkDarwinConfig / mkNixosConfig
 │   ├── shared/                    # Darwin + NixOS 공통
 │   │   ├── configuration.nix      # Nix GC, 병렬 다운로드, flakes
 │   │   └── programs/              # git, tmux, neovim, shell, claude, codex,
-│   │                              # lazygit, direnv, broot, secrets
+│   │                              # lazygit, direnv, broot, yazi, secrets
 │   ├── darwin/                    # macOS 전용
 │   │   ├── configuration.nix      # Dock, Finder, 키보드, 단축키, Touch ID sudo
 │   │   ├── home.nix               # HM 패키지 + 모듈 import

--- a/flake.lock
+++ b/flake.lock
@@ -109,7 +109,8 @@
         "disko": "disko",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "yazi-flavors": "yazi-flavors"
       }
     },
     "systems": {
@@ -124,6 +125,22 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "yazi-flavors": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775725639,
+        "narHash": "sha256-Gm6ThktOLUR+KDs6f3s1WCgrw2TOKQ4tolVvVdCxnCM=",
+        "owner": "yazi-rs",
+        "repo": "flavors",
+        "rev": "06708015bfb53b169d99bb3907829f9175105d57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yazi-rs",
+        "repo": "flavors",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # yazi 테마/플레이버 저장소 (catppuccin-mocha 등)
+    # nixpkgs에 yaziFlavors/yaziPlugins.catppuccin-mocha가 없어 flake input으로 고정.
+    yazi-flavors = {
+      url = "github:yazi-rs/flavors";
+      flake = false;
+    };
+
   };
 
   outputs =

--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -61,6 +61,7 @@
         ../shared/programs/tmux
         ../shared/programs/neovim
         ../shared/programs/cheat # 터미널 cheatsheet 즉시 조회
+        ../shared/programs/yazi # TUI 파일 매니저
 
         # macOS 전용
         ./programs/hammerspoon

--- a/modules/darwin/programs/ghostty/default.nix
+++ b/modules/darwin/programs/ghostty/default.nix
@@ -27,5 +27,11 @@
     # Split zoom 유지 (1.3.0+)
     # Ghostty 네이티브 split 간 이동 시 zoom 상태 유지
     split-preserve-zoom = navigation
+
+    # SSH integration: 원격 세션에 TERM_PROGRAM/COLORTERM 전달 (yazi SSH 이미지 프리뷰 전제)
+    # 출처: https://ghostty.org/docs/features/shell-integration
+    # ssh-terminfo는 제외 — MiniPC는 이미 pkgs.ghostty.terminfo 설치됨 (libraries/packages.nix)
+    # ssh-terminfo를 켜면 모든 SSH 대상에 tic 원격 실행 발생
+    shell-integration-features = ssh-env
   '';
 }

--- a/modules/darwin/programs/sshd/default.nix
+++ b/modules/darwin/programs/sshd/default.nix
@@ -29,5 +29,9 @@ in
     # 세션 타임아웃
     ClientAliveInterval ${toString clientAliveInterval}
     ClientAliveCountMax ${toString clientAliveCountMax}
+
+    # Ghostty SSH integration (shell-integration-features = ssh-env)이 전달하는
+    # 환경 변수 수용 — 원격 yazi SSH 이미지 프리뷰 감지에 사용됨. NixOS sshd와 동일 contract.
+    AcceptEnv COLORTERM TERM_PROGRAM TERM_PROGRAM_VERSION
   '';
 }

--- a/modules/nixos/home.nix
+++ b/modules/nixos/home.nix
@@ -37,6 +37,7 @@ in
     ../shared/programs/tmux
     ../shared/programs/neovim
     ../shared/programs/cheat # 터미널 cheatsheet 즉시 조회
+    ../shared/programs/yazi # TUI 파일 매니저
 
     # NixOS 전용
     ./programs/ssh-client # macOS SSH 접속 설정

--- a/modules/nixos/programs/ssh.nix
+++ b/modules/nixos/programs/ssh.nix
@@ -26,6 +26,14 @@ in
         "hmac-sha2-512"
         "hmac-sha2-256"
       ];
+
+      # Ghostty SSH integration (`shell-integration-features = ssh-env`)이 전달하는
+      # 환경 변수 수용 — yazi SSH 이미지 프리뷰 감지에 사용됨.
+      AcceptEnv = [
+        "COLORTERM"
+        "TERM_PROGRAM"
+        "TERM_PROGRAM_VERSION"
+      ];
     };
   };
 }

--- a/modules/shared/programs/tmux/files/tmux.conf
+++ b/modules/shared/programs/tmux/files/tmux.conf
@@ -20,6 +20,9 @@ set -ga terminal-overrides ",tmux-256color:Tc"
 # yazi SSH 이미지 프리뷰 전제: Kitty graphics 프로토콜이 tmux를 우회하도록 허용하고,
 # SSH 재접속 시 TERM/TERM_PROGRAM이 session environment로 갱신되게 한다.
 # 출처: https://yazi-rs.github.io/docs/image-preview/
+# 주의: `set -ga`는 array option에 append이므로 `prefix-r`로 반복 source 시
+#       update-environment에 동일 항목이 여러 번 쌓인다. 동작상 무해 (tmux attach 시
+#       동일 key가 중복되어도 마지막 값 전달). reload 사용 자제 권장.
 set -g allow-passthrough on
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM

--- a/modules/shared/programs/tmux/files/tmux.conf
+++ b/modules/shared/programs/tmux/files/tmux.conf
@@ -17,6 +17,13 @@ set -ga terminal-overrides ",xterm-256color:Tc"
 set -ga terminal-overrides ",xterm-ghostty:Tc"
 set -ga terminal-overrides ",tmux-256color:Tc"
 
+# yazi SSH 이미지 프리뷰 전제: Kitty graphics 프로토콜이 tmux를 우회하도록 허용하고,
+# SSH 재접속 시 TERM/TERM_PROGRAM이 session environment로 갱신되게 한다.
+# 출처: https://yazi-rs.github.io/docs/image-preview/
+set -g allow-passthrough on
+set -ga update-environment TERM
+set -ga update-environment TERM_PROGRAM
+
 # 창/pane 이름 자동 변경 비활성화
 set -g automatic-rename off
 set -g allow-rename off

--- a/modules/shared/programs/yazi/default.nix
+++ b/modules/shared/programs/yazi/default.nix
@@ -28,6 +28,7 @@
     theme.flavor.dark = "catppuccin-mocha";
 
     # git.yazi 플러그인 등록: git repo의 파일 목록에 git 상태 linemode 표시.
+    # 두 패턴 모두 필요: "*"는 개별 파일, "*/"는 디렉터리 매칭 (git.yazi 공식 README 기준).
     settings.plugin.prepend_fetchers = [
       {
         id = "git";

--- a/modules/shared/programs/yazi/default.nix
+++ b/modules/shared/programs/yazi/default.nix
@@ -1,0 +1,53 @@
+# yazi TUI 파일 매니저
+# - Ghostty + tmux + SSH 경로에서 Kitty graphics 이미지 프리뷰 전제로 통합
+#   (추가 전제: tmux `allow-passthrough on`, Ghostty `shell-integration-features = ssh-env`, sshd `AcceptEnv`)
+# - `pkgs.yazi` 래퍼가 file/jq/poppler-utils/7zz/ffmpeg/fd/ripgrep/fzf/zoxide/imagemagick/chafa/resvg를 PATH에 자동 주입
+{
+  inputs,
+  pkgs,
+  ...
+}:
+{
+  programs.yazi = {
+    enable = true;
+    enableZshIntegration = true;
+
+    # HM stateVersion 25.05 기본값은 "yy" + deprecation warn.
+    # 공식 권장값 "y"로 명시 (stateVersion 26.05+ 기본값과 동일).
+    shellWrapperName = "y";
+
+    package = pkgs.yazi;
+
+    plugins = {
+      inherit (pkgs.yaziPlugins) full-border git starship;
+    };
+
+    # catppuccin-mocha flavor: nixpkgs에 yaziFlavors/yaziPlugins.catppuccin-mocha 없어 flake input 사용.
+    # path 타입 필요 (HM: attrsOf (oneOf [path package])) → 문자열 interpolation 대신 path 연산.
+    flavors.catppuccin-mocha = inputs.yazi-flavors + "/catppuccin-mocha.yazi";
+    theme.flavor.dark = "catppuccin-mocha";
+
+    # git.yazi 플러그인 등록: git repo의 파일 목록에 git 상태 linemode 표시.
+    settings.plugin.prepend_fetchers = [
+      {
+        id = "git";
+        url = "*";
+        run = "git";
+        group = "git";
+      }
+      {
+        id = "git";
+        url = "*/";
+        run = "git";
+        group = "git";
+      }
+    ];
+
+    # 세 플러그인 모두 명시적 setup 필요 (upstream README 기준).
+    initLua = ''
+      require("full-border"):setup()
+      require("starship"):setup()
+      require("git"):setup()
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

- `modules/shared/programs/yazi/default.nix` 신설 + darwin/nixos home.nix import. `pkgs.yazi` 래퍼가 풀 프리뷰 의존성 자동 주입.
- Ghostty+tmux+SSH 경로 정렬: tmux `allow-passthrough on`, Ghostty `shell-integration-features = ssh-env`, Darwin/NixOS sshd `AcceptEnv [COLORTERM TERM_PROGRAM TERM_PROGRAM_VERSION]`.
- 플러그인 3개(`full-border` / `git` / `starship`) + `catppuccin-mocha` flavor 선언적 관리 (flake input `yazi-flavors` 추가).

Closes #496

## 기존 문제 / 배경

Mac Finder 대체 키보드 기반 파일 탐색 수단이 저장소에 없었다. Mac Ghostty → MiniPC SSH 경로에서 immich upload-cache / copyparty 공유 디렉터리 정리 시 `ls`/`cd` 반복 + 단건 `imgcat` 호출이 비효율적. Ghostty는 Kitty graphics 프로토콜을 지원하고 yazi v25.2.7+는 SSH+tmux 이미지 프리뷰를 out-of-the-box로 제공하므로, 설정만 맞추면 원격 미디어 디렉터리를 GUI 없이 훑을 수 있다.

## CIR — Change Intent Record

### 발견 경위
사용자가 `https://github.com/sxyazi/yazi`를 보고 "SSH로 MiniPC 접속하는 경우에 유용할지"를 문의. 초기 검토에서 폰 SSH 앱은 Kitty graphics 미지원이 약점이었으나, Mac Ghostty 사용 맥락으로 범위를 좁히자 이미지 프리뷰가 실제로 동작하는 판이 됨.

### 설계 의도
- **YAGNI 우선**: 키바인딩/settings 세부 튜닝 / bookmarks·chmod·restore 등 추가 플러그인은 범위 제외. 실사용 이후 필요 확인 시 별도 이슈.
- **선언적 통합**: `ya pkg` 런타임 설치 대신 `pkgs.yaziPlugins` + `programs.yazi.plugins`/`flavors`로 저장소 재현성 유지.
- **래퍼 신뢰**: `pkgs.yazi` 래퍼가 이미 `file / jq / poppler-utils / 7zz / ffmpeg / fd / ripgrep / fzf / zoxide / imagemagick / chafa / resvg`를 PATH에 자동 주입 (실측 확인). 수동 의존성 관리 부담 없음.

### 대안 거부 이력
- **flake input 대신 per-module `pkgs.fetchFromGitHub`** (DA Round 2 RD2): 사용자가 "nix flake update로 버전 관리"를 선호하여 flake input 방식 유지.
- **`ssh-terminfo` 활성화 대안** (DA Round 1 R1): `shell-integration-features = ssh-env`만 켜고 `ssh-terminfo`는 제외. MiniPC는 이미 `libraries/packages.nix:45`에서 `pkgs.ghostty.terminfo` 선언적 설치 중이라 불필요. 전역 `ssh-terminfo`는 모든 SSH 대상에 `mkdir -p ~/.terminfo && tic -x -` 원격 실행을 트리거해 부작용 범위가 큼.
- **host별 `~/.ssh/config SendEnv`로 범위 축소** (DA Round 2 RD2): scp/sftp/rsync/mosh에도 적용되는 장점 있지만, 이번 목적(yazi SSH 이미지 프리뷰)과 무관. 사용자가 "현재 안 유지" 선택.

## ADR — Architecture Decision Record

### 모듈 배치 방식

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| shared HM 모듈 + import | `modules/shared/programs/yazi/default.nix` + darwin/nixos home.nix에서 import | lazygit/tmux/fzf 등 기존 TUI 패턴과 일치. `plugins`/`flavors`/`theme`/`initLua` 선언적 관리 | 모듈 파일 1개 추가 | ✅ |
| `libraries/packages.nix`에 raw pkg만 추가 | `pkgs.yazi` 한 줄 추가 | 간단 | HM `programs.yazi` 옵션 미활용. 저장소 표준 패턴과 불일치 | ❌ |

### flavor 소스 전달 방식

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| flake input (`yazi-rs/flavors`, flake=false) | `flake.nix` `inputs`에 추가 + `inputs.yazi-flavors + "/catppuccin-mocha.yazi"` 사용 | 선언적 버전 관리 (`nix flake update yazi-flavors`). 저장소 철학과 일관. | flake.lock 1개 항목 증가 | ✅ |
| 모듈 내부 `pkgs.fetchFromGitHub` + 고정 rev/sha256 | HM 모듈 안에서 fetch | flake.nix 수정 불필요. 모듈 자가완결 | 버전 업데이트 시 rev/sha256 수동 교체 | ❌ |

### Ghostty SSH env 전달 범위

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Ghostty `shell-integration-features = ssh-env` | Ghostty interactive shell의 `ssh` 래퍼로 `COLORTERM` / `TERM_PROGRAM` / `TERM_PROGRAM_VERSION` 전달 | 설정 간단. 여러 원격 호스트에 일괄 적용. Mac에서 `ssh minipc` 직접 실행 시 커버 | scp/sftp/rsync/mosh 미적용. (이미지 프리뷰와 무관) | ✅ |
| host별 `programs.ssh.matchBlocks` `SendEnv` | MiniPC host block에만 `SendEnv` 지정 | 범위가 좁음. scp/rsync 등도 커버 | host 추가 시 matchBlocks 추가 필요. Ghostty 래퍼와 독립 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/yazi/default.nix` | 신설 (53 lines) — `programs.yazi` HM 모듈 |
| `flake.nix` | `inputs.yazi-flavors = { url = "github:yazi-rs/flavors"; flake = false; }` 추가 |
| `flake.lock` | yazi-flavors 잠금 |
| `modules/darwin/home.nix` | `../shared/programs/yazi` import 추가 |
| `modules/nixos/home.nix` | 동일 |
| `modules/shared/programs/tmux/files/tmux.conf` | `allow-passthrough on` + `update-environment TERM/TERM_PROGRAM` |
| `modules/darwin/programs/ghostty/default.nix` | `shell-integration-features = ssh-env` |
| `modules/darwin/programs/sshd/default.nix` | `AcceptEnv COLORTERM TERM_PROGRAM TERM_PROGRAM_VERSION` |
| `modules/nixos/programs/ssh.nix` | `services.openssh.settings.AcceptEnv = [ ... ]` |
| `README.md` | 개요/아키텍처 트리에 yazi 추가 |

### 핵심 스니펫

```nix
# modules/shared/programs/yazi/default.nix
{ inputs, pkgs, ... }:
{
  programs.yazi = {
    enable = true;
    enableZshIntegration = true;
    shellWrapperName = "y";  # HM stateVersion 25.05는 기본 "yy" + warn. 공식 권장 "y" 명시.
    package = pkgs.yazi;
    plugins = { inherit (pkgs.yaziPlugins) full-border git starship; };
    flavors.catppuccin-mocha = inputs.yazi-flavors + "/catppuccin-mocha.yazi";
    theme.flavor.dark = "catppuccin-mocha";
    settings.plugin.prepend_fetchers = [
      { id = "git"; url = "*"; run = "git"; group = "git"; }
      { id = "git"; url = "*/"; run = "git"; group = "git"; }
    ];
    initLua = ''
      require("full-border"):setup()
      require("starship"):setup()
      require("git"):setup()
    '';
  };
}
```

## 참고 레퍼런스

- Closes #496 (feat(shared): yazi TUI 파일 매니저 통합)
- 커밋 구성:
  - `e9eba75` feat(shared): yazi 통합 본체 (8 files, +101/-1)
  - `b1a8a68` docs(shared): DA Round 1 피드백 주석 반영 (2 files, +4)
  - `eb1d4bb` fix(darwin): parallel-audit 반영 (darwin sshd AcceptEnv + README) (2 files, +6/-2)
- 공식 문서
  - yazi 설치: https://yazi-rs.github.io/docs/installation/
  - yazi 이미지 프리뷰 / tmux passthrough: https://yazi-rs.github.io/docs/image-preview/
  - yazi v25.2.7 릴리스 (SSH+tmux preview OOTB): https://github.com/sxyazi/yazi/releases
  - Home Manager `programs.yazi` 모듈: https://github.com/nix-community/home-manager/blob/master/modules/programs/yazi.nix
  - Ghostty shell integration: https://ghostty.org/docs/features/shell-integration
  - git.yazi 플러그인 README: https://github.com/yazi-rs/plugins/tree/main/git.yazi
- 저장소 기존 패턴 레퍼런스
  - `modules/shared/programs/lazygit/default.nix:4` (HM 모듈 표준)
  - `modules/shared/programs/tmux/default.nix:33`
  - `modules/darwin/programs/ghostty/default.nix:5-35` (xdg.configFile 방식)

## Human Test Plan

> Mac 빌드는 별도 세션 필요 (`nrs` on Mac). 아래는 단계별 수동 검증.

### Phase 1 — 빌드

1. MiniPC에서 `nrs` 실행 → 성공 (이번 PR에서 이미 확인, 37s + 32s).
2. Mac에서 `nrs` 실행 → 성공 기대. 실패 시 대개 ① Ghostty config 문법 오류 ② flake input 미해결 ③ HM `flavors` path 타입 오류 중 하나. `--show-trace`로 원인 식별.

### Phase 2 — 로컬 yazi 기동 (Mac Ghostty)

1. Mac Ghostty 새 세션 → `y` 입력.
2. 기대: yazi 기동, full-border 테두리 표시, catppuccin-mocha 톤 색감, 상단에 starship prompt.
3. 이미지 디렉터리 (예: `~/Pictures`) 진입 → 선택한 이미지가 우측 프리뷰에 Kitty graphics로 인라인 렌더.
4. PDF 파일 선택 → 첫 페이지 렌더 (poppler 경유).
5. 실패 시: `yazi --debug`로 감지된 프로토콜(`Kgp`/`Iip`/`Sixel`) 확인. Kitty 미감지 시 Ghostty 버전/설정 재확인.

### Phase 3 — SSH 원격 yazi

1. Mac Ghostty → `ssh minipc` (또는 tmux 안에서 `ssh minipc` 후 `tmux attach`).
2. 원격에서 `y` 실행.
3. immich upload-cache 또는 copyparty 공유 디렉터리 진입 → 이미지 프리뷰 표시.
4. 실패 시:
   - 원격에서 `echo $TERM_PROGRAM` → Ghostty/ghostty 여부 확인. 비어있으면 Ghostty ssh-env 또는 sshd AcceptEnv 미반영.
   - tmux 안이면 `tmux show-environment | grep TERM_PROGRAM` 확인.
   - `yazi --debug`로 감지 프로토콜 확인.

### Phase 4 — shell integration

1. yazi에서 임의 디렉터리로 이동 후 `q` 종료.
2. 기대: zsh prompt가 yazi 종료 위치로 자동 `cd`.
3. 실패 시: `which y` → shell function 여부 확인. `type y`로 함수 정의 점검.

### Phase 5 — 플러그인 확인

1. nixos-config 저장소에서 `y`.
2. 기대: 파일 앞에 git 상태 아이콘(추가 `A`, 수정 `M`, 등) 표시.
3. starship prompt가 현재 git 브랜치 반영.
4. 실패 시: `~/.config/yazi/init.lua` 확인 (`require("git"):setup()` 포함 여부). `cat ~/.config/yazi/yazi.toml`로 `prepend_fetchers` 등록 확인.

### Phase 6 — 회귀 확인

1. 기존 TUI (`lazygit`, `nvim`, `broot`) 실행 → 정상 동작 (allow-passthrough 사이드이펙트 없음).
2. tmux `prefix+r`로 config reload → 에러 없음.
3. 기존 SSH 클라이언트(mosh, Echo iOS 등)로 MiniPC 접속 → AcceptEnv 추가 영향 없음.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```bash
# 파일 존재
test -f modules/shared/programs/yazi/default.nix || echo "FAIL: yazi module missing"

# 핵심 값 반영 확인
grep -q 'inputs.yazi-flavors' flake.nix                             || echo "FAIL: flake input missing"
grep -q 'catppuccin-mocha' modules/shared/programs/yazi/default.nix || echo "FAIL: flavor missing"
grep -q 'allow-passthrough on' modules/shared/programs/tmux/files/tmux.conf || echo "FAIL: tmux passthrough missing"
grep -q 'shell-integration-features = ssh-env' modules/darwin/programs/ghostty/default.nix || echo "FAIL: ghostty ssh-env missing"
grep -qE 'AcceptEnv[[:space:]]+COLORTERM' modules/darwin/programs/sshd/default.nix || echo "FAIL: darwin sshd AcceptEnv missing"
grep -qE '"COLORTERM"' modules/nixos/programs/ssh.nix               || echo "FAIL: nixos sshd AcceptEnv missing"

# old 값 부재 (ssh-terminfo는 의도적으로 제외됨)
! grep -q 'ssh-terminfo' modules/darwin/programs/ghostty/default.nix || echo "FAIL: ssh-terminfo should be absent"
```

### Phase 1 — NixOS flake eval

```bash
nix eval --raw .#nixosConfigurations.greenhead-minipc.config.system.build.toplevel.drvPath
# 기대: 정상 drvPath 출력. 오류 시 HM 모듈 타입 오류 또는 path 문법 문제.
```

### Phase 2 — Darwin flake eval

```bash
nix eval --raw .#darwinConfigurations.greenhead-MacBookPro.config.system.build.toplevel.drvPath
# 기대: 정상 drvPath 출력.
```

### Phase 3 — 생성된 yazi config 검증 (NixOS 빌드 후)

```bash
test -f ~/.config/yazi/yazi.toml    || echo "FAIL: yazi.toml missing"
test -f ~/.config/yazi/theme.toml   || echo "FAIL: theme.toml missing"
test -f ~/.config/yazi/init.lua     || echo "FAIL: init.lua missing"
test -L ~/.config/yazi/flavors/catppuccin-mocha.yazi || echo "FAIL: flavor symlink missing"
test -L ~/.config/yazi/plugins/full-border.yazi      || echo "FAIL: full-border plugin missing"
test -L ~/.config/yazi/plugins/git.yazi              || echo "FAIL: git plugin missing"
test -L ~/.config/yazi/plugins/starship.yazi         || echo "FAIL: starship plugin missing"

grep -q 'group = "git"'        ~/.config/yazi/yazi.toml  || echo "FAIL: git fetcher group missing"
grep -q 'dark = "catppuccin-mocha"' ~/.config/yazi/theme.toml || echo "FAIL: theme flavor missing"
```

### Phase 4 — sshd AcceptEnv 반영 (NixOS 빌드 후)

```bash
grep -qE '^AcceptEnv[[:space:]]+COLORTERM[[:space:]]+TERM_PROGRAM[[:space:]]+TERM_PROGRAM_VERSION$' /etc/ssh/sshd_config
# 기대: exit 0.
```

### Phase 5 — Regression

```bash
# 기존 TUI shim이 yazi wrapper 추가로 변질되지 않았는지
which lazygit nvim broot | grep -v yazi
# 기대: 각 경로가 yazi 래퍼를 거치지 않음.
```

### DA/Audit 이력

- for_plan DA 3 rounds: AcceptEnv 리스트 타입, Ghostty config 문법, git 플러그인 initLua/fetcher 등록, flavors path 타입, fetcher `group` 필드 반영.
- for_pr DA 1 round: tmux `set -ga update-environment` reload 중복 누적 주석, fetcher `*`/`*/` 패턴 주석.
- parallel-audit: Security/SideEffects SAFE. Performance/Edge는 사용자 합의 스펙. Platform BUG (darwin sshd AcceptEnv 누락) 반영. Docs REGRESSION (README 미등재) 반영.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Yazi file manager with shell integration and theme customization
  * Enhanced SSH configuration to support better terminal environment forwarding for remote sessions
  * Improved Ghostty terminal SSH compatibility and environment variable propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->