### PR TITLE
chore(claude): rm -rf deny 규칙 완화 (~/*, /* 제거)

### DIFF
--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -14,8 +14,6 @@
     "deny": [
       "Bash(rm -rf /)",
       "Bash(rm -rf ~)",
-      "Bash(rm -rf ~/*)",
-      "Bash(rm -rf /*)",
       "Bash(npm *)"
     ],
     "additionalDirectories": [


### PR DESCRIPTION
## Summary

- `permissions.deny`에서 와일드카드 2개(`Bash(rm -rf ~/*)`, `Bash(rm -rf /*)`)만 제거
- 정확 매칭 `Bash(rm -rf /)`, `Bash(rm -rf ~)`, `Bash(npm *)`는 유지
- 결과: 홈/시스템 절대경로 하위 `rm -rf` 허용, 루트·홈 직접 파괴만 차단

## 기존 문제/배경

현재 규칙:
```json
"deny": [
  "Bash(rm -rf /)",
  "Bash(rm -rf ~)",
  "Bash(rm -rf ~/*)",
  "Bash(rm -rf /*)",
  "Bash(npm *)"
]
```

Claude Code 공식 문서 ([permissions.md#bash](https://code.claude.com/docs/en/permissions.md#bash))에 따르면 `*`는 **공백과 슬래시를 포함한 모든 문자를 매칭**한다.

따라서 현재 규칙은 아래와 같이 과도하게 차단:

| 명령 | 결과 | 이유 |
|---|---|---|
| `rm -rf ~/Downloads/cache` | ⛔ 차단 | `Bash(rm -rf ~/*)` 매칭 |
| `rm -rf /tmp/build-xxx` | ⛔ 차단 | `Bash(rm -rf /*)` 매칭 |
| `rm -rf /Users/glen/Workspace/.../dist` | ⛔ 차단 | `Bash(rm -rf /*)` 매칭 |
| `rm -rf ./node_modules` | ✅ 허용 | 상대경로는 규칙 미매칭 |

결국 상대경로를 제외한 **거의 모든 실전 `rm -rf`가 차단**되어 LLM이 정리 작업을 수행하지 못하는 상황.

## CIR (Change Intent Record)

### 발견 경위
`rm -rf` 차단으로 인한 워크플로우 마찰 인식 → 대안으로 Claude Code Auto Mode(분류기 기반 동적 승인) 도입을 먼저 검토.

### 설계 의도
- **bypass permission 모드 상시 사용**이 전제 (`skipDangerousModePermissionPrompt: true`). 본 세션에서 bypass 모드에서도 deny가 강제됨을 실증 확인함.
- **LLM 자율성 vs 파괴적 가드**의 균형점을 "정확 매칭만 유지"로 설정.
- 민감 경로(`.ssh`, agenix, `nixos-config` 등) 명시 보호는 **이번 범위 밖**. 실운용 후 불안감이 확인되면 별도 이슈로 재도입.

### 대안 검토 이력 — Auto Mode 도입 기각

**공식 표현** (Anthropic 직접 제공):
- [Claude blog "Auto mode for Claude Code"](https://claude.com/blog/auto-mode) (2026-03-24):
  > "small impact on token consumption, cost, and latency"
- [permission-modes "Cost and latency" 섹션](https://code.claude.com/docs/en/permission-modes#cost-and-latency):
  > "Classifier calls count toward your token usage. Each check sends a portion of the transcript plus the pending action, adding a round-trip before execution."

**구체적 오버헤드 퍼센티지는 공식 문서 전수 부재**. 4개 축 fan-out(codex exec 병렬) 교차검증 결과:

| 축 | 결과 |
|---|---|
| code.claude.com 공식 docs 전수 | 수치 없음, 정성 서술만 |
| Anthropic blog + engineering blog | 수치 없음, "small impact"가 최강 표현 |
| CHANGELOG + anthropics/claude-code GitHub | 수치 없음 (CHANGELOG의 "10%"는 MCP tool search 임계값, 무관 기능) |
| 커뮤니티/웹 일반 | Medium 1건이 "roughly 10–15%" 언급하나 해당 글 FAQ에 "There's no official figure" 명시 |

> **정정 메모 (hallucination 경위)**: 본 PR 준비 초기 하위 에이전트가 "default 대비 10~15% 토큰 증가"를 `code.claude.com/docs/en/costs` 출처로 제시하여 초기 커밋 메시지(66dae0e)와 대화에 반영되었다. 공식 문서 재확인 및 4-agent fan-out 교차검증 결과 해당 페이지에 수치 부재가 확정. 제3자 Medium 1건만이 같은 수치를 쓰나 본인도 공식성을 부정. **서브에이전트가 Medium 글의 숫자만 따다가 "공식 수치"로 재포장한 것으로 추정**. 본 PR 본문은 정성적 근거 + 공식 인용으로 대체.

**실제 기각 근거**: 정성적 오버헤드 존재 + 구체 수치 미공개로 사전 비용 통제 어려움 + 상시 사용 시 장기 비용 리스크 불확실.

**민감 경로 명시 deny 유지 + 와일드카드 제거**: 조기 최적화로 판단, YAGNI 관점에서 단순화 선택.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| A. 와일드카드 2개 제거 | `~/*`, `/*`만 삭제. `/`, `~`, `npm *`는 유지 | 최소 변경, 정확 매칭으로 치명 케이스는 유지 | 민감 경로 개별 보호 없음 | ✅ 채택 |
| B. A + 민감 경로 명시 | SSH/agenix/nixos-config 등 별도 deny 추가 | 보수적 안전망 | 현 시점 불확실한 위험 대비 복잡도 증가 (YAGNI) | ❌ |
| C. deny 전면 제거 | `rm -rf` 관련 모든 deny 삭제 | 최대 자율성 | `rm -rf /` 같은 치명적 실수 방어막 소실 | ❌ |
| D. 현상 유지 + Auto Mode | Auto Mode로 동적 승인 | AI 기반 위험 평가 | 정성적 토큰/지연 오버헤드 존재(공식 수치 미공개), 상시 사용 시 불확실한 장기 비용 | ❌ |

## 구현 상세

| 파일 | 변경 | 이유 |
|---|---|---|
| `modules/shared/programs/claude/files/settings.json` | `deny` 배열에서 2줄 삭제 | 과차단된 와일드카드 제거 |

### Diff

```diff
 "deny": [
   "Bash(rm -rf /)",
   "Bash(rm -rf ~)",
-  "Bash(rm -rf ~/*)",
-  "Bash(rm -rf /*)",
   "Bash(npm *)"
 ],
```

### 반영 메커니즘

`~/.claude/settings.json`은 `config.lib.file.mkOutOfStoreSymlink`로 nixos-config 원본 파일을 직접 참조 (`default.nix:136-137`). 따라서 **원본 파일 편집 즉시 반영**되며 `nrs` 재빌드가 불필요 (검증: `nrs` 실행 시 "No changes" 확인).

## 참고 레퍼런스

- Claude Code 공식 permissions 문서 (wildcard 시맨틱): https://code.claude.com/docs/en/permissions.md#bash
- Permission modes 문서 (Auto mode + Cost and latency 섹션): https://code.claude.com/docs/en/permission-modes
- Claude blog "Auto mode for Claude Code" (2026-03-24, "small impact" 표현): https://claude.com/blog/auto-mode
- Anthropic Engineering "Claude Code auto mode deep dive" (2026-03-25): https://www.anthropic.com/engineering/claude-code-auto-mode
- Cost 관리 문서: https://code.claude.com/docs/en/costs
- 독립 평가 논문 arxiv 2604.04978 (Permission Gate 안전성 평가, 토큰 오버헤드와 무관): https://arxiv.org/abs/2604.04978
- `default.nix:136-137` — `mkOutOfStoreSymlink`로 settings.json 마운트
- 관련 커밋: `66dae0e chore(claude): loosen rm -rf deny rules` (이 PR 본 커밋; 메시지에 "10~15%" 수치가 남아있으나 본 본문에서 정정)

## Human Test Plan

### 1. PR 머지 전
- [ ] GitHub Diff 탭에서 2줄 삭제만 있고 다른 수정이 없는지 확인
- [ ] lefthook pre-commit/pre-push가 모두 통과했는지 확인 (flake-check, shell-script-tests, gitleaks 등)

### 2. 머지 후 로컬 검증
- [ ] main으로 전환 후 pull: `git checkout main && git pull`
- [ ] 변경 반영 확인: `jq '.permissions.deny' ~/.claude/settings.json`
  - 기대: `["Bash(rm -rf /)", "Bash(rm -rf ~)", "Bash(npm *)"]` (3개 항목)
- [ ] **새 Claude Code 세션 시작** (기존 세션은 deny 규칙을 캐시하므로 재시작 필요)
- [ ] 무해한 경로로 동작 검증:
  ```bash
  mkdir -p /tmp/rm-rf-test && rm -rf /tmp/rm-rf-test
  mkdir -p ~/rm-rf-test && rm -rf ~/rm-rf-test
  ```
  - 기대: 두 명령 모두 permission prompt 없이 통과
- [ ] 여전한 차단 확인 (실제 실행 금지, LLM에게 시도만 요청):
  - `rm -rf /` → 차단 유지
  - `rm -rf ~` → 차단 유지
  - `npm install <anything>` → 차단 유지

### 실패 시 진단

- **jq 출력에 5개 항목이 그대로** → `mkOutOfStoreSymlink` 체인 끊김. `readlink ~/.claude/settings.json` 확인 후 `nrs --force` 재적용
- **새 세션에서도 `rm -rf /tmp/...` 차단됨** → Claude Code가 `settings.json` 다른 위치를 참조 중. `claude config list` 출력과 `~/.claude/settings.local.json` 내용 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 파일 변경 확인
git diff main...HEAD -- modules/shared/programs/claude/files/settings.json
# 기대: 2줄 삭제만 (~/*, /* 와일드카드)

# 활성 설정 반영 확인 (mkOutOfStoreSymlink 덕)
jq '.permissions.deny' ~/.claude/settings.json
# 기대: 3개 항목 ["Bash(rm -rf /)", "Bash(rm -rf ~)", "Bash(npm *)"]

# 제거된 패턴이 활성 설정에 없는지 재확인
jq '.permissions.deny | any(. == "Bash(rm -rf ~/*)" or . == "Bash(rm -rf /*)")' ~/.claude/settings.json
# 기대: false
```

실패 시: `mkOutOfStoreSymlink` 체인 점검, `readlink -f ~/.claude/settings.json`이 저장소 원본을 가리키는지 확인.

### Phase 1: 허용 명령 검증 (새 세션에서)

```bash
mkdir -p /tmp/phase1-abs-tmp && rm -rf /tmp/phase1-abs-tmp && echo "PASS: /tmp 하위"
mkdir -p ~/phase1-home-test && rm -rf ~/phase1-home-test && echo "PASS: ~/ 하위"
mkdir -p /Users/glen/Workspace/phase1-ws-test && rm -rf /Users/glen/Workspace/phase1-ws-test && echo "PASS: /Users/glen/Workspace 하위"
```

기대: 3개 PASS 모두 출력, permission prompt 발생 없음.

실패 시: 현 세션이 이전 deny 규칙 캐시 중 → 세션 완전 재시작 (Cmd+Q 후 재실행).

### Phase 2: 차단 유지 검증

LLM에게 다음 명령 시도를 요청하고 차단되는지 확인 (실제 실행 금지):
- `rm -rf /` → deny 기대
- `rm -rf ~` → deny 기대
- `npm install test-package` → deny 기대

실패 시: 정확 매칭 규칙이 working tree와 활성 설정에서 일치하는지 재검증.

### Phase 3: Regression — 인접 설정 영향 없음

```bash
# 다른 permission·hook·env 값이 의도치 않게 변경되지 않았는지
jq 'del(.permissions.deny)' ~/.claude/settings.json | md5
# 현재 값 기록. 머지 전후 동일해야 함
```

기대: 해시 값 동일 (deny 외 필드 불변).

---

**주의**: 본 변경 **검증 세션에서 실증 확인**된 사항 — Claude Code의 `bypassPermissions` 모드에서도 `permissions.deny`는 hard block으로 강제됨. 공식 문서에는 이 동작이 명시되지 않음 (조사 한계).