### PR TITLE
feat(yazi): [mgr] 단일 문자 키 전체 한글 IME dual binding

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/yazi/keybinding
+++ b/modules/shared/programs/cheat/cheatsheets/yazi/keybinding
@@ -41,7 +41,7 @@ yazi TUI 파일 매니저 핵심 키 (preset 기준, v26.x)
 Tip
 - `y` wrapper: `q` 로 종료 시 yazi 현재 위치가 셸 cwd 로 따라옴. 브라우징 후 그 자리에서 작업 계속. 상속 거부는 `Q`.
 - `C` 는 nvim `<leader>C`, tmux `prefix+C` 와 동일 키. 세 환경 모두 같은 `cheat-browse` 실행.
-- 한글 2벌식 IME 활성 시 `Shift+C` → `ㅊ` 로 들어오므로 `ㅊ` 도 동일하게 바인딩 (yazi 한정).
+- 한글 2벌식 IME 활성 시에도 [mgr] 단일 키는 대부분 동작 (q, v, o, p 등 소문자 + Q, O, P, G). shift 변형이 동일 자모가 되는 키(H, L, V, K, J, Y, X, D, S, Z, N)와 다중 키 시퀀스(gg, m m)는 영문 IME 필요.
 - git.yazi 플러그인이 파일 옆 linemode 에 git 상태(M/A/D/? 등) 표시. `m m/s/p/b/o/n` 으로 linemode 전환.
 - `z` = fzf, `Z` = zoxide. 자주 반대로 기억하니 주의.
 - Ghostty + tmux + SSH 이미지 프리뷰는 tmux `allow-passthrough on` + Ghostty `shell-integration-features=ssh-env` + sshd `AcceptEnv` 3축 전제 (이 레포에 이미 구성). 프리뷰 안 뜨면 이 3축부터 확인.

--- a/modules/shared/programs/yazi/default.nix
+++ b/modules/shared/programs/yazi/default.nix
@@ -7,6 +7,146 @@
   pkgs,
   ...
 }:
