### PR TITLE
feat(codex): expose documenting-intent to direct Codex (#489)

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -38,6 +38,7 @@ let
   exposedCodexSkills = [
     "create-issue"
     "create-pr"
+    "documenting-intent"
     "parallel-audit"
     "plan-with-questions"
     "playwright-cli"
@@ -63,8 +64,6 @@ let
     # codex-fan-out: Codex 세션은 native subagent fan-out이 기본 경로이므로 자기 참조가 된다.
     # 이 스킬은 Claude/headless 세션에서 codex exec subprocess를 구동하는 패턴용.
     "codex-fan-out"
-    # documenting-intent: P1 exposure 후보 — 별도 follow-up 이슈에서 전환
-    "documenting-intent"
   ];
 
   mkCodexSkillEntry = name: {

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -349,6 +349,7 @@ CODEX_GLOBAL_SKILLS_DIR="$HOME/.codex/skills"
 EXPECTED_EXPOSED=(
   create-issue
   create-pr
+  documenting-intent
   parallel-audit
   plan-with-questions
   playwright-cli
@@ -364,7 +365,6 @@ INTENTIONAL_EXCLUDE=(
   using-claude-p
   using-codex-exec
   codex-fan-out
-  documenting-intent
 )
 
 in_list() {


### PR DESCRIPTION
## Summary

- `documenting-intent` 스킬을 direct Codex 글로벌 exposure 정책의 `intentionallyNotExposed`에서 `exposedCodexSkills`로 승격.
- direct Codex 세션에서도 CIR/ADR 라우팅이 성립하도록 한다 (`~/.codex/skills/documenting-intent` 심링크 신규 노출).
- PR #488에서 확립한 "두 리스트 SoT + 독립 감사 오라클" 구조를 그대로 유지한 채 **한 항목만** 이동.

Closes #489

## 기존 문제/배경

`documenting-intent`는 이 repo의 CIR/ADR 라우팅 canonical target이다:

- `modules/shared/programs/claude/files/skills/create-issue/SKILL.md:7` — `NOT for CIR/ADR (use documenting-intent)`로 명시적 위임
- `flake.nix:5`, `modules/shared/programs/claude/files/scripts/statusline.sh:84` — `Change Intent Record` 포맷 활용
- `.claude/skills/documenting-intent/`를 통해 Claude Code 세션에서는 정상 동작

그러나 direct Codex 세션에서는 `modules/shared/programs/codex/default.nix`의 `intentionallyNotExposed` 리스트에 P1 후보로 남아 있어 `~/.codex/skills/documenting-intent`가 부재. CIR 트리거('의도 기록', 'CIR', 'ADR', '결정 근거', …)가 Codex에서 매치되지 않아 다른 스킬의 `use documenting-intent` 위임이 무효가 되는 상태다.

## CIR (Change Intent Record)

- **v1** (PR #122, `6ee40fd`) — `documenting-intent` 스킬 최초 생성 (Claude 세션 전용 surface).
- **v2** (PR #488, `3ec2255`, Closes #486) — direct Codex runtime 정렬 시 shared exposure 정책 SoT를 `default.nix` let 블록으로 중앙화하면서 `documenting-intent`를 P1 exposure 후보로 **의도적으로** `intentionallyNotExposed`에 플래그 (별도 follow-up 이슈에서 전환하기로 결정).
- **v3** (이번 PR, #489) — v2에서 예약한 follow-up을 수행. 두 리스트 한 항목 이동 + 독립 감사 오라클 배열 동기화.

**trade-off**: SKILL.md 본문이 direct Codex 런타임에서 절차적으로 성립하는지 full 검토는 본 PR scope 밖으로 유지 (이슈 본문 Notes 명시). 대신 grep 기반 sanity check로 Claude-only API 호출(`AskUserQuestion`/`EnterPlanMode`/`ExitPlanMode`/`TaskCreate`/`TaskUpdate`) 미출현을 확인하여 risk 완화. 본문은 `git log`/`gh pr list`/`grep -rn` 등 일반 CLI만 사용.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `documenting-intent`를 `exposedCodexSkills`로 이동 + 오라클 동기화 | PR #488의 두 리스트 독립 오라클 구조를 그대로 유지한 채 한 항목 이동 | 정책 구조 보존, 변경 범위 최소(+2/-3), 회귀 위험 낮음 | 수기 동기화 의무 유지 (두 소스) | ✅ |
| SoT와 오라클을 단일 소스로 통합 | 중복 제거, 수기 동기화 불필요 | DRY | PR #488에서 3회 연속 NOT_AN_ISSUE로 현 상태 유지 결정됨 — 독립 감사 원칙 훼손 | ❌ |
| `documenting-intent` 유지 (현 상태) | exposure 변경 없음 | 변경 없음 | Codex에서 CIR/ADR 라우팅 끊김 지속, PR #488에서 예약한 follow-up 수행 불가 | ❌ |
| SKILL.md 본문까지 Codex 호환성 재작성 포함 | 본문 절차 재검토 + 노출 동시 수행 | Codex 런타임 특화 조정 완비 | 이슈 scope 초과, grep sanity check로 Claude-only 의존 미확인, follow-up으로 분리하는 게 합리적 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/codex/default.nix` | 수정 | `exposedCodexSkills` 리스트에 `documenting-intent` 삽입 (11→12), `intentionallyNotExposed`에서 제거 + P1 후보 주석 삭제 (5→4) |
| `scripts/ai/verify-ai-compat.sh` | 수정 | 독립 감사 오라클 `EXPECTED_EXPOSED` 배열에 추가 (11→12), `INTENTIONAL_EXCLUDE` 배열에서 제거 (5→4) |

### 핵심 코드

```diff
 # modules/shared/programs/codex/default.nix — exposedCodexSkills
   exposedCodexSkills = [
     "create-issue"
     "create-pr"
+    "documenting-intent"
     "parallel-audit"
     ...
   ];

 # modules/shared/programs/codex/default.nix — intentionallyNotExposed
   intentionallyNotExposed = [
     ...
     "codex-fan-out"
-    # documenting-intent: P1 exposure 후보 — 별도 follow-up 이슈에서 전환
-    "documenting-intent"
   ];

 # scripts/ai/verify-ai-compat.sh — 두 배열 동기 갱신
 EXPECTED_EXPOSED=(
   create-issue
   create-pr
+  documenting-intent
   parallel-audit
   ...
 )
 INTENTIONAL_EXCLUDE=(
   ...
   codex-fan-out
-  documenting-intent
 )
```

## 참고 레퍼런스

- PR #488 (`3ec2255`) — shared skill contracts align with direct Codex runtime, exposure 정책 SoT 중앙화 origin (P1 후보 플래그 추가)
- Issue #486 — PR #488의 parent issue (Codex runtime alignment)
- PR #122 (`6ee40fd`) — `documenting-intent` 스킬 최초 생성
- PR #275 (`8335277`) — Thariq 스타일 description 통일 + 라우팅 테이블 제거
- PR #507 / #508 / #509 / #510 (`f82ac75`) — agent-skills 벤치마크 4종 이식 (`prd`, `review-implementation` 등 추가로 현 `exposedCodexSkills` 11개 상태 형성)
- PR #516 (`bc2a91d`) — template 파싱 기반 verifier + sync-codex-config check subcommand (현 main tip)

## Human Test Plan

### 정상 동작 검증

1. direct Codex 세션에서 "CIR 기록해줘" 또는 "결정 근거 남겨줘" 등 trigger 발화.
   - **기대**: `documenting-intent` 스킬이 매치되어 CIR 작성 절차가 시작된다.
   - **실패 시**: `ls ~/.codex/skills/documenting-intent` 존재 확인, `codex --list-skills` (가능 시)로 로드 상태 확인, `readlink -f ~/.codex/skills/documenting-intent`가 shared source를 가리키는지 확인.

2. `create-issue` 스킬 trigger 발화 후 CIR/ADR 질문 시.
   - **기대**: `create-issue/SKILL.md:7`의 `NOT for CIR/ADR (use documenting-intent)` 위임이 작동하여 `documenting-intent`로 재라우팅된다.
   - **실패 시**: `documenting-intent` description/trigger가 Codex description-loading surface에 로드되지 않았을 가능성 — `~/.codex/skills/documenting-intent/SKILL.md` 내용 확인.

### 엣지 케이스

3. Claude Code 세션에서 동일 trigger 발화.
   - **기대**: 기존과 동일하게 `documenting-intent`로 라우팅된다 (회귀 없음).
   - **실패 시**: `.claude/skills/documenting-intent` repo-local 심링크 상태 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. exposedCodexSkills에 documenting-intent 존재
grep -q '"documenting-intent"' modules/shared/programs/codex/default.nix
# 기대: exit 0

# 2. intentionallyNotExposed에서 documenting-intent 부재 (Negative)
! awk '/intentionallyNotExposed = \[/,/\];/' modules/shared/programs/codex/default.nix | grep -q '"documenting-intent"'
# 기대: exit 0

# 3. P1 후보 주석 부재 (Negative)
! grep -q 'P1 exposure 후보' modules/shared/programs/codex/default.nix
# 기대: exit 0

# 4. verify-ai-compat.sh 오라클 두 배열 동기화
grep -qE 'EXPECTED_EXPOSED=\(' scripts/ai/verify-ai-compat.sh && \
  awk '/EXPECTED_EXPOSED=\(/,/\)/' scripts/ai/verify-ai-compat.sh | grep -q 'documenting-intent'
! awk '/INTENTIONAL_EXCLUDE=\(/,/\)/' scripts/ai/verify-ai-compat.sh | grep -q 'documenting-intent'
# 기대: 양쪽 모두 exit 0

# 5. Nix syntax
nix-instantiate --parse modules/shared/programs/codex/default.nix > /dev/null
# 기대: exit 0
```

### Phase 1: 런타임 노출 검증

> "nrs 실행 후 ~/.codex/skills/documenting-intent 심링크가 shared source를 가리키는지 확인"

```bash
nrs  # main-agent-only
test -L ~/.codex/skills/documenting-intent
readlink -f ~/.codex/skills/documenting-intent | grep -q 'modules/shared/programs/claude/files/skills/documenting-intent$'
```

- **기대**: 심링크 존재, canonical target이 `modules/shared/programs/claude/files/skills/documenting-intent`로 끝나는 경로.
- **실패 시**: `nrs-relink` 실패 가능성. `ls -la ~/.codex/skills/` 및 `modules/shared/scripts/nrs-relink.sh` 동작 확인.

### Phase 2: 독립 오라클 검증

> "verify-ai-compat.sh가 exposure 정책과 런타임 상태의 일관성을 재확인"

```bash
./scripts/ai/verify-ai-compat.sh
```

- **기대**: exit 0, 마지막 줄 `검증 완전 통과`, 출력에 `shared 노출 정상: documenting-intent` 포함, `의도적 비노출 확인: documenting-intent` 미출현, `shared 스킬: 16개, 노출 기대값: 12개, 비노출 기대값: 4개`.
- **실패 시**:
  - `노출 누락` → `nrs` 미반영. 재실행.
  - `미분류 shared 스킬` → 두 리스트 중 하나만 수정됨. 두 소스 동시 확인.
  - `노출 대상 불일치` → `readlink -f` resolved vs expected 불일치. `nrs-relink` 실패 가능성.

### Phase 3: Regression — 라우팅 경계

> "documenting-intent trigger가 인접 스킬과 충돌하지 않는지 확인"

| 쿼리 | 기대 스킬 | 이번 PR 영향 |
|------|----------|-------------|
| "의도 기록해줘" | `documenting-intent` | Codex 세션에서 신규 매치 (의도된 효과) |
| "CIR 본문이 포함된 PR 올려줘" | `create-pr` | 무영향이어야 함 (PR 작성 맥락 우선) |
| "이슈 하나 등록해줘" | `create-issue` | 무영향이어야 함 (delegation도 동일) |
| "결정 이력 찾아줘" | `documenting-intent` | Codex 세션에서 조회 절차 성립 |

기존 10개 노출 스킬에 대한 smoke check:

```bash
# 기존 노출 심링크 전부 생존
for s in create-issue create-pr parallel-audit plan-with-questions playwright-cli prd review-implementation review-pr-feedback run-da syncing-codex-harness write-handoff; do
  test -L "$HOME/.codex/skills/$s" || echo "MISSING: $s"
done
# 기대: 출력 없음 (전부 생존)
```

- **기대**: 기존 스킬 11개 모두 심링크 상태 유지, 새 1개(`documenting-intent`) 추가로 총 12개.
- **실패 시**: nrs activation이 부분 실패했을 가능성. `ls ~/.codex/skills/`로 전수 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The "documenting-intent" skill is now available and fully accessible within the system. This skill has been enabled and added to the list of exposed capabilities, ensuring it is properly resolvable and ready for use across all applicable components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->