### PR TITLE
fix(security): nrs-relink·detect_worktree에 worktree-list trust gate 추가 (#384)

### DIFF
--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -20,6 +20,13 @@ detect_worktree() {
     abs_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd) || return 0
     [[ "$abs_common_dir" != "${FLAKE_PATH}/.git" ]] && return 0
 
+    # 등록된 worktree인지 교차검증 (fake `.git` 파일로 common-dir/git-dir을 위조하는
+    # 우회 차단 — nrs-relink cmd_relink와 동일 패턴). worktree list는 메인 레포에
+    # 실제 등록된 worktree만 출력하므로, 미등록 fake checkout은 FLAKE_PATH로 승격되지
+    # 못한다. 비-worktree 케이스와 동일하게 silent skip하여 main 빌드로 fallback.
+    git -C "$FLAKE_PATH" worktree list --porcelain 2>/dev/null \
+        | grep -qxF "worktree $git_toplevel" || return 0
+
     log_warn "⚠️  Worktree detected: $git_toplevel"
     FLAKE_PATH="$git_toplevel"
 }

--- a/modules/shared/scripts/nrs-relink.sh
+++ b/modules/shared/scripts/nrs-relink.sh
@@ -137,6 +137,13 @@ cmd_relink() {
     # 공격자가 `.git` 파일에 `gitdir: MAIN_REPO/.git[/worktrees/<name>]`을 써 넣어
     # common-dir/git-dir을 위조해도 등록 목록에는 없으므로 차단된다.
     # MAIN_REPO 자체가 git repo가 아니면 명령이 실패해 거부 경로로 떨어진다 (fail-closed).
+    #
+    # 위협 모델 범위: "등록되지 않은 외부 레포 또는 위조된 `.git` 거부".
+    # 미대응 (out of scope): stale registered-path 재점유 — 등록된 worktree를
+    # 수동으로 삭제(git에는 prunable 등록 잔존) 후 동일 절대경로에 fake 디렉토리를
+    # 재생성하면 `worktree list` 매칭이 통과한다. 사용자 자신의 HOME에 dir를 만드는
+    # 시나리오라 trust boundary 외부에 가깝지만, 강한 방어가 필요하면 wt 레벨에서
+    # out-of-band capability marker를 부여하는 후속 작업이 필요하다.
     if ! git -C "$MAIN_REPO" worktree list --porcelain 2>/dev/null \
         | grep -qxF "worktree $git_toplevel"; then
         echo -e "${RED}Worktree $git_toplevel is not registered in $MAIN_REPO (git worktree list).${NC}" >&2

--- a/modules/shared/scripts/nrs-relink.sh
+++ b/modules/shared/scripts/nrs-relink.sh
@@ -130,6 +130,27 @@ cmd_relink() {
         return 0
     fi
 
+    # 메인 레포 worktree 신뢰 경계 검증 (lib/rebuild/common.sh detect_worktree 패턴 이식)
+    # detect_worktree는 비-worktree 시 silent return 0이지만, cmd_relink는 $HOME 심링크를
+    # 쓰는 보안 경계이므로 검증 실패 시 하드 실패한다.
+    # `pwd -P`가 아닌 `pwd`를 쓰는 이유: attacker/.git → MAIN_REPO/.git symlink spoof 시
+    # 논리 경로(pwd)는 attacker/.git로 남아 불일치 판정, 물리 경로(pwd -P)는 symlink를 따라
+    # MAIN_REPO/.git로 해석되어 우회 통과된다.
+    local git_common_dir abs_common_dir
+    git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || {
+        echo -e "${RED}Cannot determine git-common-dir${NC}" >&2
+        exit 1
+    }
+    abs_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd) || {
+        echo -e "${RED}Cannot resolve git-common-dir path${NC}" >&2
+        exit 1
+    }
+    if [[ "$abs_common_dir" != "${MAIN_REPO}/.git" ]]; then
+        echo -e "${RED}This directory is not a worktree of the main repo (${MAIN_REPO}).${NC}" >&2
+        echo -e "${RED}Refusing to relink from untrusted repository.${NC}" >&2
+        exit 1
+    fi
+
     local worktree="$git_toplevel"
 
     local hmf

--- a/modules/shared/scripts/nrs-relink.sh
+++ b/modules/shared/scripts/nrs-relink.sh
@@ -151,6 +151,17 @@ cmd_relink() {
         exit 1
     fi
 
+    # 교차검증: git worktree list --porcelain에 등록된 경로인지 확인
+    # common-dir 일치만으로는 공격자가 `.git` 파일에 `gitdir: MAIN_REPO/.git`(또는
+    # `gitdir: MAIN_REPO/.git/worktrees/<name>`)를 써 넣으면 우회할 수 있다.
+    # worktree list는 메인 레포에 실제 등록된 worktree만 출력하므로 위조가 걸러진다.
+    if ! git -C "$MAIN_REPO" worktree list --porcelain 2>/dev/null \
+        | grep -qxF "worktree $git_toplevel"; then
+        echo -e "${RED}Worktree $git_toplevel is not registered in $MAIN_REPO (git worktree list).${NC}" >&2
+        echo -e "${RED}Refusing to relink from unregistered repository.${NC}" >&2
+        exit 1
+    fi
+
     local worktree="$git_toplevel"
 
     local hmf

--- a/modules/shared/scripts/nrs-relink.sh
+++ b/modules/shared/scripts/nrs-relink.sh
@@ -130,31 +130,13 @@ cmd_relink() {
         return 0
     fi
 
-    # 메인 레포 worktree 신뢰 경계 검증 (lib/rebuild/common.sh detect_worktree 패턴 이식)
-    # detect_worktree는 비-worktree 시 silent return 0이지만, cmd_relink는 $HOME 심링크를
-    # 쓰는 보안 경계이므로 검증 실패 시 하드 실패한다.
-    # `pwd -P`가 아닌 `pwd`를 쓰는 이유: attacker/.git → MAIN_REPO/.git symlink spoof 시
-    # 논리 경로(pwd)는 attacker/.git로 남아 불일치 판정, 물리 경로(pwd -P)는 symlink를 따라
-    # MAIN_REPO/.git로 해석되어 우회 통과된다.
-    local git_common_dir abs_common_dir
-    git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || {
-        echo -e "${RED}Cannot determine git-common-dir${NC}" >&2
-        exit 1
-    }
-    abs_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd) || {
-        echo -e "${RED}Cannot resolve git-common-dir path${NC}" >&2
-        exit 1
-    }
-    if [[ "$abs_common_dir" != "${MAIN_REPO}/.git" ]]; then
-        echo -e "${RED}This directory is not a worktree of the main repo (${MAIN_REPO}).${NC}" >&2
-        echo -e "${RED}Refusing to relink from untrusted repository.${NC}" >&2
-        exit 1
-    fi
-
-    # 교차검증: git worktree list --porcelain에 등록된 경로인지 확인
-    # common-dir 일치만으로는 공격자가 `.git` 파일에 `gitdir: MAIN_REPO/.git`(또는
-    # `gitdir: MAIN_REPO/.git/worktrees/<name>`)를 써 넣으면 우회할 수 있다.
-    # worktree list는 메인 레포에 실제 등록된 worktree만 출력하므로 위조가 걸러진다.
+    # 메인 레포 worktree 신뢰 경계 검증
+    # cmd_relink는 $HOME 심링크를 쓰는 보안 경계이므로, 임의 git 디렉토리가 자신을
+    # worktree로 가장하지 못하도록 거부해야 한다.
+    # `git worktree list --porcelain`은 메인 레포에 실제 등록된 worktree만 출력한다.
+    # 공격자가 `.git` 파일에 `gitdir: MAIN_REPO/.git[/worktrees/<name>]`을 써 넣어
+    # common-dir/git-dir을 위조해도 등록 목록에는 없으므로 차단된다.
+    # MAIN_REPO 자체가 git repo가 아니면 명령이 실패해 거부 경로로 떨어진다 (fail-closed).
     if ! git -C "$MAIN_REPO" worktree list --porcelain 2>/dev/null \
         | grep -qxF "worktree $git_toplevel"; then
         echo -e "${RED}Worktree $git_toplevel is not registered in $MAIN_REPO (git worktree list).${NC}" >&2

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -209,6 +209,27 @@ install_platform_nrs_entrypoint() {
   esac
 }
 
+install_nrs_relink_for_tests() {
+  local sandbox="$1" main_repo="$2"
+  local home_dir="$sandbox/home"
+  local generated_dir="$sandbox/generated"
+  local shell_nix="$REPO_ROOT/modules/shared/programs/shell/default.nix"
+
+  # Nix 배포 정의 검증: replaceVars 패턴 + executable = true
+  # shellcheck disable=SC2016  # Literal Nix source strings.
+  assert_nix_has_attr "$shell_nix" ".local/bin/nrs-relink" \
+    '    source = pkgs.replaceVars "${sharedScriptsDir}/nrs-relink.sh" {' \
+    '      flakePath = nixosConfigDefaultPath;' \
+    '    };' \
+    '    executable = true;'
+
+  mkdir -p "$home_dir/.local/bin" "$generated_dir"
+  sed "s|@flakePath@|$main_repo|g" \
+    "$REPO_ROOT/modules/shared/scripts/nrs-relink.sh" > "$generated_dir/nrs-relink"
+  chmod +x "$generated_dir/nrs-relink"
+  ln -sf "$generated_dir/nrs-relink" "$home_dir/.local/bin/nrs-relink"
+}
+
 create_git_fixture_repo() {
   local repo_root="$1"
   local sandbox_root home_dir
@@ -969,6 +990,59 @@ EOF
   [[ ! -e "$hook_marker" ]] || fail "expected fixture git setup to ignore host global hooks"
 }
 
+test_nrs_relink_rejects_untrusted_repo() {
+  local sandbox home_dir main_repo untrusted_repo output rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  main_repo="$sandbox/main-repo"
+  untrusted_repo="$sandbox/untrusted-repo"
+
+  # fixture 메인 repo (worktree 하나 자동 생성되지만 사용하지 않음)
+  create_git_fixture_repo "$main_repo"
+  main_repo="$(cd "$main_repo" && pwd -P)"
+
+  # 별도 임의 git repo (공격자 통제를 모사)
+  mkdir -p "$untrusted_repo" "$home_dir/.config"
+  (
+    cd "$untrusted_repo"
+    HOME="$home_dir" \
+      XDG_CONFIG_HOME="$home_dir/.config" \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 \
+      git \
+      -c core.hooksPath=/dev/null \
+      -c commit.gpgSign=false \
+      -c init.templateDir= \
+      init >/dev/null 2>&1
+    HOME="$home_dir" \
+      XDG_CONFIG_HOME="$home_dir/.config" \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 \
+      git \
+      -c core.hooksPath=/dev/null \
+      -c commit.gpgSign=false \
+      -c init.templateDir= \
+      -c user.email=test@example.com \
+      -c user.name="Test User" \
+      commit --allow-empty -m init >/dev/null 2>&1
+  )
+
+  install_nrs_relink_for_tests "$sandbox" "$main_repo"
+
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      cd "'"$untrusted_repo"'"
+      "'"$home_dir/.local/bin/nrs-relink"'" relink
+    ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" == "1" ]] || fail "expected exit 1, got $rc. output: $output"
+  assert_contains "$output" "not a worktree of the main repo"
+  assert_contains "$output" "Refusing to relink"
+}
+
 test_nixos_nrs_offline_force_smoke() {
   local sandbox home_dir repo_root stub_dir output result_target
   sandbox=$(new_sandbox)
@@ -1252,6 +1326,7 @@ run_test "wt cleanup auto skips unpushed merged worktree" test_wt_cleanup_auto_s
 run_test "wt cleanup auto skips merged branch reuse" test_wt_cleanup_auto_skips_merged_branch_reuse
 run_test "missing managed helpers fail closed" test_missing_managed_helpers_fail_closed
 run_test "fixture git setup ignores host global hooks" test_fixture_git_is_hermetic_against_global_hooks
+run_test "nrs-relink rejects untrusted repo" test_nrs_relink_rejects_untrusted_repo
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -495,6 +495,43 @@ test_rebuild_common_exports_public_api() {
   assert_contains "$output" "maybe_relink_or_restore"
 }
 
+test_detect_worktree_rejects_fake_checkout() {
+  # fake `.git` 파일로 common-dir/git-dir을 위조해도 메인 레포에 등록된 worktree가
+  # 아니면 FLAKE_PATH가 승격되지 않아야 한다 (nrs build/activation 우회 차단).
+  local sandbox home_dir repo_root fake_dir output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  fake_dir="$sandbox/fake"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  # fake `.git` 파일로 common-dir 위조 (등록은 안 됨)
+  mkdir -p "$fake_dir"
+  printf 'gitdir: %s/.git\n' "$repo_root" > "$fake_dir/.git"
+
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$fake_dir"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      printf "flake=%s\nis_main=%s\n" \
+        "$FLAKE_PATH" \
+        "$(rebuild_is_main_flake && echo true || echo false)"
+    ' 2>&1
+  )
+
+  # FLAKE_PATH는 main(repo_root)으로 유지되어야 하며 fake_dir로 승격되면 안 됨
+  assert_contains "$output" "flake=$repo_root"
+  assert_contains "$output" "is_main=true"
+  assert_not_contains "$output" "flake=$fake_dir"
+}
+
 test_detect_worktree_uses_current_worktree_path() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)
@@ -1396,6 +1433,7 @@ EOF
 run_test "wt help uses deployed helper layout" test_wt_help_from_deployed_layout
 run_test "rebuild-common exports public API" test_rebuild_common_exports_public_api
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
+run_test "detect_worktree rejects fake checkout" test_detect_worktree_rejects_fake_checkout
 run_test "wt cd returns target path by name" test_wt_cd_by_name_returns_target_path
 run_test "wt ls lists deployed worktrees" test_wt_ls_from_deployed_layout_lists_worktrees
 run_test "shadow paths do not override managed helpers" test_shadow_paths_do_not_override_managed_helpers

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1039,7 +1039,7 @@ test_nrs_relink_rejects_untrusted_repo() {
   ) || rc=$?
 
   [[ "$rc" == "1" ]] || fail "expected exit 1, got $rc. output: $output"
-  assert_contains "$output" "not a worktree of the main repo"
+  assert_contains "$output" "not registered"
   assert_contains "$output" "Refusing to relink"
 }
 