+let
+  # 2벌식 한글 IME dual binding for [mgr] 단일 문자 키.
+  # preset 의 영문 단일 키 바인딩을 한글 IME 상태에서도 동일 동작하게 미러링.
+  # 충돌 규칙: shift 변형이 동일 자모(V→ㅍ = v)인 키는 소문자 우선 (더 자주 사용).
+  # shift 더블 자모(Q→ㅃ, O→ㅒ, P→ㅖ) 와 G(g 단독 없음) 는 uppercase 액션에 매핑.
+  # 다중 키 시퀀스(gg, m m 등)는 IME 조합 타이밍 불안정으로 제외.
+  mkHangul =
+    {
+      ko,
+      run,
+      desc,
+    }:
+    {
+      on = [ ko ];
+      inherit run desc;
+    };
+  hangulMgrBindings = map mkHangul [
+    # 종료
+    {
+      ko = "ㅂ";
+      run = "quit";
+      desc = "Quit the process (한글 IME)";
+    }
+    {
+      ko = "ㅃ";
+      run = "quit --no-cwd-file";
+      desc = "Quit without outputting cwd-file (한글 IME)";
+    }
+    # 네비게이션
+    {
+      ko = "ㅏ";
+      run = "arrow prev";
+      desc = "Previous file (한글 IME)";
+    }
+    {
+      ko = "ㅓ";
+      run = "arrow next";
+      desc = "Next file (한글 IME)";
+    }
+    {
+      ko = "ㅎ";
+      run = "arrow bot";
+      desc = "Go to bottom (한글 IME)";
+    }
+    {
+      ko = "ㅗ";
+      run = "leave";
+      desc = "Back to the parent directory (한글 IME)";
+    }
+    {
+      ko = "ㅣ";
+      run = "enter";
+      desc = "Enter the child directory (한글 IME)";
+    }
+    # 비주얼 모드
+    {
+      ko = "ㅍ";
+      run = "visual_mode";
+      desc = "Enter visual mode (한글 IME)";
+    }
+    # 파일 조작
+    {
+      ko = "ㅐ";
+      run = "open";
+      desc = "Open selected files (한글 IME)";
+    }
+    {
+      ko = "ㅒ";
+      run = "open --interactive";
+      desc = "Open selected files interactively (한글 IME)";
+    }
+    {
+      ko = "ㅛ";
+      run = "yank";
+      desc = "Yank selected files (copy) (한글 IME)";
+    }
+    {
+      ko = "ㅌ";
+      run = "yank --cut";
+      desc = "Yank selected files (cut) (한글 IME)";
+    }
+    {
+      ko = "ㅔ";
+      run = "paste";
+      desc = "Paste yanked files (한글 IME)";
+    }
+    {
+      ko = "ㅖ";
+      run = "paste --force";
+      desc = "Paste yanked files (overwrite) (한글 IME)";
+    }
+    {
+      ko = "ㅇ";
+      run = "remove";
+      desc = "Trash selected files (한글 IME)";
+    }
+    {
+      ko = "ㅁ";
+      run = "create";
+      desc = "Create a file (한글 IME)";
+    }
+    {
+      ko = "ㄱ";
+      run = "rename --cursor=before_ext";
+      desc = "Rename selected file(s) (한글 IME)";
+    }
+    # 검색 및 점프
+    {
+      ko = "ㄴ";
+      run = "search --via=fd";
+      desc = "Search files by name via fd (한글 IME)";
+    }
+    {
+      ko = "ㅋ";
+      run = "plugin fzf";
+      desc = "Jump to a file/directory via fzf (한글 IME)";
+    }
+    {
+      ko = "ㄹ";
+      run = "filter --smart";
+      desc = "Filter files (한글 IME)";
+    }
+    {
+      ko = "ㅜ";
+      run = "find_arrow";
+      desc = "Next found (한글 IME)";
+    }
+    # 탭/태스크
+    {
+      ko = "ㅅ";
+      run = "tab_create --current";
+      desc = "Create a new tab with CWD (한글 IME)";
+    }
+    {
+      ko = "ㅈ";
+      run = "tasks:show";
+      desc = "Show task manager (한글 IME)";
+    }
+  ];
+in
 {
   programs.yazi = {
     enable = true;
@@ -59,7 +199,8 @@
         run = ''shell "$HOME/.local/bin/cheat-browse" --block'';
         desc = "Browse cheatsheets (한글 IME)";
       }
-    ];
+    ]
+    ++ hangulMgrBindings;
 
     # 세 플러그인 모두 명시적 setup 필요 (upstream README 기준).
     initLua = ''


### PR DESCRIPTION
## Summary

- yazi `[mgr]` 섹션의 preset 단일 문자 키 23개 + 기존 `C → cheat-browse` 를 한글 2벌식 IME 상태에서도 동작하도록 dual binding 적용 (총 24개 `ㅂ/ㅏ/ㅓ/ㅗ/ㅣ/ㅍ/…` 엔트리).
- `mkHangul` 헬퍼와 `hangulMgrBindings` 리스트를 `default.nix` 의 `let` 블록에 도입하여 ASCII→Hangul 매핑을 한 곳에서 관리.
- 충돌하는 shift 변형(V/H/L/K/J 등)과 다중 키 시퀀스(gg, m m 등)는 의도적 제외.

Closes: (이슈 없음 — 57ea8c6 ㅊ 단건 대응 이후 같은 원리를 [mgr] 전체로 일반화하는 follow-up)

## 기존 문제/배경

#500 (29299cb) 에서 `C → cheat-browse` 바인딩을 추가했고, 이어서 57ea8c6 에서 한글 IME 상태의 `Shift+C → ㅊ` 대응을 단건으로 패치했다.

