### PR TITLE
refactor(skills): viewing-immich-photo SKILL.md 도구-중립 리팩토링 (#553)

### DIFF
--- a/.claude/skills/viewing-immich-photo/SKILL.md
+++ b/.claude/skills/viewing-immich-photo/SKILL.md
@@ -19,7 +19,7 @@ Immich 저장 경로 검증, 플랫폼별 파일 접근, 이미지 표시 절차
 | 항목 | 값 |
 |------|----|
 | 허용 루트 | `/mnt/data/immich/photos/`, `/var/lib/docker-data/immich/upload-cache/` |
-| macOS 동작 | `scp minipc:…`로 staging 후 이미지 표시 도구로 표시 (비이미지는 `ssh minipc -- file --`) |
+| macOS 동작 | `scp minipc:…`로 staging 후 이미지 표시 도구로 표시 (비이미지는 SSH 원격에서 `file --`) |
 | NixOS 동작 | 로컬 경로를 이미지 표시 도구에 직접 전달 (비이미지는 로컬 `file --`) |
 | 비허용 패턴 | `..` 포함 경로 |
 
@@ -33,6 +33,7 @@ Immich 저장 경로 검증, 플랫폼별 파일 접근, 이미지 표시 절차
 | 비이미지 메타데이터 명령 | 공통 셸 `file -- <path>` | 공통 셸 `file -- <path>` |
 
 **이미지 표시**는 런타임 분기, **메타데이터 명령**은 파일 형식 분기다 — 같은 축으로 섞지 않는다.
+**비이미지 메타데이터 명령의 실행 위치**는 호스트 플랫폼에 따라 다르다: macOS는 SSH 원격에서 실행, NixOS는 로컬에서 실행 (상세는 아래 macOS/NixOS 섹션 참조).
 
 ## 경로 검증 (보안)
 
@@ -60,7 +61,7 @@ MiniPC에 저장된 파일이므로 이미지는 SSH로 staging한 뒤 이미지
 1. 경로가 `/mnt/data/immich/photos` 또는 `/var/lib/docker-data/immich/upload-cache`로 시작하는지 확인 (path traversal 차단)
 2. 확장자 분기:
    - **이미지** (`.jpg/.jpeg/.png/.webp/.gif`): `scp`로 `/tmp`에 staging → 이미지 표시 도구로 표시
-   - **비이미지** (동영상/문서 등): `ssh minipc -- file -- "${FILE_PATH}"`로 메타데이터만 출력 (staging 불필요)
+   - **비이미지** (동영상/문서 등): 원격 셸에 단일 command string으로 `file --`을 보내 메타데이터만 출력 (staging 불필요). 명령 형식은 아래 명령어 블록 참조.
 3. `/tmp`는 시스템 자동 정리 (수동 삭제 불필요)
 
 ### 명령어
@@ -72,7 +73,7 @@ BASENAME="${FILE_PATH##*/}"
 
 if [[ "$BASENAME" != *.* ]]; then
   echo "오류: 파일 확장자가 없습니다." >&2
-  return 1
+  exit 1
 fi
 
 EXT="${BASENAME##*.}"
@@ -83,13 +84,17 @@ case "$EXT" in
     # 이후 이미지 표시 도구에 "$DEST"를 전달
     ;;
   *)
