### PR TITLE
feat(codex): manage ~/.codex/config.toml via activation merge

### DIFF
--- a/docs/CHROME_DEVTOOLS_MCP_AUTOCONNECT.md
+++ b/docs/CHROME_DEVTOOLS_MCP_AUTOCONNECT.md
@@ -170,12 +170,14 @@ npx --version
 ## 11. Worktree/심볼릭 링크 주의
 
 Home Manager 링크 타깃이 메인 레포를 가리키는 환경에서는, worktree 전용 파일이 링크 경로와 불일치할 수 있다.
-merge 전에는 실제 런타임 파일 링크를 반드시 확인한다.
+`~/.claude/mcp.json`은 여전히 out-of-store symlink로 관리되므로 `readlink`로 대상 확인이 유효하다.
+`~/.codex/config.toml`은 activation(`syncCodexConfig`)이 관리하는 regular file이며, 이 파일의 "관리 상태" 검증은
+`bash scripts/ai/verify-ai-compat.sh`로 수행한다 (regular file + 0600 + TOML 파싱 확인).
 
 ```bash
 ls -l ~/.claude/mcp.json ~/.codex/config.toml
-readlink ~/.claude/mcp.json
-readlink ~/.codex/config.toml
+readlink ~/.claude/mcp.json   # symlink 대상 확인
+bash scripts/ai/verify-ai-compat.sh   # ~/.codex/config.toml 관리 상태 검증
 ```
 
 ## 12. 실패 시 대안 전략

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -1,7 +1,9 @@
 # Codex CLI 설정 (공통)
 # 바이너리: macOS=brew cask, NixOS=GitHub releases 직접 다운로드
 # Claude Code 스킬을 Codex에서도 사용할 수 있도록 심볼릭 링크 관리
-# 이전 시도(5ef4e67)에서 trust 미설정으로 실패 → config.toml에 trust 필수
+# trust는 런타임 mutation(사용자 승인, 디렉토리당 1회)이 SoT. template은 trust를
+# 하드코딩하지 않으며, ~/.codex/config.toml은 activation의 syncCodexConfig가
+# repo-managed 키와 사용자 소유 섹션(projects/사용자 MCP)을 merge한 regular file.
 {
   config,
   pkgs,
@@ -13,6 +15,12 @@
 let
   codexFilesPath = "${nixosConfigPath}/modules/shared/programs/codex/files";
   codexConfigFile = if pkgs.stdenv.isDarwin then "config.darwin.toml" else "config.toml";
+  codexConfigSeedPath = "${codexFilesPath}/${codexConfigFile}";
+  # activation에서 repo-managed 키와 사용자 소유 섹션을 merge하는 Python 스크립트.
+  # 순수 store path로 실행되므로 런타임에 repo 경로를 읽지 않는다.
+  codexSyncScript = ./files/sync-codex-config.py;
+  # tomlkit: 주석/순서 보존 가능한 TOML read/write 라이브러리. nixpkgs 제공.
+  pythonWithTomlkit = pkgs.python3.withPackages (ps: [ ps.tomlkit ]);
   # Claude 파일 경로 (공유 소스)
   claudeFilesPath = "${nixosConfigPath}/modules/shared/programs/claude/files";
 
@@ -60,12 +68,6 @@ in
   # ─── 글로벌 설정 (~/.codex/) ───
 
   home.file = {
-    # Codex config.toml - 양방향 수정 가능 (codex mcp add 등 반영)
-    # ⚠️ trust 설정 포함 — 이것이 .agents/skills/ 발견의 전제조건
-    # 주의: macOS는 chrome-devtools-mcp user-scope MCP를 포함한 별도 템플릿 사용
-    ".codex/config.toml".source =
-      config.lib.file.mkOutOfStoreSymlink "${codexFilesPath}/${codexConfigFile}";
-
     # 글로벌 AGENTS.md - Claude의 CLAUDE.md와 동일 소스 공유
     ".codex/AGENTS.md".source = config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/CLAUDE.md";
 
@@ -76,6 +78,22 @@ in
   }
   # 글로벌 스킬 (Claude와 동일 소스 공유) — exposedCodexSkills에서 자동 생성
   // codexSkillEntries;
+
+  # ─── ~/.codex/config.toml 동기화 (activation) ───
+  # repo-managed 키(model, approval_policy, sandbox_mode, plugins 등)는 매 activation에서
+  # template으로 재적용한다. 사용자 소유 섹션은 보존한다:
+  #   - [projects.*]                              (runtime trust — codex CLI가 append)
+  #   - [mcp_servers.<template에 없는 이름>]      (codex mcp add 등)
+  # 결과는 regular file (mode 0600). symlink 기반 관리와 달리 codex CLI의 config write가
+  # repo 원본에 write-through되지 않아 git working tree가 오염되지 않는다.
+  home.activation.syncCodexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    config_dir="$HOME/.codex"
+    $DRY_RUN_CMD mkdir -p "$config_dir"
+    $DRY_RUN_CMD ${pythonWithTomlkit}/bin/python3 \
+      ${codexSyncScript} \
+      "${codexConfigSeedPath}" \
+      "$config_dir/config.toml"
+  '';
 
   # ─── NixOS: Codex CLI 바이너리 설치 (GitHub releases) ───
   # macOS는 brew cask로 관리 (modules/darwin/programs/homebrew.nix)

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -13,11 +13,14 @@
 }:
 
 let
-  codexFilesPath = "${nixosConfigPath}/modules/shared/programs/codex/files";
-  codexConfigFile = if pkgs.stdenv.isDarwin then "config.darwin.toml" else "config.toml";
-  codexConfigSeedPath = "${codexFilesPath}/${codexConfigFile}";
+  # Codex config template. Nix 상대경로(./files/...)를 쓰면 현재 flake 소스 트리에서
+  # store로 복사되므로, worktree에서 `nrs --flake .` 로 빌드해도 그 worktree의 최신
+  # 파일이 seed로 반영된다. `nixosConfigPath`(=항상 메인 체크아웃 경로) 기반 문자열을
+  # 쓰면 worktree 변경이 누락된다.
+  codexConfigSeedPath =
+    if pkgs.stdenv.isDarwin then ./files/config.darwin.toml else ./files/config.toml;
   # activation에서 repo-managed 키와 사용자 소유 섹션을 merge하는 Python 스크립트.
-  # 순수 store path로 실행되므로 런타임에 repo 경로를 읽지 않는다.
+  # 동일하게 store path로 copy되므로 현 flake 기준으로 동작한다.
   codexSyncScript = ./files/sync-codex-config.py;
   # tomlkit: 주석/순서 보존 가능한 TOML read/write 라이브러리. nixpkgs 제공.
   pythonWithTomlkit = pkgs.python3.withPackages (ps: [ ps.tomlkit ]);

--- a/modules/shared/programs/codex/files/sync-codex-config.py
+++ b/modules/shared/programs/codex/files/sync-codex-config.py
@@ -24,10 +24,10 @@
 # Write is atomic (tempfile + os.replace) so a codex process reading the file
 # concurrently sees either the old or new content, never a partial merge.
 #
-# If the existing file can be read but is malformed TOML, we quarantine it to
-# <target>.bad-<ts> and regenerate from the template — a stray hand-edit must
-# not brick the whole home-manager generation. Read-level failures that are
-# NOT "file missing" (permission denied, I/O error, invalid UTF-8) DO abort,
+# If the existing file can be read but is malformed TOML or invalid UTF-8, we
+# quarantine it to <target>.bad-<ts> and regenerate from the template — a stray
+# hand-edit must not brick the whole home-manager generation. Read-level
+# failures that are NOT "file missing" (permission denied, I/O error) DO abort,
 # because silently replacing an unreadable file would destroy user trust and
 # MCP data.
 

