### PR TITLE
refactor(codex): Stop dispatcher cleanup before notification (#590)

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -97,7 +97,8 @@ in
     # Claude `~/.claude/hooks/*` 무변경 보장이 필요하므로 Codex 전용 사본을 분리한다.
     # 사본은 modules/shared/programs/codex/files/hooks/ 에서 mkOutOfStoreSymlink로 노출.
     # Stop hook은 _stop-dispatcher.sh 단일 entry로 inline [[hooks.Stop]]에 등록되며
-    # dispatcher가 record-last-stop → stop-notification → nrs-session-cleanup을 순차 호출한다.
+    # dispatcher가 record-last-stop → nrs-session-cleanup → stop-notification을 순차 호출한다
+    # (issue #590: lock 해제가 notification 외부 IPC latency를 기다리지 않도록 cleanup을 앞으로 이동).
     ".codex/hooks/record-prompt-submit.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/codex/files/hooks/record-prompt-submit.sh";
     ".codex/hooks/record-last-stop.sh".source =

--- a/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
+++ b/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
@@ -7,10 +7,11 @@
 #
 # Ordering rationale (issue #590):
 #   1. record-last-stop  — statusline TTL race 방어를 위해 first-write로 고정한다.
-#   2. nrs-session-cleanup — /tmp/nrs-state lock 해제는 ~ms latency라 외부 IPC/HTTP를 동반하는
-#      stop-notification 앞에서 실행해야 한다. 직렬 실행 중에 notification(Pushover --max-time 4s,
-#      Hammerspoon hs.notify timeout 2s, transcript polling ~3s 등)이 lock 해제를 차단해 동시
-#      worktree에서 새 nrs가 5~7초 대기하던 회귀를 제거한다.
+#   2. nrs-session-cleanup — /tmp/nrs-state lock 해제는 ~ms latency라 stop-notification 앞에서
+#      실행해야 한다. notification은 외부 IPC/HTTP timeout(stop-notification.sh의
+#      HS_NOTIFY_TIMEOUT_SECONDS / PUSHOVER_TIMEOUT_SECONDS / TRANSCRIPT_STABLE_* 상수가 SoT)을
+#      합쳐 다 초 단위 대기를 발생시키므로, 직렬 실행 중에 lock 해제를 차단해 동시 worktree에서
+#      새 nrs가 대기하던 회귀를 만들어왔다.
 #   3. stop-notification — 외부 IPC/HTTP. dispatcher 마지막 단계로 두어 lock 해제와 분리한다.
 #
 # Claude 패턴에서는 nrs-session-cleanup.sh가 Stop과 SessionEnd 양쪽에서 호출되었으나,

--- a/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
+++ b/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
@@ -5,8 +5,16 @@
 # Claude의 Stop hook 배열 ordering(record-last-stop first)을 보장하려면
 # inline [[hooks.Stop]]에 dispatcher 1개만 등록하고 dispatcher가 sub-script를 순차 호출한다.
 #
+# Ordering rationale (issue #590):
+#   1. record-last-stop  — statusline TTL race 방어를 위해 first-write로 고정한다.
+#   2. nrs-session-cleanup — /tmp/nrs-state lock 해제는 ~ms latency라 외부 IPC/HTTP를 동반하는
+#      stop-notification 앞에서 실행해야 한다. 직렬 실행 중에 notification(Pushover --max-time 4s,
+#      Hammerspoon hs.notify timeout 2s, transcript polling ~3s 등)이 lock 해제를 차단해 동시
+#      worktree에서 새 nrs가 5~7초 대기하던 회귀를 제거한다.
+#   3. stop-notification — 외부 IPC/HTTP. dispatcher 마지막 단계로 두어 lock 해제와 분리한다.
+#
 # Claude 패턴에서는 nrs-session-cleanup.sh가 Stop과 SessionEnd 양쪽에서 호출되었으나,
-# Codex는 SessionEnd 이벤트가 없으므로(0.124/0.125 미지원) Stop dispatcher tail에서만 호출한다.
+# Codex는 SessionEnd 이벤트가 없으므로(0.124/0.125 미지원) Stop dispatcher에서만 호출한다.
 # Stop이 main turn 종료를 cover하므로 lock cleanup 누락은 없다.
 #
 # 어느 sub-script가 실패해도 다음 sub-script는 계속 실행되며,
@@ -24,7 +32,7 @@ run_hook() {
 }
 
 run_hook record-last-stop      "$HOME/.codex/hooks/record-last-stop.sh"      # 1번: 타임스탬프 first-write
-run_hook stop-notification     "$HOME/.codex/hooks/stop-notification.sh"     # 2번: Pushover 알림
-run_hook nrs-session-cleanup   "$HOME/.codex/hooks/nrs-session-cleanup.sh"   # 3번: nrs lock cleanup
+run_hook nrs-session-cleanup   "$HOME/.codex/hooks/nrs-session-cleanup.sh"   # 2번: nrs lock 즉시 해제 (notification 외부 IPC 차단 회피)
+run_hook stop-notification     "$HOME/.codex/hooks/stop-notification.sh"     # 3번: Pushover/Hammerspoon 알림
 
 exit 0

--- a/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
+++ b/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
@@ -24,6 +24,13 @@
 set -u
 INPUT=$(cat)
 
+# Sub-script 경로를 dispatcher 시작 시점에 한 번 resolve한다.
+# nrs-session-cleanup이 lock을 풀고 stop-notification이 시작되는 사이에 다른 worktree의 nrs가
+# rebuild + nrs-relink로 ~/.codex/hooks/* symlink를 다른 worktree로 relink할 수 있다.
+# rebuild 자체는 stop-notification 호출 ms 안에 끝날 수 없지만, 실행 hook을 호출 시점이 아닌
+# dispatcher 진입 시점에 고정해 hook 사본 일관성을 구조적으로 보장한다.
+HOOKS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+
 run_hook() {
   local name="$1"
   local path="$2"
@@ -32,8 +39,8 @@ run_hook() {
   fi
 }
 
-run_hook record-last-stop      "$HOME/.codex/hooks/record-last-stop.sh"      # 1번: 타임스탬프 first-write
-run_hook nrs-session-cleanup   "$HOME/.codex/hooks/nrs-session-cleanup.sh"   # 2번: nrs lock 즉시 해제 (notification 외부 IPC 차단 회피)
-run_hook stop-notification     "$HOME/.codex/hooks/stop-notification.sh"     # 3번: Pushover/Hammerspoon 알림
+run_hook record-last-stop      "$HOOKS_DIR/record-last-stop.sh"      # 1번: 타임스탬프 first-write
+run_hook nrs-session-cleanup   "$HOOKS_DIR/nrs-session-cleanup.sh"   # 2번: nrs lock 즉시 해제 (notification 외부 IPC 차단 회피)
+run_hook stop-notification     "$HOOKS_DIR/stop-notification.sh"     # 3번: Pushover/Hammerspoon 알림
 
 exit 0

--- a/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh
+++ b/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh
@@ -7,13 +7,12 @@
 #     lock 해제를 차단하지 않게 한다.
 #   - Programmatic codex subprocess의 lock cleanup도 의도된 동작이므로 CLAUDECODE/CODEX_PROGRAMMATIC
 #     early-exit 가드를 적용하지 않는다.
-# Claude Code Stop/SessionEnd hook: nrs lock 자동 정리
-# LLM turn 종료(Stop) 또는 CC 세션 종료(SessionEnd) 시 해당 worktree의 lock을 자동 해제
-#
-# PoC 검증 결과 (2026-03-15):
-#   - Stop은 main agent turn 종료 시에만 트리거 (sub-agent, Agent Teams 멤버는 미트리거)
-#   - SessionEnd는 main 세션 종료 시에만 트리거
-#   → 두 이벤트 모두 안전하게 lock 해제 가능
+# Claude 원본 배경 (Codex runtime 계약은 위 헤더가 SoT):
+#   - Claude에서는 Stop과 SessionEnd 양쪽에서 호출되어 LLM turn 종료 또는 CC 세션 종료 시
+#     해당 worktree의 lock을 자동 해제했다.
+#   - PoC 검증 결과 (2026-03-15): Stop은 main agent turn 종료에만, SessionEnd는 main 세션
+#     종료에만 트리거되어 두 이벤트 모두 안전하게 lock 해제 가능.
+#   - Codex 0.124+에는 SessionEnd 등가가 없으므로 Codex 사본에서는 Stop dispatcher 경유만 사용.
 
 NRS_LOCK_FILE="/tmp/nrs-state"
 [[ ! -f "$NRS_LOCK_FILE" ]] && exit 0

--- a/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh
+++ b/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # Codex 사본 — ~/.claude/hooks/nrs-session-cleanup.sh에서 파생.
-# 본문 로직은 Claude 원본과 동일하나, 호출 계약은 다음 차이가 있다 (issue #585, #590):
-#   - Codex Stop dispatcher의 두 번째 sub-script (record-last-stop 직후, stop-notification 앞)
-#     로만 호출된다. Codex 0.124+에 SessionEnd 등가는 없지만 Stop이 main turn 종료를 cover하므로
-#     lock cleanup 누락은 없다. notification 앞으로 이동시킨 이유는 #590 — 외부 IPC/HTTP latency가
-#     lock 해제를 차단하지 않게 한다.
+# 본문 로직은 Claude 원본과 동일하나, 호출 계약은 다음 차이가 있다 (issue #585):
+#   - Codex Stop dispatcher 경유로만 호출된다. Codex 0.124+에 SessionEnd 등가는 없지만 Stop이
+#     main turn 종료를 cover하므로 lock cleanup 누락은 없다. dispatcher 안에서의 구체 호출
+#     순서와 rationale은 _stop-dispatcher.sh의 헤더가 SoT다.
 #   - Programmatic codex subprocess의 lock cleanup도 의도된 동작이므로 CLAUDECODE/CODEX_PROGRAMMATIC
 #     early-exit 가드를 적용하지 않는다.
 # Claude 원본 배경 (Codex runtime 계약은 위 헤더가 SoT):

--- a/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh
+++ b/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Codex 사본 — ~/.claude/hooks/nrs-session-cleanup.sh에서 파생.
-# 본문 로직은 Claude 원본과 동일하나, 호출 계약은 다음 차이가 있다 (issue #585):
-#   - Codex Stop dispatcher의 마지막 단계로만 호출된다 (Codex 0.124+에 SessionEnd 등가 부재;
-#     Stop이 main turn 종료를 cover하므로 lock cleanup 누락 없음).
+# 본문 로직은 Claude 원본과 동일하나, 호출 계약은 다음 차이가 있다 (issue #585, #590):
+#   - Codex Stop dispatcher의 두 번째 sub-script (record-last-stop 직후, stop-notification 앞)
+#     로만 호출된다. Codex 0.124+에 SessionEnd 등가는 없지만 Stop이 main turn 종료를 cover하므로
+#     lock cleanup 누락은 없다. notification 앞으로 이동시킨 이유는 #590 — 외부 IPC/HTTP latency가
+#     lock 해제를 차단하지 않게 한다.
 #   - Programmatic codex subprocess의 lock cleanup도 의도된 동작이므로 CLAUDECODE/CODEX_PROGRAMMATIC
 #     early-exit 가드를 적용하지 않는다.
 # Claude Code Stop/SessionEnd hook: nrs lock 자동 정리

--- a/tests/lib/codex-hook-expectations.sh
+++ b/tests/lib/codex-hook-expectations.sh
@@ -24,9 +24,10 @@ EXPECTED_USER_PROMPT_COMMAND='$HOME/.codex/hooks/record-prompt-submit.sh'
 # ~/.codex/config.toml의 [[hooks.Stop.hooks]] command — 단일 dispatcher.
 EXPECTED_STOP_DISPATCHER_COMMAND='$HOME/.codex/hooks/_stop-dispatcher.sh'
 
-# dispatcher가 호출하는 sub-script. ordering은 record-last-stop → stop-notification →
-# nrs-session-cleanup. 본 배열 순서는 dispatcher 호출 순서이며 fixture ordering 검증의 expected.
-EXPECTED_DISPATCHER_SUB_SCRIPTS=(record-last-stop.sh stop-notification.sh nrs-session-cleanup.sh)
+# dispatcher가 호출하는 sub-script. ordering은 record-last-stop → nrs-session-cleanup →
+# stop-notification (issue #590: cleanup이 notification 외부 IPC latency 앞에서 lock 즉시 해제).
+# 본 배열 순서는 dispatcher 호출 순서이며 fixture ordering 검증의 expected.
+EXPECTED_DISPATCHER_SUB_SCRIPTS=(record-last-stop.sh nrs-session-cleanup.sh stop-notification.sh)
 
 # live env propagation fixture에서 codex exec --ephemeral 호출 timeout (hang 방어).
 LIVE_CODEX_TIMEOUT_SECONDS=30

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -232,9 +232,10 @@ STUB
 
 install_mock_subscripts_with_log() {
   # dispatcher가 호출하는 3 sub-script를 mock으로 교체.
-  # $1=sandbox, $2=ordering log path, $3..=각 sub-script의 exit 코드 (인자 순서: record-last-stop, stop-notification, nrs-session-cleanup).
+  # $1=sandbox, $2=ordering log path, $3..=각 sub-script의 exit 코드.
+  # 인자 순서는 dispatcher 호출 순서와 동일 (issue #590): record-last-stop, nrs-session-cleanup, stop-notification.
   local sandbox="$1" log="$2"
-  local rls_rc="${3:-0}" sn_rc="${4:-0}" nsc_rc="${5:-0}"
+  local rls_rc="${3:-0}" nsc_rc="${4:-0}" sn_rc="${5:-0}"
 
   cat > "$sandbox/home/.codex/hooks/record-last-stop.sh" <<EOF
 #!/usr/bin/env bash
@@ -337,11 +338,11 @@ test_dispatcher_ordering_with_mock_subscripts() {
 }
 
 test_dispatcher_recovers_from_subscript_failures() {
-  # (record-last-stop fail), (stop-notification fail), (nrs-session-cleanup fail) 각 시나리오.
+  # 시나리오 순서는 dispatcher 호출 순서(record-last-stop → nrs-session-cleanup → stop-notification)를 따른다.
   local scenarios=(
     "1 0 0:record-last-stop"
-    "0 1 0:stop-notification"
-    "0 0 1:nrs-session-cleanup"
+    "0 1 0:nrs-session-cleanup"
+    "0 0 1:stop-notification"
   )
 
   # expected ordering 은 baseline test와 동일 helper 사용.
@@ -354,14 +355,14 @@ test_dispatcher_recovers_from_subscript_failures() {
     local fail_target="${entry##*:}"
     # shellcheck disable=SC2086  # 의도된 word-splitting (rc_triple은 "0 0 1" 형태)
     set -- $rc_triple
-    local rls_rc="$1" sn_rc="$2" nsc_rc="$3"
+    local rls_rc="$1" nsc_rc="$2" sn_rc="$3"
 
     local sandbox log err
     sandbox=$(new_hook_sandbox)
     log="$sandbox/ordering.log"
     err="$sandbox/dispatcher.stderr"
 
-    install_mock_subscripts_with_log "$sandbox" "$log" "$rls_rc" "$sn_rc" "$nsc_rc"
+    install_mock_subscripts_with_log "$sandbox" "$log" "$rls_rc" "$nsc_rc" "$sn_rc"
 
     if ! run_hook_in_sandbox "$sandbox" "_stop-dispatcher.sh" \
         < "$FIXTURE_DIR/stdin/stop-codex-0.124.json" 2>"$err"; then


### PR DESCRIPTION
## 1. Summary

- Codex 0.124+ Stop dispatcher의 sub-script 호출 순서를 `record-last-stop → nrs-session-cleanup → stop-notification`으로 변경해 nrs lock 해제가 외부 IPC/HTTP latency 뒤에서 풀려나오던 5~7초 지연을 제거한다.
- ordering 계약을 dispatcher / nrs-session-cleanup / `default.nix` 노출 주석 / fixture oracle 4 위치에서 동기화하고, fixture 인자 순서/시나리오를 dispatcher 호출 순서로 정렬한다.
- dispatcher 진입 시점에 `BASH_SOURCE`를 resolve해 hook 디렉토리를 lock하여, cleanup 후 stop-notification 사이에 다른 worktree의 `nrs-relink`가 `~/.codex/hooks/*` symlink를 갈아치울 수 있는 이론적 race를 구조적으로 차단한다.

Closes #590

## 2. 기존 문제/배경

PR #588 머지 후 `_stop-dispatcher.sh`는 Codex 0.124+ inline `[[hooks.Stop]]`의 단일 entry로 다음 3 sub-script를 직렬 foreground 호출했다.

1. `record-last-stop.sh` — statusline TTL 타임스탬프 (~ms)
2. `stop-notification.sh` — Hammerspoon `hs.notify` (timeout 2s) 또는 Pushover `curl --max-time 4`. fallback path 진입 시 `wait_for_stable_transcript` ~3s 추가.
3. `nrs-session-cleanup.sh` — `/tmp/nrs-state` lock 정리 (jq + git rev-parse + rm, ~ms)

dispatcher가 sub-script를 직렬로 실행하므로, 마지막의 `nrs-session-cleanup`이 위 외부 IPC latency 뒤에서 5~7초 지연 실행됐다. 사용자가 동시 worktree에서 다른 `nrs`를 시작하려 하면 lock이 늦게 풀려 race condition 또는 사용자 대기가 발생했다.

ordering이 의도된 것은 `record-last-stop` first(statusline TTL race 방어)와 `nrs-session-cleanup` last(lock cleanup이 main turn 종료 시점)뿐이었고, notification의 timing-criticality는 낮아 cleanup 앞으로 이동이 가능했다.

## 3. CIR (Change Intent Record)

**Ordering 선택**: cleanup을 notification 앞으로 이동(옵션 A)을 선택했다. 단순하고 race risk가 가장 낮다. notification을 background로 분리하는 옵션 B/C는 dispatcher exit 후 background process 생존성이 codex hook lifecycle에서 [UNVERIFIED]라 거부했다. 현재 fast path(stop-notification 평균 ~ms~ms)가 충분히 짧고, 외부 IPC가 발생해도 cleanup이 이미 완료된 상태이므로 lock 지연이 분리된다.

**ordering 계약 SoT 분리**: 4 위치에 ordering이 등장한다.
- `_stop-dispatcher.sh`: runtime SoT (`run_hook` 호출 순서가 진실 원천).
- `tests/lib/codex-hook-expectations.sh`: fixture oracle SSOT (`EXPECTED_DISPATCHER_SUB_SCRIPTS` 배열).
- `modules/shared/programs/codex/default.nix`: home-manager 노출부 documentation.
- `modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh`: callee 헤더의 호출 계약 설명.

callee(nrs-session-cleanup) 헤더의 ordinal/before-after 표현은 dispatcher 변경 시 stale 위험이 가장 크므로 SoT 단일화로 제거하고 "Codex Stop dispatcher 경유로만 호출됨" 수준으로 낮춰 `_stop-dispatcher.sh` 헤더가 ordering 진실 원천임을 참조하게 했다.

**Timeout 숫자 SoT**: dispatcher 헤더의 ordering rationale에서 구체 숫자(`4s`, `2s`, `~3s`)를 제거하고 `stop-notification.sh`의 `HS_NOTIFY_TIMEOUT_SECONDS` / `PUSHOVER_TIMEOUT_SECONDS` / `TRANSCRIPT_STABLE_*` 상수가 SoT임을 참조했다. 이후 timeout 조정 시 dispatcher 주석이 stale해지지 않게 한다.

**Fixture 인자 순서 정렬**: `install_mock_subscripts_with_log` 인자 순서(`rls_rc, sn_rc, nsc_rc`)와 dispatcher 호출 순서가 어긋나면 향후 수정자가 인자 순서를 dispatcher 순서로 착각하기 쉬우므로, 인자 순서를 dispatcher 순서(`rls_rc, nsc_rc, sn_rc`)로 swap했다. `test_dispatcher_recovers_from_subscript_failures` 시나리오 정렬도 동기화했다.

**Hook 경로 lock**: 전수조사에서 cleanup 직후 ~ms 안에 다른 worktree의 `nrs`가 rebuild + `nrs-relink`로 `~/.codex/hooks/*` symlink를 다른 worktree로 갈아치워, 마지막에 호출되는 `stop-notification`이 다른 checkout의 hook 코드로 실행될 수 있는 이론적 race를 발견했다. 실제 nrs rebuild는 최소 수십 초가 걸려 stop-notification fork 시점에 relink가 완료될 가능성이 거의 0이지만, 이번 변경 전 순서에는 없던 _이론적_ regression이라 dispatcher 진입 시점에 `BASH_SOURCE`를 `readlink -f`로 한 번 resolve해 sub-script 경로를 lock하는 방어 조치를 본 PR에 병합했다. rebuild 시간 의존이 아닌 구조적 보장이다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 옵션 A: cleanup을 notification 앞으로 | record-last-stop → nrs-session-cleanup → stop-notification | 가장 단순, race risk 최저, lifecycle 의존 없음 | A 잠재 단점은 실용상 무시 가능 | ✅ |
| 옵션 B: notification을 background `&`로 | dispatcher가 stop-notification을 bg 발사 후 cleanup 실행 | dispatcher exit 빠름 | dispatcher exit 후 codex hook process 생존성 [UNVERIFIED] | ❌ |
| 옵션 C: bounded background + brief wait | bg 발사 후 1초 wait 후 cleanup | 절충안 | 같은 lifecycle 우려 + 1초 추가 지연 | ❌ |
| nrs-session-cleanup 헤더 ordinal 유지 | callee 헤더에 "두 번째 sub-script (record-last-stop 직후, stop-notification 앞)" 명시 | 단일 파일에서 호출 계약 즉시 확인 | 향후 dispatcher 순서 변경 시 callee 헤더 stale 위험 | ❌ |
| nrs-session-cleanup 헤더 SoT 단일화 | callee 헤더는 "Codex Stop dispatcher 경유로만 호출됨"만, ordinal/rationale은 dispatcher가 SoT | drift 위험 제거, single source of truth | callee만 보면 호출 위치 모름 (dispatcher 헤더 추가 참조 필요) | ✅ |
| dispatcher 주석에 timeout 숫자 박제 | `Pushover --max-time 4s, hs.notify timeout 2s, ~3s` 같이 구체값 명시 | 즉시 latency 근거 확인 | timeout 상수 변경 시 dispatcher 주석 stale | ❌ |
| dispatcher 주석에 timeout 상수명 참조 | `stop-notification.sh의 HS_NOTIFY_TIMEOUT_SECONDS / PUSHOVER_TIMEOUT_SECONDS / TRANSCRIPT_STABLE_* 상수가 SoT` | drift 차단, 자기참조 SoT 명시 | 구체값은 별도 파일 봐야 확인 가능 | ✅ |
| dispatcher 호출 시점 path 해석 (현재 동작) | `$HOME/.codex/hooks/...`로 매 호출 시점 symlink resolve | 단순 | 호출 사이에 symlink relink 가능성(이론적 race) | ❌ |
| dispatcher 진입 시점 `readlink -f` lock | `HOOKS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")`로 진입 시점 한 번 resolve | hook 사본 일관성 구조적 보장 | NixOS/nix-darwin의 GNU `readlink -f` 의존 (이미 다른 hook도 jq/git 가정) | ✅ |
| fixture helper 인자 순서 유지 (`rls_rc, sn_rc, nsc_rc`) | 인자 순서를 sub-script 별 exit code 매핑으로 둠 | 변경 최소 | dispatcher 호출 순서와 어긋나 mental model 분기 | ❌ |
| fixture helper 인자 순서를 dispatcher 순서로 정렬 | `rls_rc, nsc_rc, sn_rc`로 swap, 시나리오 정렬도 동기화 | runtime/oracle/helper mental model 일관 | 호출 사이트 변수 매핑 동기화 필요 (1 함수, 2 호출) | ✅ |

## 5. 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh` | `run_hook` 호출 순서 swap (record-last-stop → nrs-session-cleanup → stop-notification) + 헤더 ordering rationale 추가 (timeout 숫자 대신 stop-notification.sh 상수 참조) + inline 순번 주석 갱신 + dispatcher 진입 시점 `HOOKS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")`로 sub-script 경로 lock |
| `modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh` | 헤더 호출 계약을 "Codex Stop dispatcher 경유로만 호출됨"으로 단일화하고 dispatcher 헤더가 ordering SoT임을 참조 + Claude 원본 배경 주석을 "Claude 원본 배경:"으로 명시 격리. 본문 sub-script 로직 미변경 |
| `modules/shared/programs/codex/default.nix` | line 99-100 노출부 ordering 주석을 신순서로 동기화 |
| `tests/lib/codex-hook-expectations.sh` | `EXPECTED_DISPATCHER_SUB_SCRIPTS` 배열 element 순서 swap + 인접 oracle 주석 신순서 동기화 |
| `tests/test-codex-hook-fixtures.sh` | `install_mock_subscripts_with_log` 인자 순서를 dispatcher 호출 순서로 swap (`rls_rc, sn_rc, nsc_rc` → `rls_rc, nsc_rc, sn_rc`) + `test_dispatcher_recovers_from_subscript_failures` 시나리오 정렬 + 호출 사이트 변수 매핑 동기화 |

핵심 dispatcher 본문 (변경 후):

```bash
set -u
INPUT=$(cat)

# Sub-script 경로를 dispatcher 시작 시점에 한 번 resolve한다. (race 차단 의도 — issue #590)
HOOKS_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")

run_hook() {
  local name="$1"
  local path="$2"
  if ! printf '%s' "$INPUT" | "$path"; then
    printf 'codex stop dispatcher: %s exited non-zero (continuing)\n' "$name" >&2
  fi
}

run_hook record-last-stop      "$HOOKS_DIR/record-last-stop.sh"      # 1번: 타임스탬프 first-write
run_hook nrs-session-cleanup   "$HOOKS_DIR/nrs-session-cleanup.sh"   # 2번: nrs lock 즉시 해제 (notification 외부 IPC 차단 회피)
run_hook stop-notification     "$HOOKS_DIR/stop-notification.sh"     # 3번: Pushover/Hammerspoon 알림

exit 0
```

PoC 측정 (NixOS MiniPC, sandbox HOME + `curl` mock 4초 sleep으로 Pushover `--max-time` upper bound 시뮬레이션, mock `/tmp/nrs-state` lock + dead PID + 폴링 listener 10ms 해상도):

| 지표 | 변경 전 | 변경 후 |
|---|---|---|
| `cleanup_latency` | 4.126s | **0.056s** |
| `dispatcher_wallclock` | 4.118s | 4.112s |
| `dispatcher_after_cleanup` | -0.008s (cleanup이 dispatcher exit 시점) | 4.057s (notification은 cleanup 후 정상 진행) |

cleanup이 외부 IPC와 분리되어 lock 해제가 ≈74배 빨라졌다. dispatcher wall-clock은 동일(notification은 마지막 단계로 그대로 실행).

## 6. 참고 레퍼런스

- 이슈: [#590](https://github.com/greenheadHQ/nixos-config/issues/590)
- 회귀 검증 fixture 도입: [#586](https://github.com/greenheadHQ/nixos-config/issues/586) (closed)
- Codex 0.124+ stable hooks 도입 PR: [#588](https://github.com/greenheadHQ/nixos-config/pull/588)
- Stop 알림 신뢰성/보안 PR: [#597](https://github.com/greenheadHQ/nixos-config/pull/597) (helper-equivalence marker 영향 없음 — sub-script 내부 미변경)
- Codex hooks 1차 소스: https://developers.openai.com/codex/hooks
- Pushover API 1차 소스: https://pushover.net/api

## 7. Human Test Plan

| # | 단계 | 기대 동작 | 실패 시 진단 |
|---|---|---|---|
| 1 | NixOS MiniPC에서 codex 세션 종료 | `/tmp/nrs-state` lock 즉시 부재 (`ls /tmp/nrs-state` 직후) + Pushover 알림은 수 초 후 도착 | dispatcher가 새 ordering으로 호출되는지 `~/.codex/hooks/_stop-dispatcher.sh` 직접 확인. `agenix` Pushover credential 활성 확인 |
| 2 | macOS(nix-darwin)에서 codex 세션 종료 | lock 즉시 부재 + Hammerspoon 데스크탑 배너 발화 | `command -v hs` 확인. `~/.hammerspoon/init.lua` URL handler 등록 확인 |
| 3 | 동시 worktree 시나리오 — worktree A의 codex 세션 종료 직후 worktree B에서 `nrs` 호출 | B가 거의 즉시 lock 획득 (수 ms) | A의 `_stop-dispatcher.sh`가 cleanup → stop-notification 순서로 호출하는지 확인. `/tmp/nrs-state`의 PID가 A 셸 종료 후 dead 상태인지 확인 |
| 4 | dispatcher fixture 회귀 자동 검증 | `bash tests/test-codex-hook-fixtures.sh` 통과 (10 카테고리 모두 PASS, "All codex hook fixture tests passed.") | 실패 카테고리의 `==>` 라인 + 마지막 `FAIL:` 메시지 확인 |
| 5 | dispatcher 진입 path resolve 검증 | dispatcher가 worktree에서 호출되더라도 `$HOOKS_DIR`이 그 worktree의 hook directory를 가리킴 | dispatcher 안에서 `HOOKS_DIR` 값을 echo하는 임시 trace 추가, 또는 `bash -x` 로 trace 확인 |
| 6 | ordering 주석 일관성 grep | `rg "record-last-stop → stop-notification → nrs-session-cleanup"` 매치 0건 | 매치된 위치를 신순서로 갱신 |

## 8. Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 헤더 주석 ordering rationale 존재 + 신순서 명시
grep -n "Ordering rationale (issue #590)" modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh
grep -n "record-last-stop → nrs-session-cleanup → stop-notification" modules/shared/programs/codex/default.nix tests/lib/codex-hook-expectations.sh

# dispatcher 진입 시점 readlink -f resolve 확인
grep -n 'HOOKS_DIR=$(dirname.*readlink -f.*BASH_SOURCE' modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh

# 옛 ordering 잔존 확인 (매치 0건이어야 함)
! rg -n "record-last-stop → stop-notification → nrs-session-cleanup"

# fixture oracle 배열 신순서 확인
grep -n "EXPECTED_DISPATCHER_SUB_SCRIPTS=(record-last-stop.sh nrs-session-cleanup.sh stop-notification.sh)" tests/lib/codex-hook-expectations.sh

# nrs-session-cleanup callee 헤더에서 ordinal 표현 부재
! grep -E "두 번째 sub-script|마지막 단계로만 호출" modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh

# fixture helper 인자 순서 dispatcher 순서로 정렬
grep -n 'rls_rc="\${3:-0}" nsc_rc="\${4:-0}" sn_rc="\${5:-0}"' tests/test-codex-hook-fixtures.sh
```

기대: 모든 grep PASS, `!` rg/grep은 비매치.

### Phase 1: fixture self-test

```bash
bash tests/test-codex-hook-fixtures.sh
```

기대: `All codex hook fixture tests passed.` + 카테고리 10개 라인. 카테고리 2 `dispatcher ordering with mock sub-scripts` / `dispatcher recovers from sub-script failures` 신순서 통과.

실패 시: 마지막 `FAIL:` 메시지의 prefix로 시나리오 즉시 식별.

### Phase 2: shellcheck

```bash
shellcheck modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh \
           modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh \
           tests/lib/codex-hook-expectations.sh \
           tests/test-codex-hook-fixtures.sh
```

기대: 변경 라인에서 신규 경고 없음 (기존 SC2016 info는 본 PR 무관).

### Phase 3: 수동 PoC 재측정 (선택)

```bash
# /tmp/nrs-state 충돌 회피
[ -f /tmp/nrs-state ] && { echo "ABORT: production lock present"; exit 1; }

# dead PID
DEAD_PID=99999
while kill -0 "$DEAD_PID" 2>/dev/null; do DEAD_PID=$((DEAD_PID+1)); done

# sandbox setup
SANDBOX=$(mktemp -d /tmp/poc-sandbox-XXXXXX)
mkdir -p "$SANDBOX/.codex/hooks" "$SANDBOX/.config/pushover" "$SANDBOX/bin"
for f in _stop-dispatcher.sh record-last-stop.sh stop-notification.sh nrs-session-cleanup.sh; do
  ln -sf "$HOME/.codex/hooks/$f" "$SANDBOX/.codex/hooks/$f"
done
printf 'PUSHOVER_TOKEN=fake\nPUSHOVER_USER=fake\n' > "$SANDBOX/.config/pushover/claude-code"
cat > "$SANDBOX/bin/curl" <<'STUB'
#!/usr/bin/env bash
sleep 4
exit 0
STUB
chmod +x "$SANDBOX/bin/curl"

# mock lock + listener
printf '{"worktree":"%s","pid":%d}\n' "$(git rev-parse --show-toplevel)" "$DEAD_PID" > /tmp/nrs-state
(while [ -f /tmp/nrs-state ]; do sleep 0.01; done; date +%s.%N > /tmp/cleanup-t1) &
LISTENER=$!

T0=$(date +%s.%N)
echo '{"hook_event_name":"Stop","cwd":"'"$(git rev-parse --show-toplevel)"'","last_assistant_message":"poc","session_id":"poc","transcript_path":"/dev/null"}' \
  | env -u CLAUDECODE -u CODEX_PROGRAMMATIC HOME="$SANDBOX" PATH="$SANDBOX/bin:$PATH" \
    "$SANDBOX/.codex/hooks/_stop-dispatcher.sh"
DE=$(date +%s.%N)

for _ in $(seq 1 1000); do [ -f /tmp/cleanup-t1 ] && break; sleep 0.01; done
T1=$(cat /tmp/cleanup-t1 2>/dev/null || echo "$DE")
kill $LISTENER 2>/dev/null; wait $LISTENER 2>/dev/null

python3 -c "T0=$T0; T1=$T1; DE=$DE; print(f'cleanup_latency_s={T1-T0:.3f} dispatcher_wallclock_s={DE-T0:.3f}')"

rm -rf "$SANDBOX" /tmp/nrs-state /tmp/cleanup-t1
```

기대: `cleanup_latency_s` < 0.5, `dispatcher_wallclock_s` ≈ 4.0 (curl mock의 sleep 4 만큼).

### Phase 4: regression 부재 확인

```bash
# 기존 카테고리 1, 3, 4, 5, 6은 변경 없이 통과
bash tests/test-codex-hook-fixtures.sh 2>&1 | grep -E "stdin payloads|noise-guard|sync-codex-config|stop-notification (codex transcript fallback|secret redaction|timeout unavailable|helper equivalence)" | wc -l
# 기대: 6 (카테고리 1, 3, 4, 6.1, 6.2, 6.3, 6.4 — 6.3은 non-Darwin runner에서 WARN skip이지만 라인은 출력됨)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reordered shutdown hooks to ensure session cleanup executes before stop notifications, improving system reliability and preventing lock-release timing issues.
  * Enhanced consistency of hook execution across different environments during shutdown operations.

* **Documentation**
  * Updated documentation and test expectations to reflect the revised shutdown hook execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->