### PR TITLE
refactor(wt): worktree bootstrap의 Codex projection workaround 제거

### DIFF
--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -18,39 +18,8 @@ _bootstrap_worktree() {
     cp "$src_settings" "$dst_claude_dir/settings.local.json"
   fi
 
-  # .codex/ 디렉토리 복사 (기존 제거 후 복사 — 중첩 방지)
-  local src_codex="$git_root/.codex"
-  if [[ -d "$src_codex" ]]; then
-    rm -rf "$wt_path/.codex"
-    cp -r "$src_codex" "$wt_path/.codex"
-  fi
-
   # .claude/plans/ 제거 (worktree에서는 불필요)
   rm -rf "$wt_path/.claude/plans"
-
-  # Claude → Codex projection 재실행 (plugin-aware worktree bootstrap 복구)
-  local script_dir codex_sync_sh=""
-  script_dir="${WT_SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-  local repo_local_sync_sh="$script_dir/codex-sync.sh"
-  local deployed_sync_bin="$script_dir/codex-sync"
-
-  if [[ -x "$deployed_sync_bin" ]]; then
-    codex_sync_sh="$deployed_sync_bin"
-  elif [[ -f "$repo_local_sync_sh" ]]; then
-    codex_sync_sh="$repo_local_sync_sh"
-  else
-    codex_sync_sh="$(command -v codex-sync 2>/dev/null || true)"
-  fi
-
-  if [[ -n "$codex_sync_sh" ]]; then
-    if [[ "$codex_sync_sh" == "$repo_local_sync_sh" ]]; then
-      bash "$codex_sync_sh" "$wt_path" || _warn "codex-sync 실패 — 수동으로 'codex-sync $wt_path'를 실행하세요"
-    elif ! "$codex_sync_sh" "$wt_path"; then
-      _warn "codex-sync 실패 — 수동으로 'codex-sync $wt_path'를 실행하세요"
-    fi
-  else
-    _warn "codex-sync 스크립트를 찾지 못해 Codex projection을 건너뜁니다"
-  fi
 }
 
 # ── worktree 열기 (tmux 또는 stdout) ─────────────────────────────────────────

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -768,7 +768,7 @@ EOF
   assert_not_contains "$output" "MALICIOUS_REBUILD"
 }
 
