### PR TITLE
chore(codex): GPT-5.5 fast tier 비활성화 + Arbiter strong xhigh→high

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -100,7 +100,7 @@ DA 호출 자체를 생략하지 마라 — run-da를 호출하면
 **plain-text 재개 ≠ 질문 도구** — Codex 세션의 일반 채팅 "질문 후 다음 턴 재개"는 blocking tool call이 아니므로 질문 도구로 간주하지 않는다. 질문 도구가 필수인 지점(SKIP 승인, 3회 반복 판정, 5회 라운드 초과)은 Codex 세션이 Plan mode를 쓰지 않는 한 **자동 상태 전이 경로**(arbiter-scaling.md)로 처리한다.
 
 **review profile 매핑** (fan-out 대상 역할별):
-- **Arbiter (strong review profile)** — Codex: `model="gpt-5.5"`, `reasoning_effort="xhigh"`. Claude Code: `model: "opus"`.
+- **Arbiter (strong review profile)** — Codex: `model="gpt-5.5"`, `reasoning_effort="high"`. Claude Code: `model: "opus"`.
 - **reviewer / Intensity / auditor (standard review profile)** — Codex: `model="gpt-5.5"`, `reasoning_effort="medium"`. Claude Code: `model: "sonnet"`.
 
 `CODEX_CI=1`만으로 세션 유형을 구분하지 않는다 (Codex 세션에서도 같은 값이 보일 수 있음). **현재 세션 호스트**를 기준으로 경로를 고른다.
