### PR TITLE
docs(cheat): yazi 핵심 키바인딩 cheatsheet + C 바인딩 통합

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/yazi/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/yazi/keybinding
@@ -1,0 +1,43 @@
+---
+tags: [ yazi, keybinding, file-manager ]
+---
+yazi TUI 파일 매니저 핵심 키 (preset 기준, v26.x)
+
+[진입/종료]
+  y            셸에서 yazi 실행 (HM shellWrapperName=y 래퍼)
+  q            종료 — yazi 의 현재 디렉터리를 셸 cwd 로 상속
+  Q            종료 — cwd 상속 안 함
+  Esc          visual 해제 / 선택 지우기 / find 취소
+
+[네비게이션]
+  j / k        다음 / 이전 파일
+  h / l        상위 디렉터리로 / 하위 디렉터리로
+  gg / G       최상단 / 최하단
+  Enter        파일/디렉터리 열기 (l 과 달리 파일도 open)
+
+[선택]
+  Space        현재 토글 후 다음으로 이동
+  v            visual mode (커서 이동으로 범위 선택)
+
+[파일 조작]
+  y / x        복사(yank) / 잘라내기
+  p / P        붙여넣기 / 강제 덮어쓰기
+  d / D        휴지통 이동 / 영구 삭제
+  r            이름 변경 (확장자 앞에 커서)
+  a            생성 — name/ 로 끝내면 디렉터리
+
+[검색 및 점프]
+  / + n / N    이름으로 find (앞/뒤 다음/이전)
+  z / Z        fzf 점프 / zoxide 점프
+
+[기타]
+  .            숨김 파일 토글
+  ; / :        셸 실행 (논블로킹 / 블로킹)
+  ~ (F1)       내장 help (검색/필터 가능)
+
+Tip
+- `y` wrapper: `q` 로 종료 시 yazi 현재 위치가 셸 cwd 로 따라옴. 브라우징 후 그 자리에서 작업 계속. 상속 거부는 `Q`.
+- git.yazi 플러그인이 파일 옆 linemode 에 git 상태(M/A/D/? 등) 표시. `m m/s/p/b/o/n` 으로 linemode 전환.
+- `z` = fzf, `Z` = zoxide. 자주 반대로 기억하니 주의.
+- Ghostty + tmux + SSH 이미지 프리뷰는 tmux `allow-passthrough on` + Ghostty `shell-integration-features=ssh-env` + sshd `AcceptEnv` 3축 전제 (이 레포에 이미 구성). 프리뷰 안 뜨면 이 3축부터 확인.
+- 전체 기본 키는 yazi 실행 후 `~` 로 내장 help 에서 조회 (`f` 로 필터).

--- a/modules/shared/programs/cheat/cheatsheets/yazi/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/yazi/keybinding
@@ -35,8 +35,12 @@ yazi TUI 파일 매니저 핵심 키 (preset 기준, v26.x)
   ; / :        셸 실행 (논블로킹 / 블로킹)
   ~ (F1)       내장 help (검색/필터 가능)
 
+[치트시트]
+  C            치트시트 브라우징 (cheat + fzf, Ctrl-S: content 모드 전환)
+
 Tip
 - `y` wrapper: `q` 로 종료 시 yazi 현재 위치가 셸 cwd 로 따라옴. 브라우징 후 그 자리에서 작업 계속. 상속 거부는 `Q`.
+- `C` 는 nvim `<leader>C`, tmux `prefix+C` 와 동일 키. 세 환경 모두 같은 `cheat-browse` 실행.
 - git.yazi 플러그인이 파일 옆 linemode 에 git 상태(M/A/D/? 등) 표시. `m m/s/p/b/o/n` 으로 linemode 전환.
 - `z` = fzf, `Z` = zoxide. 자주 반대로 기억하니 주의.
 - Ghostty + tmux + SSH 이미지 프리뷰는 tmux `allow-passthrough on` + Ghostty `shell-integration-features=ssh-env` + sshd `AcceptEnv` 3축 전제 (이 레포에 이미 구성). 프리뷰 안 뜨면 이 3축부터 확인.

--- a/modules/shared/programs/yazi/default.nix
+++ b/modules/shared/programs/yazi/default.nix
@@ -44,6 +44,16 @@
       }
     ];
 
+    # C: cheat-browse (cheat + fzf) 띄우기. nvim <leader>C / tmux prefix+C 와 동일 키로 일관성.
+    # preset [mgr] 섹션에 C 단독 바인딩 없음 — 충돌 없음.
+    keymap.mgr.prepend_keymap = [
+      {
+        on = [ "C" ];
+        run = "shell 'cheat-browse' --block";
+        desc = "Browse cheatsheets (cheat + fzf)";
+      }
+    ];
+
     # 세 플러그인 모두 명시적 setup 필요 (upstream README 기준).
     initLua = ''
       require("full-border"):setup()