--- a/modules/shared/programs/codex/files/sync-codex-config.py
+++ b/modules/shared/programs/codex/files/sync-codex-config.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Merge repo template into ~/.codex/config.toml.
+#
+# Repo-managed keys are re-applied from the template on every activation.
+# User-owned sections are preserved across activations:
+#   - [projects.*]                        (runtime trust entries)
+#   - [mcp_servers.<name>] where <name>   is NOT present in the template
+#
+# Write is atomic (tempfile + os.replace) so a codex process reading the file
+# concurrently sees either the old or new content, never a partial merge.
+
+from __future__ import annotations
+
+import copy
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    import tomlkit
+except ImportError:
+    print("sync-codex-config: tomlkit module required", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_toml(path: Path):
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return tomlkit.document()
+    except OSError as e:
+        print(f"sync-codex-config: cannot read {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        return tomlkit.parse(text)
+    except Exception as e:
+        print(f"sync-codex-config: TOML parse failed for {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: sync-codex-config.py <template> <target>", file=sys.stderr)
+        return 2
+
+    template_path = Path(sys.argv[1])
+    target_path = Path(sys.argv[2])
+
+    template = load_toml(template_path)
+    existing = load_toml(target_path)
+
+    user_projects = existing.get("projects", None)
+    existing_mcps = existing.get("mcp_servers", {}) or {}
+    template_mcps = template.get("mcp_servers", {}) or {}
+    user_mcp_keys = [k for k in existing_mcps.keys() if k not in template_mcps]
+
+    result = copy.deepcopy(template)
+
+    if user_projects is not None:
+        result["projects"] = user_projects
+
+    if user_mcp_keys:
+        if "mcp_servers" not in result:
+            result["mcp_servers"] = tomlkit.table()
+        for k in user_mcp_keys:
+            result["mcp_servers"][k] = existing_mcps[k]
+
+    serialized = tomlkit.dumps(result)
+
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target_path.parent),
+        prefix=".config.toml.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(serialized)
+        os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, target_path)
+    except Exception as e:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        print(f"sync-codex-config: write failed: {e}", file=sys.stderr)
+        return 2
+
+    n_projects = len(user_projects) if user_projects is not None else 0
+    n_user_mcps = len(user_mcp_keys)
+    print(
+        f"sync-codex-config: preserved {n_projects} projects entries, "
+        f"{n_user_mcps} user mcps",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/shared/programs/codex/files/sync-codex-config.py
+++ b/modules/shared/programs/codex/files/sync-codex-config.py
@@ -6,68 +6,158 @@
 #   - [projects.*]                        (runtime trust entries)
 #   - [mcp_servers.<name>] where <name>   is NOT present in the template
 #
+# Merge policy for keys that exist in BOTH the template and the existing file:
+#   * template-managed keys (all top-level scalars, [notice], [features],
+#     [plugins.*], [mcp_servers.<name in template>])  -> template WINS.
+#     User edits to those are overwritten and a warning is logged to stderr.
+#   * [projects.*] and [mcp_servers.<name NOT in template>] -> user WINS.
+#
 # Write is atomic (tempfile + os.replace) so a codex process reading the file
 # concurrently sees either the old or new content, never a partial merge.
+#
+# If the existing file is malformed TOML, we DO NOT abort activation. Instead
+# we quarantine it to <target>.bad-<ts> and regenerate from the template, so a
+# stray hand-edit never bricks the whole home-manager generation.
 
 from __future__ import annotations
 
 import copy
+import datetime as _dt
 import os
 import sys
 import tempfile
 from pathlib import Path
+from typing import Optional
+
+PREFIX = "sync-codex-config"
+
+
+def log(msg: str) -> None:
+    print(f"{PREFIX}: {msg}", file=sys.stderr)
+
+
+def die(msg: str, code: int = 2) -> "None":
+    log(msg)
+    sys.exit(code)
+
+
+def usage() -> "None":
+    die(f"usage: {os.path.basename(sys.argv[0])} <template> <target>", code=2)
+
 
 try:
     import tomlkit
 except ImportError:
-    print("sync-codex-config: tomlkit module required", file=sys.stderr)
-    sys.exit(2)
+    die("tomlkit module required (nix: pkgs.python3Packages.tomlkit)", code=2)
 
 
-def load_toml(path: Path):
+def load_required_toml(path: Path):
+    # Template 등 반드시 존재하고 유효해야 하는 입력.
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        die(f"template not found: {path}", code=1)
+    except OSError as e:
+        die(f"cannot read template {path}: {e}", code=2)
+    try:
+        return tomlkit.parse(text)
+    except Exception as e:
+        die(f"template parse failed ({path}): {e}", code=1)
+
+
+def load_optional_toml(path: Path, *, quarantine: bool):
+    # 사용자 파일처럼 없거나 깨져 있어도 activation을 죽이지 않는 입력.
     try:
         text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return tomlkit.document()
     except OSError as e:
-        print(f"sync-codex-config: cannot read {path}: {e}", file=sys.stderr)
-        sys.exit(2)
+        log(f"cannot read existing {path}: {e} — treating as empty")
+        return tomlkit.document()
     try:
         return tomlkit.parse(text)
     except Exception as e:
-        print(f"sync-codex-config: TOML parse failed for {path}: {e}", file=sys.stderr)
-        sys.exit(1)
+        if quarantine and path.exists():
+            stamp = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+            bad = path.with_name(f"{path.name}.bad-{stamp}")
+            try:
+                path.rename(bad)
+                log(
+                    f"existing {path} parse failed ({e}); quarantined to {bad}, "
+                    f"regenerating from template"
+                )
+            except OSError as mv_err:
+                log(
+                    f"existing {path} parse failed ({e}); quarantine to {bad} "
+                    f"also failed ({mv_err}); regenerating in place"
+                )
+        else:
+            log(f"existing {path} parse failed ({e}); regenerating from template")
+        return tomlkit.document()
+
+
+def as_table_or_warn(value, *, where: str) -> Optional[dict]:
+    # TOML spec 위반(예: projects = 1)인 경우 방어. None 반환이면 호출부에서 무시.
+    if value is None:
+        return None
+    try:
+        # tomlkit Table / inline Table 모두 Mapping 프로토콜을 따른다.
+        iter(value.keys())  # type: ignore[attr-defined]
+        return value  # type: ignore[return-value]
+    except Exception:
+        log(f"ignoring {where}: expected a table, got {type(value).__name__}")
+        return None
 
 
 def main() -> int:
     if len(sys.argv) != 3:
-        print("usage: sync-codex-config.py <template> <target>", file=sys.stderr)
-        return 2
+        usage()
 
     template_path = Path(sys.argv[1])
     target_path = Path(sys.argv[2])
 
-    template = load_toml(template_path)
-    existing = load_toml(target_path)
+    template = load_required_toml(template_path)
+    existing = load_optional_toml(target_path, quarantine=True)
 
-    user_projects = existing.get("projects", None)
-    existing_mcps = existing.get("mcp_servers", {}) or {}
-    template_mcps = template.get("mcp_servers", {}) or {}
-    user_mcp_keys = [k for k in existing_mcps.keys() if k not in template_mcps]
+    template_projects = as_table_or_warn(template.get("projects"), where="template.projects")
+    template_mcps = as_table_or_warn(template.get("mcp_servers"), where="template.mcp_servers") or {}
+    user_projects = as_table_or_warn(existing.get("projects"), where="existing.projects")
+    user_mcps = as_table_or_warn(existing.get("mcp_servers"), where="existing.mcp_servers") or {}
 
+    # user-owned mcp = template에 없는 이름만. template에 있는 이름은 template wins.
+    user_mcp_keys = [k for k in user_mcps.keys() if k not in template_mcps]
+
+    # conflict observation: template MCP 키를 사용자가 수정했는지 감지.
+    # 수정 여부는 TOML 텍스트 기준으로 정확히 비교하기 어렵지만, 동일 키가 양쪽에
+    # 존재한다는 사실만 로그로 남겨 "template wins" 정책을 투명하게 한다.
+    for k in template_mcps.keys():
+        if k in user_mcps:
+            log(f"mcp_servers.{k}: template-managed key present in user file — template value wins")
+
+    # projects는 template에도 존재하지 않는 것이 정상. template이 projects를 선언하면 경고.
+    if template_projects is not None:
+        log("template.projects present — unusual; template wins for these keys")
+
+    # template 기반 결과 생성.
     result = copy.deepcopy(template)
 
-    if user_projects is not None:
+    # user projects 복원 (template이 projects를 선언한 드문 경우에도 user wins — trust는 runtime이 소유).
+    if user_projects is not None and len(user_projects) > 0:
         result["projects"] = user_projects
+    elif template_projects is None and "projects" in result:
+        # deepcopy는 template에 없는 키를 만들지 않지만, 방어적으로 정리.
+        del result["projects"]
 
+    # user-owned mcp 복원.
     if user_mcp_keys:
         if "mcp_servers" not in result:
             result["mcp_servers"] = tomlkit.table()
         for k in user_mcp_keys:
-            result["mcp_servers"][k] = existing_mcps[k]
+            result["mcp_servers"][k] = user_mcps[k]
 
     serialized = tomlkit.dumps(result)
 
+    # atomic write with mode 0600.
     target_path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(
         dir=str(target_path.parent),
@@ -84,15 +174,13 @@ def main() -> int:
             os.unlink(tmp_name)
         except OSError:
             pass
-        print(f"sync-codex-config: write failed: {e}", file=sys.stderr)
-        return 2
+        die(f"atomic write failed ({target_path}): {e}", code=2)
 
     n_projects = len(user_projects) if user_projects is not None else 0
-    n_user_mcps = len(user_mcp_keys)
-    print(
-        f"sync-codex-config: preserved {n_projects} projects entries, "
-        f"{n_user_mcps} user mcps",
-        file=sys.stderr,
+    log(
+        f"preserved {n_projects} projects entries, "
+        f"{len(user_mcp_keys)} user-owned mcp_servers "
+        f"(template-managed mcp_servers: {len(template_mcps)})"
     )
     return 0
 

--- a/modules/shared/programs/codex/files/sync-codex-config.py
+++ b/modules/shared/programs/codex/files/sync-codex-config.py
@@ -1,28 +1,38 @@
 #!/usr/bin/env python3
 # Merge repo template into ~/.codex/config.toml.
 #
-# Repo-managed keys are re-applied from the template on every activation.
-# User-owned sections are preserved across activations:
-#   - [projects.*]                        (runtime trust entries)
-#   - [mcp_servers.<name>] where <name>   is NOT present in the template
+# Ownership policy:
+#   * Template-owned keys   = every top-level key that appears in the template
+#                             PLUS every [mcp_servers.<name>] where <name> is
+#                             declared in the template.
+#     These are (re-)applied from the template on each activation.
+#   * User-owned sections   = everything else in the existing file — any
+#                             top-level key NOT in the template, `[projects.*]`,
+#                             and every [mcp_servers.<name>] where <name> is
+#                             NOT declared in the template.
+#     These are preserved verbatim, including unknown tables introduced by
+#     future Codex CLI features.
 #
-# Merge policy for keys that exist in BOTH the template and the existing file:
-#   * template-managed keys (all top-level scalars, [notice], [features],
-#     [plugins.*], [mcp_servers.<name in template>])  -> template WINS.
-#     User edits to those are overwritten and a warning is logged to stderr.
-#   * [projects.*] and [mcp_servers.<name NOT in template>] -> user WINS.
+# On a same-key conflict template ALWAYS wins for template-owned keys; user
+# always wins for user-owned keys. This makes the merge "repo overwrite on its
+# own keys, leave everything else alone" — the script does not need to learn
+# about new Codex sections just to avoid deleting them.
 #
 # Write is atomic (tempfile + os.replace) so a codex process reading the file
 # concurrently sees either the old or new content, never a partial merge.
 #
-# If the existing file is malformed TOML, we DO NOT abort activation. Instead
-# we quarantine it to <target>.bad-<ts> and regenerate from the template, so a
-# stray hand-edit never bricks the whole home-manager generation.
+# If the existing file can be read but is malformed TOML, we quarantine it to
+# <target>.bad-<ts> and regenerate from the template — a stray hand-edit must
+# not brick the whole home-manager generation. Read-level failures that are
+# NOT "file missing" (permission denied, I/O error, invalid UTF-8) DO abort,
+# because silently replacing an unreadable file would destroy user trust and
+# MCP data.
 
 from __future__ import annotations
 
 import copy
 import datetime as _dt
+import errno
 import os
 import sys
 import tempfile
@@ -52,13 +62,17 @@ except ImportError:
 
 
 def load_required_toml(path: Path):
-    # Template 등 반드시 존재하고 유효해야 하는 입력.
+    # Template이나 필수 입력: 모든 실패는 hard fail이다.
     try:
-        text = path.read_text(encoding="utf-8")
+        data = path.read_bytes()
     except FileNotFoundError:
         die(f"template not found: {path}", code=1)
     except OSError as e:
         die(f"cannot read template {path}: {e}", code=2)
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as e:
+        die(f"template not valid UTF-8 ({path}): {e}", code=1)
     try:
         return tomlkit.parse(text)
     except Exception as e:
@@ -66,42 +80,58 @@ def load_required_toml(path: Path):
 
 
 def load_optional_toml(path: Path, *, quarantine: bool):
-    # 사용자 파일처럼 없거나 깨져 있어도 activation을 죽이지 않는 입력.
+    # 사용자 파일처럼 없거나 깨져 있을 수 있는 입력.
+    # - ENOENT (파일 없음)            → empty document (첫 실행)
+    # - 기타 OSError (EACCES 등)      → hard fail (데이터 보존)
+    # - UnicodeDecodeError / TOML 오류 → quarantine 후 empty document (self-heal)
     try:
-        text = path.read_text(encoding="utf-8")
+        raw = path.read_bytes()
     except FileNotFoundError:
         return tomlkit.document()
     except OSError as e:
-        log(f"cannot read existing {path}: {e} — treating as empty")
-        return tomlkit.document()
-    try:
-        return tomlkit.parse(text)
-    except Exception as e:
+        # ENOENT 이외의 읽기 실패는 원본 보존이 우선이라 hard fail.
+        if e.errno in (errno.EACCES, errno.EPERM, errno.EIO, errno.EISDIR):
+            die(
+                f"cannot read existing {path} (errno={e.errno}): {e} — refusing to "
+                f"overwrite to avoid data loss. Fix permissions then re-run.",
+                code=2,
+            )
+        die(f"cannot read existing {path}: {e}", code=2)
+
+    def _quarantine(reason: str) -> "tomlkit.TOMLDocument":
         if quarantine and path.exists():
             stamp = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
             bad = path.with_name(f"{path.name}.bad-{stamp}")
             try:
                 path.rename(bad)
                 log(
-                    f"existing {path} parse failed ({e}); quarantined to {bad}, "
+                    f"existing {path} {reason}; quarantined to {bad}, "
                     f"regenerating from template"
                 )
             except OSError as mv_err:
                 log(
-                    f"existing {path} parse failed ({e}); quarantine to {bad} "
+                    f"existing {path} {reason}; quarantine to {bad} "
                     f"also failed ({mv_err}); regenerating in place"
                 )
         else:
-            log(f"existing {path} parse failed ({e}); regenerating from template")
+            log(f"existing {path} {reason}; regenerating from template")
         return tomlkit.document()
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as e:
+        return _quarantine(f"not valid UTF-8 ({e})")
+    try:
+        return tomlkit.parse(text)
+    except Exception as e:
+        return _quarantine(f"TOML parse failed ({e})")
 
 
 def as_table_or_warn(value, *, where: str) -> Optional[dict]:
-    # TOML spec 위반(예: projects = 1)인 경우 방어. None 반환이면 호출부에서 무시.
+    # TOML spec 위반(예: projects = 1)인 경우 방어. None이면 호출부에서 무시.
     if value is None:
         return None
     try:
-        # tomlkit Table / inline Table 모두 Mapping 프로토콜을 따른다.
         iter(value.keys())  # type: ignore[attr-defined]
         return value  # type: ignore[return-value]
     except Exception:
@@ -119,41 +149,48 @@ def main() -> int:
     template = load_required_toml(template_path)
     existing = load_optional_toml(target_path, quarantine=True)
 
-    template_projects = as_table_or_warn(template.get("projects"), where="template.projects")
+    # template-owned keys = template에 정의된 top-level 키 전부.
+    # mcp_servers의 subkey 중 template에 있는 이름만 template-owned로 취급한다.
     template_mcps = as_table_or_warn(template.get("mcp_servers"), where="template.mcp_servers") or {}
-    user_projects = as_table_or_warn(existing.get("projects"), where="existing.projects")
-    user_mcps = as_table_or_warn(existing.get("mcp_servers"), where="existing.mcp_servers") or {}
+    if template.get("projects") is not None:
+        # template이 projects를 선언하면 정책 위반이므로 경고만 남기고 무시.
+        # user trust는 오직 runtime mutation이 소유한다.
+        log("template.projects present — ignored; [projects.*] is user-owned only")
 
-    # user-owned mcp = template에 없는 이름만. template에 있는 이름은 template wins.
-    user_mcp_keys = [k for k in user_mcps.keys() if k not in template_mcps]
+    # result는 existing의 deep copy에서 시작한다. 즉 "user 소유 섹션은 기본적으로 보존".
+    result = copy.deepcopy(existing)
 
-    # conflict observation: template MCP 키를 사용자가 수정했는지 감지.
-    # 수정 여부는 TOML 텍스트 기준으로 정확히 비교하기 어렵지만, 동일 키가 양쪽에
-    # 존재한다는 사실만 로그로 남겨 "template wins" 정책을 투명하게 한다.
-    for k in template_mcps.keys():
-        if k in user_mcps:
-            log(f"mcp_servers.{k}: template-managed key present in user file — template value wins")
-
-    # projects는 template에도 존재하지 않는 것이 정상. template이 projects를 선언하면 경고.
-    if template_projects is not None:
-        log("template.projects present — unusual; template wins for these keys")
-
-    # template 기반 결과 생성.
-    result = copy.deepcopy(template)
-
-    # user projects 복원 (template이 projects를 선언한 드문 경우에도 user wins — trust는 runtime이 소유).
-    if user_projects is not None and len(user_projects) > 0:
-        result["projects"] = user_projects
-    elif template_projects is None and "projects" in result:
-        # deepcopy는 template에 없는 키를 만들지 않지만, 방어적으로 정리.
-        del result["projects"]
-
-    # user-owned mcp 복원.
-    if user_mcp_keys:
-        if "mcp_servers" not in result:
-            result["mcp_servers"] = tomlkit.table()
-        for k in user_mcp_keys:
-            result["mcp_servers"][k] = user_mcps[k]
+    # template top-level 키를 덮어쓴다. projects는 user-owned이므로 skip.
+    template_top_keys: list[str] = []
+    for key in list(template.keys()):
+        if key == "projects":
+            continue
+        template_top_keys.append(key)
+        if key == "mcp_servers":
+            # subkey 단위 merge: template에 있는 이름만 덮어쓰고, 사용자가 추가한
+            # 이름은 그대로 둔다.
+            existing_mcps = as_table_or_warn(
+                result.get("mcp_servers"), where="existing.mcp_servers"
+            )
+            if existing_mcps is None:
+                result["mcp_servers"] = copy.deepcopy(template_mcps)
+                continue
+            for name in list(template_mcps.keys()):
+                if name in existing_mcps:
+                    # 사용자가 template-managed MCP 키를 수정했어도 template이 이긴다.
+                    # stderr 로그로 투명하게 알린다.
+                    log(
+                        f"mcp_servers.{name}: template-managed key — overwriting "
+                        f"existing user edit (template wins)"
+                    )
+                result["mcp_servers"][name] = copy.deepcopy(template_mcps[name])
+        else:
+            if key in result:
+                log(
+                    f"top-level key '{key}': template-managed — overwriting "
+                    f"existing user edit (template wins)"
+                )
+            result[key] = copy.deepcopy(template[key])
 
     serialized = tomlkit.dumps(result)
 
@@ -176,11 +213,19 @@ def main() -> int:
             pass
         die(f"atomic write failed ({target_path}): {e}", code=2)
 
-    n_projects = len(user_projects) if user_projects is not None else 0
+    # Summary.
+    projects_tbl = as_table_or_warn(existing.get("projects"), where="existing.projects")
+    existing_mcps = as_table_or_warn(existing.get("mcp_servers"), where="existing.mcp_servers") or {}
+    user_mcp_count = sum(1 for k in existing_mcps.keys() if k not in template_mcps)
+    user_top_keys = [
+        k for k in existing.keys()
+        if k not in template_top_keys and k != "projects" and k != "mcp_servers"
+    ]
     log(
-        f"preserved {n_projects} projects entries, "
-        f"{len(user_mcp_keys)} user-owned mcp_servers "
-        f"(template-managed mcp_servers: {len(template_mcps)})"
+        f"preserved {len(projects_tbl) if projects_tbl else 0} projects entries, "
+        f"{user_mcp_count} user-owned mcp_servers, "
+        f"{len(user_top_keys)} unknown top-level keys "
+        f"(template-managed top-level: {len(template_top_keys)})"
     )
     return 0
 

--- a/modules/shared/programs/codex/files/sync-codex-config.py
+++ b/modules/shared/programs/codex/files/sync-codex-config.py
@@ -203,6 +203,19 @@ def main() -> int:
     # result는 existing의 deep copy에서 시작한다. 즉 "user 소유 섹션은 기본적으로 보존".
     result = copy.deepcopy(existing)
 
+    # Repair non-table roots. TOML은 `projects = 1` 처럼 top-level scalar 선언이
+    # 합법이지만, 이후 codex CLI가 `[projects."..."]`를 append하면 "cannot overwrite
+    # a value" 로 parse 실패한다. 같은 이유로 `mcp_servers = 1` 도 append가 깨진다.
+    # 여기서 table이 아닌 값이 발견되면 stderr 로그 후 제거해서 다음 merge/append가
+    # 정상 table을 볼 수 있게 한다.
+    for _top_key in ("projects", "mcp_servers"):
+        if _top_key in result and not _is_table(result[_top_key]):
+            log(
+                f"existing {_top_key} is not a table "
+                f"({type(result[_top_key]).__name__}); removing to allow append"
+            )
+            del result[_top_key]
+
     # template의 top-level 키를 재귀 merge. projects는 user-owned이므로 skip.
     template_top_keys: list[str] = [k for k in template.keys() if k != "projects"]
     # projects 키는 얕은 사본 내에서만 임시 제거하고 원본 template은 건드리지 않는다.

--- a/modules/shared/programs/codex/files/sync-codex-config.py
+++ b/modules/shared/programs/codex/files/sync-codex-config.py
@@ -1,22 +1,25 @@
 #!/usr/bin/env python3
 # Merge repo template into ~/.codex/config.toml.
 #
-# Ownership policy:
-#   * Template-owned keys   = every top-level key that appears in the template
-#                             PLUS every [mcp_servers.<name>] where <name> is
-#                             declared in the template.
+# Ownership policy (recursive leaf-level):
+#   * Template-owned leaves = every leaf key that the template defines,
+#                             including leaves nested inside tables the template
+#                             declares (e.g. `[features].voice_transcription`,
+#                             `[plugins."github@openai-curated"].enabled`,
+#                             `[mcp_servers.<name>]` entries the template sets).
 #     These are (re-)applied from the template on each activation.
-#   * User-owned sections   = everything else in the existing file — any
-#                             top-level key NOT in the template, `[projects.*]`,
-#                             and every [mcp_servers.<name>] where <name> is
-#                             NOT declared in the template.
-#     These are preserved verbatim, including unknown tables introduced by
-#     future Codex CLI features.
+#   * User-owned leaves     = everything the template does NOT declare at the
+#                             same path — including sibling leaves inside the
+#                             same table (e.g. user-added `[plugins.foo]`,
+#                             `[features].my_extra_flag`) and any top-level key
+#                             that is not in the template (`[projects.*]`, new
+#                             Codex CLI tables we haven't seen yet).
+#     These are preserved verbatim.
 #
-# On a same-key conflict template ALWAYS wins for template-owned keys; user
-# always wins for user-owned keys. This makes the merge "repo overwrite on its
-# own keys, leave everything else alone" — the script does not need to learn
-# about new Codex sections just to avoid deleting them.
+# On a same-path conflict template ALWAYS wins. The policy can be read as
+# "template overwrites its own leaves and leaves everything else alone" — we
+# do not need to teach the script about every new Codex section just to avoid
+# deleting user data.
 #
 # Write is atomic (tempfile + os.replace) so a codex process reading the file
 # concurrently sees either the old or new content, never a partial merge.
@@ -139,6 +142,49 @@ def as_table_or_warn(value, *, where: str) -> Optional[dict]:
         return None
 
 
+def _is_table(value) -> bool:
+    # tomlkit Table / Inline Table / dict는 모두 Mapping 프로토콜을 따른다.
+    try:
+        value.keys  # type: ignore[attr-defined]
+        return True
+    except Exception:
+        return False
+
+
+def _values_equal(a, b) -> bool:
+    # tomlkit 값 비교. 비교 중 예외 발생은 "다르다"로 간주.
+    try:
+        return a == b
+    except Exception:
+        return False
+
+
+def merge_template_into(dest, tmpl, *, path: str = "") -> int:
+    """Template leaf를 dest에 재귀적으로 덮어쓰고, template이 선언하지 않은 key는
+    건드리지 않는다. same-value 덮어쓰기는 stderr 로그에 포함하지 않는다.
+
+    반환: 실제로 교체된 leaf 개수 (debug/observability 목적).
+    """
+    changed = 0
+    for key in list(tmpl.keys()):
+        full_path = f"{path}.{key}" if path else key
+        tmpl_val = tmpl[key]
+        if key not in dest:
+            dest[key] = copy.deepcopy(tmpl_val)
+            continue
+        existing_val = dest[key]
+        if _is_table(tmpl_val) and _is_table(existing_val):
+            changed += merge_template_into(existing_val, tmpl_val, path=full_path)
+            continue
+        # scalar, array, or type mismatch: template wins.
+        if _values_equal(existing_val, tmpl_val):
+            continue
+        log(f"{full_path}: template-managed value overriding user edit (template wins)")
+        dest[key] = copy.deepcopy(tmpl_val)
+        changed += 1
+    return changed
+
+
 def main() -> int:
     if len(sys.argv) != 3:
         usage()
@@ -149,9 +195,6 @@ def main() -> int:
     template = load_required_toml(template_path)
     existing = load_optional_toml(target_path, quarantine=True)
 
-    # template-owned keys = template에 정의된 top-level 키 전부.
-    # mcp_servers의 subkey 중 template에 있는 이름만 template-owned로 취급한다.
-    template_mcps = as_table_or_warn(template.get("mcp_servers"), where="template.mcp_servers") or {}
     if template.get("projects") is not None:
         # template이 projects를 선언하면 정책 위반이므로 경고만 남기고 무시.
         # user trust는 오직 runtime mutation이 소유한다.
@@ -160,37 +203,13 @@ def main() -> int:
     # result는 existing의 deep copy에서 시작한다. 즉 "user 소유 섹션은 기본적으로 보존".
     result = copy.deepcopy(existing)
 
-    # template top-level 키를 덮어쓴다. projects는 user-owned이므로 skip.
-    template_top_keys: list[str] = []
-    for key in list(template.keys()):
-        if key == "projects":
-            continue
-        template_top_keys.append(key)
-        if key == "mcp_servers":
-            # subkey 단위 merge: template에 있는 이름만 덮어쓰고, 사용자가 추가한
-            # 이름은 그대로 둔다.
-            existing_mcps = as_table_or_warn(
-                result.get("mcp_servers"), where="existing.mcp_servers"
-            )
-            if existing_mcps is None:
-                result["mcp_servers"] = copy.deepcopy(template_mcps)
-                continue
-            for name in list(template_mcps.keys()):
-                if name in existing_mcps:
-                    # 사용자가 template-managed MCP 키를 수정했어도 template이 이긴다.
-                    # stderr 로그로 투명하게 알린다.
-                    log(
-                        f"mcp_servers.{name}: template-managed key — overwriting "
-                        f"existing user edit (template wins)"
-                    )
-                result["mcp_servers"][name] = copy.deepcopy(template_mcps[name])
-        else:
-            if key in result:
-                log(
-                    f"top-level key '{key}': template-managed — overwriting "
-                    f"existing user edit (template wins)"
-                )
-            result[key] = copy.deepcopy(template[key])
+    # template의 top-level 키를 재귀 merge. projects는 user-owned이므로 skip.
+    template_top_keys: list[str] = [k for k in template.keys() if k != "projects"]
+    # projects 키는 얕은 사본 내에서만 임시 제거하고 원본 template은 건드리지 않는다.
+    template_clone = copy.deepcopy(template)
+    if "projects" in template_clone:
+        del template_clone["projects"]
+    merge_template_into(result, template_clone)
 
     serialized = tomlkit.dumps(result)
 
@@ -215,12 +234,10 @@ def main() -> int:
 
     # Summary.
     projects_tbl = as_table_or_warn(existing.get("projects"), where="existing.projects")
+    template_mcps = as_table_or_warn(template.get("mcp_servers"), where="template.mcp_servers") or {}
     existing_mcps = as_table_or_warn(existing.get("mcp_servers"), where="existing.mcp_servers") or {}
     user_mcp_count = sum(1 for k in existing_mcps.keys() if k not in template_mcps)
-    user_top_keys = [
-        k for k in existing.keys()
-        if k not in template_top_keys and k != "projects" and k != "mcp_servers"
-    ]
+    user_top_keys = [k for k in existing.keys() if k not in template_top_keys and k != "projects"]
     log(
         f"preserved {len(projects_tbl) if projects_tbl else 0} projects entries, "
         f"{user_mcp_count} user-owned mcp_servers, "

--- a/modules/shared/scripts/lib/rebuild/relink.sh
+++ b/modules/shared/scripts/lib/rebuild/relink.sh
@@ -95,9 +95,15 @@ maybe_relink_or_restore() {
         # Migration window guard: ~/.codex/config.toml은 이제 activation이 regular
         # file로 관리한다. 이전 symlink 세대에서 업그레이드하는 환경에서는 NO_CHANGES
         # 경로가 activation을 건너뛰어 자동 self-heal이 안 될 수 있으므로 명시 경고.
+        # 또한 legacy symlink가 worktree 경로로 relink된 상태였다면 Phase 1의
+        # _remove_worktree_symlinks가 이미 그 symlink를 제거해 파일 자체가 없어진
+        # 상태로 도달할 수 있다. "symlink" / "missing" 두 케이스 모두 경고 대상.
         if [[ -L "$HOME/.codex/config.toml" ]]; then
             log_warn "⚠️  ~/.codex/config.toml is still a symlink (legacy)."
             log_warn "    Run \`nrs --force\` once to let syncCodexConfig rewrite it as a regular file."
+        elif [[ ! -e "$HOME/.codex/config.toml" ]]; then
+            log_warn "⚠️  ~/.codex/config.toml is missing (likely removed by worktree symlink cleanup)."
+            log_warn "    Run \`nrs --force\` to regenerate it via syncCodexConfig."
         fi
     fi
 }

--- a/modules/shared/scripts/lib/rebuild/relink.sh
+++ b/modules/shared/scripts/lib/rebuild/relink.sh
@@ -52,13 +52,16 @@ maybe_relink_or_restore() {
         # v1 (PR #239): probe 3개(settings.json, mcp.json, config.toml) 기반 복원 도입.
         #    기존 엔트리 전환/복원은 충분했으나, 워크트리에서 새로 추가된 엔트리는 현재
         #    HMF에 없어 nrs-relink restore가 인식 불가 → HM clobber 에러 발생.
-        # v2 (이번 변경): 대안 검토:
+        # v2 (후속): 대안 검토:
         #    (a) probe 목록 확장 → 새 엔트리가 추가될 때마다 수동 관리 필요, 근본 해결 아님
         #    (b) nrs-relink restore가 ./result의 새 HMF 참조 → 플랫폼별 경로 해석 복잡
         #    (c) dangling 심링크만 제거 → 워크트리가 살아있으면 dangling 아니라 탐지 실패
         #    (d) 워크트리 경로 패턴 매칭으로 직접 제거 → 채택
         #    trade-off: .claude/worktrees/ 외부에 수동 생성된 워크트리는 탐지 불가하지만,
         #              wt 스크립트가 .claude/worktrees/에만 생성하므로 실용적으로 충분.
+        # v3 (이번 변경): ~/.codex/config.toml을 HM out-of-store symlink에서 activation
+        #    seed+merge 기반 regular file로 전환. probe 대상에서 제외하여 이제 probe 2개
+        #    (settings.json, mcp.json)로 축소.
         if _remove_worktree_symlinks "$MAIN_FLAKE_PATH/.claude/worktrees/" "stale worktree"; then
             # stale worktree 심링크가 제거되면 probe 파일(settings.json 등)도 사라져
             # Phase 2의 probe 탐지가 실패할 수 있음. NO_CHANGES 경로에서는 HM activation이
@@ -74,7 +77,7 @@ maybe_relink_or_restore() {
             # relink skip으로 partial mismatch가 발생한 경우를 방어
             local _needs_restore=false
             local _p
-            for _p in "$HOME/.claude/settings.json" "$HOME/.claude/mcp.json" "$HOME/.codex/config.toml"; do
+            for _p in "$HOME/.claude/settings.json" "$HOME/.claude/mcp.json"; do
                 [[ ! -L "$_p" ]] && continue
                 local _target
                 _target=$(readlink "$_p" 2>/dev/null) || continue

--- a/modules/shared/scripts/lib/rebuild/relink.sh
+++ b/modules/shared/scripts/lib/rebuild/relink.sh
@@ -91,5 +91,13 @@ maybe_relink_or_restore() {
                 "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
             fi
         fi
+
+        # Migration window guard: ~/.codex/config.toml은 이제 activation이 regular
+        # file로 관리한다. 이전 symlink 세대에서 업그레이드하는 환경에서는 NO_CHANGES
+        # 경로가 activation을 건너뛰어 자동 self-heal이 안 될 수 있으므로 명시 경고.
+        if [[ -L "$HOME/.codex/config.toml" ]]; then
+            log_warn "⚠️  ~/.codex/config.toml is still a symlink (legacy)."
+            log_warn "    Run \`nrs --force\` once to let syncCodexConfig rewrite it as a regular file."
+        fi
     fi
 }

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -14,32 +14,87 @@ pass() { echo "  [OK] $1"; }
 fail() { echo "  [FAIL] $1" >&2; errors=$((errors + 1)); }
 warn() { echo "  [WARN] $1" >&2; warnings=$((warnings + 1)); }
 
+# ─── Python 사전 체크 (CORR-PR-5) ───
+# 이 스크립트는 python3 >= 3.11 (tomllib 내장)을 가정한다. 사전에 명확히 실패해서
+# "tomllib 미존재" → "TOML parse 실패" 같은 오검진을 방지한다.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  [FAIL] python3 not found in PATH" >&2
+  exit 1
+fi
+if ! python3 - <<'PY' 2>/dev/null
+import sys, tomllib  # tomllib requires 3.11+
+if sys.version_info < (3, 11):
+    raise SystemExit(1)
+PY
+then
+  echo "  [FAIL] python3 >= 3.11 with tomllib is required" >&2
+  exit 1
+fi
+
+# ─── TOML helper (MAINT-PR-4) ───
+# 여러 곳에서 쓰이는 python3 inline 블록을 단일 헬퍼로 통일.
+# 사용법:
+#   _toml_parse <file>                    : valid TOML이면 0, 아니면 1
+#   _toml_get_str <file> <dotted.path>    : 값을 stdout으로 (없으면 empty)
+#   _toml_has_path <file> <dotted.path>   : 존재하면 0, 없거나 table이어도 0
+#   _toml_has_table <file> <dotted.path>  : table로 존재하면 0
+_toml_parse() {
+  python3 - "$1" <<'PY' >/dev/null 2>&1
+import sys, tomllib
+with open(sys.argv[1], 'rb') as f:
+    tomllib.load(f)
+PY
+}
+
+_toml_get_str() {
+  python3 - "$1" "$2" <<'PY'
+import sys, tomllib
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+cur = data
+for part in sys.argv[2].split('.'):
+    if not isinstance(cur, dict) or part not in cur:
+        sys.exit(0)
+    cur = cur[part]
+if isinstance(cur, (str, int, float, bool)):
+    print(cur)
+PY
+}
+
+_toml_has_table() {
+  python3 - "$1" "$2" <<'PY'
+import sys, tomllib
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+cur = data
+for part in sys.argv[2].split('.'):
+    if not isinstance(cur, dict) or part not in cur:
+        sys.exit(1)
+    cur = cur[part]
+sys.exit(0 if isinstance(cur, dict) else 1)
+PY
+}
+
+_file_mode() {
+  python3 -c 'import os, stat, sys; print(f"{stat.S_IMODE(os.stat(sys.argv[1]).st_mode):o}")' "$1" 2>/dev/null || echo "?"
+}
+
 echo "=== Codex 실행 정책 확인 ==="
 
 CODEX_CONFIG="$HOME/.codex/config.toml"
 if [ -f "$CODEX_CONFIG" ]; then
-  if python3 - "$CODEX_CONFIG" <<'PY'
-import sys, tomllib
-with open(sys.argv[1], 'rb') as f:
-    data = tomllib.load(f)
-assert data.get('approval_policy') == 'never'
-PY
-  then
+  _ap="$(_toml_get_str "$CODEX_CONFIG" approval_policy)"
+  if [ "$_ap" = "never" ]; then
     pass "approval_policy = \"never\""
   else
-    fail "approval_policy = \"never\" 미설정"
+    fail "approval_policy = \"never\" 미설정 (actual: \"$_ap\")"
   fi
 
-  if python3 - "$CODEX_CONFIG" <<'PY'
-import sys, tomllib
-with open(sys.argv[1], 'rb') as f:
-    data = tomllib.load(f)
-assert data.get('sandbox_mode') == 'danger-full-access'
-PY
-  then
+  _sm="$(_toml_get_str "$CODEX_CONFIG" sandbox_mode)"
+  if [ "$_sm" = "danger-full-access" ]; then
     pass "sandbox_mode = \"danger-full-access\""
   else
-    fail "sandbox_mode = \"danger-full-access\" 미설정"
+    fail "sandbox_mode = \"danger-full-access\" 미설정 (actual: \"$_sm\")"
   fi
 
   if grep -q 'nixos-config' "$CODEX_CONFIG"; then
@@ -153,29 +208,24 @@ echo "=== 글로벌 설정 확인 ==="
 
 # ~/.codex/config.toml 관리 상태
 # activation의 syncCodexConfig가 repo-managed 키와 사용자 소유 섹션을 merge한 regular file로
-# 유지한다. 따라서 symlink가 아니라 (a) regular file 존재, (b) mode 0600, (c) TOML 파싱 성공을
-# PASS 기준으로 삼는다. (필수 키 검증은 위 "Codex 실행 정책 확인" 섹션에서 수행.)
+# 유지한다. PASS 기준: (a) regular file, (b) mode 0600, (c) TOML 파싱 성공,
+#                     (d) template-managed key 존재 (model/approval_policy/sandbox_mode).
+# mode 불일치는 fail로 승격 (CORR-PR-4), activation 강제 실행 안내는 nrs --force (REGR-PR-4).
 _codex_cfg="$HOME/.codex/config.toml"
 if [ ! -e "$_codex_cfg" ]; then
   fail "$_codex_cfg 없음"
 elif [ -L "$_codex_cfg" ]; then
-  fail "$_codex_cfg 심링크 — syncCodexConfig가 regular file로 migrate하지 않음 (nrs 재실행 필요)"
+  fail "$_codex_cfg 심링크 — syncCodexConfig 미적용 (NO_CHANGES 경로 회피 위해 \`nrs --force\` 실행 필요)"
 elif [ ! -f "$_codex_cfg" ]; then
   fail "$_codex_cfg regular file 아님"
 else
-  # stat의 BSD/GNU 포맷 플래그 차이를 회피하기 위해 Python으로 일원화.
-  _mode="$(python3 -c 'import os, stat, sys; print(f"{stat.S_IMODE(os.stat(sys.argv[1]).st_mode):o}")' "$_codex_cfg" 2>/dev/null || echo "?")"
+  _mode="$(_file_mode "$_codex_cfg")"
   if [ "$_mode" = "600" ]; then
     pass "$_codex_cfg regular file, mode=0600"
   else
-    warn "$_codex_cfg regular file이지만 mode=$_mode (기대: 0600)"
+    fail "$_codex_cfg mode=$_mode (기대: 0600) — 권한 제한 실패"
   fi
-  if ! python3 - "$_codex_cfg" <<'PY' >/dev/null 2>&1
-import sys, tomllib
-with open(sys.argv[1], 'rb') as f:
-    tomllib.load(f)
-PY
-  then
+  if ! _toml_parse "$_codex_cfg"; then
     fail "$_codex_cfg TOML 파싱 실패"
   fi
 fi
@@ -187,6 +237,40 @@ elif [ -f "$HOME/.codex/AGENTS.md" ]; then
   warn "$HOME/.codex/AGENTS.md 일반 파일 (심링크 아님)"
 else
   warn "$HOME/.codex/AGENTS.md 없음"
+fi
+
+# ─── template-managed 계약 검증 (DESIGN-PR-3) ───
+# syncCodexConfig merge 정책은 "repo-managed 키는 template wins"를 보장한다.
+# 이 계약을 verify 수준에서 검증할 수 있도록, template이 반드시 가져야 하는 구조를 확인한다.
+echo ""
+echo "=== template-managed 계약 확인 ==="
+
+if [ -f "$CODEX_CONFIG" ] && _toml_parse "$CODEX_CONFIG"; then
+  # top-level 필수 키
+  for _k in model approval_policy sandbox_mode service_tier personality; do
+    if [ -n "$(_toml_get_str "$CODEX_CONFIG" "$_k")" ]; then
+      pass "top-level 키 존재: $_k"
+    else
+      fail "top-level 키 누락: $_k (template-managed 계약 위반)"
+    fi
+  done
+  # template table 존재
+  if _toml_has_table "$CODEX_CONFIG" features; then
+    pass "[features] table 존재"
+  else
+    fail "[features] table 누락"
+  fi
+  # Darwin 전용: chrome-devtools MCP가 있어야 함. 다른 플랫폼에서는 경고 수준.
+  if _toml_has_table "$CODEX_CONFIG" "mcp_servers.chrome-devtools"; then
+    pass "[mcp_servers.chrome-devtools] 존재 (Darwin template)"
+  else
+    case "$(uname -s)" in
+      Darwin) fail "[mcp_servers.chrome-devtools] 누락 (Darwin template-managed 계약 위반)" ;;
+      *)      pass "[mcp_servers.chrome-devtools] 없음 (non-Darwin platform)" ;;
+    esac
+  fi
+else
+  warn "template 계약 체크 스킵 (config 파일 없음 또는 파싱 실패)"
 fi
 
 echo ""

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -151,14 +151,31 @@ fi
 echo ""
 echo "=== 글로벌 설정 확인 ==="
 
-# ~/.codex/config.toml 심링크
-if [ -L "$HOME/.codex/config.toml" ]; then
-  pass "$HOME/.codex/config.toml 심링크"
+# ~/.codex/config.toml 관리 상태
+# activation의 syncCodexConfig가 repo-managed 키와 사용자 소유 섹션을 merge한 regular file로
+# 유지한다. 따라서 symlink가 아니라 (a) regular file 존재, (b) mode 0600, (c) TOML 파싱 성공을
+# PASS 기준으로 삼는다. (필수 키 검증은 위 "Codex 실행 정책 확인" 섹션에서 수행.)
+_codex_cfg="$HOME/.codex/config.toml"
+if [ ! -e "$_codex_cfg" ]; then
+  fail "$_codex_cfg 없음"
+elif [ -L "$_codex_cfg" ]; then
+  fail "$_codex_cfg 심링크 — syncCodexConfig가 regular file로 migrate하지 않음 (nrs 재실행 필요)"
+elif [ ! -f "$_codex_cfg" ]; then
+  fail "$_codex_cfg regular file 아님"
 else
-  if [ -f "$HOME/.codex/config.toml" ]; then
-    warn "$HOME/.codex/config.toml 일반 파일 (심링크 아님)"
+  _mode="$(stat -f '%Lp' "$_codex_cfg" 2>/dev/null || stat -c '%a' "$_codex_cfg" 2>/dev/null || echo "?")"
+  if [ "$_mode" = "600" ]; then
+    pass "$_codex_cfg regular file, mode=0600"
   else
-    fail "$HOME/.codex/config.toml 없음"
+    warn "$_codex_cfg regular file이지만 mode=$_mode (기대: 0600)"
+  fi
+  if ! python3 - "$_codex_cfg" <<'PY' >/dev/null 2>&1
+import sys, tomllib
+with open(sys.argv[1], 'rb') as f:
+    tomllib.load(f)
+PY
+  then
+    fail "$_codex_cfg TOML 파싱 실패"
   fi
 fi
 

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -163,7 +163,8 @@ elif [ -L "$_codex_cfg" ]; then
 elif [ ! -f "$_codex_cfg" ]; then
   fail "$_codex_cfg regular file 아님"
 else
-  _mode="$(stat -f '%Lp' "$_codex_cfg" 2>/dev/null || stat -c '%a' "$_codex_cfg" 2>/dev/null || echo "?")"
+  # stat의 BSD/GNU 포맷 플래그 차이를 회피하기 위해 Python으로 일원화.
+  _mode="$(python3 -c 'import os, stat, sys; print(f"{stat.S_IMODE(os.stat(sys.argv[1]).st_mode):o}")' "$_codex_cfg" 2>/dev/null || echo "?")"
   if [ "$_mode" = "600" ]; then
     pass "$_codex_cfg regular file, mode=0600"
   else

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -270,7 +270,8 @@ if [ -f "$CODEX_CONFIG" ] && _toml_parse "$CODEX_CONFIG"; then
   else
     fail "[features] table 누락"
   fi
-  # Darwin 전용: chrome-devtools MCP가 있어야 함. 다른 플랫폼에서는 경고 수준.
+  # Darwin template은 [mcp_servers.chrome-devtools]를 가지며 누락 시 fail.
+  # Non-Darwin template에는 해당 섹션이 없으므로 존재하지 않는 것이 정상(pass).
   if _toml_has_table "$CODEX_CONFIG" "mcp_servers.chrome-devtools"; then
     pass "[mcp_servers.chrome-devtools] 존재 (Darwin template)"
   else

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -31,13 +31,17 @@ then
   exit 1
 fi
 
-# ─── TOML helper (MAINT-PR-4) ───
+# ─── TOML helper ───
 # 여러 곳에서 쓰이는 python3 inline 블록을 단일 헬퍼로 통일.
 # 사용법:
-#   _toml_parse <file>                    : valid TOML이면 0, 아니면 1
-#   _toml_get_str <file> <dotted.path>    : 값을 stdout으로 (없으면 empty)
-#   _toml_has_path <file> <dotted.path>   : 존재하면 0, 없거나 table이어도 0
-#   _toml_has_table <file> <dotted.path>  : table로 존재하면 0
+#   _toml_parse        <file>                : valid TOML이면 0, 아니면 1
+#   _toml_get_scalar   <file> <dotted.path>  : 경로의 scalar(str/int/float/bool)을
+#                                              stdout으로. 없거나 table이면 empty.
+#                                              TOML parse 실패 시에도 empty + 0으로
+#                                              끝나므로 `set -euo pipefail` 환경에서
+#                                              command substitution으로 안전하게 호출 가능.
+#   _toml_has_table    <file> <dotted.path>  : table로 존재하면 0, 아니면 1
+#   _file_mode         <file>                : 8진수 mode 문자열 (예: "600"), 실패 시 "?"
 _toml_parse() {
   python3 - "$1" <<'PY' >/dev/null 2>&1
 import sys, tomllib
@@ -46,11 +50,14 @@ with open(sys.argv[1], 'rb') as f:
 PY
 }
 
-_toml_get_str() {
-  python3 - "$1" "$2" <<'PY'
+_toml_get_scalar() {
+  python3 - "$1" "$2" <<'PY' 2>/dev/null || true
 import sys, tomllib
-with open(sys.argv[1], 'rb') as f:
-    data = tomllib.load(f)
+try:
+    with open(sys.argv[1], 'rb') as f:
+        data = tomllib.load(f)
+except Exception:
+    sys.exit(0)
 cur = data
 for part in sys.argv[2].split('.'):
     if not isinstance(cur, dict) or part not in cur:
@@ -64,8 +71,11 @@ PY
 _toml_has_table() {
   python3 - "$1" "$2" <<'PY'
 import sys, tomllib
-with open(sys.argv[1], 'rb') as f:
-    data = tomllib.load(f)
+try:
+    with open(sys.argv[1], 'rb') as f:
+        data = tomllib.load(f)
+except Exception:
+    sys.exit(1)
 cur = data
 for part in sys.argv[2].split('.'):
     if not isinstance(cur, dict) or part not in cur:
@@ -83,14 +93,14 @@ echo "=== Codex 실행 정책 확인 ==="
 
 CODEX_CONFIG="$HOME/.codex/config.toml"
 if [ -f "$CODEX_CONFIG" ]; then
-  _ap="$(_toml_get_str "$CODEX_CONFIG" approval_policy)"
+  _ap="$(_toml_get_scalar "$CODEX_CONFIG" approval_policy)"
   if [ "$_ap" = "never" ]; then
     pass "approval_policy = \"never\""
   else
     fail "approval_policy = \"never\" 미설정 (actual: \"$_ap\")"
   fi
 
-  _sm="$(_toml_get_str "$CODEX_CONFIG" sandbox_mode)"
+  _sm="$(_toml_get_scalar "$CODEX_CONFIG" sandbox_mode)"
   if [ "$_sm" = "danger-full-access" ]; then
     pass "sandbox_mode = \"danger-full-access\""
   else
@@ -248,7 +258,7 @@ echo "=== template-managed 계약 확인 ==="
 if [ -f "$CODEX_CONFIG" ] && _toml_parse "$CODEX_CONFIG"; then
   # top-level 필수 키
   for _k in model approval_policy sandbox_mode service_tier personality; do
-    if [ -n "$(_toml_get_str "$CODEX_CONFIG" "$_k")" ]; then
+    if [ -n "$(_toml_get_scalar "$CODEX_CONFIG" "$_k")" ]; then
       pass "top-level 키 존재: $_k"
     else
       fail "top-level 키 누락: $_k (template-managed 계약 위반)"

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -14,7 +14,7 @@ pass() { echo "  [OK] $1"; }
 fail() { echo "  [FAIL] $1" >&2; errors=$((errors + 1)); }
 warn() { echo "  [WARN] $1" >&2; warnings=$((warnings + 1)); }
 
-# ─── Python 사전 체크 (CORR-PR-5) ───
+# ─── Python 사전 체크 ───
 # 이 스크립트는 python3 >= 3.11 (tomllib 내장)을 가정한다. 사전에 명확히 실패해서
 # "tomllib 미존재" → "TOML parse 실패" 같은 오검진을 방지한다.
 if ! command -v python3 >/dev/null 2>&1; then
@@ -220,7 +220,7 @@ echo "=== 글로벌 설정 확인 ==="
 # activation의 syncCodexConfig가 repo-managed 키와 사용자 소유 섹션을 merge한 regular file로
 # 유지한다. PASS 기준: (a) regular file, (b) mode 0600, (c) TOML 파싱 성공,
 #                     (d) template-managed key 존재 (model/approval_policy/sandbox_mode).
-# mode 불일치는 fail로 승격 (CORR-PR-4), activation 강제 실행 안내는 nrs --force (REGR-PR-4).
+# mode 불일치는 fail로 승격, legacy symlink 감지 시 nrs --force 안내.
 _codex_cfg="$HOME/.codex/config.toml"
 if [ ! -e "$_codex_cfg" ]; then
   fail "$_codex_cfg 없음"
@@ -249,7 +249,7 @@ else
   warn "$HOME/.codex/AGENTS.md 없음"
 fi
 
-# ─── template-managed 계약 검증 (DESIGN-PR-3) ───
+# ─── template-managed 계약 검증 ───
 # syncCodexConfig merge 정책은 "repo-managed 키는 template wins"를 보장한다.
 # 이 계약을 verify 수준에서 검증할 수 있도록, template이 반드시 가져야 하는 구조를 확인한다.
 echo ""


### PR DESCRIPTION
## Summary

- Codex CLI가 임의 디렉토리에서 trust 프롬프트를 승인할 때, append 경로가 symlink를 타고 nixos-config repo의 template 파일을 오염시키던 구조를 해소한다.
- `~/.codex/config.toml`을 Home Manager out-of-store symlink에서 activation-managed regular file로 전환하고, `sync-codex-config.py`가 repo template과 사용자 소유 섹션(`[projects.*]`, 사용자 추가 `[mcp_servers.*]`)을 재귀 leaf-level merge로 보존한다.
- verify/relink/docs도 같은 관리 모델에 맞춰 정합화한다. 후속 개선은 `#511`에서 트래킹.

## 기존 문제/배경

- **매 실행마다 trust 프롬프트**: Codex CLI는 처음 접하는 디렉토리마다 "trust this directory?"를 묻는다. 2번(거부) 시 즉시 종료되어 자동화가 불가능하고, 1번(수락) 시 CLI가 `[projects."<abs-path>"] trust_level = "trusted"` 엔트리를 `~/.codex/config.toml`에 append한다.
- **repo 오염**: 현재 `~/.codex/config.toml`은 Home Manager의 `mkOutOfStoreSymlink`로 repo의 `modules/shared/programs/codex/files/config.{toml,darwin.toml}` template을 직접 가리키는 symlink다. Codex의 append는 symlink를 따라가 repo 파일을 수정하고, `git status`가 더러워진다.
- **구조적 한계**: Codex 공식 소스(`codex-rs/core/src/config_loader/mod.rs`)는 "모든 디렉토리를 trust"하는 전역 옵션을 제공하지 않는다. wildcard / 부모 상속도 미지원이며, `--yolo`(= `--dangerously-bypass-approvals-and-sandbox`)를 걸어도 interactive TUI의 trust 프롬프트는 그대로 뜬다 (upstream issues #14547, #14345). 따라서 "trust 프롬프트를 없애자"가 아니라 "trust 승인이 repo를 오염시키지 않게 하자"가 이 PR의 실질 목표다.
- **같은 경로의 다른 mutation도 동일 문제**: `codex mcp add`, `codex plugin marketplace` 등 CLI가 발생시키는 모든 write가 같은 symlink를 타고 repo로 흘러갔다. 본 PR로 그 모든 경로가 함께 해소된다.

## CIR (Change Intent Record)

- **seed-once 초기 구상 → 폐기**: `mkOutOfStoreSymlink` 제거 + "파일이 없을 때만 template copy" 구조를 먼저 검토했으나, seed 이후 `model`/`approval_policy`/`sandbox_mode`/`plugins`/`mcp_servers` 같은 repo-managed 선언적 기본값 전부가 template drift로 밀려나는 문제가 있어 기각.
- **TOML merge 구조 도입** (`e760db4`, `81f6b0b`): `tomlkit` 기반 Python 스크립트로 repo template과 사용자 소유 섹션을 merge. 이후 방어 코드 (`78bf02c`), worktree seed 경로를 Nix 상대경로로 교정 (`806a9bf`), verifier semantic 전환 (`b0baa53`, `fde3300`), stat BSD/GNU 호환 (`2c3daf6`), OOS probe 정리 (`dfe04aa`), 문서 정렬 (`4b35a0e`) 동반.
- **Ownership 인버전** (`158f4bf`, `5f1b427`): 초기 allowlist("projects + 템플릿 외 mcp만 보존")는 현재 특례 처리한 두 테이블에만 묶여 있어서 Codex가 향후 새 섹션(`[profile.*]` 등)을 도입하면 activation마다 조용히 삭제될 위험. 결과를 existing의 deep copy에서 시작해 template이 선언한 leaf만 덮도록 뒤집어 일반화.
- **재귀 leaf-level merge** (`196e552`, `bd8d39c`): 인버전이 top-level 단위에 머물러 `[features]`, `[plugins.*]`처럼 template이 선언한 namespace table 안의 사용자 추가 child key는 여전히 삭제되는 한계. 재귀 merge로 승격하고 legacy symlink migration warning 추가.
- **비table root 방어 + missing guard** (`4077735`, `06c69bb`): `projects = 1` 같은 비table root가 들어있으면 다음 trust/mcp append에서 TOML이 깨지는 경로 차단. legacy 사용자가 worktree에서 main으로 돌아와 no-op rebuild할 때 `_remove_worktree_symlinks`가 config.toml symlink를 지우면 파일 자체가 없어지는 경로도 경고 대상에 포함.

**최종 trade-off**: Python + `pkgs.python3Packages.tomlkit` 의존성 추가 (nix store ~50MB 증가, 체감 영향 미미). 대신 template의 특정 테이블 이름을 특례 처리하지 않아도 미래 Codex 섹션이 자동 보존되는 일반화된 merge 구조를 확보.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `mkOutOfStoreSymlink` 유지 | 현재 구조 | 선언적 관리 직관적 | Codex CLI mutation이 repo를 오염시킴 (핵심 문제) | ❌ |
| pre-seeded `[projects.*]` trust | template에 주요 경로 미리 trust 박기 | 대부분 프롬프트 회피 | Codex는 exact path match만 지원 (wildcard/부모상속 없음), 경로 증가 시 수동 등록 | ❌ |
| wrapper로 `CODEX_HOME=$(mktemp)` | 매 실행마다 임시 HOME 격리 | 완전 격리 | 세션 간 trust 공유 불가, interactive TUI trust 프롬프트는 여전 | ❌ |
| seed-once + `$HOME` regular file | 최초 1회 template copy, 이후 사용자 소유 | 단순 | repo-managed 기본값 전파 불가, template drift | ❌ |
| allowlist TOML merge | `[projects.*]`와 template 외 `[mcp_servers.*]`만 보존, 나머지 top-level은 template 소유 | SoT 명확 | 새 Codex 섹션 도입 시 allowlist 업데이트 필요 | ❌ |
| 재귀 leaf-level merge (채택) | 결과는 existing에서 시작, template 선언 leaf만 덮음, user-added child/unknown top-level은 보존 | 미래 Codex 섹션 자동 보존, template 이름 특례 불필요 | deepcopy 비용 (현재 TOML 크기에선 무시 가능) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/codex/files/sync-codex-config.py` | 신규 | Python + tomlkit 재귀 merge. required/optional load 분리, quarantine self-heal, atomic write (mode 0600), 비table root 방어 |
| `modules/shared/programs/codex/default.nix` | 수정 | `home.file.".codex/config.toml"` 엔트리 제거 → `home.activation.syncCodexConfig` 추가. seed 경로를 Nix 상대경로(`./files/...`)로 전환해 worktree 소스 반영 |
| `scripts/ai/verify-ai-compat.sh` | 수정 | symlink 기반 판정 → regular file + mode 0600 + TOML parse + 필수 키 존재 + Darwin template MCP 기반. python3/tomllib pre-flight, 공용 TOML helper로 정리 |
| `modules/shared/scripts/lib/rebuild/relink.sh` | 수정 | `~/.codex/config.toml`을 OOS probe에서 제거 (regular file 모델에 부합). migration window 동안 legacy symlink 또는 missing 상태 감지 시 `nrs --force` 안내 |
| `docs/CHROME_DEVTOOLS_MCP_AUTOCONNECT.md` | 수정 | `~/.codex/config.toml` 점검 절차를 "readlink 기반"에서 "`verify-ai-compat.sh`로 관리 상태 검증"으로 교체 |

### 핵심 코드

**activation wiring (`default.nix`)**:
```nix
let
  codexConfigSeedPath =
    if pkgs.stdenv.isDarwin then ./files/config.darwin.toml else ./files/config.toml;
  codexSyncScript = ./files/sync-codex-config.py;
  pythonWithTomlkit = pkgs.python3.withPackages (ps: [ ps.tomlkit ]);
in {
  home.activation.syncCodexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
    config_dir="$HOME/.codex"
    $DRY_RUN_CMD mkdir -p "$config_dir"
    $DRY_RUN_CMD ${pythonWithTomlkit}/bin/python3 \
      ${codexSyncScript} \
      "${codexConfigSeedPath}" \
      "$config_dir/config.toml"
  '';
}
```

**재귀 merge (`sync-codex-config.py`)**:
```python
def merge_template_into(dest, tmpl, *, path: str = "") -> int:
    """Template leaf를 dest에 재귀적으로 덮어쓰고,
    template이 선언하지 않은 key는 건드리지 않는다.
    same-value 덮어쓰기는 stderr 로그에 포함하지 않는다."""
    changed = 0
    for key in list(tmpl.keys()):
        full_path = f"{path}.{key}" if path else key
        tmpl_val = tmpl[key]
        if key not in dest:
            dest[key] = copy.deepcopy(tmpl_val)
            continue
        existing_val = dest[key]
        if _is_table(tmpl_val) and _is_table(existing_val):
            changed += merge_template_into(existing_val, tmpl_val, path=full_path)
            continue
        if _values_equal(existing_val, tmpl_val):
            continue
        log(f"{full_path}: template-managed value overriding user edit (template wins)")
        dest[key] = copy.deepcopy(tmpl_val)
        changed += 1
    return changed
```

## 참고 레퍼런스

- 핵심 commits:
  - `e760db4` — feat(codex): add tomlkit-based config merge script
  - `81f6b0b` — refactor(codex): manage ~/.codex/config.toml via activation merge
  - `b0baa53` — refactor(verify): assess by state not by symlink
  - `196e552` — refactor(codex): recursive leaf-level merge preserves user child keys
  - `806a9bf` — fix(codex): source config template from the current flake, not the main checkout
  - `bd8d39c` — fix(relink): warn users upgrading from legacy symlink
  - `4077735` — fix(codex): repair non-table projects/mcp_servers roots before merge
  - `06c69bb` — fix(relink): also warn when config.toml went missing after worktree cleanup
- Issue `#511` — 후속 개선 항목 (verifier template 파싱, HM rollback bridge, NO_CHANGES self-heal, concurrency lockfile, fixture tests)
- Codex CLI upstream:
  - [codex-rs `config_loader/mod.rs`](https://raw.githubusercontent.com/openai/codex/main/codex-rs/core/src/config_loader/mod.rs) — trust는 exact path match 전용
  - [openai/codex issue #14547](https://github.com/openai/codex/issues/14547) — `--yolo`에서도 interactive TUI trust prompt 잔존
  - [openai/codex issue #14345](https://github.com/openai/codex/issues/14345) — 전역 trust feature request
  - [openai/codex issue #17593](https://github.com/openai/codex/issues/17593) — read-only config.toml에서 0.119.0+ startup crash
- Home Manager:
  - [`home.activation`](https://home-manager.dev/manual/23.05/options.html#opt-home.activation) — writeBoundary 이후 실행 / idempotent 계약
  - [`lib.file.mkOutOfStoreSymlink`](https://github.com/nix-community/home-manager/blob/master/modules/files.nix) — 기존 구조의 write-through 거동 근거

## Human Test Plan

### 정상 동작 검증

1. 이 PR branch에서 `nrs`를 실행한다.
   - **기대**: `Activating syncCodexConfig`가 찍히고, `sync-codex-config: preserved N projects entries, M user-owned mcp_servers, K unknown top-level keys (template-managed top-level: T)` 로그 출력.
   - **실패 시**: `pkgs.python3Packages.tomlkit`가 nixpkgs channel에 존재하는지(`nix-env -qaP -A nixpkgs.python3Packages.tomlkit`), activation script의 store path가 정상 참조되는지 확인.

2. `ls -la ~/.codex/config.toml`을 실행한다.
   - **기대**: regular file, mode `-rw-------` (0600).
   - **실패 시**: `_is_table`/`os.chmod` 분기와 `tempfile.mkstemp` 기본 mode(0600)가 유지되는지 확인.

3. `/tmp` 같은 임의 디렉토리에서 `codex`를 실행한다.
   - **기대**: "trust this directory?" 프롬프트가 뜬다. 1번 수락.
   - **실패 시**: Codex CLI 버전(`codex --version`)이 trust 관련 회귀(issue #14547)에 영향받지 않는지 확인.

4. `cd` 해서 repo에 돌아온 뒤 `git status`를 실행한다.
   - **기대**: `modules/shared/programs/codex/files/*.toml`에 diff **없음**.
   - **실패 시**: `~/.codex/config.toml`이 여전히 symlink인지(`readlink ~/.codex/config.toml`) 확인. 빈 출력이어야 regular file.

5. 같은 `/tmp`에서 `codex`를 재실행한다.
   - **기대**: trust 프롬프트가 뜨지 않는다 (영구 trust).
   - **실패 시**: `~/.codex/config.toml`에 `[projects."/tmp"]` 엔트리 존재 확인.

### Merge 보존 검증

6. `~/.codex/config.toml`에 `[mcp_servers.test-sentinel]` 블록을 수동 append한 뒤 `nrs` 재실행.
   - **기대**: `[mcp_servers.test-sentinel]`이 보존되며 `[mcp_servers.chrome-devtools]`(Darwin)도 유지.
   - **실패 시**: sync-codex-config.py의 재귀 merge 분기(template 외 mcp_servers는 user-owned)가 적용됐는지 확인.

### Legacy migration 검증 (다른 호스트/fresh clone)

7. legacy generation(이전 `mkOutOfStoreSymlink` 기반)에서 이 브랜치로 전환 후 `nrs`.
   - **기대**: `relink.sh`의 guard가 `~/.codex/config.toml is still a symlink` 또는 `is missing` 경고와 함께 `nrs --force` 안내.
   - **실패 시**: `_remove_worktree_symlinks` 경로가 정상 실행됐는지, HM generation이 실제로 갱신됐는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 신규 Python 스크립트 존재 + 실행 권한
ls -l modules/shared/programs/codex/files/sync-codex-config.py

# 2. default.nix에서 home.file의 config.toml 엔트리가 제거됐는지
! grep -E "^\s*\".codex/config\.toml\"\.source\s*=" modules/shared/programs/codex/default.nix

# 3. default.nix에 syncCodexConfig activation이 추가됐는지
grep -q "home.activation.syncCodexConfig" modules/shared/programs/codex/default.nix

# 4. verify-ai-compat.sh가 python3 pre-flight를 수행하는지
grep -q 'python3 >= 3.11 with tomllib is required' scripts/ai/verify-ai-compat.sh

# 5. relink.sh probe에서 config.toml이 빠졌는지
! grep -E '"\$HOME/\.codex/config\.toml"' modules/shared/scripts/lib/rebuild/relink.sh

# 6. relink.sh에 legacy symlink 및 missing 경고가 모두 있는지
grep -q "is still a symlink (legacy)" modules/shared/scripts/lib/rebuild/relink.sh
grep -q "is missing" modules/shared/scripts/lib/rebuild/relink.sh
```

### Phase 1: 빌드 + Activation

> "`nrs` 빌드가 성공하고 syncCodexConfig activation이 실행된다"

```bash
nrs 2>&1 | grep -E "Activating syncCodexConfig|preserved .* projects entries"
```
- **기대**: `Activating syncCodexConfig` + `sync-codex-config: preserved ...` 로그가 모두 출력.
- **실패 시**: tomlkit 의존성(`nix-env -qaP -A nixpkgs.python3Packages.tomlkit`), pkgs.python3.withPackages 결과 경로, `./files/sync-codex-config.py` store path를 순서대로 확인.

### Phase 2: 관리 상태 검증

```bash
bash scripts/ai/verify-ai-compat.sh 2>&1 | tail -5
```
- **기대**: "검증 완전 통과" 또는 "검증 통과 (경고 N개)" 종료. exit 0.
- **실패 시**: 출력에서 첫 `[FAIL]` 메시지가 가리키는 섹션을 읽고 해당 경로를 Read로 확인.

```bash
python3 -c '
import tomllib, os
d = tomllib.loads(open(os.path.expanduser("~/.codex/config.toml")).read())
print(d["model"], d["approval_policy"], d["sandbox_mode"])
'
```
- **기대**: template 값과 동일. 필수 키 누락 없음.

### Phase 3: 핵심 기능 — trust 프롬프트 + repo diff 차단

> "임의 디렉토리에서 codex 실행 → trust 수락 → repo에 diff 발생하지 않는다"

```bash
# 준비: /tmp의 trust 엔트리를 사전 수동 주입 시뮬레이션
cat >> ~/.codex/config.toml <<'TOML'

[projects."/tmp/e2e-check"]
trust_level = "trusted"
TOML

# nrs 재실행해서 merge가 보존하는지 확인
nrs 2>&1 | grep "preserved"
# 기대: "preserved 1+ projects entries" (sentinel + 기존)

# repo 상태 확인
git status --porcelain modules/shared/programs/codex/files/
# 기대: 빈 출력 (repo 오염 없음)
```

### Phase 4: Merge 보존

```bash
# template-외 MCP 서버 시뮬레이션
cat >> ~/.codex/config.toml <<'TOML'

[mcp_servers.e2e-sentinel]
command = "echo"
args = ["sentinel"]
TOML

nrs 2>&1 | grep "preserved"
python3 -c '
import tomllib, os
d = tomllib.loads(open(os.path.expanduser("~/.codex/config.toml")).read())
mcps = list(d.get("mcp_servers", {}).keys())
assert "e2e-sentinel" in mcps, "user MCP 유실됨"
assert "chrome-devtools" in mcps, "template MCP 유실됨"  # Darwin 기준
print("merge OK:", mcps)
'

# cleanup
awk '
/^\[projects\."\/tmp\/e2e-check"\]$/ { s="p"; next }
/^\[mcp_servers\.e2e-sentinel\]$/    { s="m"; next }
s && /^\[/ { s="" }
!s { print }
' ~/.codex/config.toml > /tmp/cfg.new && mv /tmp/cfg.new ~/.codex/config.toml && chmod 600 ~/.codex/config.toml
```

- **기대**: `merge OK: [..., 'chrome-devtools', 'e2e-sentinel', ...]`.
- **실패 시**: `sync-codex-config.py`의 재귀 merge에서 existing deep copy 시작점, `merge_template_into` 재귀 진입 조건 확인.

### Phase 5: Regression — 인접 기능

```bash
# AGENTS.md symlink 유지 확인 (같은 default.nix 변경 중에 누락되지 않았는지)
readlink ~/.codex/AGENTS.md | grep -q CLAUDE.md

# skills projection 유지 확인
ls -la ~/.codex/skills/ | head -5

# claude 쪽 mcp.json은 여전히 symlink (이번 PR과 무관)
readlink ~/.claude/mcp.json
```
- **기대**: 위 세 항목 모두 변경 전과 동일한 거동.
- **실패 시**: `default.nix`의 `home.file` 블록이 AGENTS.md / helper / skills projection을 올바르게 유지하는지 확인.

## Rollback

1. 해당 commit들을 revert 후 `nrs`.
2. 기존 generation은 `~/.codex/config.toml`을 symlink로 되돌리려 하지만, 현재 regular file이 남아 있어 Home Manager가 "would be clobbered"로 중단할 수 있다.
3. 이 경우 `mv ~/.codex/config.toml ~/.codex/config.toml.migrated-backup` 후 `nrs` 재실행. 필요 시 `.migrated-backup`에서 `[projects.*]`와 사용자 `[mcp_servers.*]` 섹션을 수동으로 이전한다.
