### PR TITLE
fix(zed): setZedAsDefaultEditor activation duti dyn.* UTI -50 wrapping (#594)

### DIFF
--- a/docs/TRIAL_AND_ERROR.md
+++ b/docs/TRIAL_AND_ERROR.md
@@ -1200,9 +1200,11 @@ codeExtensions = [
    - 특정 UTI는 사용자가 변경할 수 없도록 잠겨 있음
    - CLI 도구로 강제 변경 불가
 
-2. **duti 에러는 치명적이지 않음**
-   - 개별 확장자 설정 실패해도 다른 확장자에 영향 없음
-   - activation 전체가 중단되지 않음
+2. **duti 에러는 set -e 환경에서 치명적임**
+   - home-manager activate 스크립트는 `set -eu -o pipefail`로 실행됨 (`setupLaunchAgents`만 `set +e`로 보호)
+   - duti 호출이 직접 실행되면 **첫 실패에서 set -e 발동 → activation 전체 중단 → darwin-rebuild exit 2**
+   - 위 (1)의 `error -54` 케이스에서도 정적 UTI 매핑이 있어 activation은 통과했지만, 정적 UTI가 없는 확장자(`.mdx`, `.nix`, `.toml` 등)는 동적 UTI로 매핑되어 `error -50`을 반환하며 첫 실패에서 빌드를 중단시킴 (실제 회귀 사례는 별도 후속 항목 참조)
+   - 활성화 스크립트는 helper로 감싸 실패를 흡수하거나 명시적으로 `set +e` 보호 필요
 
 3. **HTML 파일은 브라우저로 여는 것이 macOS 기본 정책**
    - 개발자 워크플로우와 충돌하는 부분

--- a/modules/darwin/programs/zed/default.nix
+++ b/modules/darwin/programs/zed/default.nix
@@ -104,10 +104,17 @@ in
 
     skipped=0
     total=0
+    first_failure=""
+    first_failure_err=""
     set_handler() {
       total=$((total + 1))
-      if ! ${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>/dev/null; then
+      local err
+      if ! err=$(${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>&1); then
         skipped=$((skipped + 1))
+        if [ -z "$first_failure" ]; then
+          first_failure="$1"
+          first_failure_err="$err"
+        fi
       fi
     }
 
@@ -117,7 +124,7 @@ in
     set_handler public.source-code
 
     if [ "$skipped" -gt 0 ]; then
-      echo "  ⚠️  Skipped $skipped of $total entries rejected by duti (likely no static UTI for some extensions)"
+      echo "  ⚠️  Skipped $skipped of $total entries rejected by duti (first: $first_failure → $first_failure_err)"
     fi
     echo "Zed default settings applied."
   '';

--- a/modules/darwin/programs/zed/default.nix
+++ b/modules/darwin/programs/zed/default.nix
@@ -106,6 +106,7 @@ in
     total=0
     first_failure=""
     first_failure_err=""
+    public_uti_failed=0
     set_handler() {
       total=$((total + 1))
       local err
@@ -119,11 +120,12 @@ in
     }
 
     # public.plain-text / public.source-code는 정적 UTI라 정상 등록되어야 한다.
-    # 실패는 카운트로 흡수하지 않고 즉시 출력 — 정적 UTI fallback이 깨지면 codeExtensions
-    # 매핑에 없는 파일이 Zed로 열리지 않을 수 있다.
+    # 실패는 카운트로 흡수하지 않고 즉시 출력 + 별도 카운터 — 정적 UTI fallback이 깨지면
+    # codeExtensions 매핑에 없는 파일이 Zed로 열리지 않을 수 있다.
     register_public_uti() {
       local err
       if ! err=$(${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>&1); then
+        public_uti_failed=$((public_uti_failed + 1))
         echo "  ❌ Failed to register $1: $err — Zed may not open code files via fallback UTI"
       fi
     }
@@ -136,6 +138,10 @@ in
     if [ "$skipped" -gt 0 ]; then
       echo "  ⚠️  Skipped $skipped of $total extensions rejected by duti (first: $first_failure → $first_failure_err)"
     fi
-    echo "Zed default settings applied."
+    if [ "$public_uti_failed" -gt 0 ]; then
+      echo "Zed default settings applied with warnings ($public_uti_failed public UTI registration failed)."
+    else
+      echo "Zed default settings applied."
+    fi
   '';
 }

--- a/modules/darwin/programs/zed/default.nix
+++ b/modules/darwin/programs/zed/default.nix
@@ -138,6 +138,11 @@ in
     if [ "$skipped" -gt 0 ]; then
       echo "  ⚠️  Skipped $skipped of $total extensions rejected by duti (first: $first_failure → $first_failure_err)"
     fi
+    # Catastrophic case: 모든 codeExtensions 실패 + 모든 public.* 실패 — bundle id 오류,
+    # Zed 미설치, duti 자체 고장 같은 설정 오류 신호. activation은 통과시키되 즉시 보임.
+    if [ "$total" -gt 0 ] && [ "$skipped" -eq "$total" ] && [ "$public_uti_failed" -eq 2 ]; then
+      echo "  🚨 Critical: all duti registrations failed — likely incorrect bundle id, Zed not installed, or duti broken"
+    fi
     if [ "$public_uti_failed" -gt 0 ]; then
       echo "Zed default settings applied with warnings ($public_uti_failed public UTI registration failed)."
     else

--- a/modules/darwin/programs/zed/default.nix
+++ b/modules/darwin/programs/zed/default.nix
@@ -118,13 +118,23 @@ in
       fi
     }
 
+    # public.plain-text / public.source-code는 정적 UTI라 정상 등록되어야 한다.
+    # 실패는 카운트로 흡수하지 않고 즉시 출력 — 정적 UTI fallback이 깨지면 codeExtensions
+    # 매핑에 없는 파일이 Zed로 열리지 않을 수 있다.
+    register_public_uti() {
+      local err
+      if ! err=$(${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>&1); then
+        echo "  ❌ Failed to register $1: $err — Zed may not open code files via fallback UTI"
+      fi
+    }
+
     ${lib.concatMapStringsSep "\n" (ext: ''set_handler ".${ext}"'') codeExtensions}
 
-    set_handler public.plain-text
-    set_handler public.source-code
+    register_public_uti public.plain-text
+    register_public_uti public.source-code
 
     if [ "$skipped" -gt 0 ]; then
-      echo "  ⚠️  Skipped $skipped of $total entries rejected by duti (first: $first_failure → $first_failure_err)"
+      echo "  ⚠️  Skipped $skipped of $total extensions rejected by duti (first: $first_failure → $first_failure_err)"
     fi
     echo "Zed default settings applied."
   '';

--- a/modules/darwin/programs/zed/default.nix
+++ b/modules/darwin/programs/zed/default.nix
@@ -96,17 +96,29 @@ in
   };
 
   # Zed를 기본 에디터로 설정 (duti)
+  # macOS LaunchServices에 정적 UTI가 없는 확장자(.mdx, .nix, .toml 등)는 동적 UTI(dyn.*)로
+  # 매핑되어 duti가 -50을 반환한다. activate 스크립트는 set -eu로 실행되므로 첫 실패 시
+  # darwin-rebuild가 exit 2로 종료되므로 helper로 감싸 실패를 카운터로 집계한다.
   home.activation.setZedAsDefaultEditor = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     echo "Setting Zed as default editor for code files..."
 
-    ${lib.concatMapStringsSep "\n" (
-      ext: "${pkgs.duti}/bin/duti -s ${zedBundleId} .${ext} all"
-    ) codeExtensions}
+    skipped=0
+    total=0
+    set_handler() {
+      total=$((total + 1))
+      if ! ${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>/dev/null; then
+        skipped=$((skipped + 1))
+      fi
+    }
 
-    # UTI 설정 (public.data 제거 — 범위가 너무 넓음)
-    ${pkgs.duti}/bin/duti -s ${zedBundleId} public.plain-text all
-    ${pkgs.duti}/bin/duti -s ${zedBundleId} public.source-code all
+    ${lib.concatMapStringsSep "\n" (ext: ''set_handler ".${ext}"'') codeExtensions}
 
-    echo "Zed default settings applied successfully."
+    set_handler public.plain-text
+    set_handler public.source-code
+
+    if [ "$skipped" -gt 0 ]; then
+      echo "  ⚠️  Skipped $skipped of $total entries rejected by duti (likely no static UTI for some extensions)"
+    fi
+    echo "Zed default settings applied."
   '';
 }


### PR DESCRIPTION
## Summary

- macOS 호스트에서 `nrs`를 항상 exit 2로 깨뜨리던 `setZedAsDefaultEditor` activation 회귀를 해결한다.
- duti 호출을 helper로 감싸 동적 UTI(`dyn.*`) `-50` 실패를 흡수하고, 한 줄 요약 + 첫 실패 진단 정보 + public UTI 별도 처리로 visibility를 유지한다.
- Closes #594.

## 기존 문제 / 배경

`modules/darwin/programs/zed/default.nix`의 `setZedAsDefaultEditor` 활성화 블록은 `codeExtensions` 40개 각각에 직접 `${pkgs.duti}/bin/duti -s ${zedBundleId} .${ext} all`을 호출했다.

22개 확장자(`.mdx .jsx .cjs .toml .scss .sass .less .nix .go .rs .lua .sql .graphql .gql .conf .ini .cfg .env .gitignore .editorconfig .prettierrc .eslintrc`)는 macOS LaunchServices에 정적 UTI가 등록돼 있지 않아 duti가 동적 UTI(`dyn.ah62d4qmxhk2x...`)로 변환해 `LSSetDefaultRoleHandlerForContentType`을 호출한다. Launch Services는 동적 UTI에 대한 핸들러 등록을 거부하고 `paramErr (-50)`을 반환한다.

home-manager가 생성한 `activate` 스크립트는 `set -eu -o pipefail`로 실행된다 (`setupLaunchAgents`만 `set +e ... set -e`로 보호). `setZedAsDefaultEditor` 블록은 보호가 없어 첫 실패(`.mdx` → `dyn.ah62d4qmxhk2x45peta`)에서 `set -e`가 발동, activate가 종료되며 `darwin-rebuild`가 exit 2로 회귀한다.

회귀 도입 PR은 #330 (`feat(editor): VSCode → Zed 마이그레이션`, commit `605bab4`).

## CIR (Change Intent Record)

- **옵션 A 선택 근거**: `public.source-code` / `public.plain-text` 정적 UTI 매핑이 광범위하게 작동하므로 22개 확장자도 실사용에서 대부분 Zed로 열린다. `codeExtensions` 리스트에서 22개를 제거(옵션 B)하면 macOS의 향후 정적 UTI 확장을 자동 반영하지 못해 영구 매핑 누락이 된다.
- **로깅 형식**: per-extension warn은 nrs 출력에 22줄을 추가, silent는 무엇이 안 됐는지 visibility 상실. 한 줄 요약 + 첫 실패 target/stderr 포함이 균형점이다.
- **public UTI 분리**: `public.plain-text` / `public.source-code`는 정적 UTI라 정상 등록되어야 하므로 `register_public_uti` helper로 분리. 실패 시 즉시 ❌ 메시지 + 카운터로 visibility 유지하되 activation은 통과 (옵션 A 정신).
- **catastrophic 감지**: `total>0 && skipped==total && public_uti_failed==2` 패턴(잘못된 bundle id, Zed 미설치, duti 자체 고장 신호)을 감지하면 즉시 🚨 Critical 메시지 출력. activation은 여전히 exit 0 (옵션 A 정신 유지) — 사용자 합의에 따른 결정.
- **메시지 톤**: "no static UTI"로 단정하지 않고 "rejected by duti (likely no static UTI for some extensions)"로 완화. `docs/TRIAL_AND_ERROR.md:1163`에 duti `error -54` 권한 실패 사례가 기록돼 있어 실패 원인이 정적 UTI 부재에만 한정되지 않는다.
- **TRIAL_AND_ERROR.md 정정**: Cursor 시절 항목의 "교훈 #2"가 "duti 에러는 치명적이지 않음 / activation 전체가 중단되지 않음"으로 잘못 일반화돼 있었다. 본 회귀가 정확히 그 일반화의 반증이므로 set -eu 제약 + helper/set +e 보호 필요성을 명시하도록 다시 썼다.
- **헤더 Change Intent Record (1)~(7)**: 본 fix는 구조적 결정이 아닌 회귀 패치라 헤더 항목 추가는 생략.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 옵션 A | duti 실패 허용 + helper로 감싸 카운터 집계, `codeExtensions` 리스트 유지 | macOS가 향후 정적 UTI 추가 시 자동 반영, 의도 표명용 리스트 보존, `public.source-code` fallback으로 22개도 실사용 가능 | 22개가 silent하게 dyn.*로 매핑 (디버깅 visibility는 한 줄 요약 + 첫 실패 정보로 보완) | ✅ |
| 옵션 B | `codeExtensions`에서 매핑 실패 22개 제거 + 정적 UTI에만 의존 | 의도가 코드에 명시적 | macOS 향후 정적 UTI 확장 자동 반영 안 됨. 22개가 영구히 매핑 대상에서 빠지고, `public.source-code` 미충당 확장자는 Zed로 안 열릴 수 있음 | ❌ |
| 옵션 C | helper 일반화 (`safeDuti` 공용 함수) | 다른 모듈이 duti 쓰면 재사용 가능 | 현재 duti는 zed 모듈 단독 사용. YAGNI 위반 | ❌ |
| 메시지 형식 A | 매 확장자 실패마다 warn 한 줄 출력 | 디버깅 정보 풍부 | nrs 출력에 22줄 추가, "한 줄 요약" 합의 위반 | ❌ |
| 메시지 형식 B | 한 줄 요약 + 첫 실패 target/stderr | 균형점 — 요약 정신 유지 + 디버깅 진입점 확보 | 이후 실패 정보는 손실 (사용자가 재현 시 직접 duti 실행 필요) | ✅ |
| 메시지 형식 C | silent (`\|\| true`만) | 출력 가장 깔끔 | 무엇이 등록 안 됐는지 visibility 0, 무성 회귀 위험 | ❌ |
| Catastrophic 처리 A | 모든 등록 실패 시 `exit 1` | 설정 오류 즉시 차단 | 옵션 A 정신과 정면 충돌, nrs 다시 깨짐 | ❌ |
| Catastrophic 처리 B | 모든 등록 실패 시 🚨 Critical 메시지만 | activation 통과 + visibility 확보 (사용자 합의) | 자동화된 차단 없음 (사용자가 로그 확인 필요) | ✅ |

## 구현 상세

### 변경 파일

| 파일 | 변경 |
|------|------|
| `modules/darwin/programs/zed/default.nix` | `setZedAsDefaultEditor` 활성화 블록을 helper 2개(`set_handler` / `register_public_uti`) + 카운터 5개(`skipped` / `total` / `first_failure` / `first_failure_err` / `public_uti_failed`) + catastrophic 감지 + 메시지 분기 패턴으로 교체. `codeExtensions` 리스트(line 32-80) 변경 없음. |
| `docs/TRIAL_AND_ERROR.md` | Cursor 시절 duti 사례의 "교훈 #2" 일반화를 `set -eu` 제약 + dyn.* UTI 회귀 사례로 정정. |

### 핵심 코드 스니펫 (`default.nix:99-148`)

```nix
# Zed를 기본 에디터로 설정 (duti)
# macOS LaunchServices에 정적 UTI가 없는 확장자(.mdx, .nix, .toml 등)는 동적 UTI(dyn.*)로
# 매핑되어 duti가 -50을 반환한다. activate 스크립트는 set -eu로 실행되므로 첫 실패 시
# darwin-rebuild가 exit 2로 종료되므로 helper로 감싸 실패를 카운터로 집계한다.
home.activation.setZedAsDefaultEditor = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
  echo "Setting Zed as default editor for code files..."

  skipped=0
  total=0
  first_failure=""
  first_failure_err=""
  public_uti_failed=0
  set_handler() {
    total=$((total + 1))
    local err
    if ! err=$(${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>&1); then
      skipped=$((skipped + 1))
      if [ -z "$first_failure" ]; then
        first_failure="$1"
        first_failure_err="$err"
      fi
    fi
  }

  # public.plain-text / public.source-code는 정적 UTI라 정상 등록되어야 한다.
  # 실패는 카운트로 흡수하지 않고 즉시 출력 + 별도 카운터 — 정적 UTI fallback이 깨지면
  # codeExtensions 매핑에 없는 파일이 Zed로 열리지 않을 수 있다.
  register_public_uti() {
    local err
    if ! err=$(${pkgs.duti}/bin/duti -s ${zedBundleId} "$1" all 2>&1); then
      public_uti_failed=$((public_uti_failed + 1))
      echo "  ❌ Failed to register $1: $err — Zed may not open code files via fallback UTI"
    fi
  }

  ${lib.concatMapStringsSep "\n" (ext: ''set_handler ".${ext}"'') codeExtensions}

  register_public_uti public.plain-text
  register_public_uti public.source-code

  if [ "$skipped" -gt 0 ]; then
    echo "  ⚠️  Skipped $skipped of $total extensions rejected by duti (first: $first_failure → $first_failure_err)"
  fi
  # Catastrophic case: 모든 codeExtensions 실패 + 모든 public.* 실패 — bundle id 오류,
  # Zed 미설치, duti 자체 고장 같은 설정 오류 신호. activation은 통과시키되 즉시 보임.
  if [ "$total" -gt 0 ] && [ "$skipped" -eq "$total" ] && [ "$public_uti_failed" -eq 2 ]; then
    echo "  🚨 Critical: all duti registrations failed — likely incorrect bundle id, Zed not installed, or duti broken"
  fi
  if [ "$public_uti_failed" -gt 0 ]; then
    echo "Zed default settings applied with warnings ($public_uti_failed public UTI registration failed)."
  else
    echo "Zed default settings applied."
  fi
'';
```

### 정상 케이스 출력

```
Activating setZedAsDefaultEditor
Setting Zed as default editor for code files...
  ⚠️  Skipped 22 of 40 extensions rejected by duti (first: .mdx → failed to set dev.zed.Zed as handler for dyn.ah62d4qmxhk2x45peta (error -50))
Zed default settings applied.
```

## 참고 레퍼런스

- Closes #594
- 회귀 도입: PR #330 (`feat(editor): VSCode → Zed 마이그레이션`, commit `605bab4`)
- 인접 변경: PR #367 (`refactor(zed): nixpkgs → Homebrew cask 전환`, commit `33cff69`) — 이번 회귀와 직접 인과 없음
- 사전 사례: `docs/TRIAL_AND_ERROR.md:1163` (Cursor 시절 `public.html` `error -54` 권한 실패)
- duti CLI: https://github.com/moretension/duti
- macOS UTI 동적 매핑: Apple Developer — "Uniform Type Identifiers Concepts" (dynamic identifiers는 LaunchServices role handler API에서 거부)

## Human Test Plan

이 PR이 머지되기 전, 사용자 머신에서 다음을 직접 확인한다 (모든 단계는 macOS 호스트에서).

### 1. nrs 빌드 통과 + 의도된 메시지 출력

```bash
nrs
```

기대 출력 (activation 단계):

```
Activating setZedAsDefaultEditor
Setting Zed as default editor for code files...
  ⚠️  Skipped 22 of 40 extensions rejected by duti (first: .mdx → failed to set dev.zed.Zed as handler for dyn.ah62d4qmxhk2x45peta (error -50))
Zed default settings applied.
```

- exit 0 (`echo $?` 또는 `nrs` 마지막 줄 `✅ Done!` 확인).
- "first:" 부분의 확장자 이름은 시스템 상태에 따라 달라질 수 있다 (`.mdx` 외 다른 dyn.* 매핑 확장자도 가능). `error -50` 부분은 동일.

**실패 시 진단**:
- `error -50` 외 다른 에러 코드가 첫 실패면 다른 원인이 있을 수 있음 — 메시지의 stderr를 보고 판단.
- `Skipped` 카운트가 22가 아니면 macOS 버전 변경으로 정적 UTI 등록 상태가 달라진 것 — 실제 동작에 문제 없으면 무해.

### 2. 정적 UTI 매핑 가능한 18개 확장자 등록 확인

```bash
for ext in txt text md js ts tsx mjs json yaml yml css sh bash zsh py rb xml svg; do
  printf "%-8s  " ".$ext"
  duti -d "$ext" 2>/dev/null || echo "(no static UTI)"
done
```

기대 출력: 모든 라인이 `dev.zed.Zed`로 끝남 (또는 정상적인 핸들러).

### 3. Finder에서 코드 파일 더블클릭 → Zed 실행

- `~/Workspace/nixos-config/flake.nix` Finder에서 더블클릭 → Zed에서 열림 (`.nix`는 dyn.* 매핑이지만 `public.source-code` fallback으로 열려야 함).
- `flake.lock`도 동일하게 Zed에서 열림 (확장자 없는 파일 → `public.plain-text` fallback).
- 임의의 `.ts`, `.json`, `.md` 파일도 Zed에서 열림.

**실패 시 진단**:
- "Open with..." 다이얼로그가 뜨면 정적 UTI 매핑이 깨졌거나 Zed 앱이 LaunchServices DB에 등록 안 됨 → `lsregister -kill -r -domain local -domain system -domain user` 후 재시도.

### 4. fallback UTI 핸들러 확인

```bash
/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump | grep -B2 -A2 'public.source-code' | head -40
```

기대: `dev.zed.Zed` 가 `public.source-code`의 핸들러 중 하나로 나타남.

## Pre-Merge E2E 테스트 가이드

LLM이 PR을 머지하기 전 직접 실행하는 자동 검증.

### Phase 0 — 정적 검증

변경된 파일이 main에 적용되면 다음이 참이어야 한다:

```bash
# 1. set_handler / register_public_uti helper 존재
grep -q 'set_handler()' modules/darwin/programs/zed/default.nix
grep -q 'register_public_uti()' modules/darwin/programs/zed/default.nix

# 2. catastrophic 감지 라인 존재
grep -q 'all duti registrations failed' modules/darwin/programs/zed/default.nix

# 3. TRIAL_AND_ERROR.md 일반화 정정 (이전 문구 부재 + 새 문구 존재)
! grep -q 'activation 전체가 중단되지 않음' docs/TRIAL_AND_ERROR.md
grep -q 'set -e 환경에서 치명적임' docs/TRIAL_AND_ERROR.md

# 4. codeExtensions 리스트 보존 (40 항목)
grep -A 50 'codeExtensions = \[' modules/darwin/programs/zed/default.nix | grep -c '^    "[^"]*"$'
# 기대값: 40
```

모두 exit 0 / 기대값 일치 → Phase 1 진행.

### Phase 1 — nrs 빌드 통과

```bash
nrs 2>&1 | tee /tmp/nrs-pre-merge.log
echo "exit=$?"
```

기대:
- exit 0 (`✅ Done!` 마지막 줄).
- 로그에 `Skipped \d+ of \d+ extensions rejected by duti` 한 줄 매치.
- 로그에 `Zed default settings applied` 매치 (with 또는 without "with warnings").
- 로그에 🚨 `Critical:` 매치 **없음** (정상 시).

**실패 시 진단**: 로그를 사용자에게 첨부하고 어느 단계에서 멈췄는지 확인.

### Phase 2 — UTI 등록 확인

```bash
duti -d txt
duti -d ts
duti -d md
duti -d json
```

기대: 모두 `dev.zed.Zed` 출력.

### Phase 3 — Regression: public UTI 핸들러 보존

```bash
/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump 2>/dev/null \
  | grep -A 1 'public.source-code' \
  | grep -i 'dev.zed.Zed' \
  | head -1
```

기대: 결과 라인 출력 (Zed가 `public.source-code` 핸들러로 등록됨).

### Phase 4 — 22개 dyn.* 확장자 의도된 silent 처리

```bash
# 의도적으로 dyn.* UTI 확장자에 다시 등록 시도 → -50 실패는 정상
duti -s dev.zed.Zed .mdx all 2>&1 | grep -q 'error -50'
echo "rc=$?  # 0이면 -50 에러 발견 (정상)"
```

기대: rc=0 (의도된 silent failure 확인).

---

모든 Phase 통과 시 머지 준비 완료. Phase 1 또는 3 실패 시 사용자에게 보고 후 추가 진단.