--- a/modules/shared/programs/yazi/default.nix
+++ b/modules/shared/programs/yazi/default.nix
@@ -46,10 +46,11 @@
 
     # C: cheat-browse (cheat + fzf) 띄우기. nvim <leader>C / tmux prefix+C 와 동일 키로 일관성.
     # preset [mgr] 섹션에 C 단독 바인딩 없음 — 충돌 없음.
+    # 절대경로 사용: tmux.conf 의 display-popup 과 동일 규약, PATH 환경 차이에 무관.
     keymap.mgr.prepend_keymap = [
       {
         on = [ "C" ];
-        run = "shell 'cheat-browse' --block";
+        run = ''shell "$HOME/.local/bin/cheat-browse" --block'';
         desc = "Browse cheatsheets (cheat + fzf)";
       }
     ];


### PR DESCRIPTION
## Summary

yazi 통합(#497) 이후 기본 조작이 손에 붙지 않는 진입장벽을 해소하기 위한 세 가지 변경.

### 1. yazi 핵심 키 cheatsheet 신설 (`59b38b8`)
- `modules/shared/programs/cheat/cheatsheets/yazi/keybinding` 신설.
- v26.x preset keymap (`sxyazi/yazi@v26.1.22` 의 `yazi-config/preset/keymap-default.toml`) 교차 검증.
- 섹션: 진입/종료 · 네비게이션 · 선택 · 파일 조작 · 검색 및 점프 · 기타 · 치트시트 + Tip 6개.
- Tip 에 yazi 통합 특유 맥락 포함: `y` 래퍼의 `q`/`Q` cwd 상속, `git.yazi` linemode, `z`(fzf)/`Z`(zoxide) 주의(preset 기준), Ghostty+tmux+SSH 이미지 프리뷰 3축 전제, 내장 help(`~`) 안내, 세 환경(nvim/tmux/yazi) 의 `C` 키 일관성.
- `cheat` 모듈의 `cheatpaths.path` 가 이미 이 디렉터리(`modules/shared/programs/cheat/cheatsheets`)를 가리키므로 cheatsheet 파일 자체는 Nix 재빌드 없이 즉시 조회됨.

### 2. yazi 세션에서 `C` 키로 cheat-browse 실행 (`62ff18f`)
- `modules/shared/programs/yazi/default.nix` 에 `keymap.mgr.prepend_keymap` 추가: `on=["C"]`, `run="shell ..."`.
- v26.x preset `[mgr]` 섹션에 단독 `C` 바인딩 없어 충돌 없음 (prepend 로 override 없음).
- nvim `<leader>C` · tmux `prefix+C` · yazi `C` 세 환경이 모두 동일 `cheat-browse` (cheat + fzf 브라우저) 를 띄우게 되어 키 메모리 단일화.
- `shell --block` 으로 yazi 를 잠시 숨기고 터미널 전체를 fzf 에 양보, 종료 시 yazi 복귀.
- yazi v26.1.22 소스 (`yazi-parser/src/mgr/shell.rs` 의 `ShellOpt` 에 `confirm` 필드 없음; `yazi-actor/src/mgr/shell.rs` 에서 프롬프트는 `interactive==true` 일 때만 열림) 로 `--confirm` 불필요 확증.

### 3. cheat-browse 호출 경로를 tmux 패턴과 통일 (`e46edf8`)
- `parallel-audit` B7 EDGECASE 반영: yazi 바인딩이 PATH 의존이던 것을 `"$HOME/.local/bin/cheat-browse"` 절대경로로 변경.
- `tmux.conf:149` 의 display-popup 호출과 동일 규약 → PATH 환경 차이(minimal env/subshell 변종)에 무관한 견고성 + 두 진입점의 일관성.

## Test plan
- [x] `cheat yazi/keybinding` 본문 렌더링 · `cheat -l -t yazi` 태그 조회 · `cheat -s` 본문 검색 확인
- [x] pre-commit: nixfmt · gitleaks · ai-skills-consistency · eval-tests 통과
- [x] pre-push: flake-check · shell-script-tests 통과
- [x] `nrs` 2회 성공 + 생성된 `~/.config/yazi/keymap.toml` 에 `run = "shell \"$HOME/.local/bin/cheat-browse\" --block"` 확인
- [x] yazi v26.1.22 shell command parser 동작 소스 검증 (프롬프트 없이 즉시 실행)
- [x] parallel-audit (2 agents, codex exec 경로) 통과 — EDGECASE 1건 (B7) 은 본 PR 의 3번째 커밋으로 반영
- [ ] 실제 yazi 세션에서 `C` 키로 cheat-browse 팝업 동작 확인 (사용자 수동 검증)

## 변경 파일
- `modules/shared/programs/cheat/cheatsheets/yazi/keybinding` (신설)
- `modules/shared/programs/yazi/default.nix` (keymap 추가 + 절대경로 통일)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new keybinding to the file manager enabling quick access to cheat browsing with a single keystroke.

* **Documentation**
  * Added detailed keybinding reference for the file manager, covering navigation, file operations, search/jump functionality, and miscellaneous actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->