-    # 비이미지 fallback — staging 없이 원격에서 메타데이터만 출력
-    ssh minipc -- file -- "${FILE_PATH}"
+    # 비이미지 fallback — 원격 셸에 단일 command string으로 전달.
+    # `ssh host arg...`는 arguments를 공백으로 join해 원격 셸이 재파싱하므로,
+    # 로컬에서 미리 shell-quote(`printf '%q'`, bash/zsh 공통)해야 메타문자가 보존된다.
+    ssh minipc "file -- $(printf '%q' "$FILE_PATH")"
     ;;
 esac
 ```
 
-**보안**: `<원본경로>` 같은 placeholder를 명령 문자열에 직접 삽입하지 마라. 검증 통과한 변수만 quote(`"${FILE_PATH}"`)와 `--` end-of-options 구분자와 함께 전달한다. 그러지 않으면 공백/특수문자 포함 경로에서 인자 경계가 깨진다.
+**보안**: `<원본경로>` 같은 placeholder를 명령 문자열에 직접 삽입하지 마라.
+- `scp` 같은 로컬 명령에는 검증 통과한 변수를 quote(`"${FILE_PATH}"`)와 `--` end-of-options 구분자로 전달한다.
+- `ssh host cmd args`는 args를 공백으로 join해 원격 셸이 다시 파싱하므로, 로컬 quoting만으로 원격 셸 인자 경계가 보존되지 않는다. `printf '%q'`로 미리 quote해 단일 command string을 만들어 전달한다 (위 fallback 예시 참조).
 
 **주의**: `minipc`는 SSH config에 정의된 호스트 alias.
 

--- a/.claude/skills/viewing-immich-photo/SKILL.md
+++ b/.claude/skills/viewing-immich-photo/SKILL.md
@@ -70,15 +70,10 @@ MiniPC에 저장된 파일이므로 이미지는 SSH로 staging한 뒤 이미지
 # 사전 검증된 원본 경로 (허용 루트 + ".." 부재 통과 후 변수에 담는다)
 FILE_PATH="<검증 통과한 원본경로>"
 BASENAME="${FILE_PATH##*/}"
-
-if [[ "$BASENAME" != *.* ]]; then
-  echo "오류: 파일 확장자가 없습니다." >&2
-  exit 1
-fi
-
 EXT="${BASENAME##*.}"
-case "$EXT" in
-  jpg|jpeg|png|webp|gif|JPG|JPEG|PNG|WEBP|GIF)
+# 확장자 없거나 ($BASENAME == $EXT) 비이미지 확장자면 메타데이터 fallback으로 보낸다
+case "$BASENAME" in
+  *.jpg|*.jpeg|*.png|*.webp|*.gif|*.JPG|*.JPEG|*.PNG|*.WEBP|*.GIF)
     DEST="/tmp/immich_photo_$(date +%s).$EXT"
     scp -- "minipc:${FILE_PATH}" "$DEST"
     # 이후 이미지 표시 도구에 "$DEST"를 전달

--- a/.claude/skills/viewing-immich-photo/SKILL.md
+++ b/.claude/skills/viewing-immich-photo/SKILL.md
@@ -58,7 +58,7 @@ MiniPC에 저장된 파일이므로 이미지는 SSH로 staging한 뒤 이미지
 
 ### 핵심 절차
 
-1. 경로가 `/mnt/data/immich/photos` 또는 `/var/lib/docker-data/immich/upload-cache`로 시작하는지 확인 (path traversal 차단)
+1. 위 "허용 루트" 표 기준으로 경로 검증 (`/mnt/data/immich/photos/` 또는 `/var/lib/docker-data/immich/upload-cache/`로 시작 + `..` 부재, path traversal 차단)
 2. 확장자 분기:
    - **이미지** (`.jpg/.jpeg/.png/.webp/.gif`): `scp`로 `/tmp`에 staging → 이미지 표시 도구로 표시
    - **비이미지** (동영상/문서 등): 원격 셸에 단일 command string으로 `file --`을 보내 메타데이터만 출력 (staging 불필요). 명령 형식은 아래 명령어 블록 참조.

--- a/.claude/skills/viewing-immich-photo/SKILL.md
+++ b/.claude/skills/viewing-immich-photo/SKILL.md
@@ -19,9 +19,20 @@ Immich 저장 경로 검증, 플랫폼별 파일 접근, 이미지 표시 절차
 | 항목 | 값 |
 |------|----|
 | 허용 루트 | `/mnt/data/immich/photos/`, `/var/lib/docker-data/immich/upload-cache/` |
-| macOS 동작 | `ssh minipc`로 파일을 `/tmp` 복사 후 확인 |
-| NixOS 동작 | 로컬 경로를 직접 확인 |
+| macOS 동작 | `scp minipc:…`로 staging 후 이미지 표시 도구로 표시 (비이미지는 `ssh minipc -- file --`) |
+| NixOS 동작 | 로컬 경로를 이미지 표시 도구에 직접 전달 (비이미지는 로컬 `file --`) |
 | 비허용 패턴 | `..` 포함 경로 |
+
+## 용어 binding
+
+본문은 도구-중립 용어를 쓴다. 런타임별 실제 도구는 아래 표로 binding한다.
+
+| 용어 | Claude Code | Codex |
+|------|-------------|-------|
+| 이미지 표시 도구 | `Read` 도구 | `view_image` 도구 |
+| 비이미지 메타데이터 명령 | 공통 셸 `file -- <path>` | 공통 셸 `file -- <path>` |
+
+**이미지 표시**는 런타임 분기, **메타데이터 명령**은 파일 형식 분기다 — 같은 축으로 섞지 않는다.
 
 ## 경로 검증 (보안)
 
@@ -31,53 +42,67 @@ Immich 저장 경로 검증, 플랫폼별 파일 접근, 이미지 표시 절차
 
 ## 플랫폼 감지
 
-환경 정보에서 플랫폼 확인:
-- `<env>` 블록의 `Platform: darwin` → macOS
-- `<env>` 블록의 `Platform: linux` → NixOS
+**로컬 호스트 기준**으로 판별한다. SSH 원격 `uname`은 사용하지 않는다 — MiniPC 안의 OS는 항상 Linux이므로 분기에 무의미하다.
+
+| 우선순위 | 신호 | 출처 |
+|----------|------|------|
+| 1 | `<env>` 블록의 `Platform: darwin` / `Platform: linux` | Claude Code 하네스 메타 (Claude Code 한정) |
+| 2 | 로컬 셸 `uname -s` 결과 (`Darwin` / `Linux`) | 양 런타임 공통 |
+
+`<env>` 블록이 있으면 우선 사용, 없거나 불명확하면 로컬 셸에서 `uname -s`를 실행한다.
 
 ## macOS에서 실행 시
 
-MiniPC에 저장된 파일이므로 SSH로 가져온 후 Read 도구로 확인합니다.
+MiniPC에 저장된 파일이므로 이미지는 SSH로 staging한 뒤 이미지 표시 도구로 표시하고, 비이미지는 SSH 원격에서 `file`로 메타데이터만 가져옵니다.
 
 ### 핵심 절차
 
-1. 경로가 `/mnt/data/immich/photos` 또는 `/var/lib/docker-data/immich/upload-cache`로 시작하는지 확인
-2. SSH로 파일을 `/tmp`에 복사 (확장자 유지)
-3. Read 도구로 이미지 확인
-4. 삭제 불필요 (`/tmp`는 시스템 자동 정리)
+1. 경로가 `/mnt/data/immich/photos` 또는 `/var/lib/docker-data/immich/upload-cache`로 시작하는지 확인 (path traversal 차단)
+2. 확장자 분기:
+   - **이미지** (`.jpg/.jpeg/.png/.webp/.gif`): `scp`로 `/tmp`에 staging → 이미지 표시 도구로 표시
+   - **비이미지** (동영상/문서 등): `ssh minipc -- file -- "${FILE_PATH}"`로 메타데이터만 출력 (staging 불필요)
+3. `/tmp`는 시스템 자동 정리 (수동 삭제 불필요)
 
 ### 명령어
 
 ```bash