@@ -182,7 +182,7 @@ Codex 세션에서 `spawn_agent`가 정책상 거부되면(예: `multi_agent=fal
 1. **BLOCKED + 사용자 승인 대기** (기본): `spawn_agent` 거부 감지 시 현재 DA 라운드 중단, 사용자에게 "delegation 거부 감지 — codex exec subprocess fallback 승인?"을 보고한다. 승인 수단은 런타임별로 다음과 같이 취한다:
    - 질문 도구 지원 런타임 (Claude Code 세션, Codex Plan mode `request_user_input` 지원 시): 질문 도구로 즉시 승인 요청. 승인 시 **같은 턴에서 바로** fallback 단계 진행.
    - 질문 도구 미지원 런타임 (Codex 일반 세션 등): plain-text로 상황 보고 후 DA 루프 종료한다. 사용자는 새 메시지에서 "fallback 진행"으로 명시 승인하거나 `run-da <mode>`를 다시 실행하여 **새 라운드로** 재개한다 (이전 라운드 상태는 복원하지 않음, 깨끗한 fresh round로 시작). 명시 승인 없이 자동 재개하지 않는다.
-2. **codex exec subprocess fallback** (사용자 승인 후에만): [`arbiter-scaling.md`](references/arbiter-scaling.md)의 "Codex delegation-denied fallback" 섹션이 정의한 role별 명령(standard profile = `model="gpt-5.5"`+medium, strong profile = `model="gpt-5.5"`+xhigh)을 `--sandbox read-only --ignore-user-config --ephemeral`로 실행한다 (MCP/plugin/connector surface 차단을 위해 `--ignore-user-config`가 필수다 — 상세는 SSOT 참조). 각 unit은 독립 subprocess.
+2. **codex exec subprocess fallback** (사용자 승인 후에만): [`arbiter-scaling.md`](references/arbiter-scaling.md)의 "Codex delegation-denied fallback" 섹션이 정의한 role별 명령(standard profile = `model="gpt-5.5"`+medium, strong profile = `model="gpt-5.5"`+high)을 `--sandbox read-only --ignore-user-config --ephemeral`로 실행한다 (MCP/plugin/connector surface 차단을 위해 `--ignore-user-config`가 필수다 — 상세는 SSOT 참조). 각 unit은 독립 subprocess.
 
 라운드 요약에는 경로와 sandbox 모드를 명시한다:
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md
@@ -326,7 +326,7 @@ Working directory: {cwd}
 - 비신뢰 텍스트(계획 원문, DA 결과)를 포함할 때 quoted heredoc(`<<'PROMPT'`) 사용을 의무화한다.
 
 **Selective consistency N=3 재판정 시 조립 규칙** (for_pr·for_plan 공통):
-- `## 검증 대상 findings` 섹션에 **trigger된 finding subset만** 포함한다 (전체 first-pass batch 재사용 금지). first-pass 프롬프트 전체를 N=3번 재실행하면 xhigh reasoning 비용이 batch 크기에 비례해 3배 증가한다.
+- `## 검증 대상 findings` 섹션에 **trigger된 finding subset만** 포함한다 (전체 first-pass batch 재사용 금지). first-pass 프롬프트 전체를 N=3번 재실행하면 high reasoning 비용이 batch 크기에 비례해 3배 증가한다.
 - 계획 원문(for_plan) 또는 diff 컨텍스트(for_pr)는 그대로 유지한다. 축소 대상은 finding 목록뿐이다.
 - 결과 VERDICT_JSON 블록도 trigger된 finding에 대해서만 출력된다.
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
@@ -83,7 +83,7 @@ Codex 세션에서 `spawn_agent`가 정책상 거부될 때(예: `multi_agent=fa
 - 각 review unit은 독립 subprocess (fresh 판정 경계는 프로세스 경계로 보존).
 - 사용자 승인 후에만 실행 (SKILL.md "Delegation fallback" 섹션 참조).
 
-**role별 명령** (각 역할이 사용하는 임시 디렉토리와 파일 이름 규약은 SKILL.md 본문 절차를 따른다). 아래 fenced code block은 바로 복사해 실행할 수 있도록 standard/strong profile의 model/effort 값을 **literal**로 고정한다. profile 이름·의미의 SSOT는 SKILL.md 상단 "런타임 도구 매핑"의 **review profile 매핑** 불릿이며, 값이 바뀌면 아래 literal도 함께 갱신해야 한다 (문서-코드 manual sync contract — selective consistency harness와 동일한 패턴):
+**role별 명령** (각 역할이 사용하는 임시 디렉토리와 파일 이름 규약은 SKILL.md 본문 절차를 따른다). 아래 fenced code block은 바로 복사해 실행할 수 있도록 standard/strong profile의 model/effort 값을 **literal**로 고정한다. profile 이름·의미의 SSOT는 SKILL.md 상단 "런타임 도구 매핑"의 **review profile 매핑** 불릿이며, 값이 바뀌면 아래 literal도 함께 갱신해야 한다 (문서-코드 manual sync contract — selective consistency harness와 동일한 패턴). **현재 effort 매핑**: `medium` = standard profile (reviewer/Intensity/auditor), `high` = strong profile (Arbiter), `xhigh` = `config.toml` `model_reasoning_effort` 기본값 (보존; Arbiter 호출 경로에서만 `-c`로 `high`로 다운그레이드).
 
 **reviewer / Auditor** (standard profile):
 
@@ -140,6 +140,7 @@ cat > "$ARBITER_DIR/arbiter-prompt.md" <<'PROMPT'
 PROMPT
 
 # 3. codex exec 실행 (foreground)
+# Arbiter는 strong review profile(high) — config.toml 기본값(xhigh)을 오버라이드. model은 -m 생략하여 config.toml 기본값 사용.
 cat "$ARBITER_DIR/arbiter-prompt.md" | codex exec --full-auto --ephemeral \
   -c model_reasoning_effort="high" \
   -o "$ARBITER_DIR/arbiter-result.md" \
@@ -194,7 +195,7 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
 - **headless 세션**: **serial foreground**로 3개 프로세스를 순차 실행한다 (완료 알림/`&+wait` 없음, 각 프로세스 종료 후 다음 프로세스 기동). 결과 파일 경로·환경 격리 방식은 아래와 동일하게 적용하되, 실행 방식만 serial로 바꾼다.
 
 1. 동일 Arbiter 프롬프트 파일을 3번 실행하기 위해 **3개의 `codex exec` 프로세스**를 기동한다 (Claude Code: background, headless: serial foreground). reviewer fan-out과 달리 Arbiter N=3 자체는 **모두 같은 프롬프트**다(프롬프트 조향 금지, 독립 판정 원칙).
-2. **환경 격리** — first-pass Arbiter와 selective consistency N=3 모두 strong review profile(high)을 사용한다 (`~/.codex/config.toml` 기본값 xhigh와 다르므로 `-c model_reasoning_effort="high"` 핀 필수). **selective consistency N=3**은 외부 표면과 충돌을 줄이기 위해 다음 두 방식 중 하나를 선택한다:
+2. **환경 격리** — first-pass Arbiter와 selective consistency N=3 모두 strong review profile(high)을 사용한다. `~/.codex/config.toml` 기본값(xhigh)과 다르므로 **반드시 `-c model_reasoning_effort="high"`를 명시한다**. **selective consistency N=3**은 외부 표면과 충돌을 줄이기 위해 다음 두 방식 중 하나를 선택한다:
 
    **(a) 기본 경로 + config 차단** (권장, 간단):
    - `CODEX_HOME`을 그대로 두어 기본 auth chain(`auth.json` 등)을 유지한다.

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
@@ -64,7 +64,7 @@ Claude Code에서 Codex CLI를 subprocess로 호출할 때, 비대화형 automat
 - `cat "$ARBITER_DIR/arbiter-prompt.md" | codex exec ... -` stdin pipe로 프롬프트 전달 (pipe EOF가 stdin hang 방지)
 - `2>"$ARBITER_DIR/arbiter-stderr.log"` stderr 분리
 - `-m` 플래그 생략 (config.toml 기본 모델)
-- Arbiter는 config.toml 기본 `model_reasoning_effort`(xhigh = strong review profile)를 사용한다. `-c` 오버라이드 불필요.
+- Arbiter는 strong review profile(high)을 사용한다. config.toml 기본 `model_reasoning_effort`(xhigh)와 다르므로 `-c model_reasoning_effort="high"`를 명시적으로 지정한다.
 - 프롬프트에서 "리뷰만 수행하고 파일을 수정하지 마라" 명시
 - `--ephemeral`로 세션 히스토리 오염 방지
 
@@ -105,7 +105,7 @@ cat "$INTENSITY_DIR/prompt.md" | codex exec --sandbox read-only --ignore-user-co
 
 ```bash
 cat "$ARBITER_DIR/arbiter-prompt.md" | codex exec --sandbox read-only --ignore-user-config --ephemeral \
-  -c model="gpt-5.5" -c model_reasoning_effort="xhigh" \
+  -c model="gpt-5.5" -c model_reasoning_effort="high" \
   -o "$ARBITER_DIR/arbiter-result.md" - 2>"$ARBITER_DIR/arbiter-stderr.log"
 ```
 
@@ -141,6 +141,7 @@ PROMPT
 
 # 3. codex exec 실행 (foreground)
 cat "$ARBITER_DIR/arbiter-prompt.md" | codex exec --full-auto --ephemeral \
+  -c model_reasoning_effort="high" \
   -o "$ARBITER_DIR/arbiter-result.md" \
   - \
   2>"$ARBITER_DIR/arbiter-stderr.log"
@@ -177,7 +178,7 @@ fi
 
 selective consistency trigger([stability-measurement.md](stability-measurement.md)의 trigger 조건)에 매치된 finding에 대해 N=3 독립 Arbiter를 실행한다. 각 런타임별 실행 규약은 다음과 같다.
 
-**프롬프트 축소 규칙**: N=3 재판정 프롬프트는 first-pass Arbiter 프롬프트 전체가 아니라, **trigger된 finding 목록만 포함한 축소 프롬프트**로 조립한다. first-pass 프롬프트를 그대로 N=3번 재실행하면 비용이 "애매한 finding 수"가 아니라 "전체 Arbiter batch 크기"에 비례해 xhigh reasoning으로 3배 증가한다. [arbiter-prompt.md](arbiter-prompt.md)의 for_pr/for_plan 조립 규칙은 selective consistency 모드에서 `## 검증 대상 findings` 섹션에 trigger된 subset만 포함해야 한다. 동일 규칙을 for_plan에도 적용하며, 계획 원문/diff 컨텍스트는 유지하되 finding 목록만 좁힌다.
+**프롬프트 축소 규칙**: N=3 재판정 프롬프트는 first-pass Arbiter 프롬프트 전체가 아니라, **trigger된 finding 목록만 포함한 축소 프롬프트**로 조립한다. first-pass 프롬프트를 그대로 N=3번 재실행하면 비용이 "애매한 finding 수"가 아니라 "전체 Arbiter batch 크기"에 비례해 high reasoning으로 3배 증가한다. [arbiter-prompt.md](arbiter-prompt.md)의 for_pr/for_plan 조립 규칙은 selective consistency 모드에서 `## 검증 대상 findings` 섹션에 trigger된 subset만 포함해야 한다. 동일 규칙을 for_plan에도 적용하며, 계획 원문/diff 컨텍스트는 유지하되 finding 목록만 좁힌다.
 
 ### Codex 세션 경로 (N=3)
 
@@ -193,12 +194,12 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
 - **headless 세션**: **serial foreground**로 3개 프로세스를 순차 실행한다 (완료 알림/`&+wait` 없음, 각 프로세스 종료 후 다음 프로세스 기동). 결과 파일 경로·환경 격리 방식은 아래와 동일하게 적용하되, 실행 방식만 serial로 바꾼다.
 
 1. 동일 Arbiter 프롬프트 파일을 3번 실행하기 위해 **3개의 `codex exec` 프로세스**를 기동한다 (Claude Code: background, headless: serial foreground). reviewer fan-out과 달리 Arbiter N=3 자체는 **모두 같은 프롬프트**다(프롬프트 조향 금지, 독립 판정 원칙).
-2. **환경 격리** — first-pass Arbiter는 기존 규칙(xhigh, `~/.codex/config.toml` 기본값)을 따르지만, **selective consistency N=3**은 외부 표면과 충돌을 줄이기 위해 다음 두 방식 중 하나를 선택한다:
+2. **환경 격리** — first-pass Arbiter와 selective consistency N=3 모두 strong review profile(high)을 사용한다 (`~/.codex/config.toml` 기본값 xhigh와 다르므로 `-c model_reasoning_effort="high"` 핀 필수). **selective consistency N=3**은 외부 표면과 충돌을 줄이기 위해 다음 두 방식 중 하나를 선택한다:
 
    **(a) 기본 경로 + config 차단** (권장, 간단):
    - `CODEX_HOME`을 그대로 두어 기본 auth chain(`auth.json` 등)을 유지한다.
    - codex exec 호출에 `--ignore-user-config`를 추가하여 사용자 `config.toml`(MCP 서버 포함) 로딩을 차단한다. `using-codex-exec/SKILL.md:113`에 기록된 대로 이 플래그는 **config만 차단하고 auth는 유지**한다.
-   - **주의**: `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model` / `model_reasoning_effort` 등 strong review profile 설정을 함께 제거한다. Arbiter는 strong profile을 유지해야 하므로 `-c model="gpt-5.5"`와 `-c model_reasoning_effort="xhigh"`를 **명시적으로 재지정**한다 (defensive explicit pin — config.toml default가 차단되므로).
+   - **주의**: `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model` / `model_reasoning_effort` 등 user config 설정을 함께 제거한다. Arbiter는 strong review profile(high)을 유지해야 하므로 `-c model="gpt-5.5"`와 `-c model_reasoning_effort="high"`를 **명시적으로 재지정**한다 (defensive explicit pin — config.toml default가 차단되므로).
    - 부작용: `~/.codex/sessions` 기반 세션이 생성되므로 동시 N=3 실행 시 세션 파일 경합이 발생할 수 있다. `--ephemeral`로 session 저장 자체를 회피한다.
 
    **(b) scratch CODEX_HOME + auth 복사** (세션 충돌 완전 분리가 필요할 때):
@@ -208,7 +209,7 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
      - 그렇지 않으면 `cp ~/.codex/auth.json "$CODEX_HOME/"`로 기존 auth.json을 scratch로 복사.
      - 둘 다 불가능하면 scratch CODEX_HOME에서 `codex login status`가 `Not logged in`으로 실패하므로 방식 (a)로 돌아간다.
    - 최소 `$CODEX_HOME/config.toml`을 작성하되 `[mcp_servers.<name>]` 테이블(실제 Codex TOML 스키마, `modules/shared/programs/codex/files/config.darwin.toml:34` 참조)을 **포함하지 않는다**. 또는 TOML 파서로 기존 config를 복사한 뒤 `mcp_servers` 테이블 전체를 삭제한다. (참고: `[[mcp_servers]]` array-of-table 문법은 현재 Codex가 사용하지 않으므로 혼동 방지를 위해 `[mcp_servers.*]` 정확 표기를 사용한다.)
-   - 모델/효과 옵션은 **필수로** 명시적으로 지정한다: `-c model="gpt-5.5"`와 `-c model_reasoning_effort="xhigh"`. scratch `CODEX_HOME`이므로 user config default가 적용되지 않아 호출 시점 기본값 의존이 불가하다.
+   - 모델/효과 옵션은 **필수로** 명시적으로 지정한다: `-c model="gpt-5.5"`와 `-c model_reasoning_effort="high"`. scratch `CODEX_HOME`이므로 user config default가 적용되지 않아 호출 시점 기본값 의존이 불가하다.
 3. **Claude Code 세션**: `run_in_background: true`로 3개를 병렬 발사 후 완료 알림을 기다린다 (sleep/poll 금지). **headless 세션**: 3개 프로세스를 serial foreground로 순차 실행한다 (각 종료 확인 후 다음). 결과 파일 경로는 두 경로 모두 `/tmp/da-${_DA_SID}-arbiter-selective-<round>/arbiter-{1,2,3}-result.md`로 라운드별 분리.
 4. 수집 후 세션 scope의 `fleiss-kappa.py`(Claude: `~/.claude/scripts/fleiss-kappa.py`, Codex: `~/.codex/scripts/fleiss-kappa.py`)에 `arbiter-1-result.md arbiter-2-result.md arbiter-3-result.md`를 인자로 전달하여 vote-shape를 얻는다. `--offline` 플래그는 배포 후 kappa 관찰 목적일 때만 부가한다.
 

--- a/modules/shared/programs/codex/files/config.darwin.toml
+++ b/modules/shared/programs/codex/files/config.darwin.toml
@@ -5,7 +5,6 @@ model_context_window = 1000000
 model_reasoning_effort = "xhigh"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
-service_tier = "fast"
 
 [notice]
 hide_full_access_warning = true

--- a/modules/shared/programs/codex/files/config.toml
+++ b/modules/shared/programs/codex/files/config.toml
@@ -5,7 +5,6 @@ model_context_window = 1000000
 model_reasoning_effort = "xhigh"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
-service_tier = "fast"
 
 [notice]
 hide_full_access_warning = true

--- a/tests/fixtures/shell-scripts/codex-config/bare_sync_compat/expected.toml
+++ b/tests/fixtures/shell-scripts/codex-config/bare_sync_compat/expected.toml
@@ -1,5 +1,4 @@
 model = "gpt-5.5"
-service_tier = "fast"
 
 [features]
 multi_agent = true

--- a/tests/fixtures/shell-scripts/codex-config/bare_sync_compat/template.toml
+++ b/tests/fixtures/shell-scripts/codex-config/bare_sync_compat/template.toml
@@ -1,5 +1,4 @@
 model = "gpt-5.5"
-service_tier = "fast"
 
 [features]
 multi_agent = true


### PR DESCRIPTION
## Summary

- Codex `service_tier = "fast"` 글로벌 비활성화 (default tier 회귀) — GPT-5.5 fast tier multiplier 2.5x로 인한 토큰 limit 도달 가속 완화
- run-da Arbiter strong review profile `reasoning_effort = "xhigh" → "high"` 다운그레이드 (config default xhigh는 보존하여 일반 codex 세션 reasoning 깊이 유지)
- run-da 영역 9개 위치 + first-pass codex exec 명령에 `-c model_reasoning_effort="high"` 명시 핀 추가 + sync-codex-config.py 테스트 fixture 동기화

Closes #571

## 기존 문제 / 배경

OpenAI는 2026-04-23 GPT-5.5를 출시했고 codex-cli 0.125.0이 이를 default 모델로 등록했다 ([rust-v0.125.0](https://github.com/openai/codex/releases/tag/rust-v0.125.0)). [Codex Speed docs](https://developers.openai.com/codex/speed)에 따르면 fast service tier multiplier가 GPT-5.5에서 2.5x로 책정되었다 (GPT-5.4는 2x). 즉 동일 fast tier에서 토큰 limit 도달 속도가 1.25배 가속된다.

또한 codex 0.124.0 이후 적격 ChatGPT plan에서 fast tier가 default로 활성화되며, opt-out하지 않으면 자동으로 2x/2.5x 멀티플라이어를 받게 된다.

본 변경 전 워크트리 설정:
- `modules/shared/programs/codex/files/config.{toml,darwin.toml}:8`에서 `service_tier = "fast"` 명시 활성화
- `modules/shared/programs/claude/files/skills/run-da/SKILL.md:103`에서 Arbiter strong review profile `reasoning_effort = "xhigh"` 사용

이 두 축에서 토큰 비용이 2.5x로 가속되고 있었으나 일반 codex 세션 reasoning 깊이를 유지하면서 비용에 민감한 두 축에서만 완화하는 것이 목표였다.

## CIR (Change Intent Record)

### 발견 경위
- 사용자가 GPT-5.5 출시 직후 토큰 비용 압박을 인지하고 issue #571 등록 + 이슈 본문에 11개 변경 위치를 사전 정리.
- handoff 코멘트에 Phase 1 grep 명령으로 위치를 재실측하라는 가드를 명시.

### 설계 의도
1. **이중 정책 (config default xhigh ≠ Arbiter strong high)**: config default는 일반 codex 세션 reasoning 깊이 보존을 위해 유지하고, Arbiter 호출 경로에서만 명시 핀(`-c model_reasoning_effort="high"`)으로 다운그레이드. 이는 의도된 trade-off로, `arbiter-scaling.md:86`의 manual sync contract 주석에 effort 매핑(`medium`=standard, `high`=strong, `xhigh`=config default)을 명시하여 신규 기여자 mental model 형성 부담을 완화.
2. **service_tier 줄을 다른 값으로 명시 교체하지 않고 줄 자체 삭제**: `priority`, `default` 같은 명시 값으로 교체하면 향후 codex가 default 키를 다시 도입할 때 재차 충돌 가능. 줄 삭제로 codex CLI default tier 위임.
3. **`-c model="gpt-5.5"`는 first-pass 경로에서 핀하지 않음**: line 143-146의 first-pass codex exec 명령은 user config의 model을 신뢰하여 `-m` 생략 (`arbiter-scaling.md:66` 정책). delegation-denied fallback 경로(line 107-109)는 `--ignore-user-config`로 user config가 차단되므로 model+effort 모두 핀.

### 대안 검토 이력
- DA for_plan에서 `arbiter-scaling.md:143` first-pass codex exec 명령에 `-c model_reasoning_effort` 핀 누락 발견 (Correctness-1 HIGH) → **반영**: 11개 위치를 12개로 확장.
- DA for_plan에서 `sync-codex-config.py` `merge_template_into`가 template-declared leaf만 overwrite하는 정책상 service_tier 줄 삭제만으로는 `~/.codex/config.toml`에서 키가 제거되지 않음 발견 (Correctness-2 HIGH) → **반영**: 사용자 결정으로 수동 cleanup + 검증 단계 추가.
- DA for_plan에서 `tests/fixtures/.../bare_sync_compat/{template,expected}.toml`에 `service_tier = "fast"` 잔존 발견 (Regression-2 HIGH) → **반영**: fixture 2개 파일도 함께 변경.
- DA for_plan에서 `arbiter-scaling.md:196` AFTER 텍스트가 first-pass=high만 강조하나 N=3(line 201/211)도 high가 됨을 발견 (Maintainability-2 MEDIUM) → **반영**: AFTER를 "first-pass와 N=3 모두 high"로 재작성.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| ✅ Arbiter 경로만 high 핀 | config default xhigh 보존 + Arbiter 호출 경로에서만 `-c`로 high | 일반 codex 세션 reasoning 깊이 보존, 비용 절감 효과 명확 | 9개 위치 manual sync 부담 (arbiter-scaling.md:86 contract로 documented) | **채택** — 이슈 본문 / handoff 결정 |
| ❌ config default 자체를 high로 낮춤 | `config.toml:5`의 `model_reasoning_effort = "xhigh"`을 `"high"`로 변경 | 단일 값 변경, 모든 위치 자동 동기화 | 일반 codex 세션 reasoning 깊이도 함께 감소 (목표와 충돌) | 기각 |
| ❌ service_tier = "default" 명시 | fast → default로 명시 값 교체 | 향후 codex auto-default 변경에 무관 | codex CLI 사양상 default 회귀가 줄 삭제와 등가 ([0.124.0 release](https://github.com/openai/codex/releases/tag/rust-v0.124.0)) | 기각 — 불필요한 명시 |
| ❌ sync-codex-config.py에 "사라진 key 삭제" 로직 추가 | merge-only 정책을 prune-on-missing으로 변경 | 자동 cleanup으로 수동 sed 불필요 | 다른 user-owned key 삭제 위험, 큰 행동 변경 (별도 follow-up 영역) | 기각 — YAGNI |

## 구현 상세

### 변경 파일

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/codex/files/config.toml` | line 8 `service_tier = "fast"` 줄 삭제 |
| `modules/shared/programs/codex/files/config.darwin.toml` | line 8 동일 삭제 |
| `modules/shared/programs/claude/files/skills/run-da/SKILL.md` | line 103, 185: `xhigh → high` (Arbiter strong profile 정의 + codex exec subprocess fallback 표기) |
| `modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md` | line 67, 198 의미 반전 재작성 (Arbiter는 strong profile high 사용 + N=3 동등성 명시) + line 108, 180, 202, 213 단순 치환 + line 144 `-c model_reasoning_effort="high"` 신규 추가 + line 86 manual sync contract에 effort 매핑 보강 + line 143 인라인 주석 추가 |
| `modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md` | line 329: N=3 비용 코멘트 `xhigh → high` |
| `tests/fixtures/shell-scripts/codex-config/bare_sync_compat/template.toml` | line 2 `service_tier = "fast"` 줄 삭제 |
| `tests/fixtures/shell-scripts/codex-config/bare_sync_compat/expected.toml` | 동일 |

총 7개 파일, 두 커밋 (99a08ba 메인 + c532a71 가독성 보강).

### 핵심 코드 스니펫

#### Arbiter strong review profile 정의 (`SKILL.md:103`)

```diff
-- **Arbiter (strong review profile)** — Codex: `model="gpt-5.5"`, `reasoning_effort="xhigh"`. Claude Code: `model: "opus"`.
+- **Arbiter (strong review profile)** — Codex: `model="gpt-5.5"`, `reasoning_effort="high"`. Claude Code: `model: "opus"`.
```

#### first-pass codex exec 명령 핀 추가 (`arbiter-scaling.md:143-146`)

```diff
+# Arbiter는 strong review profile(high) — config.toml 기본값(xhigh)을 오버라이드. model은 -m 생략하여 config.toml 기본값 사용.
 cat "$ARBITER_DIR/arbiter-prompt.md" | codex exec --full-auto --ephemeral \
+  -c model_reasoning_effort="high" \
   -o "$ARBITER_DIR/arbiter-result.md" \
   - \
   2>"$ARBITER_DIR/arbiter-stderr.log"
```

#### 의미 반전 라인 재작성 (`arbiter-scaling.md:67`)

```diff
-- Arbiter는 config.toml 기본 `model_reasoning_effort`(xhigh = strong review profile)를 사용한다. `-c` 오버라이드 불필요.
+- Arbiter는 strong review profile(high)을 사용한다. config.toml 기본 `model_reasoning_effort`(xhigh)와 다르므로 `-c model_reasoning_effort="high"`를 명시적으로 지정한다.
```

#### service_tier 줄 삭제 (`config.toml`)

```diff
 model_reasoning_effort = "xhigh"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
-service_tier = "fast"

 [notice]
```

## 참고 레퍼런스

### 외부 1차 출처
- [Introducing GPT-5.5 (OpenAI, 2026-04-23)](https://openai.com/index/introducing-gpt-5-5/) — GPT-5.5 출시 공지
- [Codex Speed docs](https://developers.openai.com/codex/speed) — fast tier multiplier 정의 (GPT-5.5=2.5x, GPT-5.4=2x)
- [openai/codex rust-v0.125.0 release](https://github.com/openai/codex/releases/tag/rust-v0.125.0) — `gpt-5.5` 등록 (PR #19323)
- [openai/codex rust-v0.124.0 release (#19053)](https://github.com/openai/codex/releases/tag/rust-v0.124.0) — fast tier auto-default 변경

### 본 PR 커밋
- `99a08ba` — chore(codex): GPT-5.5 토큰 비용 완화 — fast mode 비활성화 + Arbiter strong xhigh→high (메인 변경)
- `c532a71` — docs(skills): run-da arbiter-scaling 가독성 보강 (DA for_pr Round 1 반영)

### 관련 내부
- `modules/shared/programs/codex/files/sync-codex-config.py:411` `merge_template_into` — template-declared leaf만 dest에 overwrite하는 정책 (DA Correctness-2 근거)
- `modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md:86` — manual sync contract (effort 매핑 + 단일 SSOT 표기)
- `~/.codex/config.toml:14` — `notice.fast_default_opt_out = true` (codex 0.124.0+ auto-default 차단)

## Human Test Plan

### Phase 1: 정적 검증
1. **service_tier 부재 확인** (4 files, expect 0 matches)
   ```zsh
   grep -n 'service_tier' modules/shared/programs/codex/files/config.toml \
     modules/shared/programs/codex/files/config.darwin.toml \
     tests/fixtures/shell-scripts/codex-config/bare_sync_compat/template.toml \
     tests/fixtures/shell-scripts/codex-config/bare_sync_compat/expected.toml \
     || echo "OK"
   ```
   - 기대: `OK` 출력
   - 실패 시: 어느 파일에 service_tier가 잔존했는지 확인 후 수동 삭제

2. **config default xhigh 보존** (expect 2 matches)
   ```zsh
   grep -n 'model_reasoning_effort = "xhigh"' modules/shared/programs/codex/files/config.toml \
     modules/shared/programs/codex/files/config.darwin.toml
   ```
   - 기대: 양 파일 line 5 출력
   - 실패 시: 일반 codex 세션 reasoning 깊이가 의도치 않게 변경됨 — 즉시 복원

3. **run-da 영역 의도된 xhigh 잔존 확인** (expect 2 matches: line 67, 198)
   ```zsh
   grep -n 'xhigh' modules/shared/programs/claude/files/skills/run-da/SKILL.md \
     modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md \
     modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md
   ```
   - 기대: arbiter-scaling.md line 67, 198만 출력 ("config.toml 기본값(xhigh)와 다르므로" 비교 기준 표기). line 86은 effort 매핑 설명 — 추가 매치 가능
   - 실패 시: 누락된 위치 확인 후 high로 변경

4. **high pin 위치 확인** (Arbiter 경로 4개 + N=3 강조 1개 + 매핑 1개)
   ```zsh
   grep -n 'reasoning_effort="high"' modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
   ```
   - 기대: 최소 6 lines (line 67, 108, 145, 198, 202, 213) 출력

### Phase 2: nrs 빌드 + cleanup

각 머신(macOS Mac + NixOS MiniPC)에서 1회 수행:

1. **macOS 적용** (워크트리 또는 main 후)
   ```bash
   nrs
   ```
   - 기대: exit 0, "Activating syncCodexConfig" 로그 출력

2. **macOS BSD sed cleanup** (sync-codex-config.py merge-only 정책 한계 — 아래 "한계" 섹션 참조)
   ```zsh
   sed -i '' '/^service_tier = "fast"$/d' ~/.codex/config.toml
   grep -n 'service_tier' ~/.codex/config.toml || echo "OK: service_tier 키 제거 확인"
   ```
   - 기대: `OK: ...` 출력

3. **MiniPC GNU sed cleanup** (PR merge 후 ssh minipc + nrs 후 1회)
   ```bash
   ssh minipc 'nrs && sed -i "/^service_tier = \"fast\"$/d" ~/.codex/config.toml && grep -n service_tier ~/.codex/config.toml || echo OK'
   ```
   - 기대: `OK` 출력

### Phase 3: 동작 확인

1. **새 codex 세션이 default tier로 동작**
   ```bash
   codex 2>&1 | grep -i 'tier\|service' | head -5
   ```
   - 기대: fast tier 언급 없음

2. **run-da 호출 시 Arbiter codex exec 명령에 -c high가 명시되는지**
   - 다음 PR에서 `/run-da for_pr` 실행 시 Arbiter spawn 명령 echo 확인
   - 기대: `codex exec --full-auto --ephemeral -c model_reasoning_effort="high" -o ... -`

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```zsh
# 1. service_tier 부재 (output 0 lines)
grep -rn 'service_tier' modules/shared/programs/codex/files/ tests/fixtures/shell-scripts/codex-config/bare_sync_compat/ || echo "PASS: service_tier 제거"

# 2. config default xhigh 보존 (output 2 lines)
grep -n 'model_reasoning_effort = "xhigh"' modules/shared/programs/codex/files/config.toml modules/shared/programs/codex/files/config.darwin.toml | wc -l
# Expected: 2

# 3. run-da xhigh는 line 67/198 비교 기준 + line 86 매핑 표기 외 잔존 없음
grep -n 'xhigh' modules/shared/programs/claude/files/skills/run-da/SKILL.md modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md || echo "PASS: SKILL.md/arbiter-prompt.md xhigh 0건"

# 4. arbiter-scaling.md xhigh는 의도된 위치(line 67, 86, 198)만
grep -nc 'xhigh' modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
# Expected: 3 (line 67, 86, 198)

# 5. high pin 위치 6개 이상 (line 67, 108, 145, 198, 202, 213)
grep -nc 'reasoning_effort="high"' modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
# Expected: ≥6
```

### Phase 1: nrs 빌드 적용 (macOS)

```bash
# 메인 작업 환경 (macOS)에서:
nrs
# Expected: exit 0
```

### Phase 2: ~/.codex/config.toml cleanup (각 머신 1회)

```zsh
# macOS BSD sed
sed -i '' '/^service_tier = "fast"$/d' ~/.codex/config.toml
grep -n 'service_tier' ~/.codex/config.toml || echo "PASS: macOS cleanup OK"

# MiniPC (PR merge 후, ssh minipc)
# ssh minipc 'sed -i "/^service_tier = \"fast\"$/d" ~/.codex/config.toml && grep -n service_tier ~/.codex/config.toml || echo "PASS: MiniPC cleanup OK"'
```

### Phase 3: regression 확인

```zsh
# standard profile (medium)는 변경되지 않았는지
grep -n 'reasoning_effort="medium"' modules/shared/programs/claude/files/skills/run-da/SKILL.md modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
# Expected: ≥3 lines (SKILL.md:104, arbiter-scaling.md:92, :100)

# settings.json effortLevel은 별개 축이므로 보존
grep -n 'effortLevel' modules/shared/programs/claude/files/settings.json
# Expected: "effortLevel": "xhigh" 보존 (line 181 부근)

# notice.fast_default_opt_out (글로벌 ~/.codex/config.toml)은 보존
grep -n 'fast_default_opt_out' ~/.codex/config.toml
# Expected: line ~14에 fast_default_opt_out = true 출력
```

## Cleanup 안내 (각 머신 1회 수행 — 중요)

`sync-codex-config.py`의 `merge_template_into`는 template-declared leaf만 dest에 overwrite하는 ownership 정책이므로, repo template에서 `service_tier = "fast"` 줄을 삭제해도 기존 머신의 `~/.codex/config.toml`의 해당 키는 user-owned로 잔존합니다. **각 머신에서 1회 수동 cleanup이 필요**합니다.

| 머신 | 명령 |
|------|------|
| **macOS** (BSD sed) | `sed -i '' '/^service_tier = "fast"$/d' ~/.codex/config.toml` |
| **NixOS MiniPC** (GNU sed) | `sed -i '/^service_tier = "fast"$/d' ~/.codex/config.toml` |
| **새 clone 머신** | cleanup 불필요 — `nrs` 첫 실행 시 `~/.codex/config.toml`이 template로부터 신규 생성됨 |

검증: `grep -n 'service_tier' ~/.codex/config.toml || echo OK` (출력 `OK`이면 cleanup 완료).

cleanup하지 않으면 `service_tier = "fast"`가 잔존하여 fast tier로 계속 동작합니다 (이슈 #571 본래 목표 미달).

## DA 피드백 루프 결과 (참고)

| Round | Mode | Intensity | reviewer findings | Arbiter verdict | 반영 |
|-------|------|-----------|-------------------|------------------|------|
| 0 | for_plan | FULL | 14건 (4 reviewer + Maintainability nit) | CONFIRMED 4건 (Correctness-1 HIGH, Correctness-2 HIGH, Regression-2 HIGH, Maintainability-2 MEDIUM) | 모두 plan에 반영 (line 143-146 핀 추가, fixture 2개 추가, line 196 AFTER 재작성, 사용자 수동 cleanup 결정) |
| 1 | for_pr | FULL | 8건 | CONFIRMED 4건 (Design-2 LOW, Regression-1 MEDIUM, Maintainability-1 LOW, Maintainability-2 LOW) | 코드 3건 반영 (line 86 매핑 보강, line 143 주석 추가, line 198 강조 분리) + Regression-1는 본 PR description에 cleanup 안내 명시 (위 "Cleanup 안내" 섹션) |
| 2 | for_pr | FULL | 8건 | (LOW readability nits만, 사용자 결정으로 마무리) | 권고사항으로 따로 follow-up 가능, 본 PR에는 미반영 |