@@ -1091,9 +1091,9 @@ test_nrs_relink_rejects_fake_checkout() {
 }
 
 test_nrs_relink_passes_gate_on_registered_worktree() {
-  # 정상 worktree에서 trust gate(common-dir + worktree list)가 모두 통과하는지 확인.
-  # 테스트 환경에는 home-manager-files가 없으므로 이후 HMF discovery 단계에서 exit 1,
-  # 단 차단 메시지는 없어야 한다.
+  # 정상 worktree에서 trust gate를 통과하고 정상 completion까지 가는지 확인.
+  # _discover_hmf의 probe 역추적 경로를 트리거하는 fake symlink 하나만 두면 충분
+  # (target dir 실재 불요; 패턴 매칭만 통과하면 _discover_oos_entries는 빈 출력).
   local sandbox home_dir main_repo worktree_root output rc
   sandbox=$(new_sandbox)
   home_dir="$sandbox/home"
@@ -1105,6 +1105,12 @@ test_nrs_relink_passes_gate_on_registered_worktree() {
 
   install_nrs_relink_for_tests "$sandbox" "$main_repo"
 
+  # Minimal HMF probe fixture: _discover_hmf의 두 번째 경로(probe 역추적) 트리거.
+  # /nix/store/*-home-manager-files/* 패턴만 매칭하면 되며 target dir 실재 불요.
+  mkdir -p "$home_dir/.claude"
+  ln -sfn "/nix/store/fake-home-manager-files/.claude/settings.json" \
+    "$home_dir/.claude/settings.json"
+
   rc=0
   output=$(
     HOME="$home_dir" \
@@ -1114,11 +1120,10 @@ test_nrs_relink_passes_gate_on_registered_worktree() {
     ' 2>&1
   ) || rc=$?
 
-  assert_not_contains "$output" "not a worktree of the main repo"
+  [[ "$rc" == "0" ]] || fail "expected exit 0 (gate passed + HMF probe), got $rc. output: $output"
+  assert_contains "$output" "Relinked"
   assert_not_contains "$output" "not registered"
   assert_not_contains "$output" "Refusing to relink"
-  [[ "$rc" == "1" ]] || fail "expected exit 1 (HMF absent in sandbox), got $rc. output: $output"
-  assert_contains "$output" "home-manager-files"
 }
 
 test_nixos_nrs_offline_force_smoke() {

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1043,6 +1043,84 @@ test_nrs_relink_rejects_untrusted_repo() {
   assert_contains "$output" "Refusing to relink"
 }
 
+test_nrs_relink_rejects_fake_checkout() {
+  # `.git` 파일에 `gitdir: MAIN_REPO/.git`(또는 `.git/worktrees/<name>`)를 써 넣어
+  # common-dir 비교를 위조하더라도 `git worktree list`에 등록되지 않은 디렉토리는
+  # 거부되어야 한다.
+  local sandbox home_dir main_repo fake_common fake_worktree output rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  main_repo="$sandbox/main-repo"
+  fake_common="$sandbox/fake-common"
+  fake_worktree="$sandbox/fake-worktree"
+
+  create_git_fixture_repo "$main_repo"
+  main_repo="$(cd "$main_repo" && pwd -P)"
+
+  install_nrs_relink_for_tests "$sandbox" "$main_repo"
+
+  # Case A: .git 파일이 MAIN_REPO/.git를 가리킴 (main repo 위조)
+  mkdir -p "$fake_common"
+  printf 'gitdir: %s/.git\n' "$main_repo" > "$fake_common/.git"
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      cd "'"$fake_common"'"
+      "'"$home_dir/.local/bin/nrs-relink"'" relink
+    ' 2>&1
+  ) || rc=$?
+  [[ "$rc" == "1" ]] || fail "Case A: expected exit 1, got $rc. output: $output"
+  assert_contains "$output" "not registered"
+  assert_contains "$output" "Refusing to relink"
+
+  # Case B: .git 파일이 MAIN_REPO/.git/worktrees/feature_one를 가리킴 (등록 worktree 위조)
+  mkdir -p "$fake_worktree"
+  printf 'gitdir: %s/.git/worktrees/feature_one\n' "$main_repo" > "$fake_worktree/.git"
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      cd "'"$fake_worktree"'"
+      "'"$home_dir/.local/bin/nrs-relink"'" relink
+    ' 2>&1
+  ) || rc=$?
+  [[ "$rc" == "1" ]] || fail "Case B: expected exit 1, got $rc. output: $output"
+  assert_contains "$output" "not registered"
+  assert_contains "$output" "Refusing to relink"
+}
+
+test_nrs_relink_passes_gate_on_registered_worktree() {
+  # 정상 worktree에서 trust gate(common-dir + worktree list)가 모두 통과하는지 확인.
+  # 테스트 환경에는 home-manager-files가 없으므로 이후 HMF discovery 단계에서 exit 1,
+  # 단 차단 메시지는 없어야 한다.
+  local sandbox home_dir main_repo worktree_root output rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  main_repo="$sandbox/main-repo"
+
+  create_git_fixture_repo "$main_repo"
+  main_repo="$(cd "$main_repo" && pwd -P)"
+  worktree_root="$main_repo/.claude/worktrees/feature_one"
+
+  install_nrs_relink_for_tests "$sandbox" "$main_repo"
+
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      cd "'"$worktree_root"'"
+      "'"$home_dir/.local/bin/nrs-relink"'" relink
+    ' 2>&1
+  ) || rc=$?
+
+  assert_not_contains "$output" "not a worktree of the main repo"
+  assert_not_contains "$output" "not registered"
+  assert_not_contains "$output" "Refusing to relink"
+  [[ "$rc" == "1" ]] || fail "expected exit 1 (HMF absent in sandbox), got $rc. output: $output"
+  assert_contains "$output" "home-manager-files"
+}
+
 test_nixos_nrs_offline_force_smoke() {
   local sandbox home_dir repo_root stub_dir output result_target
   sandbox=$(new_sandbox)
@@ -1327,6 +1405,8 @@ run_test "wt cleanup auto skips merged branch reuse" test_wt_cleanup_auto_skips_
 run_test "missing managed helpers fail closed" test_missing_managed_helpers_fail_closed
 run_test "fixture git setup ignores host global hooks" test_fixture_git_is_hermetic_against_global_hooks
 run_test "nrs-relink rejects untrusted repo" test_nrs_relink_rejects_untrusted_repo
+run_test "nrs-relink rejects fake checkout" test_nrs_relink_rejects_fake_checkout
+run_test "nrs-relink passes gate on registered worktree" test_nrs_relink_passes_gate_on_registered_worktree
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock


### PR DESCRIPTION
## Summary

- `nrs-relink.sh` `cmd_relink()`와 `lib/rebuild/common.sh` `detect_worktree()`에 `git worktree list --porcelain` 기반 trust gate 추가 — 임의 git 디렉토리에서 `$HOME` 심링크 탈취 + nrs `--flake` activation 우회 차단
- 회귀 테스트 4건 추가 (untrusted repo / fake `.git` 위조 2 케이스 / 정상 worktree 양성 / detect_worktree fake 거부)
- Closes #384

## 기존 문제/배경

`nrs-relink.sh`의 `cmd_relink()`는 `git rev-parse --show-toplevel` 결과가 `MAIN_REPO`와 다르면 무조건 worktree로 간주하고 `$HOME/.claude/*`, `$HOME/.codex/*` 등 out-of-store 심링크를 그 디렉토리로 relink했다. 결과:

- 임의 git 저장소에서 `nrs-relink relink`를 실행하면 hooks(`*.sh`), `settings.json`, `mcp.json`, `~/.codex/config.toml` 등 실행·권한 파일이 공격자 제어 경로로 교체됨
- 다음 세션부터 사용자 권한으로 임의 코드 실행 가능
- #380 DA for_plan에서 SECURITY-1/SECURITY-2로 발견됨

`rebuild-common.sh` 리팩터링 결과인 `lib/rebuild/common.sh:11-25`의 `detect_worktree()`는 이미 `git-common-dir` 비교 패턴을 쓰고 있었지만, 이는 fake `.git` 파일(`gitdir: $MAIN_REPO/.git[/worktrees/<name>]`)로 우회 가능했다. 즉 nrs-relink뿐 아니라 `nrs` 빌드 진입 단계인 `detect_worktree`도 같은 위협 모델에 노출되어 있었다.

## CIR (Change Intent Record)

본 PR은 DA for_pr 3 라운드 + parallel-audit 6 bundle을 거쳐 점진적으로 trust gate를 강화·통합한 결과다. 의사결정 흐름:

1. **Round 1 (commit `cf91c8d`)** — 이슈 본문이 권고한 `git-common-dir` 비교 추가. `detect_worktree`와 달리 보안 경계이므로 silent skip 대신 `exit 1` 하드 실패.
2. **DA Round 1 → Round 2 (commit `a40f8ec`)** — Arbiter가 PoC로 우회 입증: `.git` 파일에 `gitdir: $MAIN_REPO/.git`(또는 `.git/worktrees/<name>`) 작성 시 common-dir이 `$MAIN_REPO/.git`을 반환해 통과. `git worktree list --porcelain` 교차검증 추가. fake-checkout 회귀 테스트 2건 추가.
3. **DA Round 2 → Round 3 (commit `18dcccd`)** — Arbiter가 PoC로 단일화 가능성 증명: `worktree list` 검증이 `common-dir` 검증의 strict subset이고 4가지 우회 케이스 모두 단독으로 처리. `common-dir` 블록 제거하여 trust gate를 `worktree list` 단일 검증으로 통합. 양성 smoke을 minimal HMF probe fixture로 강화.
4. **DA Round 3 → 위협 모델 명시 (commit `bc53632`)** — Arbiter가 새 PoC: 등록된 worktree 디렉토리 삭제(git에는 prunable 잔존) → 동일 절대경로 재점유 시 통과. 사용자 자가 시나리오에 가까워 본 gate 범위 외이므로 코드 주석에 위협 모델 경계 명시 + 후속 작업 분리 권고.
5. **parallel-audit Adjacent → detect_worktree 확장 (commit `17e1e80`)** — `detect_worktree()`도 동일 위협 모델에 노출됨이 발견됨 (FLAKE_PATH가 fake_dir로 승격되면 `darwin-rebuild --flake "$fake_dir"`로 fake activation 가능). 사용자 승인 후 본 PR 범위에 포함하여 동일 worktree-list 교차검증 추가.

핵심 설계 선택:
- **`pwd` vs `pwd -P`**: DA Round 1 Arbiter PoC가 `pwd -P`(물리 경로)는 `.git` symlink spoof를 따라가 우회 통과시킴을 확인. 논리 경로 비교가 정답.
- **`cmd_relink` hard fail vs `detect_worktree` silent skip**: cmd_relink는 `$HOME` 심링크를 쓰는 보안 경계라 `exit 1`. detect_worktree는 비-worktree 시 main으로 fallback이 정상 동작이므로 동일 silent return 0.
- **`worktree list` 단일 검증**: `common-dir`은 strict subset이라 중복. 단순성 우선 (YAGNI).

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| common-dir만 검증 | `git rev-parse --git-common-dir == $MAIN_REPO/.git` | 단순 | fake `.git` 위조 우회 가능 (PoC 확인) | ❌ |
| common-dir + worktree-list | 두 단계 검증 | defense-in-depth | `worktree list`가 strict superset이라 첫 단계가 무의미 | ❌ |
| **worktree-list 단일** | `git worktree list --porcelain \| grep -qxF "worktree $git_toplevel"` | 단순, 모든 위조 차단, fail-closed | stale registered-path 재점유 미차단 (사용자 자가 시나리오) | ✅ |
| trust tier / whitelist 도입 | 실행 파일별 분리 또는 trusted worktree 명시 | 더 세밀한 제어 | YAGNI (단일 사용자 환경) | ❌ |
| out-of-band capability marker (wt 레벨) | wt가 worktree 생성 시 marker 부여, relink가 검증 | stale registered-path 재점유까지 차단 | wt 변경 큰 작업, 본 이슈 범위 외 | 후속 이슈로 분리 |

## 구현 상세

### 변경 파일

| 파일 | 변경 |
|---|---|
| `modules/shared/scripts/nrs-relink.sh` | `cmd_relink()`에 worktree-list 교차검증 + 위협 모델 주석 |
| `modules/shared/scripts/lib/rebuild/common.sh` | `detect_worktree()`에 동일 worktree-list 교차검증 (silent skip) |
| `tests/shell-script-tests.sh` | helper `install_nrs_relink_for_tests` + 테스트 4건 + run_test 등록 |

### 핵심 코드

`cmd_relink()` (hard fail, 보안 경계):

```bash
if ! git -C "$MAIN_REPO" worktree list --porcelain 2>/dev/null \
    | grep -qxF "worktree $git_toplevel"; then
    echo -e "${RED}Worktree $git_toplevel is not registered in $MAIN_REPO (git worktree list).${NC}" >&2
    echo -e "${RED}Refusing to relink from unregistered repository.${NC}" >&2
    exit 1
fi
```

`detect_worktree()` (silent skip, fallback):

```bash
git -C "$FLAKE_PATH" worktree list --porcelain 2>/dev/null \
    | grep -qxF "worktree $git_toplevel" || return 0
```

신규 테스트:
- `test_nrs_relink_rejects_untrusted_repo`: 임의 git repo에서 rc=1 + "not registered"
- `test_nrs_relink_rejects_fake_checkout`: fake `.git` 위조 2 케이스 (`gitdir: $MAIN_REPO/.git`, `gitdir: $MAIN_REPO/.git/worktrees/feature_one`)
- `test_nrs_relink_passes_gate_on_registered_worktree`: 정상 worktree에서 minimal HMF probe로 trust gate 통과 + "Relinked" 출력 검증
- `test_detect_worktree_rejects_fake_checkout`: fake `.git` 위조에서 FLAKE_PATH가 main으로 유지

## 참고 레퍼런스

- 이슈 #384 (본 PR 대상)
- #380 — DA for_plan에서 SECURITY-1/SECURITY-2로 본 취약점 발견
- 커밋 `cf91c8d` — Round 1: git-common-dir 추가
- 커밋 `a40f8ec` — Round 2: worktree-list 교차검증 추가 (Arbiter PoC 반영)
- 커밋 `18dcccd` — Round 3: trust gate 단일화 (Arbiter PoC 반영)
- 커밋 `bc53632` — 위협 모델 범위 주석 명시 (stale registered-path 후속 이슈 권고)
- 커밋 `17e1e80` — parallel-audit Adjacent 발견에 따른 detect_worktree 확장
- 패턴 출처: `modules/shared/scripts/lib/rebuild/common.sh:11-25` `detect_worktree()` (이슈 본문이 참조)

## Human Test Plan

### Phase 0: 정상 worktree 동작 확인

```bash
cd /Users/green/Workspace/nixos-config/.claude/worktrees/issue_384
nrs-relink status   # 정상 worktree 심링크 목록 출력
```

기대: 53개 항목이 `[worktree]` 또는 `[main]` 표기로 출력.
실패 시: `git worktree list --porcelain | grep -qxF "worktree $(pwd)"` 결과 확인.

### Phase 1: 임의 repo 거부

```bash
tmp=$(mktemp -d) && cd "$tmp" && git init >/dev/null
nrs-relink relink   # rc=1 + "Refusing to relink from unregistered repository"
```

기대: rc=1, "not registered" + "Refusing to relink".
실패 시: `~/.local/bin/nrs-relink`가 새 코드인지 `grep -c "not registered" ~/.local/bin/nrs-relink`로 확인.

### Phase 2: fake checkout 거부 (`.git` 파일 위조)

```bash
tmp=$(mktemp -d); mkdir -p "$tmp/fake"
printf 'gitdir: /Users/green/Workspace/nixos-config/.git\n' > "$tmp/fake/.git"
cd "$tmp/fake" && nrs-relink relink   # rc=1 + "not registered"

# .git/worktrees/<name>를 가리키는 spoof도 동일
printf 'gitdir: /Users/green/Workspace/nixos-config/.git/worktrees/issue_384\n' > "$tmp/fake/.git"
nrs-relink relink   # rc=1 + "not registered"
```

기대: 두 케이스 모두 rc=1.
실패 시: `git -C /Users/green/Workspace/nixos-config worktree list --porcelain | grep "$(pwd)"` 결과 확인 — 출력이 있으면 stale registered-path 시나리오.

### Phase 3: detect_worktree fake 거부

```bash
tmp=$(mktemp -d); mkdir -p "$tmp/fake"
printf 'gitdir: /Users/green/Workspace/nixos-config/.git\n' > "$tmp/fake/.git"
HOME=$HOME REBUILD_CMD=darwin-rebuild bash -c '
  cd "'"$tmp/fake"'"
  source ~/.local/lib/rebuild-common.sh
  echo "FLAKE_PATH=[$FLAKE_PATH]"
'
```

기대: `FLAKE_PATH=[/Users/green/Workspace/nixos-config]` (main 유지).
실패 시: 시스템에 새 코드가 배포되지 않았거나 `git worktree list` 출력에 fake 경로가 잔존.

### Regression Phase: nrs 정상 빌드

```bash
nrs   # darwin-rebuild 정상 완료, "Relinked N symlink(s) to worktree" 출력
```

기대: 빌드 성공 + relink 정상.
실패 시: `git -C /Users/green/Workspace/nixos-config worktree list --porcelain`에 현재 worktree가 등록되어 있는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
cd /Users/green/Workspace/nixos-config/.claude/worktrees/issue_384

# 새 trust gate 코드 존재 확인
grep -c "worktree list --porcelain" modules/shared/scripts/nrs-relink.sh   # 1 expected
grep -c "worktree list --porcelain" modules/shared/scripts/lib/rebuild/common.sh   # 1 expected
grep -c "is not registered" modules/shared/scripts/nrs-relink.sh   # 1 expected

# 회귀 테스트 4건 등록 확인
grep -c "test_nrs_relink_" tests/shell-script-tests.sh   # 6 expected (3 def + 3 run_test)
grep -c "test_detect_worktree_rejects_fake_checkout" tests/shell-script-tests.sh   # 2 expected (1 def + 1 run_test)

# 정적 점검
bash -n modules/shared/scripts/nrs-relink.sh modules/shared/scripts/lib/rebuild/common.sh tests/shell-script-tests.sh
shellcheck modules/shared/scripts/nrs-relink.sh modules/shared/scripts/lib/rebuild/common.sh tests/shell-script-tests.sh
```

### Phase 1: 신규 테스트 통과

```bash
bash tests/shell-script-tests.sh
```

기대 출력에 다음 5건이 모두 포함:
```
==> detect_worktree rejects fake checkout
==> nrs-relink rejects untrusted repo
==> nrs-relink rejects fake checkout
==> nrs-relink passes gate on registered worktree
```

실패 시: 실패한 테스트의 stderr 메시지 분석. fixture 격리 확인 (`HOME`, `XDG_CONFIG_HOME`, `GIT_CONFIG_*`).

### Phase 2: 시스템 레벨 거부 재현

`Human Test Plan` Phase 1, 2, 3을 그대로 실행하고 모든 케이스에서 차단을 확인한다.

### Phase 3: Regression — 기존 nrs 빌드 무결성

```bash
nrs   # 빌드 성공 + "Relinked N symlink(s) to worktree" 출력
```

기존 maybe_relink_or_restore의 non-fatal wrapping(`|| log_warn ...`)으로 trust gate exit 1이 fatal로 승격되지 않음을 확인.

### 후속 이슈 권고

stale registered-path 재점유 시나리오(등록된 worktree를 디렉토리만 삭제 후 동일 절대경로에 fake 디렉토리 재생성)는 본 PR 범위 외다. 강한 방어가 필요하면 wt 레벨에서 worktree 생성 시 out-of-band capability marker(예: wt-managed marker file)를 부여하고 cmd_relink/detect_worktree에서 marker 존재 + 소유 repo 일치를 함께 검증하는 후속 이슈가 필요하다.