-# 파일명에서 확장자 추출 (Scriptable 업로드는 일반적으로 .jpg)
+# 사전 검증된 원본 경로 (허용 루트 + ".." 부재 통과 후 변수에 담는다)
+FILE_PATH="<검증 통과한 원본경로>"
 BASENAME="${FILE_PATH##*/}"
+
 if [[ "$BASENAME" != *.* ]]; then
-  echo "오류: 파일 확장자가 없습니다 (.jpg/.jpeg/.png/.webp/.gif 필요)." >&2
-  exit 1
+  echo "오류: 파일 확장자가 없습니다." >&2
+  return 1
 fi
 
 EXT="${BASENAME##*.}"
 case "$EXT" in
-  jpg|jpeg|png|webp|gif|JPG|JPEG|PNG|WEBP|GIF) ;;
+  jpg|jpeg|png|webp|gif|JPG|JPEG|PNG|WEBP|GIF)
+    DEST="/tmp/immich_photo_$(date +%s).$EXT"
+    scp -- "minipc:${FILE_PATH}" "$DEST"
+    # 이후 이미지 표시 도구에 "$DEST"를 전달
+    ;;
   *)
-    echo "오류: 지원하지 않는 확장자: $EXT" >&2
-    exit 1
+    # 비이미지 fallback — staging 없이 원격에서 메타데이터만 출력
+    ssh minipc -- file -- "${FILE_PATH}"
     ;;
 esac