-test_wt_create_creates_worktree_without_shadow_codex_sync() {
+test_wt_create_does_not_run_codex_sync() {
   local sandbox home_dir repo_root output new_worktree fallback_dir marker_file
   sandbox=$(new_sandbox)
   home_dir="$sandbox/home"
@@ -779,6 +779,10 @@ test_wt_create_creates_worktree_without_shadow_codex_sync() {
   create_git_fixture_repo "$repo_root"
   repo_root="$(cd "$repo_root" && pwd -P)"
   install_deployed_layout "$sandbox" "$repo_root"
+
+  # src_codex seed — bootstrap이 실수로 .codex 복사 경로를 재도입하면 여기가 새 worktree로 전파된다.
+  mkdir -p "$repo_root/.codex"
+  echo "seed = true" > "$repo_root/.codex/config.toml"
 
   mkdir -p "$home_dir/.local/bin" "$fallback_dir"
   cat > "$home_dir/.local/bin/codex-sync" <<'EOF'
@@ -817,8 +821,8 @@ EOF
   [[ -d "$new_worktree" ]] || fail "expected worktree directory to exist: $new_worktree"
   assert_contains "$output" "$new_worktree"
   assert_not_contains "$output" "SHADOW_CODEX_SYNC"
-  assert_contains "$(cat "$marker_file")" "managed"
-  assert_not_contains "$(cat "$marker_file")" "fallback"
+  [[ ! -e "$marker_file" ]] || fail "expected wt bootstrap to not run codex-sync"
+  [[ ! -e "$new_worktree/.codex" ]] || fail "expected wt bootstrap to not copy .codex into new worktree"
 }
 
 test_wt_recreate_guard_uses_physical_paths() {
@@ -1354,7 +1358,7 @@ run_test "wt ls lists deployed worktrees" test_wt_ls_from_deployed_layout_lists_
 run_test "shadow paths do not override managed helpers" test_shadow_paths_do_not_override_managed_helpers
 run_test "wt symlink alias does not load adjacent helpers" test_wt_symlink_alias_does_not_load_adjacent_helpers
 run_test "rebuild-common symlink alias does not load adjacent helpers" test_rebuild_common_symlink_alias_does_not_load_adjacent_helpers
-run_test "wt create uses managed codex-sync path" test_wt_create_creates_worktree_without_shadow_codex_sync
+run_test "wt create does not run codex-sync" test_wt_create_does_not_run_codex_sync
 run_test "wt recreate guard uses physical paths" test_wt_recreate_guard_uses_physical_paths
 run_test "wt cleanup auto removes merged worktree" test_wt_cleanup_auto_removes_merged_worktree
 run_test "wt cleanup auto skips dirty merged worktree" test_wt_cleanup_auto_skips_dirty_merged_worktree


### PR DESCRIPTION
## Summary

- `wt` worktree bootstrap에서 `.codex/` 복사와 `codex-sync` 자동 실행 경로를 제거해, fresh worktree가 `.agents/*` 생성 artifact 없이 깨끗하게 시작한다
- shell fixture `test_wt_create_*`를 의미 반전 (`.codex` seed + managed/shadow `codex-sync` stub을 둔 채 marker 미생성 + `.codex` 미복사 assertion)으로 bootstrap이 해당 경로를 다시 태우는 회귀를 방어한다
- `codex-sync.sh`와 `syncing-codex-harness` 스킬은 manual `codex-sync <path>` 워크플로로 유지

Closes #482

## 기존 문제/배경

- `wt` bootstrap은 #394 시점에 "Claude plugin → Codex 하네스 투영"을 복구하기 위해 강화되었고 #398에서 deployed `codex-sync` binary 탐지까지 추가되었다. 로직상 새 worktree를 만들 때마다 메인 repo `.codex/`를 복사한 뒤 `codex-sync <new-wt>`를 다시 실행하게 되어 있다 (`modules/shared/scripts/lib/wt/bootstrap.sh` 21-53)
- 현재 Codex는 native Plugins 문서 + `config.toml` 기반 plugin 설정 표면이 존재하고, 이 저장소의 Darwin Codex 설정도 GitHub/Figma/Slack/Notion native plugin을 직접 enable하고 있다 (`modules/shared/programs/codex/files/config.darwin.toml:22-39`). repo-local tracked project docs/skills는 이미 `.agents/skills/*`, `AGENTS*.md`, `AGENTS.override.md`로 worktree에 자동 포함된다
- 로컬 재현 결과 clean clone에 `codex-sync` 1회 실행만으로 `.agents/*` 계열 untracked projection artifact 22개가 생성됐다 (이슈 본문 PoC). 즉 bootstrap이 매 worktree마다 이 경로를 다시 태우고 있어서 사용자가 체감하는 새 worktree가 시작부터 "더러워진" 상태였다
- `#76`(글로벌 gitignore 정책)과 증상은 겹치지만 해결 레이어가 다르다. 이 PR은 artifact 생성 자체를 bootstrap 시점에서 제거한다 (ignore 정책은 건드리지 않는다)

## CIR (Change Intent Record)

- **범위 고정 의도**: `syncing-codex-harness` 스킬과 `modules/shared/scripts/codex-sync.sh` 자체는 이 PR에서 건드리지 않는다. manual `codex-sync <path>`를 여전히 쓰는 사용자/운영 경로를 보존하기 위해서다. 이슈 본문에서 "이 이슈는 `syncing-codex-harness` 전체 삭제가 아니라, `wt` 실행 후 obsolete workaround를 자동으로 다시 태우는 경로를 제거하는 것이 목적이다"로 범위를 미리 좁혔다
- **테스트는 삭제보다 의미 반전**: 기존 `test_wt_create_creates_worktree_without_shadow_codex_sync`는 managed/fallback/shadow `codex-sync` 경로를 검증하고 있었다. fixture 인프라를 그대로 살려 "bootstrap이 더 이상 `codex-sync`를 호출하지 않는다"를 직접 검증하는 회귀 테스트로 전환했다. fixture가 남아 있어야 실수로 bootstrap이 다시 `codex-sync`를 호출하는 회귀를 즉시 잡을 수 있다
- **DA for_plan Round 1 반영 (Correctness CONFIRMED LOW)**: 초기 계획에서 smoke test가 `clean clone + wt <branch>`였으나 `.gitignore:16`이 `.codex/`를 ignore해서 `src_codex`가 없어 copy 블록이 trigger되지 않는다는 지적을 받았다. 그래서 shell fixture에 `$repo_root/.codex/config.toml`을 명시적으로 seed하고 새 worktree에 복사되지 않음을 assert하도록 보강했다
- **DA for_plan Round 1 기각 (Regression NOT_AN_ISSUE)**: fresh worktree가 project-scope `.codex/config.toml`을 자동으로 받지 못하는 것이 regression으로 제기됐으나, Arbiter는 "계획 원문이 manual `codex-sync <path>` 워크플로 전환을 명시하고 syncing-codex-harness / codex-sync.sh manual 경로를 유지한다"는 근거로 NOT_AN_ISSUE 판정
- **parallel-audit Docs/Consistency REGRESSION — scope 밖 처리**: `syncing-codex-harness/SKILL.md:184-188`과 `references/sync.sh:154-160`이 `.agents/`/`AGENTS.md`/`AGENTS.override.md`를 "projection artifact, global gitignore에서 관리"로 기술하는 stale이 남아 있다. 이는 이번 diff에 포함되지 않은 pre-existing stale이며 `#76`이 다뤄야 할 범위다

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `_bootstrap_worktree()`에서 projection 블록 제거 | `.codex` 복사 + `codex-sync` 재실행을 bootstrap 시점에서 빼고 manual 경로로 일원화 | 새 worktree가 기본 상태에서 깨끗. manual 경로는 유지 | project-scope `.codex/config.toml`이 필요한 사용자는 수동 `codex-sync <path>` 1회 실행 | ✅ 채택 |
| `.codex` 복사만 제거하고 `codex-sync`는 자동 실행 유지 | `.agents` projection은 bootstrap 시점에서 여전히 자동 | 기존 manual 경로 보존 | `.agents/*` 22개 artifact churn은 해소되지 않음 — 이슈의 주된 증상 그대로 | ❌ 기각 |
| `codex-sync.sh` 및 `syncing-codex-harness` 전체 제거 | user-scope에서 아예 없애는 한층 큰 리팩터링 | 잔여 stale 문서까지 정리 가능 | manual 경로 의존 사용자를 동시에 깨뜨림. scope이 `#76`/`#482` 범위를 초과 | ❌ 기각 |
| bootstrap 유지 + 글로벌 gitignore 갱신으로 우회 (`#76` 단독) | artifact는 계속 생기지만 `git status`에서 보이지 않도록만 처리 | artifact churn은 시각적으로만 해소 | 실제 worktree는 여전히 generated artifact를 품은 채 시작. 근본 원인 미해결 | ❌ 기각 (`#76` 스코프는 별도 유지) |

## 구현 상세

| 파일 | 역할 | 변경 |
|------|------|------|
| `modules/shared/scripts/lib/wt/bootstrap.sh` | worktree bootstrap orchestration | `_bootstrap_worktree()`에서 `.codex` 복사 블록과 `codex-sync` 탐지/실행 블록을 함께 제거. 중첩 가드, `.claude/settings.local.json` 복사, `.claude/plans` 제거는 유지 |
| `tests/shell-script-tests.sh` | deployed-layout regression | `test_wt_create_creates_worktree_without_shadow_codex_sync` → `test_wt_create_does_not_run_codex_sync`로 rename. `$repo_root/.codex/config.toml` seed + `.codex` 미복사 + `codex-sync` marker 미생성 assertion. 기존 SHADOW_CODEX_SYNC 방어 유지. 1357줄 `run_test` label도 동기화 |

### bootstrap.sh (요지)

변경 후 `_bootstrap_worktree()`는 아래 세 가지만 수행한다.

```bash
_bootstrap_worktree() {
  local wt_path="$1"
  local git_root="$2"

  # 중첩 회귀 가드
  if [[ -d "$wt_path/.claude/.claude" ]] || [[ -d "$wt_path/.codex/.codex" ]]; then
    _die "중첩 .claude/.claude 또는 .codex/.codex 감지 — bootstrap 중단"
  fi

  # .claude/settings.local.json 복사 (파일 단위)
  local src_settings="$git_root/.claude/settings.local.json"
  local dst_claude_dir="$wt_path/.claude"
  if [[ -f "$src_settings" ]]; then
    mkdir -p "$dst_claude_dir"
    cp "$src_settings" "$dst_claude_dir/settings.local.json"
  fi

  # .claude/plans/ 제거 (worktree에서는 불필요)
  rm -rf "$wt_path/.claude/plans"
}
```

### shell-script-tests.sh (요지)

```bash
test_wt_create_does_not_run_codex_sync() {
  # ... sandbox, install_deployed_layout 준비 ...

  # src_codex seed — bootstrap이 실수로 .codex 복사 경로를 재도입하면 여기가 새 worktree로 전파된다.
  mkdir -p "$repo_root/.codex"
  echo "seed = true" > "$repo_root/.codex/config.toml"

  # managed / shadow / fallback codex-sync stub (bootstrap이 이들 중 어느 것도 호출하지 않아야 한다)
  # ... stub 생성 ...

  # wt <branch> 실행
  # ...

  assert_not_contains "$output" "SHADOW_CODEX_SYNC"
  [[ ! -e "$marker_file" ]] || fail "expected wt bootstrap to not run codex-sync"
  [[ ! -e "$new_worktree/.codex" ]] || fail "expected wt bootstrap to not copy .codex into new worktree"
}
```

`run_test`도 `"wt create does not run codex-sync"`로 의미 맞춤.

## 참고 레퍼런스

- `4fd46e0` — 이 PR의 단일 커밋 `refactor(wt): remove Codex projection from bootstrap`
- `39af947` — fix(wt): restore codex harness sync in worktrees (#394 — 이번에 제거되는 경로가 도입된 커밋)
- `4cf66df` — fix(wt): detect deployed codex-sync binary during bootstrap (#398 — `deployed_sync_bin` fallback 추가)
- `32a8511` — feat(codex): sync compatible hooks from Claude harness (이번 경로가 태우는 downstream)
- [Codex Plugins docs](https://developers.openai.com/codex/plugins) — native plugin 표면 존재를 뒷받침
- [Codex config reference](https://developers.openai.com/codex/config-reference) — `config.toml` plugin/app 설정 키
- #76 — 글로벌 gitignore에서 Codex 프로젝션 산출물 제거 (ignore 정책 레이어, 본 PR과 scope 분리)
- #394 — wt worktree에서 Claude plugin -> Codex 하네스 투영 자동 동기화 복구 (본 PR이 제거하는 경로의 기원)
- #482 — 이 PR이 닫는 이슈

## Human Test Plan

### 1. 로컬 shell fixture 테스트
```bash
bash tests/shell-script-tests.sh
```
- **기대**: 전체 테스트 PASS. 특히 `==> wt create does not run codex-sync` 라벨 출력 후 에러 없음
- **실패 시**: 해당 테스트 함수 쪽 assertion(`fail "..."`) 메시지를 확인한다. `.codex` 복사 또는 `codex-sync` 호출이 재도입됐을 가능성

### 2. fresh worktree smoke
```bash
cd "$(git rev-parse --show-toplevel)"  # main repo
wt smoke-branch
cd "$(git rev-parse --show-toplevel)/.claude/worktrees/smoke-branch"  # 또는 wt가 출력한 경로
git status --short --untracked-files=all
```
- **기대**: 새 worktree의 `git status`에 `.agents/*` 또는 `.codex/*` 계열 추가 파일이 생성되지 않음. (`AGENTS.md`, `.agents/skills/*` 등 tracked symlink/파일은 이미 repo에 포함되어 있으므로 status 에 나타나지 않아야 한다)
- **실패 시**: `modules/shared/scripts/lib/wt/bootstrap.sh`에 `codex-sync` 또는 `src_codex` 관련 심볼이 다시 들어갔는지 확인

### 3. manual codex-sync 경로가 여전히 동작
```bash
modules/shared/scripts/codex-sync.sh <worktree-path>
```
- **기대**: 기존과 동일하게 project-scope `.codex/config.toml`/`.agents/*`를 생성/갱신
- **실패 시**: `codex-sync.sh` 자체는 이 PR 범위가 아니므로 별도 이슈. 이 PR로는 `wt` 시점의 자동 실행만 제거됐음을 확인

### 4. Claude 세션 local 설정 유지
- 새 worktree에서 Claude Code 실행 시 `.claude/settings.local.json`이 그대로 복사돼 있는지 확인. `.claude/plans/`는 삭제된 상태여야 한다

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증
```bash
# bootstrap.sh에 obsolete projection 심볼이 완전히 사라졌는지
! rg -n 'src_codex|codex_sync_sh|repo_local_sync_sh|deployed_sync_bin|command -v codex-sync' \
  modules/shared/scripts/lib/wt/bootstrap.sh && echo OK
# 새 테스트 이름/label 등록 확인
rg -n 'test_wt_create_does_not_run_codex_sync' tests/shell-script-tests.sh
rg -n 'wt create does not run codex-sync' tests/shell-script-tests.sh
# 범위 밖 유지 확인
test -f modules/shared/scripts/codex-sync.sh && echo codex-sync.sh present
test -f modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md && echo harness skill present
```
- **기대**: 첫 번째 명령이 `OK`. 두 번째/세 번째가 새 이름/label을 각각 잡음. 4/5째 명령이 범위 밖 파일의 존재를 확인

### Phase 1 — shell fixture 회귀 방어
```bash
bash tests/shell-script-tests.sh
```
- **기대**: 전체 PASS. `wt create does not run codex-sync`가 성공
- **실패 시**: 테스트 출력의 assertion 메시지를 추적. bootstrap이 실수로 projection을 재도입했을 가능성

### Phase 2 — fresh worktree 시나리오 (manual)
1. main repo에서 `wt e2e-branch` 실행
2. 생성된 worktree로 이동 후 `git status --short --untracked-files=all`
- **기대**: 추가 `.agents/*`/`.codex/*` untracked artifact 없음. tracked symlink는 정상 포함
- **실패 시**: bootstrap이 projection을 다시 태우는지, 혹은 tracked symlink가 누락됐는지 구분하여 확인

### Phase 3 — manual codex-sync 회귀
1. 위에서 만든 worktree에 `modules/shared/scripts/codex-sync.sh <path>` 수동 실행
- **기대**: project-scope `.codex/config.toml`과 `.agents/*` 재생성. 이 경로는 본 PR에서 건드리지 않았으므로 기존 동작 그대로