### PR TITLE
feat(skills): shared user-scope 스킬 description skill-creator eval 최적화 확산 (#518)

### DIFF
--- a/modules/shared/programs/claude/files/scripts/improve-description.sh
+++ b/modules/shared/programs/claude/files/scripts/improve-description.sh
@@ -171,6 +171,7 @@ raw_output=$(env -u CLAUDECODE -u ANTHROPIC_API_KEY SKILL_EVAL_MODE=1 \
     --output-format json \
     --max-turns 1 \
     --no-session-persistence \
+    --tools "" \
   2>/dev/null) || { echo "Error: claude -p failed" >&2; exit 1; }
 
 # --- Parse response ---
@@ -210,6 +211,7 @@ ${shorten_prompt}"
       --output-format json \
       --max-turns 1 \
       --no-session-persistence \
+      --tools "" \
     2>/dev/null) || true
 
   shortened=$(echo "$shorten_output" | jq -r '

--- a/modules/shared/programs/claude/files/scripts/improve-description.sh
+++ b/modules/shared/programs/claude/files/scripts/improve-description.sh
@@ -172,6 +172,7 @@ raw_output=$(env -u CLAUDECODE -u ANTHROPIC_API_KEY SKILL_EVAL_MODE=1 \
     --max-turns 1 \
     --no-session-persistence \
     --tools "" \
+    --strict-mcp-config \
   2>/dev/null) || { echo "Error: claude -p failed" >&2; exit 1; }
 
 # --- Parse response ---
@@ -212,6 +213,7 @@ ${shorten_prompt}"
       --max-turns 1 \
       --no-session-persistence \
       --tools "" \
+      --strict-mcp-config \
     2>/dev/null) || true
 
   shortened=$(echo "$shorten_output" | jq -r '

--- a/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-issue/SKILL.md
@@ -2,9 +2,11 @@
 name: create-issue
 argument-hint: "[issue title or description (optional)]"
 description: |
-  Create a structured GitHub issue with auto-enriched labels.
-  Trigger: '이슈 등록', '이슈 만들어', 'todo 등록', '버그 등록', '이슈 추가'.
-  NOT for CIR/ADR (use documenting-intent). NOT for PR 본문 (use create-pr).
+  Use this skill when the user wants to file, log, or track a piece of work in GitHub issues — whether phrased as creating an issue, logging a bug, adding a todo, or more implicit framings like "추적하게 등록해둬", "나중에 할 일로 남겨둬", "이거 기록해둬", "따로 남겨두자", "백로그에 올려". Triggers on any intent to capture work-to-be-done as a trackable item: bugs, feature requests, refactors, follow-ups, deferred tasks, or reminders. Produces a structured issue with auto-enriched labels via `gh` CLI.
+
+  NOT for recording decisions/rationale (use documenting-intent for CIR/ADR).
+  NOT for writing PR descriptions (use create-pr).
+  NOT for querying/editing/closing existing issues (use `gh` directly).
 ---
 
 # 이슈 등록

--- a/modules/shared/programs/claude/files/skills/create-issue/evals/queries.json
+++ b/modules/shared/programs/claude/files/skills/create-issue/evals/queries.json
@@ -1,0 +1,19 @@
+[
+  {"query": "이슈 등록해줘", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "이슈 만들어줘", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "todo 등록해줘", "should_trigger": true, "why": "명시적: todo는 create-issue 트리거"},
+  {"query": "버그 등록해줘", "should_trigger": true, "why": "명시적: 버그 리포트 등록"},
+  {"query": "이슈 추가", "should_trigger": true, "why": "명시적: 트리거 키워드"},
+  {"query": "GitHub 이슈 만들어줘", "should_trigger": true, "why": "명시적: GitHub + 이슈"},
+  {"query": "이거 추적하게 등록해둬", "should_trigger": true, "why": "경계선: 추적/등록은 create-issue 의도"},
+  {"query": "나중에 할 일로 남겨둬", "should_trigger": true, "why": "경계선: 할 일 = todo issue"},
+  {"query": "PR 만들어줘", "should_trigger": false, "why": "혼동 쌍: create-pr"},
+  {"query": "PR 본문 작성", "should_trigger": false, "why": "혼동 쌍: create-pr"},
+  {"query": "CIR 기록해줘", "should_trigger": false, "why": "혼동 쌍: documenting-intent (excluded peer)"},
+  {"query": "ADR 작성해줘", "should_trigger": false, "why": "혼동 쌍: documenting-intent (excluded peer)"},
+  {"query": "결정 근거 기록", "should_trigger": false, "why": "혼동 쌍: documenting-intent"},
+  {"query": "왜 이렇게 했는지 기록해줘", "should_trigger": false, "why": "혼동 쌍: documenting-intent"},
+  {"query": "계획 세우자", "should_trigger": false, "why": "혼동 쌍: plan-with-questions"},
+  {"query": "PRD 만들어줘", "should_trigger": false, "why": "혼동 쌍: prd"},
+  {"query": "DA 피드백 돌려줘", "should_trigger": false, "why": "혼동 쌍: run-da"}
+]

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
@@ -2,11 +2,15 @@
 name: plan-with-questions
 argument-hint: "[for_action|for_issue] [issue-ref | task description]"
 description: |
-  Structured planning with requirements clarification via iterative Q&A.
-  Two modes: for_action (issue ref → plan), for_issue (idea → issue creation).
-  Trigger: '계획 수립', '계획 세우기', 'plan', '스무고개', '요구사항 파악', '불명확점 질문',
-  '파악하자', '접근', '같이 정리', '논의', '어떻게 할지', '이슈 분석'.
-  NOT for DA (use run-da). NOT for PR 본문 (use create-pr).
+  Use this skill when a user wants to figure out WHAT to build or HOW to approach work through iterative Q&A — NOT when a spec/PRD already exists that just needs translating to tasks.
+
+  Two modes auto-detect:
+  - **for_action**: User references an issue (URL, `#123`, `DEV-123`, Linear/Jira key) or says "착수/작업 시작/이슈 분석/질문 정리" → resolve issue, explore code, ask questions, produce approved execution plan.
+  - **for_issue**: Vague feature wish or problem without an issue ref — "...하고 싶어", "...기능 추가", "...했으면 좋겠어", raw brainstorming → probe with questions, then file a GitHub issue.
+
+  Also triggers: "계획 세워/수립", "plan", "스무고개", "요구사항 파악", "어떻게 할지", "brainstorming → plan 전환", "불명확점 정리".
+
+  Do NOT use when: spec/PRD already exists (use prd), checking implementation against existing PRD/spec (use review-implementation), user wants bare implementation plan without discovery, filing issues without Q&A (create-issue), DA review (run-da), or PR bodies (create-pr).
 ---
 
 # 스무고개식 계획 수립

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
@@ -2,15 +2,15 @@
 name: plan-with-questions
 argument-hint: "[for_action|for_issue] [issue-ref | task description]"
 description: |
-  Use this skill when a user wants to figure out WHAT to build or HOW to approach work through iterative Q&A — NOT when a spec/PRD already exists that just needs translating to tasks.
+  Use when a user wants to figure out WHAT to build or HOW to approach work via iterative Q&A — NOT when a spec/PRD already exists and just needs translating to tasks.
 
   Two modes auto-detect:
-  - **for_action**: User references an issue (URL, `#123`, `DEV-123`, Linear/Jira key) or explicitly passes `for_action` as the first arg → resolve issue, explore code, ask questions, produce approved execution plan.
-  - **for_issue**: No issue ref and no explicit `for_action`/`for_issue` token — vague feature wish or problem ("...하고 싶어", "...기능 추가", "...했으면 좋겠어", raw brainstorming, 단독 phrase like "착수/작업 시작/이슈 분석") → probe with questions, then file a GitHub issue.
+  - **for_action**: Issue ref (URL, `#123`, `DEV-123`, Linear/Jira key) or explicit `for_action` first arg → resolve issue, explore code, ask questions, produce approved plan.
+  - **for_issue**: No issue ref and no explicit token — vague wish/problem ("...하고 싶어", "...기능 추가", brainstorming, 단독 phrase "착수/이슈 분석") → probe with questions, file a GitHub issue.
 
-  Also triggers: "계획 세워/수립", "plan", "스무고개", "요구사항 파악", "어떻게 할지", "brainstorming → plan 전환", "불명확점 정리".
+  Also triggers: "계획 수립", "plan", "스무고개", "요구사항 파악", "brainstorming → plan 전환", "불명확점 정리".
 
-  Do NOT use when: spec/PRD already exists (use prd), checking implementation against existing PRD/spec (use review-implementation), user wants bare implementation plan without discovery, filing issues without Q&A (create-issue), DA review (run-da), or PR bodies (create-pr).
+  Do NOT use when: spec/PRD exists (use prd), checking impl vs PRD/spec (use review-implementation), bare impl plan, filing issues without Q&A (create-issue), DA review (run-da), or PR bodies (create-pr).
 ---
 
 # 스무고개식 계획 수립

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/SKILL.md
@@ -5,8 +5,8 @@ description: |
   Use this skill when a user wants to figure out WHAT to build or HOW to approach work through iterative Q&A — NOT when a spec/PRD already exists that just needs translating to tasks.
 
   Two modes auto-detect:
-  - **for_action**: User references an issue (URL, `#123`, `DEV-123`, Linear/Jira key) or says "착수/작업 시작/이슈 분석/질문 정리" → resolve issue, explore code, ask questions, produce approved execution plan.
-  - **for_issue**: Vague feature wish or problem without an issue ref — "...하고 싶어", "...기능 추가", "...했으면 좋겠어", raw brainstorming → probe with questions, then file a GitHub issue.
+  - **for_action**: User references an issue (URL, `#123`, `DEV-123`, Linear/Jira key) or explicitly passes `for_action` as the first arg → resolve issue, explore code, ask questions, produce approved execution plan.
+  - **for_issue**: No issue ref and no explicit `for_action`/`for_issue` token — vague feature wish or problem ("...하고 싶어", "...기능 추가", "...했으면 좋겠어", raw brainstorming, 단독 phrase like "착수/작업 시작/이슈 분석") → probe with questions, then file a GitHub issue.
 
   Also triggers: "계획 세워/수립", "plan", "스무고개", "요구사항 파악", "어떻게 할지", "brainstorming → plan 전환", "불명확점 정리".
 

--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -2,9 +2,11 @@
 name: run-da
 argument-hint: "[for_plan|for_pr|both] [full] [fresh]"
 description: |
-  Run Devil's Advocate review on plans or code. Args: for_plan, for_pr, both. Modifier: full, fresh.
-  Trigger: 'DA', 'DA 피드백', '피드백 루프', 'YAGNI 리뷰', '코드 리뷰 루프', 'run-da'.
-  NOT for PR 코멘트 (use review-pr-feedback). NOT for 전수조사 (use parallel-audit).
+  Use this skill whenever the user wants a rigorous, adversarial review of a plan or code change — including any mention of "DA", "Devil's Advocate", 피드백 루프, 설계 검토, 코드 품질/리뷰, YAGNI/NGMI/HALLUCINATION/SECURITY/SIDE_EFFECT/CONSISTENCY/READABILITY/CLEAN_CODE 관점 점검, or requests framed as "이 계획/PR 엄격히 봐줘", "이거 괜찮을까 검증". Args: `for_plan`, `for_pr`, `both`. Modifiers: `full` (exhaustive 8-domain override), `fresh` (no prior-round context).
+
+  **Also invoke this skill when the user asks whether DA is needed or proposes skipping DA for "simple" changes** (e.g. "간단하니까 DA 생략하자", "오타 수정인데 DA 필요해?"). The skill's independent intensity agent decides SKIP/LITE/FULL — the main LLM must not rationalize skipping on its own.
+
+  NOT for applying existing PR comments/CodeRabbit feedback (use review-pr-feedback). NOT for exhaustive side-effect/regression sweeps via many parallel auditors (use parallel-audit).
 ---
 
 # Devil's Advocate 피드백 루프

--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/evals/queries.json
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/evals/queries.json
@@ -1,0 +1,18 @@
+[
+  {"query": "codex sync 실행해줘", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "codex 동기화", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "하네스 동기화", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "sync.sh 실행해줘", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "Codex CLI에 Claude 스킬 투영", "should_trigger": true, "why": "명시적: sync.sh의 핵심 기능"},
+  {"query": ".agents/skills 갱신해줘", "should_trigger": true, "why": "경계선: sync.sh이 수행하는 투영 경로"},
+  {"query": "claude와 codex 구조 맞춰줘", "should_trigger": true, "why": "경계선: 두 하네스 동기화 의미"},
+  {"query": "codex exec 실행해줘", "should_trigger": false, "why": "혼동 쌍: using-codex-exec (intentionally excluded peer)"},
+  {"query": "비대화형 codex 돌려줘", "should_trigger": false, "why": "혼동 쌍: using-codex-exec (excluded)"},
+  {"query": "codex review 돌려줘", "should_trigger": false, "why": "혼동 쌍: using-codex-exec (excluded)"},
+  {"query": "--yolo 모드로 실행", "should_trigger": false, "why": "혼동 쌍: using-codex-exec (excluded)"},
+  {"query": "codex 실행", "should_trigger": false, "why": "혼동 쌍: using-codex-exec — 'codex 실행'은 exec 트리거"},
+  {"query": "claude -p 호출 방법", "should_trigger": false, "why": "혼동 쌍: using-claude-p (intentionally excluded peer)"},
+  {"query": "PR 만들어줘", "should_trigger": false, "why": "혼동 쌍: create-pr"},
+  {"query": "DA 피드백", "should_trigger": false, "why": "혼동 쌍: run-da"},
+  {"query": "이슈 등록해줘", "should_trigger": false, "why": "혼동 쌍: create-issue"}
+]

--- a/modules/shared/programs/claude/files/skills/write-handoff/evals/queries.json
+++ b/modules/shared/programs/claude/files/skills/write-handoff/evals/queries.json
@@ -1,0 +1,19 @@
+[
+  {"query": "LLM 이행 가이드 작성해줘", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "이행 가이드 작성", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "인수인계 작성해줘", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "세션 인수인계", "should_trigger": true, "why": "명시적: 핵심 트리거 키워드"},
+  {"query": "write-handoff #252", "should_trigger": true, "why": "명시적: 스킬 이름 + 이슈 번호"},
+  {"query": "handoff 써줘", "should_trigger": true, "why": "명시적: handoff 키워드"},
+  {"query": "이 이슈 다른 LLM이 처음부터 할 수 있게 정리해줘", "should_trigger": true, "why": "경계선: LLM 이행 의도"},
+  {"query": "Phase 기반 이행 가이드 작성", "should_trigger": true, "why": "경계선: 스킬 산출물 형식"},
+  {"query": "이슈 등록해줘", "should_trigger": false, "why": "혼동 쌍: create-issue"},
+  {"query": "PR 만들어줘", "should_trigger": false, "why": "혼동 쌍: create-pr"},
+  {"query": "PR 본문 업데이트", "should_trigger": false, "why": "혼동 쌍: create-pr"},
+  {"query": "계획 수립해줘", "should_trigger": false, "why": "혼동 쌍: plan-with-questions"},
+  {"query": "스무고개로 요구사항 정리", "should_trigger": false, "why": "혼동 쌍: plan-with-questions"},
+  {"query": "PRD 작성해줘", "should_trigger": false, "why": "혼동 쌍: prd"},
+  {"query": "DA 피드백 돌려줘", "should_trigger": false, "why": "혼동 쌍: run-da"},
+  {"query": "PR 코멘트 반영", "should_trigger": false, "why": "혼동 쌍: review-pr-feedback"},
+  {"query": "CIR 기록해줘", "should_trigger": false, "why": "혼동 쌍: documenting-intent"}
+]


### PR DESCRIPTION
## Summary

- PR #513(prd, accuracy 82.35→100%) 절차를 9종 공유 user-scope 스킬에 확산. 9종 중 3종 intent prose 교체 + 3종 신규 `queries.json` 작성 + `improve-description.sh` SECURITY hardening.
- DA for_plan Arbiter **CONFIRMED 6건 전건 반영** (Correctness-1·2, Design-1·2, Regression-1·2). NOT_AN_ISSUE 3건은 판정 근거 수용.
- Phase 3 peer matrix **mandatory** 교차 검증 수행 → regression 1건(review-implementation 94.12→88.24) 탐지 후 plan-with-questions negative 추가로 100% 회복.

Closes #518

## Accuracy 표

| 스킬                   | baseline | final    | 조치        |
|------------------------|---------:|---------:|-------------|
| run-da                 |   79.17% |   79.17% | intent prose 교체 (round 2 악화로 round 1 rollback) |
| plan-with-questions    |   70.37% |   74.07% | intent prose + review-implementation negative |
| create-pr              |   91.30% |   skip   | —                                            |
| review-pr-feedback     |   92.31% |   skip   | —                                            |
| parallel-audit         |   95.00% |   skip   | —                                            |
| review-implementation  |   94.12% |  100.00% | peer 교차 검증에서 회복                       |
| create-issue           |   88.24% |   88.24% | queries.json 신규 + intent prose 교체         |
| syncing-codex-harness  |   93.75% |   skip   | queries.json 신규 (using-codex-exec negative 필수 포함) |
| write-handoff          |  100.00% |   skip   | queries.json 신규                             |

## 주요 변경

- `improve-description.sh`의 `claude -p` 두 호출에 `--tools ""` 추가 (DA SECURITY CONFIRMED — 불필요한 도구 표면 제거).
- 9종 중 3종 description을 `Trigger:` 단일 줄 style에서 intent prose style로 교체. 길이·구성은 스킬별 혼동 축에 맞춰 조정 (prd 3-paragraph 템플릿을 강제하지 않음 — DA Design-1 CONFIRMED 반영).
- 3종 신규 `evals/queries.json` 작성 (16~17개 항목). `syncing-codex-harness`는 intentionally excluded peer `using-codex-exec`의 대표 trigger 6개를 negative로 포함 (DA Regression-2 CONFIRMED).
- Peer matrix 교차 검증을 optional → **mandatory**로 승격 (DA Regression-1 CONFIRMED). 검증 대상: parallel-audit, prd, review-implementation.

## 사용자 승인 사항 반영

- `review-implementation`을 Phase 1 scope에 추가 (이슈 본문 실측 누락 정정).
- 단일 PR 산출 (스킬별 분리 안 함).
- 90% 미달 3종(run-da, plan-with-questions, create-issue)은 개선 description으로 Phase 3/4 진행.

## DA Arbiter 판정 반영

CONFIRMED 6건 전건 반영. NOT_AN_ISSUE 3건(Correctness-3, Maintainability-1·2) 판정 근거 수용하여 보류. 상세: `.claude/plans/abstract-coalescing-pearl.md` (gitignored).

## 비고 (토큰 절약으로 세션 종료)

사용자 요청에 따라 DA for_pr / parallel-audit / 10-pass review는 이번 세션에서 **생략**. 대신 pre-commit hook(gitleaks, shellcheck, ai-skills-consistency, eval-tests) + `verify-ai-compat.sh` 전수 통과 확인 완료.

## Test plan

- [x] Phase 1+2 baseline/optimize eval (9 스킬)
- [x] Phase 3 peer matrix regression (parallel-audit, prd, review-implementation)
- [x] `nrs --force` 실행, home-manager activation 정상
- [x] `./scripts/ai/verify-ai-compat.sh` 완전 통과
- [x] pre-commit hook 전수 통과
- [ ] Human test: 실제 대화에서 9종 스킬 trigger 체감

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill descriptions with clearer guidance on when to use create-issue, plan-with-questions, and run-da features.
  * Expanded trigger definitions to better capture user intents across various scenarios.
  * Added explicit boundaries to prevent feature misuse and redirect users to appropriate tools.

* **Tests**
  * Introduced evaluation queries to improve skill detection accuracy based on natural language input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->