하지만 문제의 본질은 `C` 하나에 국한되지 않는다. yazi `[mgr]` 의 **모든 단일 문자 키**(`q` 종료, `v` visual mode, `o` open, `p` paste …)가 한글 IME 활성 상태에서는 대응 자모(`ㅂ/ㅍ/ㅐ/ㅔ/…`)로 들어오기 때문에 매칭되지 않는다.

**AS-IS**: 사용자가 다른 앱에서 한글을 쓰다 터미널로 복귀하여 `y` 로 yazi 를 띄우면 (IME 는 한글), `q` 로 종료하려 해도 `ㅂ` 만 전달되어 무반응. 매번 IME 를 영문으로 수동 전환해야 하는 마찰.

**TO-BE**: 한글 IME 상태에서도 `[mgr]` 단일 문자 키 대부분이 대응 자모로 동작. shift 변형 중 일부(11개)는 2벌식 키보드 특성상 lowercase 와 동일 자모를 생성하므로 영문 IME 가 여전히 필요하지만, 가장 빈번한 lowercase 액션은 완전 커버.

## CIR (Change Intent Record)

- **v1** (`57ea8c6`, merged): `C` 키 한 개에 대해서만 `ㅊ` dual binding 추가. 당시에는 scope 최소화 원칙으로 단건 대응.
- **v2** (이번 PR): 같은 원리를 `[mgr]` 단일 키 전체로 일반화. 사용자 피드백: _"q 도, 그리고 사실 yazi 내부에서 사용할 수 있는 모든 키바인딩에 한글 입력소스 지원을 넣고 싶어"_.
- **스코프 결정 (AskUserQuestion)**: `[mgr]` vs `[mgr]+[tasks]+[spot]+[help]` vs `전부` → `[mgr]` 만. 실제 사용 빈도 + 리뷰 복잡도 균형.
- **멀티키 시퀀스(`gg`, `m m/s/p/b/o/n`) 처리**: 포함 vs 제외 → 제외. 한글 IME 조합 버퍼(자음+모음) 타이밍상 `ㅎㅎ` 매칭이 불안정.
- **구현 스타일**: 수동 나열 vs Nix 헬퍼 함수 → 헬퍼 함수. 매핑 테이블 한 곳에서 유지보수.
- **치트시트 업데이트**: 행별 한글 병기 vs 매핑표 별도 섹션 vs Tip 한 줄 → Tip 한 줄. 각 행 자모 병기는 YAGNI (사용자 명시적 합의).

**trade-off**: shift 변형 중 2벌식에서 lowercase 와 동일 자모가 되는 11개 키(H, L, V, K, J, Y, X, D, S, Z, N) 는 한글 IME 로 접근 불가. 이 경우 영문 IME 필요. 소문자 액션을 우선 매핑한 이유는 사용 빈도상 `v`(visual mode) 가 `V`(visual unset) 보다 훨씬 잦기 때문.

## ADR

### 충돌 해결 전략

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 소문자 우선 | v/V → ㅍ 에 소문자 액션 매핑, 대문자는 커버리지 밖 | 사용 빈도 높은 액션 우선, 단순 | uppercase 액션은 한글 IME 접근 불가 (11개 키) | ✅ |
| 대문자 우선 | v/V → ㅍ 에 대문자 액션 매핑 | shift 강조 액션 보호 | 기본 액션을 잃는 것이 더 큰 마찰 | ❌ |
| 충돌 쌍 양쪽 skip | 11개 lowercase 도 제외 | 규칙 일관성 | 커버리지 급감 (실용성 훼손) | ❌ |

### 구현 스타일

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 수동 나열 | 각 dual binding 을 `prepend_keymap` 에 직접 작성 | 리뷰 투명, Nix 지식 요구 낮음 | ~130 줄 boilerplate, 매핑 변경 시 error-prone | ❌ |
| Nix 헬퍼 함수 | `mkHangul { ko, run, desc }` + `map mkHangul [...]` | 매핑 테이블 중앙화, 유지보수 용이 | 약간의 Nix 추상화 | ✅ |

