### PR TITLE
fix(flake): nixpkgs/home-manager 26.05 breaking change 대응 (nodePackages 제거 + HM realpath 체크)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773025010,
-        "narHash": "sha256-khlHllTsovXgT2GZ0WxT4+RvuMjNeR5OW0UYeEHPYQo=",
+        "lastModified": 1776613567,
+        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "7b9f7f88ab3b339f8142dc246445abb3c370d3d3",
+        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773179137,
-        "narHash": "sha256-EdW2bwzlfme0vbMOcStnNmKlOAA05Bp6su2O8VLGT0k=",
+        "lastModified": 1777000050,
+        "narHash": "sha256-SnungQ8w1+5Mz+axhxZJKzj3OawvwXfqhGyeFFUJnYU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3f98e2bbc661ec0aaf558d8a283d6955f05f1d09",
+        "rev": "4bf1f0bcd156d1f1b23f46902a170c93cd197b88",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773000227,
-        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
+        "lastModified": 1775037210,
+        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
+        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/modules/darwin/programs/zed/default.nix
+++ b/modules/darwin/programs/zed/default.nix
@@ -84,7 +84,7 @@ in
     pkgs.duti # macOS 파일 연결 CLI 도구
     pkgs.nixd # Nix LSP (Zed nix 확장 의존성)
     pkgs.nixfmt # Nix 포매터 (nixd formatting 의존성)
-    pkgs.nodePackages.prettier # JS/TS/JSON 포매터 (Zed formatter 의존성)
+    pkgs.prettier # JS/TS/JSON 포매터 (Zed formatter 의존성)
   ];
 
   # settings.json / keymap.json — 양방향 수정 가능

--- a/modules/shared/programs/neovim/default.nix
+++ b/modules/shared/programs/neovim/default.nix
@@ -22,6 +22,17 @@ in
     # 모든 neovim 설정은 files/nvim/에서 lazy.nvim이 관리합니다.
     # HM이 xdg.configFile."nvim/" 파일을 생성하면 디렉토리 심볼릭 링크와 충돌합니다.
 