-
-ssh minipc "cat <원본경로>" > "/tmp/immich_photo_$(date +%s).$EXT"
 ```
+
+**보안**: `<원본경로>` 같은 placeholder를 명령 문자열에 직접 삽입하지 마라. 검증 통과한 변수만 quote(`"${FILE_PATH}"`)와 `--` end-of-options 구분자와 함께 전달한다. 그러지 않으면 공백/특수문자 포함 경로에서 인자 경계가 깨진다.
 
 **주의**: `minipc`는 SSH config에 정의된 호스트 alias.
 
 ## NixOS에서 실행 시
 
-로컬 파일이므로 경로를 직접 Read 도구에 전달합니다.
+로컬 파일이므로 이미지는 경로를 직접 이미지 표시 도구에 전달하고, 비이미지는 로컬 `file`로 메타데이터만 출력합니다.
 
 ### 핵심 절차
 
 1. 경로 검증 규칙(허용 루트, `..` 부재)을 먼저 확인
-2. 로컬 경로를 Read 도구에 직접 전달
+2. 확장자 분기:
+   - **이미지** (`.jpg/.jpeg/.png/.webp/.gif`): 로컬 경로를 이미지 표시 도구에 직접 전달
+   - **비이미지**: `file -- "${FILE_PATH}"`로 메타데이터 출력
 
 ## 경로 패턴
 
@@ -95,9 +120,9 @@ ssh minipc "cat <원본경로>" > "/tmp/immich_photo_$(date +%s).$EXT"
 
 ## 지원 파일 형식
 
-Read 도구는 이미지를 시각적으로 표시:
+이미지 표시 도구는 이미지를 시각적으로 표시한다 (런타임 매핑은 위 "용어 binding" 표 참조):
 - 이미지: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`
-- 동영상: 확인 불가 (메타데이터만 표시)
+- 비이미지 (동영상/문서 등): `file -- <path>`로 메타데이터만 출력 (시각적 표시는 불가)
 
 **참고**: Scriptable 업로드는 항상 `.jpg`로 저장됨
 
@@ -108,6 +133,7 @@ Read 도구는 이미지를 시각적으로 표시:
 | SSH 연결 실패 | `tailscale status` 확인, `ssh minipc "echo ok"` 테스트 |
 | 파일 없음 | 경로 오타 확인, Immich API 경로→호스트 경로 변환 확인 |
 | 권한 없음 | 파일 소유자/권한 확인 (`ls -la <path>`) |
+| 외부 전제조건 | `minipc`/`mac`은 SSH config alias, MiniPC는 Tailscale 도달 가정. SSH/Tailscale 가용성은 본 스킬 범위 밖 — `managing-ssh` 스킬 참조. |
 
 ## 참조
 