### 멀티키 시퀀스 처리

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 포함 (`ㅎㅎ`, `ㅁ ㅅ` 등) | preset 의 다중 키 시퀀스도 dual binding | 커버리지 최대화 | 한글 IME 조합 타이밍(자음+모음 버퍼)상 매칭 불안정 | ❌ |
| 제외 (단일 키만) | `gg/m m/c c` 등은 영문 IME 요구 | 안정성 보장 | 특정 액션은 IME 전환 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/yazi/default.nix` | 수정 | `let` 블록에 `mkHangul` + `hangulMgrBindings` 추가, `prepend_keymap` 에 concat |
| `modules/shared/programs/cheat/cheatsheets/yazi/keybinding` | 수정 | Tip 항목에 한글 IME 커버리지 1줄 추가 |

### 핵심 코드

```nix
# modules/shared/programs/yazi/default.nix (let 블록)
mkHangul =
  { ko, run, desc }:
  {
    on = [ ko ];
    inherit run desc;
  };
hangulMgrBindings = map mkHangul [
  { ko = "ㅂ"; run = "quit";               desc = "Quit the process (한글 IME)"; }
  { ko = "ㅃ"; run = "quit --no-cwd-file"; desc = "Quit without outputting cwd-file (한글 IME)"; }
  { ko = "ㅏ"; run = "arrow prev";         desc = "Previous file (한글 IME)"; }
  { ko = "ㅓ"; run = "arrow next";         desc = "Next file (한글 IME)"; }
  { ko = "ㅎ"; run = "arrow bot";          desc = "Go to bottom (한글 IME)"; }
  # ... (23 entries total)
];
```

```nix
# keymap.mgr.prepend_keymap concat
keymap.mgr.prepend_keymap = [
  { on = [ "C" ];  run = ''shell "$HOME/.local/bin/cheat-browse" --block''; desc = "..."; }
  { on = [ "ㅊ" ]; run = ''shell "$HOME/.local/bin/cheat-browse" --block''; desc = "..."; }
] ++ hangulMgrBindings;
```

### 커버리지 표

| 유형 | 개수 | 예 |
|------|------|---|
| 소문자 단일 키 | 19 | q→ㅂ, v→ㅍ, o→ㅐ, p→ㅔ, t→ㅅ, y→ㅛ, w→ㅈ |
| shift 더블 자모 | 3 | Q→ㅃ, O→ㅒ, P→ㅖ |
| shift 단독 (lowercase 없음) | 1 | G→ㅎ |
| 커스텀 (기존) | 1 | C→ㅊ |
| **합계** | **24** | — |
| 제외 (shift 충돌) | 11 | H, L, V, K, J, Y, X, D, S, Z, N |
| 제외 (멀티키) | — | `gg`, `m m/s/p/b/o/n`, `c a/c/d/f` 등 |

## 참고 레퍼런스

- PR #500 (`29299cb`) — yazi 치트시트 + `C → cheat-browse` 최초 바인딩.
- 커밋 `57ea8c6` — `C` 에 대한 `ㅊ` 단건 dual binding (이번 PR 의 v1).
- PR #497 (`ec98c26`) — yazi TUI 파일 매니저 통합 (원본 모듈 도입).
- [yazi keymap docs](https://yazi-rs.github.io/docs/configuration/keymap) — `prepend_keymap` / `on` 필드 스펙.
- [sxyazi/yazi v26.1.22 preset](https://raw.githubusercontent.com/sxyazi/yazi/v26.1.22/yazi-config/preset/keymap-default.toml) — 매핑 교차검증 기준.
- 2벌식 한글 키보드 레이아웃 — `q=ㅂ, w=ㅈ, e=ㄷ, …` 표준 매핑.

## Human Test Plan

### 정상 동작 검증 (macOS + Ghostty + tmux)

1. **한글 IME 상태에서 yazi 진입 → 종료**
   - 입력소스를 `한국어 - 2벌식` 으로 전환.
   - `y` 로 yazi 실행 (IME 는 그대로 한글 유지).
   - `q` (→ `ㅂ` 입력) 눌러 종료.
   - **기대**: yazi 가 즉시 종료되고 현재 디렉터리가 셸 cwd 로 상속됨.
   - **실패 시**: `~/.config/yazi/keymap.toml` 에 `on = ["ㅂ"]` / `run = "quit"` 엔트리가 있는지 확인.

2. **비주얼 모드 진입**
   - 한글 IME 상태로 yazi 진입, `v` (→ `ㅍ`) 입력.
   - **기대**: visual mode 활성 (상태바 표시 변화).
   - **실패 시**: `on = ["ㅍ"]` / `run = "visual_mode"` 확인.

3. **cheat-browse 트리거 (기존 기능 유지)**
   - 한글 IME 상태로 yazi 진입, `Shift+C` (→ `ㅊ`) 입력.
   - **기대**: cheat-browse 팝업이 yazi 숨김 후 표시됨.
   - **실패 시**: `on = ["ㅊ"]` / `run = 'shell "$HOME/.local/bin/cheat-browse" --block'` 확인.

### 엣지 케이스

4. **shift 충돌 키 (한글 IME 불가)**
   - 한글 IME 상태로 yazi 진입, `Shift+V` (→ `ㅍ`, v 와 동일 자모) 입력.
   - **기대**: `visual_mode` (소문자 액션) 가 동작 — `visual_mode --unset` 아님. 이는 설계상 의도된 결과.
   - 영문 IME 로 전환 후 `V` 입력 시 `visual_mode --unset` 정상 동작 확인.

5. **영문 IME 에서 기존 바인딩 regression**
   - 영문 IME 상태로 yazi 진입.
   - `q`, `v`, `o`, `p`, `y` 등 기본 키가 preset 대로 동작하는지 확인.
   - **기대**: 한글 dual binding 추가 후에도 영문 단일 키 동작 변화 없음.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. generated keymap.toml 존재 확인
ls -L ~/.config/yazi/keymap.toml

# 2. 한글 IME 엔트리 개수 확인 (기대: 24 = 23 preset mirror + 1 C→ㅊ 커스텀)
grep -c '한글 IME' ~/.config/yazi/keymap.toml
# 기대: 24

# 3. 핵심 dual binding 몇 개 샘플 검증
grep -A1 'run = "quit"$' ~/.config/yazi/keymap.toml | grep -q 'on = \["ㅂ"\]'
grep -A1 'run = "visual_mode"$' ~/.config/yazi/keymap.toml | grep -q 'on = \["ㅍ"\]'
grep -A1 'run = "yank"$' ~/.config/yazi/keymap.toml | grep -q 'on = \["ㅛ"\]'
# 기대: 모두 exit 0

# 4. 충돌 해결 검증 — ㅍ 에 visual_mode (소문자) 가 매핑됐고 visual_mode --unset 은 아님
! grep -B1 'run = "visual_mode --unset"' ~/.config/yazi/keymap.toml | grep -q 'ㅍ'
# 기대: exit 0 (ㅍ 가 --unset 옆에 없어야 성공)

# 5. 멀티키 시퀀스 미포함 확인 — ㅎㅎ (gg) dual 이 없어야 함
! grep -q '"ㅎㅎ"' ~/.config/yazi/keymap.toml
! grep -q '\["ㅎ", "ㅎ"\]' ~/.config/yazi/keymap.toml
# 기대: 둘 다 exit 0

# 6. nixfmt 통과 확인
nixfmt --check modules/shared/programs/yazi/default.nix
# 기대: exit 0
```