+    # init.lua 파일 생성 금지 — HM은 provider 설정 등을 init.lua에 주입하는데,
+    # mkOutOfStoreSymlink로 대체된 ~/.config/nvim/ 아래 별도 파일로 설치하면
+    # 새 home-manager(26.05+)의 realpath 체크가 "$HOME 외부"로 판단해 실패한다.
+    # sideload=true면 init.lua 파일 대신 wrapper --cmd 인자로 주입하므로 충돌 없음.
+    sideloadInitLua = true;
+
+    # 새 기본값(false)에 수렴 — provider를 쓰지 않으므로 legacy warning 제거.
+    withRuby = false;
+    withPython3 = false;
+    withNodeJs = false;
+
     extraPackages =
       with pkgs;
       [


### PR DESCRIPTION
## Summary
- `pkgs.nodePackages` attrset 제거(nixpkgs 26.05)에 따라 `pkgs.nodePackages.prettier` → `pkgs.prettier`로 이동.
- home-manager 26.05의 강화된 realpath 체크가 `mkOutOfStoreSymlink`로 대체된 `~/.config/nvim/` 아래 HM-자동 생성된 `init.lua`를 "outside \$HOME"으로 거부하여 실패 → `programs.neovim.sideloadInitLua = true`로 파일 생성을 억제(인자로 주입).

## 기존 문제/배경

`nfu`로 flake inputs(nixpkgs/home-manager/nix-darwin/disko/agenix/yazi-flavors) 업데이트를 시도했는데 두 단계에서 연속 실패했다.

**1. Evaluation 단계 — `nodePackages` 제거**

```
error: nodePackages has been removed. Many packages are now available at the top level
       (e.g. `pkgs.package-name`). Check on https://search.nixos.org to see if the package
       is still available.
… while evaluating definitions from `.../modules/darwin/programs/zed':
```

`modules/darwin/programs/zed/default.nix:87`의 `pkgs.nodePackages.prettier` 참조가 새 nixpkgs rev에서 존재하지 않음.

**2. Build 단계 — HM realpath 체크 강화**

1차 fix 후 재빌드하면 build phase에서:

```
> Error installing file '.config/nvim/init.lua' outside $HOME
error: Cannot build '/nix/store/....-home-manager-files.drv'.
```

`modules/shared/programs/neovim/default.nix:59`의 `home.file.".config/nvim".source = mkOutOfStoreSymlink nvimConfigPath`로 nvim 설정 디렉토리 전체를 repo 내부로 심링크하고 있다. 새 HM(26.05)은 `home-manager/modules/files.nix:395-401`에서 각 파일의 `realpath -m`을 계산해 `$realOut` 범위 내에 있는지 엄격히 검증하는데, HM이 provider 설정(ruby/python3 host_prog, node/perl disable)을 위해 자동 생성한 `xdg.configFile."nvim/init.lua"`가 심링크 디렉토리 안쪽 → 외부 경로로 resolved → reject.

## CIR (Change Intent Record)

- **v1 (2a3a255)**: 양쪽 모두 nixpkgs/home-manager 26.05 breaking change 대응이므로 한 PR로 묶음. `zed/default.nix`는 경로 교체로 단순 해결.
- **v2 (2a3a255)**: neovim 쪽은 초기에 `withRuby/withPython3/withNodeJs = false`로 "provider 설정 제거 → initLua 비워짐 → init.lua 파일 미생성"을 노렸으나, `nix eval` 확인 결과 `false`로 해도 `vim.g.loaded_*_provider=0` disable 라인이 남아 initLua가 여전히 비어있지 않았음 (`enable = mkIf (cfg.initLua != "")`).
- **v3 (2a3a255)**: HM 모듈 옵션 `sideloadInitLua`를 발견(`home-manager/modules/programs/neovim.nix:263`) — "writing initLua to \$XDG_CONFIG_HOME/nvim/init.lua를 피하고 wrapper args로 로드". 이게 의도와 정확히 일치하므로 채택. `withRuby/withPython3/withNodeJs = false`는 warning 제거 및 새 기본값 수렴 용도로 유지(lazy.nvim이 provider를 쓰지 않음).

**trade-off**: `sideloadInitLua = true`는 provider disable 선언이 `--cmd` 인자로 추가되어 neovim 기동 시마다 평가된다. 성능 영향은 무시 가능. `withNodeJs`는 coc.nvim 등이 활성화되면 자동으로 true가 되는 조건부 로직이 있으나(`modules/programs/neovim.nix:518`), 우리 설정은 coc를 쓰지 않아 무관.

## ADR

### 문제 1: `nodePackages.prettier` 대체 경로

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `pkgs.prettier` | nixpkgs top-level로 승격된 경로 | 1줄 수정, top-level 공식 경로 | — | ✅ |
| `pkgs.nodejs.pkgs.prettier` | nodejs passthru 경로 | node 런타임과 동일 버전 보장 | 경로 장황, nodejs 버전 변경 영향 | ❌ |
| 다른 포매터로 교체 | dprint 등 | rust 바이너리로 가벼움 | Zed formatter가 prettier를 직접 호출 | ❌ |

검증: `nix eval --raw github:nixos/nixpkgs/b12141ef619e0a9c1c84dc8c684040326f27cdcc#prettier.pname` → `prettier` 반환.

### 문제 2: `init.lua` 설치 충돌

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `sideloadInitLua = true` | init.lua 파일 대신 wrapper `--cmd`로 주입 | HM 공식 옵션, symlink 디렉토리와 공존 가능, imperative init.lua 관리를 위해 설계됨 | `--cmd` 인자 추가(성능 무시 가능) | ✅ |
| `withRuby/withPython3/withNodeJs = false`만 | provider 설정 제거 시도 | warning 제거 부수효과 | disable 선언(`loaded_*_provider=0`)이 남아 initLua가 비어지지 않음 → 실패 | ❌ (단독으로는 불충분, 보조로 유지) |
| `programs.neovim.enable = false` + `home.packages = [ pkgs.neovim ]` | HM neovim 모듈 자체를 우회 | breaking change 완전 회피 | defaultEditor/wrapping/alias 관리 포기, 스코프 확대 | ❌ |
| `xdg.configFile."nvim".source = mkOutOfStoreSymlink …` | `home.file` → `xdg.configFile`로 전환 | 동일 HM 관리 트리에 통합 | macOS는 기본 `xdg.enable = false`라 경로 해석이 모호, 근본 충돌 미해결 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `flake.lock` | 수정 | nixpkgs/home-manager/nix-darwin/disko/agenix/yazi-flavors 업데이트 |
| `modules/darwin/programs/zed/default.nix` | 수정 | `pkgs.nodePackages.prettier` → `pkgs.prettier` |
| `modules/shared/programs/neovim/default.nix` | 수정 | `sideloadInitLua = true` + `withRuby/withPython3/withNodeJs = false` |

### 핵심 코드

```nix
# modules/darwin/programs/zed/default.nix
# BEFORE
pkgs.nodePackages.prettier # JS/TS/JSON 포매터 (Zed formatter 의존성)
# AFTER
pkgs.prettier # JS/TS/JSON 포매터 (Zed formatter 의존성)
```

```nix
# modules/shared/programs/neovim/default.nix
programs.neovim = {
  enable = true;
  defaultEditor = true;
  viAlias = true;
  vimAlias = true;

  # init.lua 파일 생성 금지 — HM은 provider 설정 등을 init.lua에 주입하는데,
  # mkOutOfStoreSymlink로 대체된 ~/.config/nvim/ 아래 별도 파일로 설치하면
  # 새 home-manager(26.05+)의 realpath 체크가 "$HOME 외부"로 판단해 실패한다.
  # sideload=true면 init.lua 파일 대신 wrapper --cmd 인자로 주입하므로 충돌 없음.
  sideloadInitLua = true;

  # 새 기본값(false)에 수렴 — provider를 쓰지 않으므로 legacy warning 제거.
  withRuby = false;
  withPython3 = false;
  withNodeJs = false;

  # ...extraPackages...
};

home.file.".config/nvim".source = config.lib.file.mkOutOfStoreSymlink nvimConfigPath;
```

## 참고 레퍼런스

- nixpkgs rev `b12141ef6` — `nodePackages` attrset 제거 및 top-level 승격 포함.
- home-manager rev `4bf1f0bcd` — `modules/files.nix:395-401`에 `realpath -m` 기반 `$HOME` 범위 검증 추가.
- home-manager `modules/programs/neovim.nix:263-274` — `sideloadInitLua` 옵션 정의 ("manage your own init.lua imperatively").
- home-manager `modules/programs/neovim.nix:623-626` — `xdg.configFile."nvim/init.lua".enable = !cfg.sideloadInitLua` — sideload 시 파일 생성 비활성화.
- 커밋 `2a3a255` — 이번 변경.

## Human Test Plan

### 정상 동작 검증

1. `nfu -a` 또는 `nfu`(fzf로 6개 input 선택)을 실행한다.
   - **기대**: FOD hash 검증 통과 → nrs 실행 → darwin 시스템 generation 정상 생성.
   - **실패 시**: `nix eval '.#darwinConfigurations."$(scutil --get LocalHostName)".config.home-manager.users.glen.programs.neovim.sideloadInitLua'`로 `true`가 나오는지 확인.

2. 시스템 switch 후 `nvim` 실행.
   - **기대**: lazy.nvim이 `~/.config/nvim/init.lua`(repo 내부 심링크 대상)를 정상 로드, LSP/포매터 동작.
   - **실패 시**: `readlink ~/.config/nvim` 경로가 repo 내 `modules/shared/programs/neovim/files/nvim`를 가리키는지, `~/.config/nvim/init.lua`가 별도 파일로 존재하지 않는지 확인.

3. Zed에서 `.js`/`.json` 파일 포매팅.
   - **기대**: prettier가 동작하여 포매팅 성공.
   - **실패 시**: `which prettier`와 `pkgs.prettier`가 실제로 PATH에 있는지 확인.

### 엣지 케이스

4. `nvim --version`으로 provider 상태 확인.
   - **기대**: `-ruby`, `-python3`, `-nodejs`, `-perl` 표기(provider 비활성).
   - **실패 시**: extraPackages/wrapper 설정과 withRuby 등의 값 재확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 경로 존재 확인 (zed)
grep -q 'pkgs\.prettier ' modules/darwin/programs/zed/default.nix
# 기대: exit 0

# 2. old 경로 부재 확인 (Negative — zed)
! grep -q 'pkgs\.nodePackages\.prettier' modules/darwin/programs/zed/default.nix
# 기대: exit 0

# 3. sideloadInitLua 설정 확인
grep -q 'sideloadInitLua = true' modules/shared/programs/neovim/default.nix
# 기대: exit 0

# 4. flake.lock 업데이트 확인 (nixpkgs rev 갱신)
grep -q 'b12141ef619e0a9c1c84dc8c684040326f27cdcc' flake.lock
# 기대: exit 0

# 5. 저장소 전체에 nodePackages 잔존 참조 없음 (Negative)
! grep -rn --include='*.nix' 'pkgs\.nodePackages\.' modules/ hosts/ 2>/dev/null
# 기대: exit 0
```

### Phase 1: Evaluation 검증

> "새 flake inputs 하에서 darwin 시스템 toplevel이 평가 에러 없이 평가되는지 확인"

```bash
nix eval --raw ".#darwinConfigurations.\"$(scutil --get LocalHostName)\".config.system.build.toplevel.outPath" >/dev/null 2>&1
```
- **기대**: exit 0, 유효한 `/nix/store/...` 경로 출력.
- **실패 시**: `nix eval ... --show-trace`로 재실행하여 trace의 최상단 모듈(`modules/darwin/...`)을 특정. 추가 nixpkgs 26.05 breaking change 후보를 탐색.

### Phase 2: HM files 빌드 검증 (realpath 체크 통과)

> "home-manager-files.drv가 `outside \$HOME` 없이 빌드되는지 확인"

```bash
./scripts/fix-fod-hashes.sh
```
- **기대**: `✓ FOD hash mismatch 없음`로 종료, exit 0.
- **실패 시**: `nix log <home-manager-files.drv>`로 어떤 파일이 outside로 reject되는지 확인. HM이 `~/.config/nvim/` 아래 별도 파일을 만드는 추가 항목(`coc-settings.json` 등)이 있는지 `nix eval '.#…home.file' --apply 'x: builtins.attrNames x'`로 점검.

### Phase 3: init.lua 파일 억제 검증

> "sideloadInitLua=true가 실제로 nvim/init.lua 설치를 비활성화하는지 확인"

```bash
nix eval '.#darwinConfigurations."'"$(scutil --get LocalHostName)"'".config.home-manager.users.glen.home.file."/Users/glen/.config/nvim/init.lua".enable'
```
- **기대**: `false`.
- **실패 시**: `programs.neovim.sideloadInitLua` 값이 실제로 `true`로 평가되는지 확인. `lib.mkForce`가 필요한지 점검.

### Phase 4: Regression — nvim/zed 인접 동작

> "sideload 전환이 nvim 기본 동작(alias, defaultEditor, extraPackages)을 깨뜨리지 않았는지 확인"

```bash
# viAlias/vimAlias 유지
nix eval '.#darwinConfigurations."'"$(scutil --get LocalHostName)"'".config.home-manager.users.glen.programs.neovim.viAlias'
# 기대: true

# extraPackages의 prettier가 여전히 존재(nvim 포매터용, zed와 독립)
nix eval --raw '.#darwinConfigurations."'"$(scutil --get LocalHostName)"'".config.home-manager.users.glen.programs.neovim.finalPackage.outPath' >/dev/null
# 기대: exit 0

# zed 경로 교체가 전역 prettier 사용 가능성을 깨지 않음
nix eval --raw 'nixpkgs#prettier.pname'
# 기대: prettier
```

### Phase 5: Cross-host Regression (참고)

> "NixOS(MiniPC) 쪽에도 영향이 있는지 확인"

- `nodePackages` 참조는 저장소 전체 스캔에서 zed 1건만 발견됨 → NixOS 무영향.
- `programs.neovim` 모듈은 `modules/shared/`에 있어 NixOS에도 적용됨 → MiniPC에서 `nfu` 별도 실행 필요(FOD 검증은 host-local이라는 스크립트 주석 `scripts/fix-fod-hashes.sh:9-13` 참고).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated legacy provider-related warnings that appeared during Neovim editor startup, resulting in a cleaner and more streamlined initialization experience.

* **Chores**
  * Updated package sources for code formatting tools to ensure compatibility with current versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