--- a/libraries/packages.nix
+++ b/libraries/packages.nix
@@ -23,6 +23,7 @@
 
     # 기타 유틸리티
     pkgs.curl # HTTP 클라이언트
+    pkgs.file # 파일 타입/메타데이터 (viewing-immich-photo 비이미지 fallback)
     pkgs.jq # JSON 처리
     pkgs.nvd # Nix 변경사항 비교
     pkgs.qrencode # QR 코드 생성 (MiniPC -> iPhone 텍스트 공유)


### PR DESCRIPTION
## Summary

- Claude Code 전용 `Read 도구` literal 5건을 도구-중립 용어 ("이미지 표시 도구")로 치환하고, 런타임별 매핑 표(Claude=`Read`, Codex=`view_image`)를 신설해 viewing-immich-photo 스킬을 Codex CLI 세션에서도 동등하게 동작하게 한다.
- 비이미지 fallback(`file --` 메타데이터 출력) 흐름을 macOS/NixOS 분기로 추가하고, 시나리오 B 충족을 위해 `pkgs.file`을 `libraries/packages.nix`의 shared 목록에 추가한다.
- Codex CLI 호환성 캠페인 epic #547의 Wave 2 sub-issue.

Closes #553

## 기존 문제/배경

`viewing-immich-photo` SKILL.md는 본문 5곳(L40/46/75/80/98)에서 Claude Code 전용 `Read 도구` literal로 이미지를 표시하라고 지시했다. Codex CLI 세션에는 `Read` 도구가 없고 대신 `view_image` 도구로 이미지를 표시하므로, Codex 세션에서 이 스킬을 호출하면 literal 해석으로 실패하거나 우회 흐름을 따른다.

이슈 #553(parent epic #547)의 codex exec 3-pass 평가에서 본 스킬의 blocker A reach가 2/3으로 측정되어 도구-중립 리팩토링 대상으로 선정되었다.

## CIR (Change Intent Record)

- **v0** (`plan-with-questions`): 사용자 결정사항 4건 — scp 교체, `<env>`+`uname -s` 듀얼 명시, `file` fallback만(ffprobe 미포함), parallel-audit식 "용어 정책" 섹션 도입.
- **v1 베이스 리팩토링** (`c41c67e`): 위 결정 사항 + DA for_plan Round 1 Arbiter CONFIRMED 7건 자동 반영 후 베이스 작성. "용어 정책" 거창한 섹션은 Design-1 (LOW)에 따라 짧은 "용어 binding" + 표 1개로 축소.
- **v2 DA for_pr Round 1 반영** (`762a995`): 4건 반영 (HIGH 1 + MEDIUM 2 + LOW 1).
  - Correctness-1 SECURITY HIGH: `ssh minipc -- file -- "${FILE_PATH}"`는 ssh의 destination 뒤 `--`가 ssh 옵션 구분자가 아니라 원격 command 토큰이라 `file`이 실행되지 않음을 PoC로 확인. `ssh minipc "file -- $(printf '%q' "$FILE_PATH")"`로 교체.
  - Correctness-2 + Regression-1: stand-alone bash snippet에서 `return 1`은 invalid → `exit 1`로 복원.
  - Maintainability-1: 용어 binding 표에 macOS=원격/NixOS=로컬 실행 위치 비대칭 1행 추가.
- **v3 DA for_pr Round 2 반영** (`5fc1c7d`): Maintainability LOW 1건 — macOS step 1의 허용 루트 표기를 단일 기준 참조로 통일. Round 1 다른 3개 bundle은 모두 CLEAR로 회복. Round 3 LITE Maintainability 검증도 CLEAR.
- **v4 parallel-audit 반영** (`bafd72d`): Platform BUG (HIGH) + Docs EDGECASE 반영. Adjacent의 REGRESSION은 별도 이슈 #556 cleanup batch 범위라 NOT_AN_ISSUE로 기각.
  - `ssh minipc 'command -v file'` rc=1 실측 확인 후 `pkgs.file`을 `libraries/packages.nix`의 shared에 추가.
  - 확장자 없는 비이미지가 fallback 전에 `exit 1`로 차단되던 EDGECASE를 `*.{ext}` glob 매칭 case 분기로 자연스럽게 fallback에 흘러가게 재구성.