### Phase 1: 빌드 및 활성화

> "`nrs` 가 성공하여 새 keymap 이 `~/.config/yazi/keymap.toml` symlink 로 반영되는지 확인"

```bash
# darwin-rebuild (macOS) 성공 여부
nrs 2>&1 | tail -5 | grep -q "Done!"
# 기대: exit 0
```
- **기대**: `Done! (Ns)` 메시지로 정상 종료, 에러 없음.
- **실패 시**: `nrs` 전체 로그에서 nix evaluation error / HM activation error 확인. `let` 블록 syntax 오류 여지 점검.

### Phase 2: cheatsheet 정합성

> "cheat 의 `yazi/keybinding` 치트시트에 한글 IME 커버 범위 Tip 이 반영됐는지 확인"

```bash
grep -q '한글 2벌식 IME' modules/shared/programs/cheat/cheatsheets/yazi/keybinding
grep -q 'shift 변형이 동일 자모' modules/shared/programs/cheat/cheatsheets/yazi/keybinding
grep -q '영문 IME 필요' modules/shared/programs/cheat/cheatsheets/yazi/keybinding
# 기대: 모두 exit 0

# cheat 모듈 symlink 경로로도 조회 가능한지
cheat yazi/keybinding 2>/dev/null | grep -q '한글 2벌식 IME'
# 기대: exit 0
```
- **실패 시**: cheatsheet 파일이 `modules/shared/programs/cheat/cheatsheets/yazi/keybinding` 에 위치하고 cheat 모듈 `cheatpaths.path` 가 이 디렉터리를 포함하는지 확인.

