### PR TITLE
fix(codex): Stop 알림 신뢰성/보안

### DIFF
--- a/modules/shared/programs/claude/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/claude/files/hooks/stop-notification.sh
@@ -100,7 +100,7 @@ normalize_reply() {
 # fail-open 신호를 유지하여 dispatcher hang을 방지한다. ask/plan-notification.sh 와 정책 일관성을
 # 위해 `gtimeout` 분기는 두지 않는다 — Homebrew coreutils 사용자도 ask/plan과 동일하게 Pushover
 # fallback으로 전이된다. (gtimeout 지원은 본 PR 외 follow-up 범위.)
-# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
 # === HELPER_BEGIN: run_with_timeout ===
 run_with_timeout() {
   local secs="$1"; shift
@@ -125,7 +125,7 @@ run_with_timeout() {
 # jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
-# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
 # === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"

--- a/modules/shared/programs/claude/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/claude/files/hooks/stop-notification.sh
@@ -92,6 +92,46 @@ normalize_reply() {
   fi
 }
 
+# Hammerspoon 호출 timeout wrapper (issue #589).
+# macOS BSD coreutils에는 `timeout`이 없다. nix-darwin이 GNU coreutils를 PATH에 추가하면 정상이지만,
+# nix 없는 macOS는 `command not found (exit 127)`로 빠진다. 이 hook의 fail-open 패턴은
+# `timeout 2 hs -c "..." && HS_SENT=true || true` 형태라 exit 127이면 HS_SENT=false 유지 →
+# Pushover fallback으로 전이된다. helper는 두 후보(timeout/gtimeout) 모두 부재 시 직접 실행 대신
+# `return 127`로 동일한 fail-open 신호를 유지하여 dispatcher hang을 방지한다 (REGRESSION-1).
+# Keep in sync with claude/files/hooks/stop-notification.sh의 run_with_timeout() (test 6.4가 동등성 검증).
+run_with_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    return 127
+  fi
+}
+
+# Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹 (issue #589).
+# 적용 시점은 두 곳:
+#   1) LAST_REPLY 추출 직후 — clip 전 원본에서 redact (긴 토큰 prefix가 잘려 매칭 실패하는 문제 차단)
+#   2) 최종 MESSAGE clip 후 — 방어적 2차 redact
+# Pattern order rationale: 더 specific한 prefix(sk-ant-, github_pat_)를 먼저 적용한다. ***REDACTED***
+# 토큰 자체는 다른 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
+# jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
+# Keep in sync with claude/files/hooks/stop-notification.sh의 redact_secrets() (test 6.4가 동등성 검증).
+redact_secrets() {
+  local s="$1"
+  command -v jq >/dev/null 2>&1 || { printf '%s' "$s"; return 0; }
+  jq -Rrn --arg s "$s" '
+    $s
+    | gsub("sk-ant-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
+    | gsub("sk-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
+    | gsub("github_pat_[A-Za-z0-9_]{82,}"; "***REDACTED***")
+    | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
+    | gsub("eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"; "***REDACTED***")
+    | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
+  ' 2>/dev/null || printf '%s' "$s"
+}
+
 # transcript(JSONL)에서 마지막 assistant 텍스트 응답 추출
 extract_last_assistant_text() {
   local transcript_path="$1"
@@ -160,6 +200,8 @@ fi
 
 LAST_REPLY="$(extract_last_assistant_text "$TRANSCRIPT_PATH")"
 LAST_REPLY="$(normalize_reply "$LAST_REPLY")"
+# 1차 redaction: clip 전 원본에서 secret 마스킹 (issue #589).
+LAST_REPLY="$(redact_secrets "$LAST_REPLY")"
 
 # 응답 텍스트가 있으면 본문에 포함, 없으면 기존 컨텍스트만 전송
 if [ -n "$LAST_REPLY" ]; then
@@ -187,6 +229,8 @@ fi
 
 # 최종 안전망: 전체 메시지 1024자 상한 보장
 MESSAGE="$(clip_tail_chars "$MESSAGE" "$MAX_MESSAGE_CHARS")"
+# 2차 방어적 redaction: clip이 secret prefix를 잘라 1차에서 누락했을 가능성을 보강.
+MESSAGE="$(redact_secrets "$MESSAGE")"
 
 # === Change Intent Record: 중복 알림 해소 ===
 # v1 (초기): Pushover와 hs.notify를 독립 실행 → 개인맥북에서 2중 알림(폰+데스크탑)으로 알림 피로 발생
@@ -238,7 +282,7 @@ if [[ "$OSTYPE" == darwin* ]] && command -v hs >/dev/null 2>&1; then
   HS_BODY_SAFE="${HS_BODY_SAFE//\`/}"
   HS_BODY_SAFE="${HS_BODY_SAFE//\$/}"
   HS_BODY_SAFE="${HS_BODY_SAFE//$'\n'/\\n}"
-  timeout 2 hs -c "
+  run_with_timeout 2 hs -c "
     local n = hs.notify.new({
       title = 'Claude Code [✅작업 완료]',
       informativeText = '${HS_BODY_SAFE}',

--- a/modules/shared/programs/claude/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/claude/files/hooks/stop-notification.sh
@@ -116,8 +116,12 @@ run_with_timeout() {
 # 적용 시점: LAST_REPLY 추출 직후 — clip 전 원본에서 한 번 redact한다. clip은 LAST_REPLY를
 # 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. (DA for_pr DESIGN-1
 # 반영: 1차 redaction만으로 충분하며 2차는 redundant.)
-# Pattern order rationale: 더 specific한 prefix(sk-ant-, github_pat_)를 먼저 적용한다. ***REDACTED***
-# 토큰 자체는 다른 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
+# Pattern order rationale:
+# - Family 내부에서 prefix가 겹치거나 가까운 패턴은 specific -> generic 순서로 둔다.
+#   Anthropic/OpenAI API keys: `sk-ant-...` before generic `sk-...`.
+#   GitHub tokens: fine-grained PAT `github_pat_...` before classic `gh[opsu]_...`.
+# - Family 간 overlap이 없는 JWT/AWS access key 패턴은 redaction test fixture의 family 순서를 따른다.
+# - Redaction marker 자체는 다른 secret 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
 # jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.

--- a/modules/shared/programs/claude/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/claude/files/hooks/stop-notification.sh
@@ -122,14 +122,16 @@ run_with_timeout() {
 #   GitHub tokens: fine-grained PAT `github_pat_...` before classic `gh[opsu]_...`.
 # - Family 간 overlap이 없는 JWT/AWS access key 패턴은 redaction test fixture의 family 순서를 따른다.
 # - Redaction marker 자체는 다른 secret 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
-# jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
+# jq 부재 시 fail-closed: 빈 문자열 반환하여 본문이 외부로 전송되지 않도록 한다.
+# extract_last_assistant_text/normalize_reply 등 다른 jq 의존 함수도 jq 부재 시 결과가 약화되므로 일관.
+# (Auditor Security-2 반영: jq 없으면 redaction이 적용되지 않은 원문이 Pushover로 전송되는 fail-open 차단.)
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
 # Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
 # === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"
-  command -v jq >/dev/null 2>&1 || { printf '%s' "$s"; return 0; }
+  command -v jq >/dev/null 2>&1 || { return 0; }
   jq -Rrn --arg s "$s" '
     $s
     | gsub("sk-ant-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
@@ -138,7 +140,7 @@ redact_secrets() {
     | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
     | gsub("e[wy][A-Za-z0-9_-]{8,}\\.e[wy][A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{10,}"; "***REDACTED***")
     | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
-  ' 2>/dev/null || printf '%s' "$s"
+  ' 2>/dev/null
 }
 # === HELPER_END: redact_secrets ===
 

--- a/modules/shared/programs/claude/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/claude/files/hooks/stop-notification.sh
@@ -96,28 +96,33 @@ normalize_reply() {
 # macOS BSD coreutils에는 `timeout`이 없다. nix-darwin이 GNU coreutils를 PATH에 추가하면 정상이지만,
 # nix 없는 macOS는 `command not found (exit 127)`로 빠진다. 이 hook의 fail-open 패턴은
 # `timeout 2 hs -c "..." && HS_SENT=true || true` 형태라 exit 127이면 HS_SENT=false 유지 →
-# Pushover fallback으로 전이된다. helper는 두 후보(timeout/gtimeout) 모두 부재 시 직접 실행 대신
-# `return 127`로 동일한 fail-open 신호를 유지하여 dispatcher hang을 방지한다 (REGRESSION-1).
-# Keep in sync with claude/files/hooks/stop-notification.sh의 run_with_timeout() (test 6.4가 동등성 검증).
+# Pushover fallback으로 전이된다. helper는 `timeout` 부재 시 직접 실행 대신 `return 127`로 동일한
+# fail-open 신호를 유지하여 dispatcher hang을 방지한다. ask/plan-notification.sh 와 정책 일관성을
+# 위해 `gtimeout` 분기는 두지 않는다 — Homebrew coreutils 사용자도 ask/plan과 동일하게 Pushover
+# fallback으로 전이된다. (gtimeout 지원은 본 PR 외 follow-up 범위.)
+# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# === HELPER_BEGIN: run_with_timeout ===
 run_with_timeout() {
   local secs="$1"; shift
   if command -v timeout >/dev/null 2>&1; then
     timeout "$secs" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$secs" "$@"
   else
     return 127
   fi
 }
+# === HELPER_END: run_with_timeout ===
 
 # Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹 (issue #589).
-# 적용 시점은 두 곳:
-#   1) LAST_REPLY 추출 직후 — clip 전 원본에서 redact (긴 토큰 prefix가 잘려 매칭 실패하는 문제 차단)
-#   2) 최종 MESSAGE clip 후 — 방어적 2차 redact
+# 적용 시점: LAST_REPLY 추출 직후 — clip 전 원본에서 한 번 redact한다. clip은 LAST_REPLY를
+# 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. (DA for_pr DESIGN-1
+# 반영: 1차 redaction만으로 충분하며 2차는 redundant.)
 # Pattern order rationale: 더 specific한 prefix(sk-ant-, github_pat_)를 먼저 적용한다. ***REDACTED***
 # 토큰 자체는 다른 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
 # jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
-# Keep in sync with claude/files/hooks/stop-notification.sh의 redact_secrets() (test 6.4가 동등성 검증).
+# JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
+# (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
+# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"
   command -v jq >/dev/null 2>&1 || { printf '%s' "$s"; return 0; }
@@ -127,10 +132,11 @@ redact_secrets() {
     | gsub("sk-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
     | gsub("github_pat_[A-Za-z0-9_]{82,}"; "***REDACTED***")
     | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
-    | gsub("eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"; "***REDACTED***")
+    | gsub("e[wy][A-Za-z0-9_-]{8,}\\.e[wy][A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{10,}"; "***REDACTED***")
     | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
   ' 2>/dev/null || printf '%s' "$s"
 }
+# === HELPER_END: redact_secrets ===
 
 # transcript(JSONL)에서 마지막 assistant 텍스트 응답 추출
 extract_last_assistant_text() {
@@ -229,8 +235,6 @@ fi
 
 # 최종 안전망: 전체 메시지 1024자 상한 보장
 MESSAGE="$(clip_tail_chars "$MESSAGE" "$MAX_MESSAGE_CHARS")"
-# 2차 방어적 redaction: clip이 secret prefix를 잘라 1차에서 누락했을 가능성을 보강.
-MESSAGE="$(redact_secrets "$MESSAGE")"
 
 # === Change Intent Record: 중복 알림 해소 ===
 # v1 (초기): Pushover와 hs.notify를 독립 실행 → 개인맥북에서 2중 알림(폰+데스크탑)으로 알림 피로 발생

--- a/modules/shared/programs/claude/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/claude/files/hooks/stop-notification.sh
@@ -92,15 +92,15 @@ normalize_reply() {
   fi
 }
 
-# Hammerspoon 호출 timeout wrapper (issue #589).
+# Hammerspoon 호출 timeout wrapper.
 # macOS BSD coreutils에는 `timeout`이 없다. nix-darwin이 GNU coreutils를 PATH에 추가하면 정상이지만,
 # nix 없는 macOS는 `command not found (exit 127)`로 빠진다. 이 hook의 fail-open 패턴은
 # `timeout 2 hs -c "..." && HS_SENT=true || true` 형태라 exit 127이면 HS_SENT=false 유지 →
 # Pushover fallback으로 전이된다. helper는 `timeout` 부재 시 직접 실행 대신 `return 127`로 동일한
 # fail-open 신호를 유지하여 dispatcher hang을 방지한다. ask/plan-notification.sh 와 정책 일관성을
 # 위해 `gtimeout` 분기는 두지 않는다 — Homebrew coreutils 사용자도 ask/plan과 동일하게 Pushover
-# fallback으로 전이된다. (gtimeout 지원은 본 PR 외 follow-up 범위.)
-# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
+# fallback으로 전이된다.
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; helper-equivalence test enforces this marked block only.
 # === HELPER_BEGIN: run_with_timeout ===
 run_with_timeout() {
   local secs="$1"; shift
@@ -112,10 +112,10 @@ run_with_timeout() {
 }
 # === HELPER_END: run_with_timeout ===
 
-# Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹 (issue #589).
+# Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹.
 # 적용 시점: LAST_REPLY 추출 직후 — clip 전 원본에서 한 번 redact한다. clip은 LAST_REPLY를
-# 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. (DA for_pr DESIGN-1
-# 반영: 1차 redaction만으로 충분하며 2차는 redundant.)
+# 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. clip 이후 추가 redaction은
+# redundant이므로 두지 않는다.
 # Pattern order rationale:
 # - Family 내부에서 prefix가 겹치거나 가까운 패턴은 specific -> generic 순서로 둔다.
 #   Anthropic/OpenAI API keys: `sk-ant-...` before generic `sk-...`.
@@ -124,10 +124,9 @@ run_with_timeout() {
 # - Redaction marker 자체는 다른 secret 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
 # jq 부재 시 fail-closed: 빈 문자열 반환하여 본문이 외부로 전송되지 않도록 한다.
 # extract_last_assistant_text/normalize_reply 등 다른 jq 의존 함수도 jq 부재 시 결과가 약화되므로 일관.
-# (Auditor Security-2 반영: jq 없으면 redaction이 적용되지 않은 원문이 Pushover로 전송되는 fail-open 차단.)
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
-# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; helper-equivalence test enforces this marked block only.
 # === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"
@@ -212,7 +211,7 @@ fi
 
 LAST_REPLY="$(extract_last_assistant_text "$TRANSCRIPT_PATH")"
 LAST_REPLY="$(normalize_reply "$LAST_REPLY")"
-# 1차 redaction: clip 전 원본에서 secret 마스킹 (issue #589).
+# clip 전 원본에서 secret 마스킹.
 LAST_REPLY="$(redact_secrets "$LAST_REPLY")"
 
 # 응답 텍스트가 있으면 본문에 포함, 없으면 기존 컨텍스트만 전송

--- a/modules/shared/programs/codex/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/codex/files/hooks/stop-notification.sh
@@ -113,28 +113,33 @@ normalize_reply() {
 # macOS BSD coreutils에는 `timeout`이 없다. nix-darwin이 GNU coreutils를 PATH에 추가하면 정상이지만,
 # nix 없는 macOS는 `command not found (exit 127)`로 빠진다. 이 hook의 fail-open 패턴은
 # `timeout 2 hs -c "..." && HS_SENT=true || true` 형태라 exit 127이면 HS_SENT=false 유지 →
-# Pushover fallback으로 전이된다. helper는 두 후보(timeout/gtimeout) 모두 부재 시 직접 실행 대신
-# `return 127`로 동일한 fail-open 신호를 유지하여 dispatcher hang을 방지한다 (REGRESSION-1).
-# Keep in sync with claude/files/hooks/stop-notification.sh의 run_with_timeout() (test 6.4가 동등성 검증).
+# Pushover fallback으로 전이된다. helper는 `timeout` 부재 시 직접 실행 대신 `return 127`로 동일한
+# fail-open 신호를 유지하여 dispatcher hang을 방지한다. ask/plan-notification.sh 와 정책 일관성을
+# 위해 `gtimeout` 분기는 두지 않는다 — Homebrew coreutils 사용자도 ask/plan과 동일하게 Pushover
+# fallback으로 전이된다. (gtimeout 지원은 본 PR 외 follow-up 범위.)
+# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# === HELPER_BEGIN: run_with_timeout ===
 run_with_timeout() {
   local secs="$1"; shift
   if command -v timeout >/dev/null 2>&1; then
     timeout "$secs" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$secs" "$@"
   else
     return 127
   fi
 }
+# === HELPER_END: run_with_timeout ===
 
 # Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹 (issue #589).
-# 적용 시점은 두 곳:
-#   1) LAST_REPLY 추출 직후 — clip 전 원본에서 redact (긴 토큰 prefix가 잘려 매칭 실패하는 문제 차단)
-#   2) 최종 MESSAGE clip 후 — 방어적 2차 redact
+# 적용 시점: LAST_REPLY 추출 직후 — clip 전 원본에서 한 번 redact한다. clip은 LAST_REPLY를
+# 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. (DA for_pr DESIGN-1
+# 반영: 1차 redaction만으로 충분하며 2차는 redundant.)
 # Pattern order rationale: 더 specific한 prefix(sk-ant-, github_pat_)를 먼저 적용한다. ***REDACTED***
 # 토큰 자체는 다른 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
 # jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
-# Keep in sync with claude/files/hooks/stop-notification.sh의 redact_secrets() (test 6.4가 동등성 검증).
+# JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
+# (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
+# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"
   command -v jq >/dev/null 2>&1 || { printf '%s' "$s"; return 0; }
@@ -144,16 +149,16 @@ redact_secrets() {
     | gsub("sk-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
     | gsub("github_pat_[A-Za-z0-9_]{82,}"; "***REDACTED***")
     | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
-    | gsub("eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"; "***REDACTED***")
+    | gsub("e[wy][A-Za-z0-9_-]{8,}\\.e[wy][A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{10,}"; "***REDACTED***")
     | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
   ' 2>/dev/null || printf '%s' "$s"
 }
+# === HELPER_END: redact_secrets ===
 
-# transcript(JSONL)에서 마지막 assistant 텍스트 응답 추출.
-# Codex 0.124+ session JSONL은 `type=response_item` / `payload.role=assistant` /
-# `payload.content[].type=output_text` 형태이고, Claude session JSONL은
-# `type=assistant` / `message.content[].type=text` 형태다 (issue #589). last_assistant_message가
-# 빈 fallback 진입 시 두 schema 어느 쪽이든 처리 가능하도록 Codex schema 우선 + Claude schema fallback.
+# Codex 0.124+ session JSONL transcript에서 마지막 assistant 텍스트 응답 추출 (issue #589).
+# Codex schema: `type=response_item` / `payload.type=message` / `payload.role=assistant` /
+# `payload.content[].type=output_text`. last_assistant_message가 빈 fallback 진입 시 사용.
+# 이 hook은 Codex 사본이므로 Codex schema만 처리한다 (Claude transcript는 Claude 원본 hook이 처리).
 extract_last_assistant_text() {
   local transcript_path="$1"
 
@@ -161,8 +166,7 @@ extract_last_assistant_text() {
   [ -f "$transcript_path" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  local codex_text claude_text
-  codex_text=$(jq -Rrs '
+  jq -Rrs '
     split("\n")
     | map(select(length > 0) | fromjson?)
     | map(
@@ -178,31 +182,7 @@ extract_last_assistant_text() {
       )
     | map(select(length > 0))
     | last // ""
-  ' "$transcript_path" 2>/dev/null || true)
-
-  if [ -n "$codex_text" ]; then
-    printf '%s' "$codex_text"
-    return 0
-  fi
-
-  claude_text=$(jq -Rrs '
-    split("\n")
-    | map(select(length > 0) | fromjson?)
-    | map(
-        select(.type == "assistant")
-        | (
-            if ((.message | type) == "object") and ((.message.content | type) == "array") then
-              [ .message.content[]? | select(.type == "text") | .text ] | join("\n")
-            else
-              ""
-            end
-          )
-      )
-    | map(select(length > 0))
-    | last // ""
-  ' "$transcript_path" 2>/dev/null || true)
-
-  printf '%s' "$claude_text"
+  ' "$transcript_path" 2>/dev/null || true
 }
 
 # --- 정보 수집 ---
@@ -280,8 +260,6 @@ fi
 
 # 최종 안전망: 전체 메시지 1024자 상한 보장
 MESSAGE="$(clip_tail_chars "$MESSAGE" "$MAX_MESSAGE_CHARS")"
-# 2차 방어적 redaction: clip이 secret prefix를 잘라 1차에서 누락했을 가능성을 보강.
-MESSAGE="$(redact_secrets "$MESSAGE")"
 
 # === Change Intent Record: 중복 알림 해소 ===
 # v1 (초기): Pushover와 hs.notify를 독립 실행 → 개인맥북에서 2중 알림(폰+데스크탑)으로 알림 피로 발생

--- a/modules/shared/programs/codex/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/codex/files/hooks/stop-notification.sh
@@ -133,8 +133,12 @@ run_with_timeout() {
 # 적용 시점: LAST_REPLY 추출 직후 — clip 전 원본에서 한 번 redact한다. clip은 LAST_REPLY를
 # 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. (DA for_pr DESIGN-1
 # 반영: 1차 redaction만으로 충분하며 2차는 redundant.)
-# Pattern order rationale: 더 specific한 prefix(sk-ant-, github_pat_)를 먼저 적용한다. ***REDACTED***
-# 토큰 자체는 다른 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
+# Pattern order rationale:
+# - Family 내부에서 prefix가 겹치거나 가까운 패턴은 specific -> generic 순서로 둔다.
+#   Anthropic/OpenAI API keys: `sk-ant-...` before generic `sk-...`.
+#   GitHub tokens: fine-grained PAT `github_pat_...` before classic `gh[opsu]_...`.
+# - Family 간 overlap이 없는 JWT/AWS access key 패턴은 redaction test fixture의 family 순서를 따른다.
+# - Redaction marker 자체는 다른 secret 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
 # jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.

--- a/modules/shared/programs/codex/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/codex/files/hooks/stop-notification.sh
@@ -139,14 +139,16 @@ run_with_timeout() {
 #   GitHub tokens: fine-grained PAT `github_pat_...` before classic `gh[opsu]_...`.
 # - Family 간 overlap이 없는 JWT/AWS access key 패턴은 redaction test fixture의 family 순서를 따른다.
 # - Redaction marker 자체는 다른 secret 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
-# jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
+# jq 부재 시 fail-closed: 빈 문자열 반환하여 본문이 외부로 전송되지 않도록 한다.
+# extract_last_assistant_text/normalize_reply 등 다른 jq 의존 함수도 jq 부재 시 결과가 약화되므로 일관.
+# (Auditor Security-2 반영: jq 없으면 redaction이 적용되지 않은 원문이 Pushover로 전송되는 fail-open 차단.)
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
 # Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
 # === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"
-  command -v jq >/dev/null 2>&1 || { printf '%s' "$s"; return 0; }
+  command -v jq >/dev/null 2>&1 || { return 0; }
   jq -Rrn --arg s "$s" '
     $s
     | gsub("sk-ant-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
@@ -155,7 +157,7 @@ redact_secrets() {
     | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
     | gsub("e[wy][A-Za-z0-9_-]{8,}\\.e[wy][A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{10,}"; "***REDACTED***")
     | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
-  ' 2>/dev/null || printf '%s' "$s"
+  ' 2>/dev/null
 }
 # === HELPER_END: redact_secrets ===
 

--- a/modules/shared/programs/codex/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/codex/files/hooks/stop-notification.sh
@@ -117,7 +117,7 @@ normalize_reply() {
 # fail-open 신호를 유지하여 dispatcher hang을 방지한다. ask/plan-notification.sh 와 정책 일관성을
 # 위해 `gtimeout` 분기는 두지 않는다 — Homebrew coreutils 사용자도 ask/plan과 동일하게 Pushover
 # fallback으로 전이된다. (gtimeout 지원은 본 PR 외 follow-up 범위.)
-# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
 # === HELPER_BEGIN: run_with_timeout ===
 run_with_timeout() {
   local secs="$1"; shift
@@ -142,7 +142,7 @@ run_with_timeout() {
 # jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
-# Codex/Claude copies of stop-notification.sh — enforced by test 6.4 (helper equivalence).
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
 # === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"

--- a/modules/shared/programs/codex/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/codex/files/hooks/stop-notification.sh
@@ -109,7 +109,51 @@ normalize_reply() {
   fi
 }
 
-# transcript(JSONL)에서 마지막 assistant 텍스트 응답 추출
+# Hammerspoon 호출 timeout wrapper (issue #589).
+# macOS BSD coreutils에는 `timeout`이 없다. nix-darwin이 GNU coreutils를 PATH에 추가하면 정상이지만,
+# nix 없는 macOS는 `command not found (exit 127)`로 빠진다. 이 hook의 fail-open 패턴은
+# `timeout 2 hs -c "..." && HS_SENT=true || true` 형태라 exit 127이면 HS_SENT=false 유지 →
+# Pushover fallback으로 전이된다. helper는 두 후보(timeout/gtimeout) 모두 부재 시 직접 실행 대신
+# `return 127`로 동일한 fail-open 신호를 유지하여 dispatcher hang을 방지한다 (REGRESSION-1).
+# Keep in sync with claude/files/hooks/stop-notification.sh의 run_with_timeout() (test 6.4가 동등성 검증).
+run_with_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$secs" "$@"
+  else
+    return 127
+  fi
+}
+
+# Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹 (issue #589).
+# 적용 시점은 두 곳:
+#   1) LAST_REPLY 추출 직후 — clip 전 원본에서 redact (긴 토큰 prefix가 잘려 매칭 실패하는 문제 차단)
+#   2) 최종 MESSAGE clip 후 — 방어적 2차 redact
+# Pattern order rationale: 더 specific한 prefix(sk-ant-, github_pat_)를 먼저 적용한다. ***REDACTED***
+# 토큰 자체는 다른 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
+# jq 부재 시 fallback은 원본 반환 (현재 hook의 jq 의존 정책과 일관).
+# Keep in sync with claude/files/hooks/stop-notification.sh의 redact_secrets() (test 6.4가 동등성 검증).
+redact_secrets() {
+  local s="$1"
+  command -v jq >/dev/null 2>&1 || { printf '%s' "$s"; return 0; }
+  jq -Rrn --arg s "$s" '
+    $s
+    | gsub("sk-ant-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
+    | gsub("sk-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
+    | gsub("github_pat_[A-Za-z0-9_]{82,}"; "***REDACTED***")
+    | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
+    | gsub("eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+"; "***REDACTED***")
+    | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
+  ' 2>/dev/null || printf '%s' "$s"
+}
+
+# transcript(JSONL)에서 마지막 assistant 텍스트 응답 추출.
+# Codex 0.124+ session JSONL은 `type=response_item` / `payload.role=assistant` /
+# `payload.content[].type=output_text` 형태이고, Claude session JSONL은
+# `type=assistant` / `message.content[].type=text` 형태다 (issue #589). last_assistant_message가
+# 빈 fallback 진입 시 두 schema 어느 쪽이든 처리 가능하도록 Codex schema 우선 + Claude schema fallback.
 extract_last_assistant_text() {
   local transcript_path="$1"
 
@@ -117,7 +161,31 @@ extract_last_assistant_text() {
   [ -f "$transcript_path" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  jq -Rrs '
+  local codex_text claude_text
+  codex_text=$(jq -Rrs '
+    split("\n")
+    | map(select(length > 0) | fromjson?)
+    | map(
+        select(.type == "response_item" and (.payload | type) == "object"
+               and .payload.type == "message" and .payload.role == "assistant")
+        | (
+            if ((.payload.content | type) == "array") then
+              [ .payload.content[]? | select(.type == "output_text") | .text ] | join("\n")
+            else
+              ""
+            end
+          )
+      )
+    | map(select(length > 0))
+    | last // ""
+  ' "$transcript_path" 2>/dev/null || true)
+
+  if [ -n "$codex_text" ]; then
+    printf '%s' "$codex_text"
+    return 0
+  fi
+
+  claude_text=$(jq -Rrs '
     split("\n")
     | map(select(length > 0) | fromjson?)
     | map(
@@ -132,7 +200,9 @@ extract_last_assistant_text() {
       )
     | map(select(length > 0))
     | last // ""
-  ' "$transcript_path" 2>/dev/null || true
+  ' "$transcript_path" 2>/dev/null || true)
+
+  printf '%s' "$claude_text"
 }
 
 # --- 정보 수집 ---
@@ -181,6 +251,8 @@ else
   LAST_REPLY="$(extract_last_assistant_text "$TRANSCRIPT_PATH")"
 fi
 LAST_REPLY="$(normalize_reply "$LAST_REPLY")"
+# 1차 redaction: clip 전 원본에서 secret 마스킹 (issue #589).
+LAST_REPLY="$(redact_secrets "$LAST_REPLY")"
 
 # 응답 텍스트가 있으면 본문에 포함, 없으면 기존 컨텍스트만 전송
 if [ -n "$LAST_REPLY" ]; then
@@ -208,6 +280,8 @@ fi
 
 # 최종 안전망: 전체 메시지 1024자 상한 보장
 MESSAGE="$(clip_tail_chars "$MESSAGE" "$MAX_MESSAGE_CHARS")"
+# 2차 방어적 redaction: clip이 secret prefix를 잘라 1차에서 누락했을 가능성을 보강.
+MESSAGE="$(redact_secrets "$MESSAGE")"
 
 # === Change Intent Record: 중복 알림 해소 ===
 # v1 (초기): Pushover와 hs.notify를 독립 실행 → 개인맥북에서 2중 알림(폰+데스크탑)으로 알림 피로 발생
@@ -259,7 +333,7 @@ if [[ "$OSTYPE" == darwin* ]] && command -v hs >/dev/null 2>&1; then
   HS_BODY_SAFE="${HS_BODY_SAFE//\`/}"
   HS_BODY_SAFE="${HS_BODY_SAFE//\$/}"
   HS_BODY_SAFE="${HS_BODY_SAFE//$'\n'/\\n}"
-  timeout "$HS_NOTIFY_TIMEOUT_SECONDS" hs -c "
+  run_with_timeout "$HS_NOTIFY_TIMEOUT_SECONDS" hs -c "
     local n = hs.notify.new({
       title = 'Claude Code [✅작업 완료]',
       informativeText = '${HS_BODY_SAFE}',

--- a/modules/shared/programs/codex/files/hooks/stop-notification.sh
+++ b/modules/shared/programs/codex/files/hooks/stop-notification.sh
@@ -3,7 +3,7 @@
 # to avoid duplicate Pushover notifications. Original lacks `set -euo pipefail`
 # so guard placed immediately after shebang, before all real work
 # (locale export, function defs, stdin parse).
-# Keep in sync with ~/.claude/hooks/stop-notification.sh (issue #585).
+# Keep in sync with ~/.claude/hooks/stop-notification.sh.
 if [ "${CLAUDECODE:-}" = "1" ] || [ "${CODEX_PROGRAMMATIC:-}" = "1" ]; then
   exit 0
 fi
@@ -23,13 +23,13 @@ export LC_ALL=en_US.UTF-8
 # Pushover 메시지 최대 길이
 MAX_MESSAGE_CHARS=1024
 
-# 외부 통신 타임아웃 — issue #585 DA MNT-3.
+# 외부 통신 타임아웃.
 # Hammerspoon hs.notify는 macOS 로컬 IPC라 빠르고 hang 시 짧은 cutoff(2s)로 fallback에 위임.
 # Pushover는 외부 HTTPS POST라 네트워크 jitter 여유로 4s.
 HS_NOTIFY_TIMEOUT_SECONDS=2
 PUSHOVER_TIMEOUT_SECONDS=4
 
-# Transcript 파일이 완전히 기록될 때까지 대기 — issue #585 DA MNT-2.
+# Transcript 파일이 완전히 기록될 때까지 대기.
 # Race condition 방어: Stop hook이 transcript flush보다 먼저 실행되는 경우
 # 폴링하여 안정화 감지. POLL_INTERVAL × MAX_POLLS = 최대 대기 시간 (현재 3초).
 TRANSCRIPT_STABLE_POLL_INTERVAL_SECONDS=0.3
@@ -109,15 +109,15 @@ normalize_reply() {
   fi
 }
 
-# Hammerspoon 호출 timeout wrapper (issue #589).
+# Hammerspoon 호출 timeout wrapper.
 # macOS BSD coreutils에는 `timeout`이 없다. nix-darwin이 GNU coreutils를 PATH에 추가하면 정상이지만,
 # nix 없는 macOS는 `command not found (exit 127)`로 빠진다. 이 hook의 fail-open 패턴은
 # `timeout 2 hs -c "..." && HS_SENT=true || true` 형태라 exit 127이면 HS_SENT=false 유지 →
 # Pushover fallback으로 전이된다. helper는 `timeout` 부재 시 직접 실행 대신 `return 127`로 동일한
 # fail-open 신호를 유지하여 dispatcher hang을 방지한다. ask/plan-notification.sh 와 정책 일관성을
 # 위해 `gtimeout` 분기는 두지 않는다 — Homebrew coreutils 사용자도 ask/plan과 동일하게 Pushover
-# fallback으로 전이된다. (gtimeout 지원은 본 PR 외 follow-up 범위.)
-# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
+# fallback으로 전이된다.
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; helper-equivalence test enforces this marked block only.
 # === HELPER_BEGIN: run_with_timeout ===
 run_with_timeout() {
   local secs="$1"; shift
@@ -129,10 +129,10 @@ run_with_timeout() {
 }
 # === HELPER_END: run_with_timeout ===
 
-# Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹 (issue #589).
+# Pushover 외부 전송 본문에서 알려진 secret pattern을 마스킹.
 # 적용 시점: LAST_REPLY 추출 직후 — clip 전 원본에서 한 번 redact한다. clip은 LAST_REPLY를
-# 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. (DA for_pr DESIGN-1
-# 반영: 1차 redaction만으로 충분하며 2차는 redundant.)
+# 그대로 자르므로 redact가 clip 후 원본 secret으로 되돌아오지 않는다. clip 이후 추가 redaction은
+# redundant이므로 두지 않는다.
 # Pattern order rationale:
 # - Family 내부에서 prefix가 겹치거나 가까운 패턴은 specific -> generic 순서로 둔다.
 #   Anthropic/OpenAI API keys: `sk-ant-...` before generic `sk-...`.
@@ -141,10 +141,9 @@ run_with_timeout() {
 # - Redaction marker 자체는 다른 secret 패턴과 매칭되지 않으므로 후속 패턴에 의해 재치환되지 않는다.
 # jq 부재 시 fail-closed: 빈 문자열 반환하여 본문이 외부로 전송되지 않도록 한다.
 # extract_last_assistant_text/normalize_reply 등 다른 jq 의존 함수도 jq 부재 시 결과가 약화되므로 일관.
-# (Auditor Security-2 반영: jq 없으면 redaction이 적용되지 않은 원문이 Pushover로 전송되는 fail-open 차단.)
 # JWT pattern: header/payload base64url segment는 JSON `{` 시작 인코딩이라 첫 두 글자가 `e[wy]`
 # (`eyJ`/`eyA`/`ewo` 등 포함). whitespace JSON header 변형(`{ "...`)도 매칭하도록 prefix를 넓힌다.
-# Shared helper body mirrored between Codex/Claude stop-notification.sh; test 6.4 enforces this marked block only.
+# Shared helper body mirrored between Codex/Claude stop-notification.sh; helper-equivalence test enforces this marked block only.
 # === HELPER_BEGIN: redact_secrets ===
 redact_secrets() {
   local s="$1"
@@ -161,7 +160,7 @@ redact_secrets() {
 }
 # === HELPER_END: redact_secrets ===
 
-# Codex 0.124+ session JSONL transcript에서 마지막 assistant 텍스트 응답 추출 (issue #589).
+# Codex 0.124+ session JSONL transcript에서 마지막 assistant 텍스트 응답 추출.
 # Codex schema: `type=response_item` / `payload.type=message` / `payload.role=assistant` /
 # `payload.content[].type=output_text`. last_assistant_message가 빈 fallback 진입 시 사용.
 # 이 hook은 Codex 사본이므로 Codex schema만 처리한다 (Claude transcript는 Claude 원본 hook이 처리).
@@ -212,8 +211,8 @@ fi
 
 # Stop hook stdin에서 transcript_path / last_assistant_message 읽기.
 # Codex 0.124+ Stop input은 last_assistant_message를 직접 제공하므로 우선 사용한다
-# (Claude transcript JSONL parser는 Codex JSONL schema와 호환되지 않음, issue #585 DA C-1).
-# Codex stdin에 agent_id 키는 없으므로 (openai/codex#16226) subagent guard는 적용하지 않는다.
+# (Claude transcript JSONL parser는 Codex JSONL schema와 호환되지 않으므로 fallback path도 별개로 둔다).
+# Codex stdin에 agent_id 키는 없으므로 subagent guard는 적용하지 않는다.
 INPUT=""
 TRANSCRIPT_PATH=""
 DIRECT_REPLY=""
@@ -237,7 +236,7 @@ else
   LAST_REPLY="$(extract_last_assistant_text "$TRANSCRIPT_PATH")"
 fi
 LAST_REPLY="$(normalize_reply "$LAST_REPLY")"
-# 1차 redaction: clip 전 원본에서 secret 마스킹 (issue #589).
+# clip 전 원본에서 secret 마스킹.
 LAST_REPLY="$(redact_secrets "$LAST_REPLY")"
 
 # 응답 텍스트가 있으면 본문에 포함, 없으면 기존 컨텍스트만 전송

--- a/scripts/ai/commit-msg-pinning.sh
+++ b/scripts/ai/commit-msg-pinning.sh
@@ -52,21 +52,25 @@ check_ere() {
   fi
 }
 
-# 패턴 A — 진행 라운드 카운터: "Round N" (단어경계 + Round prefix 의무화).
+# 패턴 A — 진행 라운드 카운터: "Round N" / "round N" / "ROUND N" (case-insensitive).
 # 단독 R[0-9]+는 false positive 너무 많아 제외 (정당한 약어 IPv4 R3, docs 표 R1/R2/R3 등).
-PATTERN_A='\bRound [0-9]+\b'
+# Round 변형 case는 모두 매치 — commit message에서 'DA round 3' / 'Round 1' 모두 박제 대상.
+PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
 
-# 패턴 B — DA finding ID 형식: BUNDLE-순번 (BUNDLE은 Title Case 풀이름 / UPPERCASE 세부 도메인 /
-# 약어 모두 가능, suffix는 항상 숫자 시작). DA 출력 형식 SSOT는 modules/.../run-da/references/da-domains.md.
-# 본 토큰 enum은 SSOT 스냅샷이며 자동 동기화되지 않는다 — da-domains.md에서 bundle/세부 도메인을
-# 추가/제거하면 본 패턴도 함께 갱신해야 한다. 숫자 시작 suffix 의무화로 자연어 (Design-pattern,
-# Regression-fix, YAGNI-concern, F-string, CIR-section, REG-istry 등) false positive 회피.
-# 'F' 토큰은 SSOT 정의 없어 제거. 'DESIGN'/'REGR'은 'Design'/'REG'와 중복이라 제거.
-PATTERN_B='\b(Correctness|Design|Regression|Maintainability|SECURITY|HALLUCINATION|SIDE_EFFECT|CONSISTENCY|READABILITY|CLEAN_CODE|YAGNI|NGMI|CORR|MAINT|REG|CIR)-[0-9][A-Za-z0-9-]*\b'
+# 패턴 B — DA finding ID 형식: BUNDLE-순번 (suffix는 항상 숫자 시작). DA 출력 형식 SSOT는
+# modules/.../run-da/references/da-domains.md. 본 토큰 enum은 SSOT 스냅샷이며 자동 동기화되지
+# 않는다 — da-domains.md에서 bundle/세부 도메인을 추가/제거하면 본 패턴도 함께 갱신해야 한다.
+# 숫자 시작 suffix 의무화로 자연어 (Design-pattern, Regression-fix, YAGNI-concern, F-string,
+# CIR-section, REG-istry 등) false positive 회피.
+# Bundle 풀이름은 reviewer 출력에서 Title Case (`Maintainability-1`) / UPPERCASE (`MAINTAINABILITY-1`)
+# 둘 다 등장하므로 양쪽 모두 enum. 세부 도메인도 Title Case (`Security-2`) / UPPERCASE (`SECURITY-2`)
+# 둘 다 등장. 약어 (CORR/MAINT/REG/CIR)와 'MNT' (Maintainability 단축형)도 commit msg에 자주 등장.
+PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Maintainability|MAINTAINABILITY|Security|SECURITY|Hallucination|HALLUCINATION|Side_effect|SIDE_EFFECT|Consistency|CONSISTENCY|Readability|READABILITY|Clean_code|CLEAN_CODE|Yagni|YAGNI|Ngmi|NGMI|CORR|MAINT|MNT|REG|CIR)-[0-9][A-Za-z0-9-]*\b'
 
-# 패턴 C — DA 키워드 컨텍스트: "DA for_pr" / "DA for_plan" / "DA 피드백".
-# 앞쪽 단어경계 + 컨텍스트 좁힘. "DA Round N"은 패턴 A가 처리하므로 중복 분기 제거 (alert fatigue 회피).
-PATTERN_C='\bDA (for_pr|for_plan|피드백)\b'
+# 패턴 C — DA/검토 키워드 컨텍스트: "DA for_pr" / "DA for_plan" / "DA 피드백" / "DA round" /
+# "Auditor X-N" / "parallel-audit 반영". reviewer/auditor 출력 인용을 commit msg에 박는 패턴 차단.
+# "Round N"은 패턴 A가 처리하므로 'DA round'는 중복 안전망.
+PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
 
 # 패턴 D — partial hex 박제. 백틱 토큰뿐 아니라 raw `7e75df6` / `(7e75df6)` / `commit 7e75df6`
 # 같은 일반 인용 형태도 감지한다 (Codex review로 백틱 전용 PATTERN_D가 raw hex 박제 사례를

--- a/tests/fixtures/codex-hooks/README.md
+++ b/tests/fixtures/codex-hooks/README.md
@@ -7,8 +7,16 @@ runner: `tests/test-codex-hook-fixtures.sh`.
 
 | 경로 | 의도 | 소비처 |
 |------|------|--------|
-| `stdin/` | Codex 0.124+ stdin payload (실측 schema). `record-prompt-submit.sh`, `record-last-stop.sh`, `stop-notification.sh` 등 hook이 stdin으로 받는 JSON. | `test_stdin_payloads_create_expected_hook_artifacts_codex_0_124` |
+| `stdin/` | Codex 0.124+ stdin payload (실측 schema). `record-prompt-submit.sh`, `record-last-stop.sh`, `stop-notification.sh` 등 hook이 stdin으로 받는 JSON. | `test_stdin_payloads_create_expected_hook_artifacts_codex_0_124`, `test_stop_notification_codex_transcript_fallback`, `test_stop_notification_secret_redaction` |
 | `sync-preservation/` | `sync-codex-config.py`가 `~/.codex/config.toml`을 merge할 때 user-owned 영역을 어떻게 보존/덮어쓰는지 검증할 user 측 입력 TOML. | `test_sync_preservation_scenarios` |
+| `transcripts/` | Codex 0.124+ session JSONL transcript 샘플. stop-notification.sh의 `extract_last_assistant_text` fallback 경로 검증용. | `test_stop_notification_codex_transcript_fallback` (6.1) |
+
+### stdin/ 카테고리 6 fixture
+
+| 파일 | 카테고리 | placeholder 규약 |
+|------|----------|------------------|
+| `stop-no-last-message-codex-transcript.json` | 6.1 | `transcript_path` 값의 `__SANDBOX_TRANSCRIPT_PATH__`를 runner가 sandbox 내부 transcript 경로로 sed 치환 |
+| `stop-with-secret-reply.json` | 6.2 | `last_assistant_message`에 7 token family 패턴(`sk-ant`/`sk-openai`/`gh-classic`/`github-pat`/`jwt`/`aws-akia`/`aws-asia`)이 함께 포함된 통합 fixture |
 
 ## 외부 contract만 디렉토리로 노출
 

--- a/tests/fixtures/codex-hooks/stdin/stop-no-last-message-codex-transcript.json
+++ b/tests/fixtures/codex-hooks/stdin/stop-no-last-message-codex-transcript.json
@@ -1,0 +1,6 @@
+{
+  "session_id": "01234567-89ab-cdef-0123-456789abcdef",
+  "transcript_path": "__SANDBOX_TRANSCRIPT_PATH__",
+  "cwd": "/tmp/codex-fixture-cwd",
+  "last_assistant_message": null
+}

--- a/tests/fixtures/codex-hooks/stdin/stop-with-secret-reply.json
+++ b/tests/fixtures/codex-hooks/stdin/stop-with-secret-reply.json
@@ -2,5 +2,5 @@
   "session_id": "01234567-89ab-cdef-0123-456789abcdef",
   "transcript_path": "/tmp/codex-fixture-transcript.jsonl",
   "cwd": "/tmp/codex-fixture-cwd",
-  "last_assistant_message": "PROBE_PREFIX sk-ant-aBcDeFgHiJkLmNoPqRsTuVwXyZ then sk-aBcDeFgHiJkLmNoPqRsTuVwXyZ then ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then ghu_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then github_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkL then eyJabc.eyJdef.signature_segment then AKIA0123456789ABCDEF then ASIA0123456789ABCDEF PROBE_SUFFIX"
+  "last_assistant_message": "PROBE_PREFIX sk-ant-aBcDeFgHiJkLmNoPqRsTuVwXyZ then sk-aBcDeFgHiJkLmNoPqRsTuVwXyZ then ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then ghu_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then github_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkL then eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEyMzR9.signature_segment_xyz then eyAhbGciOiJIUzI1NiJ9.eyJzdWIiOjEyMzR9.whitespace_jwt_var then AKIA0123456789ABCDEF then ASIA0123456789ABCDEF PROBE_SUFFIX"
 }

--- a/tests/fixtures/codex-hooks/stdin/stop-with-secret-reply.json
+++ b/tests/fixtures/codex-hooks/stdin/stop-with-secret-reply.json
@@ -1,0 +1,6 @@
+{
+  "session_id": "01234567-89ab-cdef-0123-456789abcdef",
+  "transcript_path": "/tmp/codex-fixture-transcript.jsonl",
+  "cwd": "/tmp/codex-fixture-cwd",
+  "last_assistant_message": "PROBE_PREFIX sk-ant-aBcDeFgHiJkLmNoPqRsTuVwXyZ then sk-aBcDeFgHiJkLmNoPqRsTuVwXyZ then ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then ghu_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 then github_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkL then eyJabc.eyJdef.signature_segment then AKIA0123456789ABCDEF then ASIA0123456789ABCDEF PROBE_SUFFIX"
+}

--- a/tests/fixtures/codex-hooks/transcripts/codex-0.124-sample.jsonl
+++ b/tests/fixtures/codex-hooks/transcripts/codex-0.124-sample.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-04-29T02:45:00.000Z","type":"session_meta","payload":{"id":"01234567-89ab-cdef-0123-456789abcdef"}}
+{"timestamp":"2026-04-29T02:45:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello fixture"}]}}
+{"timestamp":"2026-04-29T02:45:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"FIXTURE_LAST_ASSISTANT_OUTPUT"}],"phase":"final_answer"}}

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -8,7 +8,7 @@
 #   3. noise-guard env 변형              — runner 내부 helper (4 env 조합)
 #   4. sync-codex-config.py preservation — fixtures/codex-hooks/sync-preservation/*.toml
 #   5. env propagation (live opt-in)      — CODEX_HOOK_LIVE=1 / --live
-#   6. stop-notification reliability/security (issue #589) — transcripts/ + stdin secret/transcript fixtures
+#   6. stop-notification reliability/security — transcripts/ + stdin secret/transcript fixtures
 #
 # nrs-session-cleanup.sh는 NRS_LOCK_FILE을 하드코딩하므로 (host /tmp/nrs-state 누수 위험)
 # fixture는 real script를 직접 호출하지 않고 mock subscript로 대체한다.
@@ -540,7 +540,7 @@ assert cmd == expected_stop_cmd, f"command={cmd!r} expected={expected_stop_cmd!r
 PY
 }
 
-# ─── 카테고리 6: stop-notification reliability/security (issue #589) ───
+# ─── 카테고리 6: stop-notification reliability/security ───
 # 6.1 Codex JSONL transcript fallback 추출 검증.
 # fixture stdin은 last_assistant_message=null + transcript_path를 sandbox 안의 Codex schema
 # JSONL fixture로 가리키게 만든다. extract_last_assistant_text 호출 결과가 fixture transcript의
@@ -652,7 +652,7 @@ STUB
 # Codex 사본과 Claude 원본의 redact_secrets()/run_with_timeout() 함수 본문이 byte-for-byte
 # 동일함을 보장한다. hook이 cp 동기화 패턴이라 한쪽만 패턴 추가/regex 수정하는 drift를 차단.
 # Marker 기반 추출: helper 위/아래에 `# === HELPER_BEGIN: <name> ===` / `HELPER_END` 주석을 두고
-# 그 사이를 추출한다. 함수 선언부 포맷(공백/괄호 위치) 변화에 robust하다 (DA for_pr DESIGN-2 반영).
+# 그 사이를 추출한다. 함수 선언부 포맷(공백/괄호 위치) 변화에 robust하다.
 _extract_function_block() {
   local file="$1" name="$2"
   awk -v name="$name" '

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -599,7 +599,8 @@ test_stop_notification_secret_redaction() {
     "gh-classic-gho:gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
     "gh-classic-ghu:ghu_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
     "github-pat:github_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkL"
-    "jwt:eyJabc.eyJdef.signature_segment"
+    "jwt-standard:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOjEyMzR9.signature_segment_xyz"
+    "jwt-whitespace-header:eyAhbGciOiJIUzI1NiJ9.eyJzdWIiOjEyMzR9.whitespace_jwt_var"
     "aws-akia:AKIA0123456789ABCDEF"
     "aws-asia:ASIA0123456789ABCDEF"
   )
@@ -617,12 +618,17 @@ test_stop_notification_secret_redaction() {
     || fail "[6.2] ***REDACTED*** 마커가 curl 인자에 등장하지 않음 (redaction 자체 실패 가능성)"
 }
 
-# 6.3 timeout 미가용 fail-open 검증.
-# bin-stubs에 timeout/gtimeout을 exit 127 stub으로 둬서 macOS BSD coreutils 환경(GNU coreutils 부재)
-# 시나리오를 시뮬레이션한다. run_with_timeout이 if branch에 진입하더라도 exit 127로 hs는 실행되지
-# 않고, 호출부 `&& HS_SENT=true || true`가 HS_SENT=false 유지 → Pushover fallback (curl mock 호출).
-# else branch(`return 127`)의 정적 동등성은 6.4 helper-equivalence 가 보장한다.
+# 6.3 timeout 미가용 fail-open 검증 (Darwin 전용).
+# bin-stubs에 timeout을 exit 127 stub으로 둬서 macOS BSD coreutils 환경(GNU coreutils 부재) 시나리오를
+# 시뮬레이션한다. hook의 run_with_timeout 호출은 `[[ "$OSTYPE" == darwin* ]] && command -v hs` 블록
+# 내부이므로 non-Darwin runner에서는 Hammerspoon 블록이 통째로 skip되어 검증 의미가 없다 → skip.
+# Darwin runner에서는 timeout stub의 exit 127로 HS_SENT=false 유지 → Pushover fallback (curl mock).
 test_stop_notification_timeout_unavailable_failopen() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    warn "[6.3] non-Darwin runner — Hammerspoon 블록 skip되므로 검증 의미 없음. skip."
+    return 0
+  fi
+
   local sandbox
   sandbox=$(new_hook_sandbox)
   install_pushover_mock_with_curl_log "$sandbox"
@@ -631,11 +637,7 @@ test_stop_notification_timeout_unavailable_failopen() {
 #!/usr/bin/env bash
 exit 127
 STUB
-  cat > "$sandbox/bin-stubs/gtimeout" <<'STUB'
-#!/usr/bin/env bash
-exit 127
-STUB
-  chmod +x "$sandbox/bin-stubs/timeout" "$sandbox/bin-stubs/gtimeout"
+  chmod +x "$sandbox/bin-stubs/timeout"
 
   run_hook_in_sandbox "$sandbox" "stop-notification.sh" \
     < "$FIXTURE_DIR/stdin/stop-codex-0.124.json" \
@@ -648,12 +650,14 @@ STUB
 # 6.4 양쪽 hook helper 블록 동등성 검증.
 # Codex 사본과 Claude 원본의 redact_secrets()/run_with_timeout() 함수 본문이 byte-for-byte
 # 동일함을 보장한다. hook이 cp 동기화 패턴이라 한쪽만 패턴 추가/regex 수정하는 drift를 차단.
+# Marker 기반 추출: helper 위/아래에 `# === HELPER_BEGIN: <name> ===` / `HELPER_END` 주석을 두고
+# 그 사이를 추출한다. 함수 선언부 포맷(공백/괄호 위치) 변화에 robust하다 (DA for_pr DESIGN-2 반영).
 _extract_function_block() {
   local file="$1" name="$2"
   awk -v name="$name" '
-    $0 == name "() {" { in_block = 1 }
+    $0 == "# === HELPER_BEGIN: " name " ===" { in_block = 1; next }
+    in_block && $0 == "# === HELPER_END: " name " ===" { in_block = 0; exit }
     in_block { print }
-    in_block && $0 == "}" { in_block = 0; exit }
   ' "$file"
 }
 

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -2,12 +2,13 @@
 # tests/test-codex-hook-fixtures.sh
 # Codex 0.124+ stable hook 회귀 차단 fixture runner.
 #
-# 5 카테고리:
+# 6 카테고리:
 #   1. stdin schema baseline 0.124       — fixtures/codex-hooks/stdin/*.json
 #   2. dispatcher ordering / failure recovery — runner 내부 mock subscript
 #   3. noise-guard env 변형              — runner 내부 helper (4 env 조합)
 #   4. sync-codex-config.py preservation — fixtures/codex-hooks/sync-preservation/*.toml
 #   5. env propagation (live opt-in)      — CODEX_HOOK_LIVE=1 / --live
+#   6. stop-notification reliability/security (issue #589) — transcripts/ + stdin secret/transcript fixtures
 #
 # nrs-session-cleanup.sh는 NRS_LOCK_FILE을 하드코딩하므로 (host /tmp/nrs-state 누수 위험)
 # fixture는 real script를 직접 호출하지 않고 mock subscript로 대체한다.
@@ -465,7 +466,7 @@ _sync_preservation_run_one() {
 }
 
 test_sync_preservation_scenarios() {
-  # tomlkit이 없으면 sync-codex-config.py가 sync 모드에서 fail하므로 5 카테고리 중 한 카테고리가
+  # tomlkit이 없으면 sync-codex-config.py가 sync 모드에서 fail하므로 sync-preservation 카테고리가
   # 누락된 상태로 "All passed"가 출력될 위험이 있다. hard fail로 회귀 차단.
   if ! python3 -c 'import tomlkit' >/dev/null 2>&1; then
     fail "tomlkit 미가용 — pre-commit/pre-push hook 또는 'nix shell .#pythonWithTomlkit' 환경에서 실행 필요"

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -201,6 +201,34 @@ _run_hook_in_sandbox_core() {
       "$sandbox/home/.codex/hooks/$hook" "$@"
 }
 
+# 카테고리 6 (stop-notification reliability/security) 공용: Pushover credential + curl mock 설치.
+# - sandbox/home/.config/pushover/claude-code: dummy credential (실제 Pushover API 차단)
+# - sandbox/bin-stubs/curl: 호출 인자를 sandbox/curl-args.log에 dump 후 exit 0 (redaction 검증용)
+# heredoc unquoted라 $sandbox는 expansion되고 \$@/\$arg는 stub 안에 escape 상태로 남는다.
+install_pushover_mock_with_curl_log() {
+  local sandbox="$1"
+  local creds_dir="$sandbox/home/.config/pushover"
+  mkdir -p "$creds_dir"
+  cat > "$creds_dir/claude-code" <<'CRED'
+PUSHOVER_TOKEN=dummy_token_for_fixture_only
+PUSHOVER_USER=dummy_user_for_fixture_only
+CRED
+  chmod 0600 "$creds_dir/claude-code"
+
+  cat > "$sandbox/bin-stubs/curl" <<STUB
+#!/usr/bin/env bash
+# fixture curl mock — 호출 단위로 invocation marker + 각 인자를 줄바꿈 구분 dump.
+{
+  echo "===CURL_INVOCATION==="
+  for arg in "\$@"; do
+    printf '%s\n' "\$arg"
+  done
+} >> "$sandbox/curl-args.log"
+exit 0
+STUB
+  chmod +x "$sandbox/bin-stubs/curl"
+}
+
 install_mock_subscripts_with_log() {
   # dispatcher가 호출하는 3 sub-script를 mock으로 교체.
   # $1=sandbox, $2=ordering log path, $3..=각 sub-script의 exit 코드 (인자 순서: record-last-stop, stop-notification, nrs-session-cleanup).
@@ -511,6 +539,143 @@ assert cmd == expected_stop_cmd, f"command={cmd!r} expected={expected_stop_cmd!r
 PY
 }
 
+# ─── 카테고리 6: stop-notification reliability/security (issue #589) ───
+# 6.1 Codex JSONL transcript fallback 추출 검증.
+# fixture stdin은 last_assistant_message=null + transcript_path를 sandbox 안의 Codex schema
+# JSONL fixture로 가리키게 만든다. extract_last_assistant_text 호출 결과가 fixture transcript의
+# output_text 본문(FIXTURE_LAST_ASSISTANT_OUTPUT)을 반환하여 Pushover 본문에 포함됨을 검증한다.
+test_stop_notification_codex_transcript_fallback() {
+  local sandbox transcript_dest stdin_dest
+  sandbox=$(new_hook_sandbox)
+  install_pushover_mock_with_curl_log "$sandbox"
+
+  transcript_dest="$sandbox/codex-transcript.jsonl"
+  cp "$FIXTURE_DIR/transcripts/codex-0.124-sample.jsonl" "$transcript_dest"
+
+  # fixture stdin의 __SANDBOX_TRANSCRIPT_PATH__ placeholder를 실제 sandbox path로 치환.
+  stdin_dest="$sandbox/stop-input.json"
+  sed "s|__SANDBOX_TRANSCRIPT_PATH__|$transcript_dest|g" \
+    "$FIXTURE_DIR/stdin/stop-no-last-message-codex-transcript.json" > "$stdin_dest"
+
+  run_hook_in_sandbox "$sandbox" "stop-notification.sh" \
+    < "$stdin_dest" \
+    || fail "[6.1] stop-notification (codex transcript fallback) 비정상 종료"
+
+  [[ -s "$sandbox/curl-args.log" ]] \
+    || fail "[6.1] curl mock이 호출되지 않음 (Pushover fallback 미진입)"
+  grep -q "FIXTURE_LAST_ASSISTANT_OUTPUT" "$sandbox/curl-args.log" \
+    || fail "[6.1] Codex schema transcript의 output_text가 Pushover 본문에 추출되지 않음"
+}
+
+# 6.2 secret pattern redaction 검증.
+# last_assistant_message에 7 token family 패턴을 모두 포함하고, Pushover curl mock 호출 인자에서
+# 각 family 원본이 사라지고 ***REDACTED***가 등장하는지 family별로 assert. 회귀 시 어느 family가
+# 깨졌는지 즉시 식별 가능하도록 family 이름을 fail 메시지에 포함한다.
+test_stop_notification_secret_redaction() {
+  local sandbox
+  sandbox=$(new_hook_sandbox)
+  install_pushover_mock_with_curl_log "$sandbox"
+
+  run_hook_in_sandbox "$sandbox" "stop-notification.sh" \
+    < "$FIXTURE_DIR/stdin/stop-with-secret-reply.json" \
+    || fail "[6.2] stop-notification (secret reply) 비정상 종료"
+
+  [[ -s "$sandbox/curl-args.log" ]] \
+    || fail "[6.2] curl mock이 호출되지 않음 (Pushover fallback 미진입)"
+
+  local log="$sandbox/curl-args.log"
+
+  # PROBE 마커는 본문이 실제로 message 인자에 포함됐음을 확인 (sanity check).
+  grep -q "PROBE_PREFIX" "$log" \
+    || fail "[6.2] message 본문이 curl 인자에 전달되지 않음 (sanity check 실패)"
+
+  # family별 원본 fragment 부재 + ***REDACTED*** 등장.
+  # 각 family 고유의 원본 fragment를 검사한다 (full 원본 토큰 일부; ***REDACTED***로 치환됐다면 부재).
+  local families_negative=(
+    "sk-ant:sk-ant-aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+    "sk-openai:sk-aBcDeFgHiJkLmNoPqRsTuVwXyZ"
+    "gh-classic-ghp:ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    "gh-classic-ghs:ghs_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    "gh-classic-gho:gho_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    "gh-classic-ghu:ghu_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"
+    "github-pat:github_pat_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789aBcDeFgHiJkL"
+    "jwt:eyJabc.eyJdef.signature_segment"
+    "aws-akia:AKIA0123456789ABCDEF"
+    "aws-asia:ASIA0123456789ABCDEF"
+  )
+
+  local entry family fragment
+  for entry in "${families_negative[@]}"; do
+    family="${entry%%:*}"
+    fragment="${entry#*:}"
+    if grep -qF "$fragment" "$log"; then
+      fail "[6.2/$family] 원본 secret fragment가 curl 인자에 그대로 남아 있음: '$fragment'"
+    fi
+  done
+
+  grep -q "\*\*\*REDACTED\*\*\*" "$log" \
+    || fail "[6.2] ***REDACTED*** 마커가 curl 인자에 등장하지 않음 (redaction 자체 실패 가능성)"
+}
+
+# 6.3 timeout 미가용 fail-open 검증.
+# bin-stubs에 timeout/gtimeout을 exit 127 stub으로 둬서 macOS BSD coreutils 환경(GNU coreutils 부재)
+# 시나리오를 시뮬레이션한다. run_with_timeout이 if branch에 진입하더라도 exit 127로 hs는 실행되지
+# 않고, 호출부 `&& HS_SENT=true || true`가 HS_SENT=false 유지 → Pushover fallback (curl mock 호출).
+# else branch(`return 127`)의 정적 동등성은 6.4 helper-equivalence 가 보장한다.
+test_stop_notification_timeout_unavailable_failopen() {
+  local sandbox
+  sandbox=$(new_hook_sandbox)
+  install_pushover_mock_with_curl_log "$sandbox"
+
+  cat > "$sandbox/bin-stubs/timeout" <<'STUB'
+#!/usr/bin/env bash
+exit 127
+STUB
+  cat > "$sandbox/bin-stubs/gtimeout" <<'STUB'
+#!/usr/bin/env bash
+exit 127
+STUB
+  chmod +x "$sandbox/bin-stubs/timeout" "$sandbox/bin-stubs/gtimeout"
+
+  run_hook_in_sandbox "$sandbox" "stop-notification.sh" \
+    < "$FIXTURE_DIR/stdin/stop-codex-0.124.json" \
+    || fail "[6.3] stop-notification (timeout 부재 stub) 비정상 종료"
+
+  [[ -s "$sandbox/curl-args.log" ]] \
+    || fail "[6.3] timeout 부재 시 Pushover fallback으로 전이되지 않음 (HS_SENT=false 보존 실패)"
+}
+
+# 6.4 양쪽 hook helper 블록 동등성 검증.
+# Codex 사본과 Claude 원본의 redact_secrets()/run_with_timeout() 함수 본문이 byte-for-byte
+# 동일함을 보장한다. hook이 cp 동기화 패턴이라 한쪽만 패턴 추가/regex 수정하는 drift를 차단.
+_extract_function_block() {
+  local file="$1" name="$2"
+  awk -v name="$name" '
+    $0 == name "() {" { in_block = 1 }
+    in_block { print }
+    in_block && $0 == "}" { in_block = 0; exit }
+  ' "$file"
+}
+
+test_stop_notification_helper_equivalence() {
+  local codex_hook="$REPO_ROOT/modules/shared/programs/codex/files/hooks/stop-notification.sh"
+  local claude_hook="$REPO_ROOT/modules/shared/programs/claude/files/hooks/stop-notification.sh"
+
+  local fn
+  for fn in redact_secrets run_with_timeout; do
+    local codex_block claude_block
+    codex_block=$(_extract_function_block "$codex_hook" "$fn")
+    claude_block=$(_extract_function_block "$claude_hook" "$fn")
+
+    [[ -n "$codex_block" ]] || fail "[6.4/$fn] Codex 사본에서 함수 본문을 추출하지 못함"
+    [[ -n "$claude_block" ]] || fail "[6.4/$fn] Claude 원본에서 함수 본문을 추출하지 못함"
+
+    if [[ "$codex_block" != "$claude_block" ]]; then
+      fail "[6.4/$fn] Codex 사본과 Claude 원본의 helper 본문이 drift 됨 — sync 필요"
+    fi
+  done
+}
+
 # ─── 카테고리 5: env propagation live (opt-in) ───
 # codex exec --ephemeral로 임시 dump-env hook을 실행해 CLAUDECODE/CODEX_PROGRAMMATIC propagation
 # 도달을 검증한다. 환경 결함(timeout 부재 / codex 부재 / hang / session 실패)이면 WARN skip.
@@ -621,6 +786,15 @@ run_test "noise-guard env variants (cleanup unguarded)" \
   test_noise_guard_env_variants_with_cleanup_unguarded
 run_test "sync-codex-config preservation scenarios A/B/C/D" \
   test_sync_preservation_scenarios
+
+run_test "stop-notification codex transcript fallback (6.1)" \
+  test_stop_notification_codex_transcript_fallback
+run_test "stop-notification secret redaction (6.2)" \
+  test_stop_notification_secret_redaction
+run_test "stop-notification timeout unavailable fail-open (6.3)" \
+  test_stop_notification_timeout_unavailable_failopen
+run_test "stop-notification helper equivalence (6.4)" \
+  test_stop_notification_helper_equivalence
 
 if [[ "$LIVE_MODE" == "1" ]]; then
   run_test "env propagation live (codex exec --ephemeral)" \


### PR DESCRIPTION
## 1. Summary

- `stop-notification.sh` (Codex 사본 + Claude 원본)에 3 변경: Codex 0.124+ JSONL transcript fallback parser schema 분기, Pushover 외부 본문 secret pattern redaction, Hammerspoon `timeout` 부재 시 fail-open 보존.
- `tests/test-codex-hook-fixtures.sh`에 카테고리 6 (4 시나리오) 신설 — Codex JSONL fallback / secret redaction / timeout fail-open / 양쪽 hook helper byte-for-byte 동등성.

## 2. 기존 문제/배경

Codex 0.124+ stable hooks 도입 이후 `~/.codex/hooks/stop-notification.sh`는 Claude 원본을 cp + Codex stdin schema 반영 형태로 운영된다. 다음 3 시나리오에서 알림이 실종 또는 의도치 않은 데이터를 외부로 전송할 수 있다:

1. **Codex JSONL transcript schema mismatch** — `last_assistant_message`가 빈 fallback path는 Claude JSONL schema(`type=assistant`/`message.content[].type==text`)를 가정하지만, Codex 0.124+ session JSONL은 `type=response_item`/`payload.role=assistant`/`payload.content[].type==output_text` 형태다. 실측: 실 Codex session JSONL을 현재 parser에 통과시키면 길이 0 반환, Codex schema parser PoC는 416자 정상 추출.
2. **Pushover 본문 secret 평문 노출** — `last_assistant_message` 또는 transcript fallback 본문이 외부 HTTPS Pushover API로 전송된다. token/key/JWT 같은 secret pattern 포함 시 외부 유출.
3. **macOS timeout 부재 시 silent fail** — `timeout "$HS_NOTIFY_TIMEOUT_SECONDS" hs -c ...`에서 `timeout` 부재 → exit 127 → `HS_SENT=false` → Pushover fallback. Pushover credential 없는 macOS 사용자는 알림 실종.

## 3. CIR (Change Intent Record)

**Transcript parser scope**: Codex hook의 transcript fallback은 Codex 0.124+ JSONL schema만 처리한다. Claude 세션은 Claude JSONL만 받으므로 Claude 원본 hook의 parser는 변경 없음. 코드 책임 경계를 좁혀 "Codex hook이 Claude format도 보장해야 하는가" 같은 모호한 유지보수 계약을 만들지 않는다.

**Redaction 적용 시점**: `LAST_REPLY` 추출 직후 1회만 적용한다. `clip_tail_chars`는 redact 후 LAST_REPLY를 그대로 자르므로 secret 원본이 clip 후 본문에 다시 등장할 일 없다 — 추가 방어 redaction은 redundant.

**Pattern set**: 알려진 prefix가 있는 family에 한정 (GitHub classic PAT, fine-grained PAT, OpenAI/Anthropic API key, JWT, AWS access key including STS `ASIA*`). false-positive 최소화를 위해 generic high-entropy hex/base64 매칭은 도입하지 않는다. JWT 패턴은 base64url segment 첫 두 글자가 `e[wy]`로 시작하는 점을 활용해 whitespace JSON header 변형(`eyAi...` 등)도 매칭하도록 prefix를 넓힌다 + minimum length로 false-positive 차단.

**Helper duplication**: 두 hook이 cp 동기화 패턴이라 `redact_secrets`/`run_with_timeout`을 양쪽에 복제했다. drift 위험은 helper-equivalence test가 `# === HELPER_BEGIN/END: <name> ===` marker 사이를 byte-for-byte 비교하여 차단한다. shared shell fragment로 분리하지 않은 이유: home-manager mkOutOfStoreSymlink 관리 대상 path 의존성 추가 비용이 fixture-enforced 동등성 비용을 상회.

**Timeout policy**: ask/plan-notification.sh와 정책을 일치시키기 위해 `gtimeout` 분기는 두지 않는다. `timeout` 부재 시 `return 127`로 기존 fail-open(`HS_SENT=false` → Pushover fallback)을 그대로 보존. 직접 실행 fallback은 `hs` hang 시 dispatcher cleanup 단계까지 차단 가능성이 있어 거부.

**jq 부재 시 redaction 동작**: fail-closed로 빈 문자열 반환. `extract_last_assistant_text`/`normalize_reply` 등 다른 jq 의존 함수도 jq 부재 시 결과가 약화되므로 일관. jq 없는 환경에서는 LAST_REPLY가 비워져 Pushover로는 BASE_MESSAGE(repo/branch)만 전송 — secret 원본이 redaction 우회로 외부 전송되는 fail-open 위험 차단.

**Opt-out env 부재**: redaction default ON이면 본문 자체 비활성화 옵션은 YAGNI — 실제 운영에서 본문 자체를 끄는 시나리오가 빈번하지 않고, hidden env가 설정 표면을 늘린다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| Codex 사본에만 schema 분기 | Codex schema-only fallback | 단순, 책임 경계 명확 | Claude 원본 미변경 | ✅ |
| 양쪽 hook 모두 schema 분기 | 양쪽 parser 동등성 | drift 차단 | YAGNI — Claude 세션은 Claude JSONL만 받음 | ❌ |
| Redact: LAST_REPLY 추출 직후 1회 | clip 전 원본 redact | 단순, secret 원본이 clip 후 노출 안 됨 | — | ✅ |
| Redact: 추출 직후 + clip 후 2회 | 방어적 2차 적용 | 추가 안전 | redundant — LAST_REPLY가 이미 redact된 상태로 clip | ❌ |
| Pattern: 알려진 prefix family만 | gh*, sk-*, JWT, AKIA/ASIA | false-positive 낮음 | 미지 family 누락 가능 | ✅ |
| Pattern: high-entropy 추가 | 32자+ hex/base64 generic 매칭 | 미지 family 포함 | false-positive ↑ (commit hash, UUID 잘림) | ❌ |
| Timeout: `timeout`만, 부재 시 return 127 | ask/plan과 정책 일관 | drift 없음, fail-open 보존 | Homebrew coreutils 사용자 gtimeout 미지원 | ✅ |
| Timeout: `timeout` → `gtimeout` → 직접 실행 | 모든 환경 지원 | 알림 발화 보장 | `hs` hang 시 dispatcher 차단 위험 | ❌ |
| Helper: byte-for-byte fixture enforce | cp 복제 + helper-equivalence test 검증 | 추가 파일 없음, drift fixture로 차단 | 양쪽 동시 수정 필요 | ✅ |
| Helper: shared file source | 별도 파일 분리 + source | 구조적 drift 차단 | mkOutOfStoreSymlink 관리 path 의존성 추가 | ❌ |
| jq 부재 redaction: fail-closed (빈 문자열) | jq 없으면 본문 자체 비움 | secret 누출 차단 | 본문 사라짐 (BASE_MESSAGE만 전송) | ✅ |
| jq 부재 redaction: fail-open (원본 반환) | jq 없으면 마스킹 미적용 본문 전송 | 알림 본문 보존 | secret 원본 외부 전송 위험 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/codex/files/hooks/stop-notification.sh` | `extract_last_assistant_text` Codex schema 전용 + `redact_secrets()` 신설 + `run_with_timeout()` 신설 + Hammerspoon 호출 wrapper 적용 + Pushover 직전 1차 redaction. helper 본문은 `# === HELPER_BEGIN/END: <name> ===` marker로 감싸 helper-equivalence test가 검증 |
| `modules/shared/programs/claude/files/hooks/stop-notification.sh` | parser 변경 없음 + `redact_secrets()` + `run_with_timeout()` (Codex 사본과 byte-for-byte 동일 helper 본문) + 동일 적용 시점 |
| `tests/test-codex-hook-fixtures.sh` | 카테고리 6 (4 시나리오) 추가: 6.1 Codex JSONL fallback / 6.2 redaction (7 family + JWT whitespace 변형) / 6.3 timeout 미가용 fail-open (Darwin 전용) / 6.4 helper 동등성 / + Pushover credential + curl mock helper |
| `tests/fixtures/codex-hooks/transcripts/codex-0.124-sample.jsonl` (신규) | Codex schema sample JSONL (response_item / output_text) |
| `tests/fixtures/codex-hooks/stdin/stop-no-last-message-codex-transcript.json` (신규) | `last_assistant_message=null` + `__SANDBOX_TRANSCRIPT_PATH__` placeholder |
| `tests/fixtures/codex-hooks/stdin/stop-with-secret-reply.json` (신규) | 7 token family + JWT whitespace header 변형 통합 |
| `tests/fixtures/codex-hooks/README.md` | transcripts/ 디렉토리 + 카테고리 6 fixture 표 + placeholder 규약 |
| `scripts/ai/commit-msg-pinning.sh` | 검토 메타데이터 박제 차단 패턴 결함 수정 — case-insensitive Round, bundle 풀이름 Title/UPPERCASE 양쪽 enum, Auditor/parallel-audit 키워드 확장 |

핵심 helper 본문 (양쪽 hook에 byte-for-byte 동일):

```bash
# === HELPER_BEGIN: run_with_timeout ===
run_with_timeout() {
  local secs="$1"; shift
  if command -v timeout >/dev/null 2>&1; then
    timeout "$secs" "$@"
  else
    return 127
  fi
}
# === HELPER_END: run_with_timeout ===

# === HELPER_BEGIN: redact_secrets ===
redact_secrets() {
  local s="$1"
  command -v jq >/dev/null 2>&1 || { return 0; }
  jq -Rrn --arg s "$s" '
    $s
    | gsub("sk-ant-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
    | gsub("sk-[a-zA-Z0-9_-]{20,}"; "***REDACTED***")
    | gsub("github_pat_[A-Za-z0-9_]{82,}"; "***REDACTED***")
    | gsub("gh[opsu]_[A-Za-z0-9_]{36,}"; "***REDACTED***")
    | gsub("e[wy][A-Za-z0-9_-]{8,}\\.e[wy][A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{10,}"; "***REDACTED***")
    | gsub("A[KS]IA[0-9A-Z]{16}"; "***REDACTED***")
  ' 2>/dev/null
}
# === HELPER_END: redact_secrets ===
```

## 6. 참고 레퍼런스

- Codex hooks 1차 소스: https://developers.openai.com/codex/hooks
- Pushover API 1차 소스: https://pushover.net/api

### Follow-up 후보 (별도 처리)

- ask-notification.sh / plan-notification.sh의 timeout/redaction 일관 적용
- Pushover credential argv 노출 (`--data-urlencode "token=$PUSHOVER_TOKEN"`은 본 변경 이전부터 존재; 별도 보안 hardening)
- Homebrew coreutils 사용자 `gtimeout` 지원 확장
- `last_assistant_message` empty/missing/boundary fixture 보강
- concurrent stop dispatcher 검증

## 7. Human Test Plan

| # | 단계 | 기대 동작 | 실패 시 진단 |
|---|---|---|---|
| 1 | macOS에서 일반 codex 세션 종료 | Hammerspoon 데스크탑 배너 발화 | `command -v timeout`이 host PATH에 있는지 확인. `~/.hammerspoon/init.lua`의 `hs` URL handler 등록 확인 |
| 2 | NixOS MiniPC에서 codex 세션 종료 | Pushover 푸시 발화 | `~/.config/pushover/claude-code` credential 존재 + `curl --max-time 4` 네트워크 reachable 확인 |
| 3 | secret pattern 포함 응답으로 codex 세션 종료 (NixOS 또는 Pushover credential 임시 활성화 macOS) | Pushover 본문에 `***REDACTED***` 노출, 원본 secret fragment 부재 | 카테고리 6.2 fixture가 7 family 각각의 원본 fragment 부재 + `***REDACTED***` 등장을 assert하므로 자동 검증 신뢰 가능 |
| 4 | macOS에서 `PATH`에서 timeout 제거된 셸 → 직접 hook 실행 | hook exit 0 + Pushover fallback 또는 즉시 종료 (HS_SENT=false) | `bash -x` trace로 `run_with_timeout` 분기 진입 확인 |
| 5 | fixture runner 전체 실행 | 6 카테고리 모두 통과 | 실패 시 fail 메시지의 `[6.x/family]` prefix로 family/시나리오 즉시 식별 가능 |

## 8. Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 헤더 주석 6 카테고리 갱신 확인
grep -q "^# 6 카테고리:" tests/test-codex-hook-fixtures.sh

# 양쪽 hook의 helper marker 존재 확인
grep -c "HELPER_BEGIN: redact_secrets" modules/shared/programs/{codex,claude}/files/hooks/stop-notification.sh
grep -c "HELPER_BEGIN: run_with_timeout" modules/shared/programs/{codex,claude}/files/hooks/stop-notification.sh

# fixture 파일 존재 확인
ls tests/fixtures/codex-hooks/transcripts/codex-0.124-sample.jsonl \
   tests/fixtures/codex-hooks/stdin/stop-no-last-message-codex-transcript.json \
   tests/fixtures/codex-hooks/stdin/stop-with-secret-reply.json

# gtimeout 분기 부재 확인 (ask/plan과 정책 일관)
! grep -q "gtimeout" modules/shared/programs/{codex,claude}/files/hooks/stop-notification.sh

# jq 부재 fail-closed 확인
grep -q 'command -v jq >/dev/null 2>&1 || { return 0; }' \
  modules/shared/programs/{codex,claude}/files/hooks/stop-notification.sh
```

### Phase 1: fixture runner

```bash
bash tests/test-codex-hook-fixtures.sh
```

기대: `All codex hook fixture tests passed.` + 9개 `==>` 라인 (5 기존 + 4 신규).

실패 시 진단: 마지막 `FAIL:` 메시지의 `[6.x/family]` prefix로 시나리오 식별.

### Phase 2: shellcheck

```bash
shellcheck modules/shared/programs/codex/files/hooks/stop-notification.sh
shellcheck modules/shared/programs/claude/files/hooks/stop-notification.sh
shellcheck tests/test-codex-hook-fixtures.sh
shellcheck scripts/ai/commit-msg-pinning.sh
```

기대: 변경 라인에서 신규 경고 없음 (PATTERN_D backtick 의도 매칭에 대한 SC2016 info는 기존 코드).

### Phase 3: helper 동등성 검증 (수동)

```bash
diff <(awk '/^# === HELPER_BEGIN: redact_secrets ===$/,/^# === HELPER_END: redact_secrets ===$/' \
  modules/shared/programs/codex/files/hooks/stop-notification.sh) \
     <(awk '/^# === HELPER_BEGIN: redact_secrets ===$/,/^# === HELPER_END: redact_secrets ===$/' \
  modules/shared/programs/claude/files/hooks/stop-notification.sh)
```

기대: 빈 출력 (양쪽 byte-for-byte 동일).

### Phase 4: PoC — 실 Codex JSONL 추출 (선택)

본 머신의 최근 Codex session JSONL이 있으면 새 parser가 마지막 assistant 응답을 정상 추출하는지 직접 검증:

```bash
F=$(ls -t ~/.codex/sessions/*/*/*/rollout-*.jsonl 2>/dev/null | head -1)
[ -n "$F" ] && jq -Rrs '
  split("\n") | map(select(length > 0) | fromjson?)
  | map(select(.type == "response_item" and .payload.type == "message" and .payload.role == "assistant")
        | [.payload.content[]? | select(.type == "output_text") | .text] | join("\n"))
  | map(select(length > 0)) | last // ""' "$F" | head -c 200
```

기대: 마지막 assistant 응답 텍스트의 첫 200자 출력. (Codex CLI 사용 이력 없으면 skip.)

### Phase 5: pinning hook 회귀 검증

```bash
# 박제 키워드를 포함한 가짜 commit msg를 만들어 hook이 매치하는지 확인
TMP=$(mktemp)
printf 'fix: case mismatch test\n\nMAINTAINABILITY-1 finding 반영. round 3 라운드 보고.\n' > "$TMP"
bash scripts/ai/commit-msg-pinning.sh "$TMP"
rm -f "$TMP"
```

기대: `[WARN] pinning:` warning 출력 (PATTERN_A round + PATTERN_B MAINTAINABILITY-1 매치). exit 0.

### Phase 6: Regression 부재 확인

```bash
# 기존 카테고리 1~5는 변경 없이 통과
bash tests/test-codex-hook-fixtures.sh 2>&1 | grep -E "stdin payloads|dispatcher ordering|dispatcher recovers|noise-guard|sync-codex-config" | wc -l
# 기대: 5
```