**trade-off**: 본 PR이 `pkgs.file` 추가까지 범위를 확장. 본래 SKILL.md 단독 변경 의도였지만 시나리오 B AC 충족을 위한 필수 의존성. 머지 후 minipc에서 `nrs`로 적용해야 시나리오 B 수동 검증이 가능하다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| **scp 교체 + `printf '%q'`** | 변수 quote + `--` + 원격 셸 quote 보강 | binary-safe + 인자 경계 보존 | bash/zsh 한정 | ✅ |
| ssh "cat" 유지 | 한 줄 redirect | 변경 최소 | scp가 더 표준이고 binary-safe, 이슈 #553 fix 직접 권장 | ❌ |
| `printf '%q'` 대신 stdin pipe | `printf '%s\n' "$P" \| ssh minipc 'IFS= read -r p && file -- "$p"'` | 가장 robust한 quote | 가독성 낮음 | ❌ |
| `pkgs.file` 위치 — shared | macOS+NixOS 양쪽 보장 | 의도 명시적, redundancy OK | 약간의 중복 (macOS는 stock 포함) | ✅ |
| `pkgs.file` 위치 — nixosOnly | NixOS에만 추가 | 분류 정확 | macOS 사용자 입장에서 의존성 위치 불명확 | ❌ |
| 거창한 "용어 정책" 섹션 (parallel-audit/run-da 패턴) | full glossary + 4-row 매핑 표 | 캠페인 톤 통일 | 단일 도구 매핑 1.5건에 과한 추상화 (Design-1 지적) | ❌ |
| 짧은 "용어 binding" + 표 1개 | 도입 단락 2줄 + 매핑 표 + 1줄 메모 | YAGNI 원칙 부합 | 캠페인 톤이 살짝 다름 (수용 가능) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `.claude/skills/viewing-immich-photo/SKILL.md` | 수정 | literal `Read 도구` 5건 제거 → "이미지 표시 도구" 치환. "용어 binding" 섹션 신설 (매핑 표 + 실행 위치 메모). 플랫폼 감지 우선순위 표 (`<env>` → `uname -s`, SSH 원격 `uname` 미사용 명시). macOS staging을 `scp -- "minipc:${FILE_PATH}" "$DEST"`로 교체. 이미지 vs 비이미지 case 분기 (`*.{ext}` glob 매칭). 비이미지 fallback (macOS=원격 SSH, NixOS=로컬 `file --`). 보안 노트 분리 (scp / ssh 두 케이스). 트러블슈팅 외부 전제조건 1행. |
| `libraries/packages.nix` | 수정 | shared 목록에 `pkgs.file` 추가 (viewing-immich-photo 비이미지 fallback 의존성 명시 코멘트). |

### 핵심 코드 — 도구-중립 binding 표

```markdown
## 용어 binding

본문은 도구-중립 용어를 쓴다. 런타임별 실제 도구는 아래 표로 binding한다.

| 용어 | Claude Code | Codex |
|------|-------------|-------|
| 이미지 표시 도구 | `Read` 도구 | `view_image` 도구 |
| 비이미지 메타데이터 명령 | 공통 셸 `file -- <path>` | 공통 셸 `file -- <path>` |

**비이미지 메타데이터 명령의 실행 위치**는 호스트 플랫폼에 따라 다르다: macOS는 SSH 원격에서 실행, NixOS는 로컬에서 실행.
```

### 핵심 코드 — case 분기 (확장자 없음도 fallback)