### Phase 3: Regression — 기존 C→ㅊ 바인딩 유지

> "57ea8c6 의 단건 fix 가 이번 일반화에 의해 깨지지 않는지 확인"

```bash
# C / ㅊ 모두 cheat-browse 로 매핑됨
grep -c '"$HOME/.local/bin/cheat-browse"' ~/.config/yazi/keymap.toml
# 기대: 2 (C 와 ㅊ)

grep -B1 'Browse cheatsheets (cheat + fzf)' ~/.config/yazi/keymap.toml | grep -q 'on = \["C"\]'
grep -B1 'Browse cheatsheets (한글 IME)' ~/.config/yazi/keymap.toml | grep -q 'on = \["ㅊ"\]'
# 기대: 모두 exit 0
```
- **실패 시**: `prepend_keymap` 의 order 가 바뀌었거나 concat (`++`) 로직이 잘못된 가능성 점검.

### Phase 4: Regression — preset 영문 바인딩 유지

> "dual binding 추가가 preset 의 영문 단일 키를 override 하지 않는지 확인"

```bash
# prepend_keymap 은 preset 앞에 추가될 뿐 영문 C/q/v 등을 덮지 않음을 이론적으로 보장하므로
# 실제로는 keymap.toml 에 prepend 만 있고 preset 전체 바인딩은 yazi 런타임 merge 로 처리됨.
# prepend_keymap 엔트리 총 수만 확인.
grep -c '^\[\[mgr.prepend_keymap\]\]$' ~/.config/yazi/keymap.toml
# 기대: 25 (C + ㅊ + 23 hangul mirror)
```
- **실패 시**: `++ hangulMgrBindings` concat 이 누락됐거나 `mkHangul` 매핑 개수가 23 이 아닌 경우.

### 결과 보고 형식

| Phase | 테스트명 | 결과 |
|-------|---------|------|
| 0 | 한글 IME 엔트리 24개 존재 | — |
| 0 | 충돌 키 (ㅍ → visual_mode) | — |
| 0 | 멀티키 시퀀스 미포함 | — |
| 0 | nixfmt 통과 | — |
| 1 | `nrs` 빌드 성공 | — |
| 2 | cheatsheet Tip 반영 | — |
| 3 | C/ㅊ → cheat-browse 유지 | — |
| 4 | prepend_keymap 총 25개 | — |

실패 시 [Pre-Merge 가이드](.claude/skills/create-pr/references/pre-merge-guide.md) 의 실패 항목 상세 템플릿에 따라 원인 분석 및 수정 방향을 보고.