```bash
FILE_PATH="<검증 통과한 원본경로>"
BASENAME="${FILE_PATH##*/}"
EXT="${BASENAME##*.}"
case "$BASENAME" in
  *.jpg|*.jpeg|*.png|*.webp|*.gif|*.JPG|*.JPEG|*.PNG|*.WEBP|*.GIF)
    DEST="/tmp/immich_photo_$(date +%s).$EXT"
    scp -- "minipc:${FILE_PATH}" "$DEST"
    ;;
  *)
    # 원격 셸이 args를 재파싱하므로 printf '%q'로 미리 quote
    ssh minipc "file -- $(printf '%q' "$FILE_PATH")"
    ;;
esac
```

## 참고 레퍼런스

- Parent epic: #547 — Codex CLI 호환성 캠페인 SKILL.md 도구-중립 리팩토링 (Wave 2)
- 동일 캠페인 sibling 머지본:
  - PR #564 (`84b25c0`) — `parallel-audit` 도구-중립 리팩토링 (#548)
  - PR #563 (`ccac103`) — `run-da` 도구-중립 리팩토링 (#549)
  - PR #565 (`aca021b`) — `sharing-text` 도구-중립 리팩토링 (#554)
- 관련 이슈: #556 (cleanup batch — `running-containers/references` Read 도구 잔존은 본 이슈 범위 밖, parallel-audit Adjacent에서 NOT_AN_ISSUE 기각 근거)
- 본 작업 commit chain:
  - `c41c67e` 베이스 리팩토링 (DA for_plan 7건 반영)
  - `762a995` DA for_pr Round 1 반영 (4건)
  - `5fc1c7d` DA for_pr Round 2 반영 (1건)
  - `bafd72d` parallel-audit 반영 (Platform BUG + Docs EDGECASE)

## Human Test Plan

### 정상 동작 검증 (post-merge + minipc nrs 후)

1. macOS Claude Code 세션에서 `immich 사진 보여줘 /mnt/data/immich/photos/library/<UUID>/<YYYY>/<MM>/<file>.jpg`를 호출.
   - **기대**: scp staging 후 Read 도구로 이미지 시각적 표시.
   - **실패 시**: `ssh minipc "echo ok"` 연결 확인, `scp` 명령 직접 실행해 staging 가능 여부 확인.
2. macOS Codex 세션에서 같은 호출.
   - **기대**: scp staging 후 view_image 도구로 표시.
   - **실패 시**: Codex의 view_image 도구 가용성 확인.
3. macOS에서 비이미지(예: `.mov`) 경로로 호출 (시나리오 B).
   - **기대**: `ssh minipc "file -- ..."` 출력 (예: `... ISO Media, MP4 Base Media v1`).
   - **실패 시**: `ssh minipc 'command -v file'`로 file 미설치 확인 (이 PR 머지 후 nrs 필요).
4. NixOS Claude Code 세션에서 로컬 immich 경로로 호출 (이미지/비이미지 양쪽).
   - **기대**: 로컬 경로를 그대로 이미지 표시 도구 또는 `file --`에 전달.
   - **실패 시**: 허용 루트 검증 통과 여부, 로컬 `file` 명령 가용성 확인.

### 엣지 케이스

5. 확장자 없는 파일 경로 (`/mnt/data/immich/photos/library/<UUID>/<YYYY>/<MM>/file_without_ext`).
   - **기대**: case 분기에서 fallback으로 흘러 메타데이터 출력 (이전 베이스 동작은 `exit 1`로 차단).
   - **실패 시**: case glob 패턴 확인.
6. 공백 포함 path (`/mnt/data/immich/photos/has space/file.mov`).
   - **기대**: `printf '%q'` quote로 원격 셸 인자 경계 보존.
   - **실패 시**: 로컬에서 `printf '%q' "$FILE_PATH"` 출력 직접 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
cd "$(git rev-parse --show-toplevel)"

# 1. literal `Read 도구` 0건 (AC 1)
! grep -nE 'Read 도구' .claude/skills/viewing-immich-photo/SKILL.md
# 기대: exit 0 (매치 없으면 0)

# 2. 핵심 신규 키워드 존재
grep -q '용어 binding' .claude/skills/viewing-immich-photo/SKILL.md
grep -q 'view_image' .claude/skills/viewing-immich-photo/SKILL.md
grep -q "uname -s" .claude/skills/viewing-immich-photo/SKILL.md
grep -q 'scp -- "minipc:' .claude/skills/viewing-immich-photo/SKILL.md
grep -qF "printf '%q'" .claude/skills/viewing-immich-photo/SKILL.md
# 기대: 모두 exit 0

# 3. pkgs.file 추가 확인
grep -q '^    pkgs\.file ' libraries/packages.nix
# 기대: exit 0

# 4. exit 1 (return 1 아님) 확인 — sharing-text와 다른 stand-alone snippet 패턴
grep -q 'exit 1' .claude/skills/viewing-immich-photo/SKILL.md
! grep -q 'return 1' .claude/skills/viewing-immich-photo/SKILL.md

# 5. verify-ai-compat.sh — 본 변경 관련 regression 0건 (sibling PR #564와 동일하게 워크트리 환경 한정 심링크 drift만 발생, main 머지 후 자동 정상화)
./scripts/ai/verify-ai-compat.sh; rc=$?
echo "verify rc=$rc"
```

### Phase 1: case 분기 PoC

> "확장자별 분기가 의도대로 동작하는지 확인"

```bash
mkdir -p /tmp/issue-553-poc && cat > /tmp/issue-553-poc/test.sh <<'POC'
#!/usr/bin/env bash
test_case() {
  local FILE_PATH="$1"
  local BASENAME="${FILE_PATH##*/}"
  local EXT="${BASENAME##*.}"
  case "$BASENAME" in
    *.jpg|*.jpeg|*.png|*.webp|*.gif|*.JPG|*.JPEG|*.PNG|*.WEBP|*.GIF) echo "image" ;;
    *) echo "fallback" ;;
  esac
}
[ "$(test_case /a/b.jpg)" = "image" ] || exit 1
[ "$(test_case /a/b.mov)" = "fallback" ] || exit 1
[ "$(test_case /a/no_ext)" = "fallback" ] || exit 1
[ "$(test_case /a/b.PNG)" = "image" ] || exit 1
echo "PoC PASS"
POC
chmod +x /tmp/issue-553-poc/test.sh && /tmp/issue-553-poc/test.sh
rm -rf /tmp/issue-553-poc
```
- **기대**: `PoC PASS` 출력.
- **실패 시**: case glob 패턴(`*.{ext}`) 매칭 확인.

### Phase 2: printf %q 공백 PoC

```bash
QUOTED=$(printf '%q' "/mnt/data/immich/photos/has space/file.mov")
echo "$QUOTED" | grep -qF 'has\ space'
```
- **기대**: exit 0 (`\` escape로 공백 보존).
- **실패 시**: bash/zsh 환경 확인.

### Phase 3: post-merge minipc 적용 검증 (수동, PR 머지 후)

> "pkgs.file이 minipc에 적용되어야 시나리오 B가 동작"

```bash
ssh minipc 'command -v file' && echo "file installed"
```
- **기대 (PR 머지 + minipc nrs 후)**: file 경로 출력 + "file installed".
- **실패 시**: minipc에서 `nrs --force`(또는 동등 명령) 적용 확인.

### Phase 4: Regression

> "이미지 표시 핵심 흐름이 깨지지 않았는지 인접 스킬과 비교"

```bash
# managing-ssh 스킬과의 정합 (외부 전제조건 인용)
grep -q 'managing-ssh' .claude/skills/viewing-immich-photo/SKILL.md
# 기대: exit 0
```
- **실패 시**: 트러블슈팅 표 외부 전제조건 행 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for improved image and metadata handling across different platforms.

* **Chores**
  * Enhanced system utilities for file type inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->