### PR TITLE
feat(hooks): PostToolUse warn-only pinning alert (Claude+Codex)

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -163,6 +163,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/fragile-hardcoding-guard.sh";
     ".claude/hooks/system-bash-guard.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/system-bash-guard.sh";
+    ".claude/hooks/pinning-alert.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/pinning-alert.sh";
     # Cache TTL tracking hooks
     ".claude/hooks/record-last-stop.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-last-stop.sh";

--- a/modules/shared/programs/claude/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-alert.sh
@@ -4,7 +4,9 @@
 # 패턴 SSOT: scripts/ai/commit-msg-pinning.sh (PATTERN_A/B/C/D + HASH_MIN/MAX).
 #   ↑ 본 파일은 그 SSOT의 inline 사본이다. commit-msg-pinning.sh 패턴을 갱신할 때 본 파일 +
 #     Codex 사본(modules/shared/programs/codex/files/hooks/pinning-alert.sh)도 함께
-#     갱신해야 한다 (lockstep 갱신 의무, drift 감지 자동화 없음 — 운영 검증으로 대체).
+#     갱신해야 한다. lockstep 동등성은 scripts/ai/verify-ai-compat.sh가 PATTERN_A/B/C/D +
+#     HASH_MIN/MAX 변수 라인 동등성으로 강제한다 (helper/scan/eligibility까지 cover하지는
+#     않으므로 _should_check_path / _scan_file 본문 변경 시 두 사본을 수동 정합 필요).
 # 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
 #
 # pipefail 안전 모델 (commit-msg-pinning.sh:26-29와 동일 SSOT):

--- a/modules/shared/programs/claude/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-alert.sh
@@ -70,7 +70,7 @@ HASH_MAX=12
 PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
 PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Maintainability|MAINTAINABILITY|Security|SECURITY|Hallucination|HALLUCINATION|Side_effect|SIDE_EFFECT|Consistency|CONSISTENCY|Readability|READABILITY|Clean_code|CLEAN_CODE|Yagni|YAGNI|Ngmi|NGMI|CORR|MAINT|MNT|REG|CIR)-[0-9][A-Za-z0-9-]*\b'
 PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
-PATTERN_D='\b[a-f0-9]{7,40}\b'
+PATTERN_D='\b[a-f0-9]{7,40}\b|`[a-f0-9]+`'
 
 # 검사 텍스트를 mktemp 파일에 저장 후 파일 기반 grep으로 SIGPIPE 회피.
 SCAN_FILE=$(mktemp "${TMPDIR:-/tmp}/pinning-scan-XXXXXX") || exit 0

--- a/modules/shared/programs/claude/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-alert.sh
@@ -6,6 +6,11 @@
 #     Codex 사본(modules/shared/programs/codex/files/hooks/pinning-alert.sh)도 함께
 #     갱신해야 한다 (lockstep 갱신 의무, drift 감지 자동화 없음 — 운영 검증으로 대체).
 # 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
+#
+# pipefail 안전 모델 (commit-msg-pinning.sh:26-29와 동일 SSOT):
+#   `printf '%s' "$TEXT" | grep -qE ...` 조합은 큰 입력에서 grep -q 조기 종료 + SIGPIPE로
+#   producer가 nonzero를 반환해 pipefail 환경에서 silent miss를 만든다. 검사 텍스트를 mktemp
+#   파일에 저장하고 `grep -qE "$PATTERN" "$tmpfile"`로 검사하여 회피한다.
 set -euo pipefail
 
 # 환경 가드(CLAUDECODE/CODEX_PROGRAMMATIC) 없음 — PostToolUse pinning-alert는 자식 LLM 세션의
@@ -67,17 +72,22 @@ PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Mainta
 PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
 PATTERN_D='\b[a-f0-9]{7,40}\b'
 
+# 검사 텍스트를 mktemp 파일에 저장 후 파일 기반 grep으로 SIGPIPE 회피.
+SCAN_FILE=$(mktemp "${TMPDIR:-/tmp}/pinning-scan-XXXXXX") || exit 0
+trap 'rm -f "$SCAN_FILE"' EXIT
+printf '%s' "$TEXT" > "$SCAN_FILE"
+
 findings=""
-if printf '%s' "$TEXT" | grep -qE "$PATTERN_A"; then
+if grep -qE "$PATTERN_A" "$SCAN_FILE"; then
   findings="${findings}\n  - Round counter 박제: 'Round N'"
 fi
-if printf '%s' "$TEXT" | grep -qE "$PATTERN_B"; then
+if grep -qE "$PATTERN_B" "$SCAN_FILE"; then
   findings="${findings}\n  - Bundle finding ID 박제: 'Bundle-N'"
 fi
-if printf '%s' "$TEXT" | grep -qE "$PATTERN_C"; then
+if grep -qE "$PATTERN_C" "$SCAN_FILE"; then
   findings="${findings}\n  - DA 실행 키워드 박제"
 fi
-if printf '%s' "$TEXT" | grep -oE "$PATTERN_D" 2>/dev/null \
+if grep -oE "$PATTERN_D" "$SCAN_FILE" 2>/dev/null \
   | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
        length($0) >= min && length($0) <= max && /[a-f]/ { found = 1 }
        END { exit !found }

--- a/modules/shared/programs/claude/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-alert.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# pinning-alert.sh — PostToolUse Edit/Write/NotebookEdit warn-only alert (Claude Code).
+# 정책 출처: https://github.com/greenheadHQ/nixos-config/issues/603
+# 패턴 SSOT: scripts/ai/commit-msg-pinning.sh (PATTERN_A/B/C/D + HASH_MIN/MAX).
+#   ↑ 본 파일은 그 SSOT의 inline 사본이다. commit-msg-pinning.sh 패턴을 갱신할 때 본 파일 +
+#     Codex 사본(modules/shared/programs/codex/files/hooks/pinning-alert.sh)도 함께
+#     갱신해야 한다 (lockstep 갱신 의무, drift 감지 자동화 없음 — 운영 검증으로 대체).
+# 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
+set -euo pipefail
+
+# 환경 가드(CLAUDECODE/CODEX_PROGRAMMATIC) 없음 — PostToolUse pinning-alert는 자식 LLM 세션의
+# Edit/Write를 부모가 보지 못하기 때문에 항상 검사해야 한다 (record-prompt-submit/stop-notification
+# 등의 부모-처리-신뢰 가드와 의미가 다르다). 중복 alert는 운영 noise로 수용.
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+case "$TOOL_NAME" in
+  Edit | Write | NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '
+  .tool_input.file_path
+  // .tool_input.notebook_path
+  // empty
+' 2>/dev/null)
+[ -n "$FILE_PATH" ] || exit 0
+
+# 파일 한정 (실측: .md 317 + .sh 11 + mktemp tmpfile ~35 ≈ 박제 매치의 ~98.5% cover, 이슈 #603 본문).
+# mktemp tmpfile은 모두 `body` substring을 가진 PR/issue body 작성 임시 파일이었으므로 그 형태로
+# 한정한다. 일반 코드 확장자(.ts/.py/.nix 등)가 임시 디렉토리 안에 있어도 false positive 회피.
+case "$FILE_PATH" in
+  *.md | *.sh) ;;
+  /tmp/*body* | /var/folders/*/T/*body*) ;;
+  *) exit 0 ;;
+esac
+
+# Self-exclude: 정책 정의 파일, 본 hook 자기 자신, fixture/eval 데이터
+case "$FILE_PATH" in
+  */hooks/pinning-alert.sh) exit 0 ;;
+  */scripts/ai/commit-msg-pinning.sh) exit 0 ;;
+  */skills/run-da/*) exit 0 ;;
+  */skills/parallel-audit/*) exit 0 ;;
+  */tests/fixtures/*) exit 0 ;;
+  */evals/queries.json) exit 0 ;;
+  */eval-workspace/*) exit 0 ;;
+esac
+
+# 검사 대상 텍스트 추출
+TEXT=""
+case "$TOOL_NAME" in
+  Edit) TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null) ;;
+  Write) TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null) ;;
+  NotebookEdit) TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_source // empty' 2>/dev/null) ;;
+esac
+[ -n "$TEXT" ] || exit 0
+
+# Pinning hash 길이 경계 (commit-msg-pinning.sh와 동일)
+HASH_MIN=7
+HASH_MAX=12
+
+# Patterns (commit-msg-pinning.sh PATTERN_A~D와 동일 — lockstep 갱신)
+PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
+PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Maintainability|MAINTAINABILITY|Security|SECURITY|Hallucination|HALLUCINATION|Side_effect|SIDE_EFFECT|Consistency|CONSISTENCY|Readability|READABILITY|Clean_code|CLEAN_CODE|Yagni|YAGNI|Ngmi|NGMI|CORR|MAINT|MNT|REG|CIR)-[0-9][A-Za-z0-9-]*\b'
+PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
+PATTERN_D='\b[a-f0-9]{7,40}\b'
+
+findings=""
+if printf '%s' "$TEXT" | grep -qE "$PATTERN_A"; then
+  findings="${findings}\n  - Round counter 박제: 'Round N'"
+fi
+if printf '%s' "$TEXT" | grep -qE "$PATTERN_B"; then
+  findings="${findings}\n  - Bundle finding ID 박제: 'Bundle-N'"
+fi
+if printf '%s' "$TEXT" | grep -qE "$PATTERN_C"; then
+  findings="${findings}\n  - DA 실행 키워드 박제"
+fi
+if printf '%s' "$TEXT" | grep -oE "$PATTERN_D" 2>/dev/null \
+  | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
+       length($0) >= min && length($0) <= max && /[a-f]/ { found = 1 }
+       END { exit !found }
+     '; then
+  findings="${findings}\n  - Partial commit hash 박제 (${HASH_MIN}~${HASH_MAX}자)"
+fi
+
+if [ -n "$findings" ]; then
+  printf '[pinning-alert] %s on %s 매치:%b\n' "$TOOL_NAME" "$FILE_PATH" "$findings" >&2
+fi
+
+exit 0

--- a/modules/shared/programs/claude/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-alert.sh
@@ -89,7 +89,8 @@ if grep -qE "$PATTERN_C" "$SCAN_FILE"; then
 fi
 if grep -oE "$PATTERN_D" "$SCAN_FILE" 2>/dev/null \
   | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
-       length($0) >= min && length($0) <= max && /[a-f]/ { found = 1 }
+       { tok = $0; gsub(/`/, "", tok);
+         if (length(tok) >= min && length(tok) <= max && tok ~ /[a-f]/) found = 1 }
        END { exit !found }
      '; then
   findings="${findings}\n  - Partial commit hash 박제 (${HASH_MIN}~${HASH_MAX}자)"

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -150,6 +150,15 @@
             "command": "~/.local/bin/nrs-relink fix-dangling"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pinning-alert.sh"
+          }
+        ]
       }
     ]
   },

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -109,6 +109,9 @@ in
       config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/codex/files/hooks/nrs-session-cleanup.sh";
     ".codex/hooks/_stop-dispatcher.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh";
+    # PostToolUse pinning-alert hook (issue #603) — apply_patch envelope + Edit/Write/NotebookEdit warn-only.
+    ".codex/hooks/pinning-alert.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/codex/files/hooks/pinning-alert.sh";
   }
   # 글로벌 스킬 (Claude와 동일 소스 공유) — exposedCodexSkills에서 자동 생성
   // codexSkillEntries;

--- a/modules/shared/programs/codex/files/config.darwin.toml
+++ b/modules/shared/programs/codex/files/config.darwin.toml
@@ -26,13 +26,14 @@ voice_transcription = true
 # subagent agent_id 부재 등은 graceful fallback에 의존.
 #
 # 사용자 hook 추가 워크플로 주의 (sync-codex-config.py 정책):
-# template이 선언한 `[[hooks.UserPromptSubmit]]` 또는 `[[hooks.Stop]]` array에 사용자가
-# 별도 entry를 추가하면, nrs 재실행 시 array 전체가 template-owned로 덮어써져 사용자
-# entry가 손실된다. 보존되는 사용자 hook 등록은 다음 한 가지뿐이다:
+# template이 선언한 `[[hooks.UserPromptSubmit]]`, `[[hooks.Stop]]`, `[[hooks.PostToolUse]]`
+# array에 사용자가 별도 entry를 추가하면, nrs 재실행 시 array 전체가 template-owned로
+# 덮어써져 사용자 entry가 손실된다. 보존되는 사용자 hook 등록은 다음 한 가지뿐이다:
 #   - template이 선언하지 않은 다른 이벤트(`PreToolUse`/`SessionStart` 등)에 추가.
 # Stop dispatcher 경유 sub-script 등록은 _stop-dispatcher.sh 자체가 tracked 파일이므로
 # 본 repo의 dispatcher 수정이 필요하며 user-config 작업으로는 지원되지 않는다.
 # same-event append/identity merge는 sync-codex-config.py 변경 필요로 별도 follow-up.
+# PostToolUse pinning-alert는 issue #603에서 template-owned로 등록되었다.
 
 [[hooks.UserPromptSubmit]]
 
@@ -45,6 +46,12 @@ command = "$HOME/.codex/hooks/record-prompt-submit.sh"
 [[hooks.Stop.hooks]]
 type = "command"
 command = "$HOME/.codex/hooks/_stop-dispatcher.sh"
+
+[[hooks.PostToolUse]]
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "$HOME/.codex/hooks/pinning-alert.sh"
 
 [plugins."github@openai-curated"]
 enabled = true

--- a/modules/shared/programs/codex/files/config.toml
+++ b/modules/shared/programs/codex/files/config.toml
@@ -25,13 +25,14 @@ prevent_idle_sleep = true
 # subagent agent_id 부재 등은 graceful fallback에 의존.
 #
 # 사용자 hook 추가 워크플로 주의 (sync-codex-config.py 정책):
-# template이 선언한 `[[hooks.UserPromptSubmit]]` 또는 `[[hooks.Stop]]` array에 사용자가
-# 별도 entry를 추가하면, nrs 재실행 시 array 전체가 template-owned로 덮어써져 사용자
-# entry가 손실된다. 보존되는 사용자 hook 등록은 다음 한 가지뿐이다:
+# template이 선언한 `[[hooks.UserPromptSubmit]]`, `[[hooks.Stop]]`, `[[hooks.PostToolUse]]`
+# array에 사용자가 별도 entry를 추가하면, nrs 재실행 시 array 전체가 template-owned로
+# 덮어써져 사용자 entry가 손실된다. 보존되는 사용자 hook 등록은 다음 한 가지뿐이다:
 #   - template이 선언하지 않은 다른 이벤트(`PreToolUse`/`SessionStart` 등)에 추가.
 # Stop dispatcher 경유 sub-script 등록은 _stop-dispatcher.sh 자체가 tracked 파일이므로
 # 본 repo의 dispatcher 수정이 필요하며 user-config 작업으로는 지원되지 않는다.
 # same-event append/identity merge는 sync-codex-config.py 변경 필요로 별도 follow-up.
+# PostToolUse pinning-alert는 issue #603에서 template-owned로 등록되었다.
 
 [[hooks.UserPromptSubmit]]
 
@@ -44,3 +45,9 @@ command = "$HOME/.codex/hooks/record-prompt-submit.sh"
 [[hooks.Stop.hooks]]
 type = "command"
 command = "$HOME/.codex/hooks/_stop-dispatcher.sh"
+
+[[hooks.PostToolUse]]
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "$HOME/.codex/hooks/pinning-alert.sh"

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -4,7 +4,9 @@
 # 패턴 SSOT: scripts/ai/commit-msg-pinning.sh (PATTERN_A/B/C/D + HASH_MIN/MAX).
 #   ↑ 본 파일은 그 SSOT의 inline 사본이다. commit-msg-pinning.sh 패턴을 갱신할 때 본 파일 +
 #     Claude 사본(modules/shared/programs/claude/files/hooks/pinning-alert.sh)도 함께
-#     갱신해야 한다 (lockstep 갱신 의무, drift 감지 자동화 없음 — 운영 검증으로 대체).
+#     갱신해야 한다. lockstep 동등성은 scripts/ai/verify-ai-compat.sh가 PATTERN_A/B/C/D +
+#     HASH_MIN/MAX 변수 라인 동등성으로 강제한다 (helper/scan/eligibility까지 cover하지는
+#     않으므로 _should_check_path / _scan_file 본문 변경 시 두 사본을 수동 정합 필요).
 # 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
 #
 # pipefail 안전 모델 (commit-msg-pinning.sh:26-29와 동일 SSOT):

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# pinning-alert.sh — Codex 0.124+ PostToolUse warn-only alert.
+# 정책 출처: https://github.com/greenheadHQ/nixos-config/issues/603
+# 패턴 SSOT: scripts/ai/commit-msg-pinning.sh (PATTERN_A/B/C/D + HASH_MIN/MAX).
+#   ↑ 본 파일은 그 SSOT의 inline 사본이다. commit-msg-pinning.sh 패턴을 갱신할 때 본 파일 +
+#     Claude 사본(modules/shared/programs/claude/files/hooks/pinning-alert.sh)도 함께
+#     갱신해야 한다 (lockstep 갱신 의무, drift 감지 자동화 없음 — 운영 검증으로 대체).
+# 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
+#
+# Codex 0.125 PostToolUse stdin schema 실측 (issue #603 Phase 0):
+#   - tool_name="Bash"        → tool_input.command (shell command text)
+#   - tool_name="apply_patch" → tool_input.command (V4A patch envelope text)
+#       envelope: '*** Begin Patch\n*** {Update,Add,Delete} File: <path>\n@@\n+<line>\n*** End Patch'
+#       matcher alias `Edit|Write|NotebookEdit`로 매칭은 트리거되지만 stdin tool_name은 apply_patch.
+#       (openai/codex#18391 + 본 PR Phase 0 echo hook 캡처)
+#   - tool_name="Edit|Write|NotebookEdit" → Claude Code-호환 키 (.tool_input.file_path / .new_string /
+#     .content / .new_source). Codex 0.125에서는 미관측이지만 미래 호환을 위해 fallback path 유지.
+set -euo pipefail
+
+# 환경 가드(CLAUDECODE/CODEX_PROGRAMMATIC) 없음 — PostToolUse pinning-alert는 자식 LLM 세션의
+# Edit/Write/apply_patch를 부모가 보지 못하기 때문에 항상 검사해야 한다
+# (record-prompt-submit/stop-notification 등의 부모-처리-신뢰 가드와 의미가 다르다).
+# Claude Code 안에서 Codex programmatic subprocess가 호출되면 부모 Claude hook은
+# Bash matcher만 검사하고 Codex 안의 Edit/apply_patch는 못 보므로 자식 Codex hook이 직접
+# 검사해야 박제를 놓치지 않는다. 중복 alert는 운영 noise로 수용.
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+
+# Pinning hash 길이 경계 (commit-msg-pinning.sh와 동일)
+HASH_MIN=7
+HASH_MAX=12
+
+# Patterns (commit-msg-pinning.sh PATTERN_A~D와 동일 — lockstep 갱신)
+PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
+PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Maintainability|MAINTAINABILITY|Security|SECURITY|Hallucination|HALLUCINATION|Side_effect|SIDE_EFFECT|Consistency|CONSISTENCY|Readability|READABILITY|Clean_code|CLEAN_CODE|Yagni|YAGNI|Ngmi|NGMI|CORR|MAINT|MNT|REG|CIR)-[0-9][A-Za-z0-9-]*\b'
+PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
+PATTERN_D='\b[a-f0-9]{7,40}\b'
+
+# 검사 대상 후보 (file_path, text) 쌍을 표준 출력 친화적 형태로 모은다.
+# 단일 파일 케이스(Edit/Write/NotebookEdit)는 1쌍, apply_patch envelope는 N쌍.
+# 각 쌍은 newline-separated `path\ttext_marker_id`로 표현하지 않고, 함수 호출 + 직접 grep으로 처리.
+
+# 공통: file path가 본 hook 검사 대상에 부합하는지 판정. 통과하면 0, skip이면 1.
+# mktemp tmpfile 한정: 실측 35건 모두 `body` substring(PR/issue body 작성 임시) → 그 형태로 한정.
+# 일반 코드 확장자(.ts/.py/.nix 등)가 임시 디렉토리 안에 있어도 false positive 회피.
+_should_check_path() {
+  local p="$1"
+  case "$p" in
+    *.md | *.sh) ;;
+    /tmp/*body* | /var/folders/*/T/*body*) ;;
+    *) return 1 ;;
+  esac
+  case "$p" in
+    */hooks/pinning-alert.sh) return 1 ;;
+    */scripts/ai/commit-msg-pinning.sh) return 1 ;;
+    */skills/run-da/*) return 1 ;;
+    */skills/parallel-audit/*) return 1 ;;
+    */tests/fixtures/*) return 1 ;;
+    */evals/queries.json) return 1 ;;
+    */eval-workspace/*) return 1 ;;
+  esac
+  return 0
+}
+
+# 공통: TEXT를 받아 패턴 4종 검사 후 매치된 finding 라인을 stdout으로 출력한다 (없으면 빈 출력).
+_scan_text() {
+  local text="$1"
+  local out=""
+  if printf '%s' "$text" | grep -qE "$PATTERN_A"; then
+    out="${out}\n  - Round counter 박제: 'Round N'"
+  fi
+  if printf '%s' "$text" | grep -qE "$PATTERN_B"; then
+    out="${out}\n  - Bundle finding ID 박제: 'Bundle-N'"
+  fi
+  if printf '%s' "$text" | grep -qE "$PATTERN_C"; then
+    out="${out}\n  - DA 실행 키워드 박제"
+  fi
+  if printf '%s' "$text" | grep -oE "$PATTERN_D" 2>/dev/null \
+    | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
+        length($0) >= min && length($0) <= max && /[a-f]/ { found = 1 }
+        END { exit !found }
+      '; then
+    out="${out}\n  - Partial commit hash 박제 (${HASH_MIN}~${HASH_MAX}자)"
+  fi
+  printf '%b' "$out"
+}
+
+case "$TOOL_NAME" in
+  Edit | Write | NotebookEdit)
+    # Claude Code-호환 단일 파일 케이스 (Codex 0.125에서는 미관측이지만 미래 호환).
+    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '
+      .tool_input.file_path
+      // .tool_input.notebook_path
+      // empty
+    ' 2>/dev/null)
+    [ -n "$FILE_PATH" ] || exit 0
+    _should_check_path "$FILE_PATH" || exit 0
+
+    case "$TOOL_NAME" in
+      Edit) TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null) ;;
+      Write) TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null) ;;
+      NotebookEdit) TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_source // empty' 2>/dev/null) ;;
+    esac
+    [ -n "$TEXT" ] || exit 0
+
+    findings="$(_scan_text "$TEXT")"
+    if [ -n "$findings" ]; then
+      printf '[pinning-alert] %s on %s 매치:%b\n' "$TOOL_NAME" "$FILE_PATH" "$findings" >&2
+    fi
+    ;;
+  apply_patch)
+    # Codex 0.125 V4A apply_patch envelope: tool_input.command 안에 patch text.
+    # patch text에서 `*** {Update,Add,Delete} File: <path>` 헤더로 영향 파일 목록을 추출하고,
+    # 하나라도 검사 대상에 부합하면 patch text 전체에 박제 grep을 수행한다.
+    PATCH_TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+    [ -n "$PATCH_TEXT" ] || exit 0
+
+    SHOULD_CHECK=0
+    REPORTED_PATH=""
+    while IFS= read -r p; do
+      [ -n "$p" ] || continue
+      if _should_check_path "$p"; then
+        SHOULD_CHECK=1
+        REPORTED_PATH="$p"
+        break
+      fi
+    done < <(printf '%s' "$PATCH_TEXT" | grep -oE '^\*\*\* (Update|Add|Delete) File: .+$' | sed 's/^\*\*\* [A-Za-z]* File: //')
+
+    [ "$SHOULD_CHECK" -eq 1 ] || exit 0
+
+    findings="$(_scan_text "$PATCH_TEXT")"
+    if [ -n "$findings" ]; then
+      printf '[pinning-alert] apply_patch on %s 매치:%b\n' "$REPORTED_PATH" "$findings" >&2
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+
+exit 0

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -7,6 +7,11 @@
 #     갱신해야 한다 (lockstep 갱신 의무, drift 감지 자동화 없음 — 운영 검증으로 대체).
 # 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
 #
+# pipefail 안전 모델 (commit-msg-pinning.sh:26-29와 동일 SSOT):
+#   `printf '%s' "$TEXT" | grep -qE ...` 조합은 큰 입력에서 grep -q 조기 종료 + SIGPIPE로
+#   producer가 nonzero를 반환해 pipefail 환경에서 silent miss를 만든다. 검사 텍스트를 mktemp
+#   파일에 저장하고 `grep -qE "$PATTERN" "$tmpfile"`로 검사하여 회피한다.
+#
 # Codex 0.125 PostToolUse stdin schema 실측 (issue #603 Phase 0):
 #   - tool_name="Bash"        → tool_input.command (shell command text)
 #   - tool_name="apply_patch" → tool_input.command (V4A patch envelope text)
@@ -15,6 +20,11 @@
 #       (openai/codex#18391 + 본 PR Phase 0 echo hook 캡처)
 #   - tool_name="Edit|Write|NotebookEdit" → Claude Code-호환 키 (.tool_input.file_path / .new_string /
 #     .content / .new_source). Codex 0.125에서는 미관측이지만 미래 호환을 위해 fallback path 유지.
+#
+# apply_patch attribution 모델:
+#   patch envelope을 파일 섹션별로 분리하여, eligible path마다 그 파일의 added line(`^+`,
+#   `*** Begin/End Patch` 헤더 제외)만 검사한다. 삭제 라인(`^-`)·context 라인(` `)·헤더는 제외.
+#   매치된 파일 path를 alert에 보고. multi-file patch에서 첫 파일만 보고하던 구조 회귀 (#603 DA for_pr Design-1/Regression-2).
 set -euo pipefail
 
 # 환경 가드(CLAUDECODE/CODEX_PROGRAMMATIC) 없음 — PostToolUse pinning-alert는 자식 LLM 세션의
@@ -39,9 +49,9 @@ PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Mainta
 PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
 PATTERN_D='\b[a-f0-9]{7,40}\b'
 
-# 검사 대상 후보 (file_path, text) 쌍을 표준 출력 친화적 형태로 모은다.
-# 단일 파일 케이스(Edit/Write/NotebookEdit)는 1쌍, apply_patch envelope는 N쌍.
-# 각 쌍은 newline-separated `path\ttext_marker_id`로 표현하지 않고, 함수 호출 + 직접 grep으로 처리.
+# 임시 디렉토리 (모든 mktemp 파일을 한 곳에 두고 EXIT trap으로 일괄 정리).
+SCAN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pinning-scan-XXXXXX") || exit 0
+trap 'rm -rf "$SCAN_DIR"' EXIT
 
 # 공통: file path가 본 hook 검사 대상에 부합하는지 판정. 통과하면 0, skip이면 1.
 # mktemp tmpfile 한정: 실측 35건 모두 `body` substring(PR/issue body 작성 임시) → 그 형태로 한정.
@@ -65,20 +75,21 @@ _should_check_path() {
   return 0
 }
 
-# 공통: TEXT를 받아 패턴 4종 검사 후 매치된 finding 라인을 stdout으로 출력한다 (없으면 빈 출력).
-_scan_text() {
-  local text="$1"
+# 공통: SCAN_FILE을 받아 패턴 4종 검사 후 매치된 finding 라인을 stdout으로 출력 (없으면 빈 출력).
+# 파일 기반 grep으로 SIGPIPE 회피 (commit-msg-pinning.sh와 동일 안전 모델).
+_scan_file() {
+  local scan_file="$1"
   local out=""
-  if printf '%s' "$text" | grep -qE "$PATTERN_A"; then
+  if grep -qE "$PATTERN_A" "$scan_file"; then
     out="${out}\n  - Round counter 박제: 'Round N'"
   fi
-  if printf '%s' "$text" | grep -qE "$PATTERN_B"; then
+  if grep -qE "$PATTERN_B" "$scan_file"; then
     out="${out}\n  - Bundle finding ID 박제: 'Bundle-N'"
   fi
-  if printf '%s' "$text" | grep -qE "$PATTERN_C"; then
+  if grep -qE "$PATTERN_C" "$scan_file"; then
     out="${out}\n  - DA 실행 키워드 박제"
   fi
-  if printf '%s' "$text" | grep -oE "$PATTERN_D" 2>/dev/null \
+  if grep -oE "$PATTERN_D" "$scan_file" 2>/dev/null \
     | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
         length($0) >= min && length($0) <= max && /[a-f]/ { found = 1 }
         END { exit !found }
@@ -106,35 +117,61 @@ case "$TOOL_NAME" in
     esac
     [ -n "$TEXT" ] || exit 0
 
-    findings="$(_scan_text "$TEXT")"
+    SCAN_FILE="$SCAN_DIR/scan.txt"
+    printf '%s' "$TEXT" > "$SCAN_FILE"
+
+    findings="$(_scan_file "$SCAN_FILE")"
     if [ -n "$findings" ]; then
       printf '[pinning-alert] %s on %s 매치:%b\n' "$TOOL_NAME" "$FILE_PATH" "$findings" >&2
     fi
     ;;
   apply_patch)
-    # Codex 0.125 V4A apply_patch envelope: tool_input.command 안에 patch text.
-    # patch text에서 `*** {Update,Add,Delete} File: <path>` 헤더로 영향 파일 목록을 추출하고,
-    # 하나라도 검사 대상에 부합하면 patch text 전체에 박제 grep을 수행한다.
+    # Codex 0.125 V4A apply_patch envelope을 파일 섹션별로 분해한다.
+    # 각 파일의 added line(`^+`)만 추출해 그 파일이 eligible일 때 그 파일에 한정해 박제 검사.
+    # 삭제(`^-`)·context(` `)·헤더(`^***`)는 제외하므로 박제 패턴 제거 patch는 alert를 발생시키지 않는다.
+    # multi-file patch에서도 매치된 파일 단위로 정확히 보고한다.
     PATCH_TEXT=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
     [ -n "$PATCH_TEXT" ] || exit 0
 
-    SHOULD_CHECK=0
-    REPORTED_PATH=""
-    while IFS= read -r p; do
+    PATCH_FILE="$SCAN_DIR/patch.txt"
+    printf '%s' "$PATCH_TEXT" > "$PATCH_FILE"
+
+    # awk로 파일별 added line을 분리. 출력: <path>\t<line> per line.
+    # path는 다음 헤더가 나오기 전까지 유지. End Patch 또는 새 File 헤더에서 reset.
+    SECTIONS_FILE="$SCAN_DIR/sections.tsv"
+    awk '
+      /^\*\*\* (Update|Add|Delete) File: / {
+        path = $0
+        sub(/^\*\*\* [A-Za-z]+ File: /, "", path)
+        next
+      }
+      /^\*\*\* End Patch/ { path = ""; next }
+      path != "" && /^\+/ && !/^\*\*\*/ {
+        line = $0
+        sub(/^\+/, "", line)
+        printf "%s\t%s\n", path, line
+      }
+    ' "$PATCH_FILE" > "$SECTIONS_FILE"
+
+    [ -s "$SECTIONS_FILE" ] || exit 0
+
+    # 각 eligible path마다 added line만 모아 검사
+    # path 목록 (unique, eligible only)
+    awk -F'\t' '{print $1}' "$SECTIONS_FILE" | sort -u | while IFS= read -r p; do
       [ -n "$p" ] || continue
-      if _should_check_path "$p"; then
-        SHOULD_CHECK=1
-        REPORTED_PATH="$p"
-        break
+      if ! _should_check_path "$p"; then
+        continue
       fi
-    done < <(printf '%s' "$PATCH_TEXT" | grep -oE '^\*\*\* (Update|Add|Delete) File: .+$' | sed 's/^\*\*\* [A-Za-z]* File: //')
-
-    [ "$SHOULD_CHECK" -eq 1 ] || exit 0
-
-    findings="$(_scan_text "$PATCH_TEXT")"
-    if [ -n "$findings" ]; then
-      printf '[pinning-alert] apply_patch on %s 매치:%b\n' "$REPORTED_PATH" "$findings" >&2
-    fi
+      # 해당 path의 added line만 추출
+      PATH_SCAN_FILE="$SCAN_DIR/scan-$(printf '%s' "$p" | tr '/' '_').txt"
+      awk -F'\t' -v target="$p" '$1 == target { print substr($0, length(target) + 2) }' \
+        "$SECTIONS_FILE" > "$PATH_SCAN_FILE"
+      [ -s "$PATH_SCAN_FILE" ] || continue
+      findings="$(_scan_file "$PATH_SCAN_FILE")"
+      if [ -n "$findings" ]; then
+        printf '[pinning-alert] apply_patch on %s 매치:%b\n' "$p" "$findings" >&2
+      fi
+    done
     ;;
   *) exit 0 ;;
 esac

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -47,7 +47,7 @@ HASH_MAX=12
 PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
 PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Maintainability|MAINTAINABILITY|Security|SECURITY|Hallucination|HALLUCINATION|Side_effect|SIDE_EFFECT|Consistency|CONSISTENCY|Readability|READABILITY|Clean_code|CLEAN_CODE|Yagni|YAGNI|Ngmi|NGMI|CORR|MAINT|MNT|REG|CIR)-[0-9][A-Za-z0-9-]*\b'
 PATTERN_C='\bDA (for_pr|for_plan|피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9]|\bparallel-audit (반영|결과|finding)\b'
-PATTERN_D='\b[a-f0-9]{7,40}\b'
+PATTERN_D='\b[a-f0-9]{7,40}\b|`[a-f0-9]+`'
 
 # 임시 디렉토리 (모든 mktemp 파일을 한 곳에 두고 EXIT trap으로 일괄 정리).
 SCAN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pinning-scan-XXXXXX") || exit 0
@@ -155,15 +155,17 @@ case "$TOOL_NAME" in
 
     [ -s "$SECTIONS_FILE" ] || exit 0
 
-    # 각 eligible path마다 added line만 모아 검사
-    # path 목록 (unique, eligible only)
+    # 각 eligible path마다 added line만 모아 검사.
+    # scan 파일명에 path 원문을 사용하지 않는다 — 긴 nested path가 NAME_MAX(보통 255 bytes)를
+    # 초과하면 redirection이 'File name too long'으로 실패하고 set -e로 hook이 exit 1이 되어
+    # warn-only 계약을 위반한다 (#603 DA for_pr R2 Correctness-1/Regression-1). path는 보고용
+    # 변수로만 유지하고 scan 파일은 mktemp으로 익명 basename을 받는다.
     awk -F'\t' '{print $1}' "$SECTIONS_FILE" | sort -u | while IFS= read -r p; do
       [ -n "$p" ] || continue
       if ! _should_check_path "$p"; then
         continue
       fi
-      # 해당 path의 added line만 추출
-      PATH_SCAN_FILE="$SCAN_DIR/scan-$(printf '%s' "$p" | tr '/' '_').txt"
+      PATH_SCAN_FILE=$(mktemp "$SCAN_DIR/scan-XXXXXX")
       awk -F'\t' -v target="$p" '$1 == target { print substr($0, length(target) + 2) }' \
         "$SECTIONS_FILE" > "$PATH_SCAN_FILE"
       [ -s "$PATH_SCAN_FILE" ] || continue

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -91,7 +91,8 @@ _scan_file() {
   fi
   if grep -oE "$PATTERN_D" "$scan_file" 2>/dev/null \
     | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
-        length($0) >= min && length($0) <= max && /[a-f]/ { found = 1 }
+        { tok = $0; gsub(/`/, "", tok);
+          if (length(tok) >= min && length(tok) <= max && tok ~ /[a-f]/) found = 1 }
         END { exit !found }
       '; then
     out="${out}\n  - Partial commit hash 박제 (${HASH_MIN}~${HASH_MAX}자)"
@@ -138,11 +139,19 @@ case "$TOOL_NAME" in
 
     # awk로 파일별 added line을 분리. 출력: <path>\t<line> per line.
     # path는 다음 헤더가 나오기 전까지 유지. End Patch 또는 새 File 헤더에서 reset.
+    # `*** Move to: <newpath>`를 만나면 current section의 effective path를 새 경로로 갱신
+    # (V4A rename 케이스: old.txt → new.md에서 새 산출물의 확장자 기준 eligibility 판단 — 이슈 #603 R3 Correctness-1/Regression-1).
     SECTIONS_FILE="$SCAN_DIR/sections.tsv"
     awk '
       /^\*\*\* (Update|Add|Delete) File: / {
         path = $0
         sub(/^\*\*\* [A-Za-z]+ File: /, "", path)
+        next
+      }
+      /^\*\*\* Move to: / {
+        newpath = $0
+        sub(/^\*\*\* Move to: /, "", newpath)
+        path = newpath
         next
       }
       /^\*\*\* End Patch/ { path = ""; next }

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -39,6 +39,13 @@ command -v jq >/dev/null 2>&1 || exit 0
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
 
+# tool_name 사전 분기 — Codex의 PostToolUse는 모든 tool 호출(Bash 포함)에 발화하므로,
+# 검사 대상이 아닌 tool은 SCAN_DIR 생성/cleanup 비용 없이 즉시 종료한다.
+case "$TOOL_NAME" in
+  Edit | Write | NotebookEdit | apply_patch) ;;
+  *) exit 0 ;;
+esac
+
 # Pinning hash 길이 경계 (commit-msg-pinning.sh와 동일)
 HASH_MIN=7
 HASH_MAX=12

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -641,6 +641,35 @@ for _sub in "${EXPECTED_DISPATCHER_SUB_SCRIPTS[@]}"; do
 done
 _check_hook_executable ".codex/hooks/pinning-alert.sh"
 
+# Pinning patterns lockstep 검사 (issue #603 R2 Maintainability-1):
+#   scripts/ai/commit-msg-pinning.sh를 SSOT로 두고 신규 PostToolUse hook 두 개가 PATTERN_A/B/C/D
+#   + HASH_MIN/MAX를 inline 사본으로 들고 있다. drift 자동 감지 자동화 없음을 운영 검증으로
+#   대체한다는 정책이지만, 최소한 수동 갱신 누락을 verifier가 잡아내야 한다.
+echo ""
+echo "=== Pinning patterns SSOT lockstep 검사 ==="
+_pinning_ssot="$REPO_ROOT/scripts/ai/commit-msg-pinning.sh"
+_pinning_hooks=(
+  "$REPO_ROOT/modules/shared/programs/claude/files/hooks/pinning-alert.sh"
+  "$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-alert.sh"
+)
+for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX; do
+  _ssot_line=$(grep -E "^${_var}=" "$_pinning_ssot" | head -1)
+  if [ -z "$_ssot_line" ]; then
+    fail "SSOT $_var 정의 부재 (scripts/ai/commit-msg-pinning.sh)"
+    continue
+  fi
+  for _hook in "${_pinning_hooks[@]}"; do
+    _hook_basename="${_hook#"$REPO_ROOT"/}"
+    _hook_line=$(grep -E "^${_var}=" "$_hook" | head -1)
+    if [ "$_hook_line" = "$_ssot_line" ]; then
+      pass "pinning $_var lockstep OK: $_hook_basename"
+    else
+      fail "pinning $_var drift: $_hook_basename" \
+        "$(printf '\n    SSOT: %s\n    HOOK: %s' "$_ssot_line" "$_hook_line")"
+    fi
+  done
+done
+
 # fixture self-test (deterministic, live 미실행).
 if [ ! -x "$_active_hooks_runner" ]; then
   fail "tests/test-codex-hook-fixtures.sh 실행 불가 (path=$_active_hooks_runner)"

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -653,19 +653,22 @@ _pinning_hooks=(
   "$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-alert.sh"
 )
 for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX; do
-  _ssot_line=$(grep -E "^${_var}=" "$_pinning_ssot" | head -1)
+  # `set -euo pipefail` 아래에서 grep 매치 실패 시 nonzero가 command substitution을
+  # 통해 부모 shell을 종료시켜 drift 보고 자체가 막히므로 `|| true`로 무력화한다.
+  _ssot_line="$(grep -m1 -E "^${_var}=" "$_pinning_ssot" || true)"
   if [ -z "$_ssot_line" ]; then
     fail "SSOT $_var 정의 부재 (scripts/ai/commit-msg-pinning.sh)"
     continue
   fi
   for _hook in "${_pinning_hooks[@]}"; do
     _hook_basename="${_hook#"$REPO_ROOT"/}"
-    _hook_line=$(grep -E "^${_var}=" "$_hook" | head -1)
+    _hook_line="$(grep -m1 -E "^${_var}=" "$_hook" || true)"
     if [ "$_hook_line" = "$_ssot_line" ]; then
       pass "pinning $_var lockstep OK: $_hook_basename"
     else
-      fail "pinning $_var drift: $_hook_basename" \
-        "$(printf '\n    SSOT: %s\n    HOOK: %s' "$_ssot_line" "$_hook_line")"
+      # fail()는 첫 인자만 출력하므로 SSOT/HOOK 세부 비교를 단일 형식 문자열로 결합한다.
+      fail "$(printf 'pinning %s drift: %s\n    SSOT: %s\n    HOOK: %s' \
+        "$_var" "$_hook_basename" "$_ssot_line" "${_hook_line:-<missing>}")"
     fi
   done
 done

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -487,8 +487,10 @@ echo "=== Codex active hooks 검사 ==="
 #      template 미선언 event로 등록하는 것이 보존된다. 본 검사는 managed entry 존재만 확인한다.
 #   2) ~/.codex/config.toml의 [[hooks.Stop]]는 정확히 single managed dispatcher entry — Codex가
 #      same-event multiple command를 concurrent 실행하므로 ordering 보장을 dispatcher에 위임한다.
-#   3) UserPromptSubmit / Stop expected command가 가리키는 hook + dispatcher 사본 + 3 sub-script 실재
-#   4) tests/test-codex-hook-fixtures.sh deterministic 모드 통과 (live fixture 미실행)
+#   3) ~/.codex/config.toml의 [[hooks.PostToolUse]]에 expected pinning-alert managed command가 포함되어 있는지.
+#      issue #603에서 PostToolUse도 template-owned event로 전환되었다 (warn-only pinning alert).
+#   4) UserPromptSubmit / Stop / PostToolUse expected command가 가리키는 hook + dispatcher 사본 + 3 sub-script + pinning-alert 실재
+#   5) tests/test-codex-hook-fixtures.sh deterministic 모드 통과 (live fixture 미실행)
 # fail() 한 건이라도 발생하면 errors++ → exit 1 (FAIL gate).
 
 _active_hooks_runner="$REPO_ROOT/tests/test-codex-hook-fixtures.sh"
@@ -508,15 +510,17 @@ else
   # UserPromptSubmit은 expected managed command가 포함되었는지만 검증 (사용자 추가 entry 허용).
   # Stop은 정확히 single managed dispatcher entry 강제 (concurrent 회피 contract).
   _hooks_dump=""
-  if ! _hooks_dump="$(python3 - "$CODEX_CONFIG" "$EXPECTED_USER_PROMPT_COMMAND" "$EXPECTED_STOP_DISPATCHER_COMMAND" <<'PY'
+  if ! _hooks_dump="$(python3 - "$CODEX_CONFIG" "$EXPECTED_USER_PROMPT_COMMAND" "$EXPECTED_STOP_DISPATCHER_COMMAND" "$EXPECTED_POST_TOOL_USE_PINNING_COMMAND" <<'PY'
 import sys, tomllib
 with open(sys.argv[1], "rb") as f:
     data = tomllib.load(f)
 expected_ups = sys.argv[2]
 expected_stop = sys.argv[3]
+expected_post = sys.argv[4]
 hooks = data.get("hooks", {})
 ups = hooks.get("UserPromptSubmit", []) or []
 stop = hooks.get("Stop", []) or []
+post = hooks.get("PostToolUse", []) or []
 
 ups_managed = any(
     h.get("command") == expected_ups
@@ -532,6 +536,14 @@ if len(stop) == 1:
     print(f"STOP_INNER_COUNT {len(sub)}")
     if sub:
         print(f"STOP_COMMAND {sub[0].get('command', '')}")
+
+post_managed = any(
+    h.get("command") == expected_post
+    for entry in post
+    for h in (entry.get("hooks", []) or [])
+)
+print(f"POST_TOTAL_COUNT {len(post)}")
+print(f"POST_HAS_MANAGED {'1' if post_managed else '0'}")
 PY
   )"; then
     fail "$CODEX_CONFIG hooks 구조 파싱 실패 (race 또는 invariant 위반)"
@@ -541,6 +553,8 @@ PY
     _stop_count="$(printf '%s\n' "$_hooks_dump" | awk '$1=="STOP_COUNT"{print $2}')"
     _stop_inner_count="$(printf '%s\n' "$_hooks_dump" | awk '$1=="STOP_INNER_COUNT"{print $2}')"
     _stop_command="$(printf '%s\n' "$_hooks_dump" | sed -n 's/^STOP_COMMAND //p')"
+    _post_total_count="$(printf '%s\n' "$_hooks_dump" | awk '$1=="POST_TOTAL_COUNT"{print $2}')"
+    _post_has_managed="$(printf '%s\n' "$_hooks_dump" | awk '$1=="POST_HAS_MANAGED"{print $2}')"
 
     if [ "${_ups_total_count:-0}" -ge 1 ] 2>/dev/null; then
       pass "[[hooks.UserPromptSubmit]] entry 존재 (count=$_ups_total_count)"
@@ -568,6 +582,20 @@ PY
       pass "Stop dispatcher command = $EXPECTED_STOP_DISPATCHER_COMMAND"
     else
       fail "Stop dispatcher command 불일치 (actual='$_stop_command' expected='$EXPECTED_STOP_DISPATCHER_COMMAND')"
+    fi
+
+    # PostToolUse는 issue #603에서 template-owned로 등록 — pinning-alert managed entry 포함 여부 검사.
+    # 사용자 추가 entry는 sync-codex-config.py 정책상 보존되지 않지만, 본 검사는 managed entry 존재만 확인.
+    if [ "${_post_total_count:-0}" -ge 1 ] 2>/dev/null; then
+      pass "[[hooks.PostToolUse]] entry 존재 (count=$_post_total_count)"
+    else
+      fail "[[hooks.PostToolUse]] entry 부재 (count=${_post_total_count:-?})"
+    fi
+
+    if [ "$_post_has_managed" = "1" ]; then
+      pass "PostToolUse에 expected managed command 포함: $EXPECTED_POST_TOOL_USE_PINNING_COMMAND"
+    else
+      fail "PostToolUse에 expected managed command 없음 (expected='$EXPECTED_POST_TOOL_USE_PINNING_COMMAND')"
     fi
   fi
 fi
@@ -611,6 +639,7 @@ _check_hook_executable ".codex/hooks/_stop-dispatcher.sh"
 for _sub in "${EXPECTED_DISPATCHER_SUB_SCRIPTS[@]}"; do
   _check_hook_executable ".codex/hooks/$_sub"
 done
+_check_hook_executable ".codex/hooks/pinning-alert.sh"
 
 # fixture self-test (deterministic, live 미실행).
 if [ ! -x "$_active_hooks_runner" ]; then

--- a/tests/fixtures/codex-hooks/README.md
+++ b/tests/fixtures/codex-hooks/README.md
@@ -51,3 +51,4 @@ agent_id 키는 0.124 schema에 없으며 hook은 graceful fallback에 의존한
 | `scenario-B-user-added-same-event.toml` | template이 선언한 이벤트에 사용자가 entry 추가 시 sync-codex-config.py가 template 값으로 덮어씀 | 사용자 추가 marker가 사라짐 |
 | `scenario-C-user-different-event.toml` | template 미선언 이벤트는 user-owned로 보존 | hooks.SessionStart 등이 그대로 유지 |
 | `scenario-D-mcp-servers-coexist.toml` | mcp_servers와 hooks 인접 ownership view | 사용자 mcp_servers entry 보존 + hooks template 적용 |
+| `scenario-E-posttooluse-template-owned.toml` | template이 선언한 PostToolUse 이벤트(issue #603)에 사용자가 entry 추가 시 sync가 template 값으로 덮어씀 | 사용자 PostToolUse marker가 사라지고 managed pinning-alert command만 남음 |

--- a/tests/fixtures/codex-hooks/sync-preservation/scenario-E-posttooluse-template-owned.toml
+++ b/tests/fixtures/codex-hooks/sync-preservation/scenario-E-posttooluse-template-owned.toml
@@ -1,0 +1,24 @@
+# Scenario E: 사용자가 template이 declare한 동일 event(hooks.PostToolUse)에 추가 entry를
+# 넣은 경우. issue #603에서 PostToolUse도 template-owned event로 전환되었으므로,
+# sync-codex-config.py는 array 전체를 template 값으로 덮어써 사용자 entry
+# "/tmp/test-marker-USER-POSTTOOLUSE-LOST.sh"를 손실시켜야 한다.
+# scenario-B(UserPromptSubmit)와 동일 정책의 PostToolUse 변형이다.
+
+model = "gpt-5.5"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "$HOME/.codex/hooks/record-prompt-submit.sh"
+
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "$HOME/.codex/hooks/_stop-dispatcher.sh"
+
+[[hooks.PostToolUse]]
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "/tmp/test-marker-USER-POSTTOOLUSE-LOST.sh"

--- a/tests/lib/codex-hook-expectations.sh
+++ b/tests/lib/codex-hook-expectations.sh
@@ -24,6 +24,12 @@ EXPECTED_USER_PROMPT_COMMAND='$HOME/.codex/hooks/record-prompt-submit.sh'
 # ~/.codex/config.toml의 [[hooks.Stop.hooks]] command — 단일 dispatcher.
 EXPECTED_STOP_DISPATCHER_COMMAND='$HOME/.codex/hooks/_stop-dispatcher.sh'
 
+# ~/.codex/config.toml의 [[hooks.PostToolUse.hooks]] command — 본 PR(#603)에서 등록.
+# Codex 0.125 PostToolUse stdin은 apply_patch envelope을 `tool_input.command`로 전달하므로
+# hook이 V4A patch text에서 영향 파일과 추가 라인을 직접 파싱한다 (자세한 schema는
+# modules/shared/programs/codex/files/hooks/pinning-alert.sh 헤더 주석 참조).
+EXPECTED_POST_TOOL_USE_PINNING_COMMAND='$HOME/.codex/hooks/pinning-alert.sh'
+
 # dispatcher가 호출하는 sub-script. ordering은 record-last-stop → nrs-session-cleanup →
 # stop-notification (issue #590: cleanup이 notification 외부 IPC latency 앞에서 lock 즉시 해제).
 # 본 배열 순서는 dispatcher 호출 순서이며 fixture ordering 검증의 expected.

--- a/tests/lib/codex-hook-expectations.sh
+++ b/tests/lib/codex-hook-expectations.sh
@@ -7,9 +7,10 @@
 #
 # 주의: 본 파일은 test/verifier oracle이며 hook의 runtime source of truth가 아니다.
 # hook command / dispatcher sub-script의 실제 정의는 다음 위치에 있다:
-#   - modules/shared/programs/codex/files/config.toml         ([[hooks.UserPromptSubmit]] / [[hooks.Stop]])
+#   - modules/shared/programs/codex/files/config.toml         ([[hooks.UserPromptSubmit]] / [[hooks.Stop]] / [[hooks.PostToolUse]])
 #   - modules/shared/programs/codex/files/config.darwin.toml  (Darwin 분기)
 #   - modules/shared/programs/codex/files/hooks/_stop-dispatcher.sh (sub-script 호출 ordering)
+#   - modules/shared/programs/codex/files/hooks/pinning-alert.sh (PostToolUse pinning warn-only, issue #603)
 # hook 추가 / rename 시 위 runtime 파일들과 본 oracle을 함께 수정해야 한다.
 # shellcheck disable=SC2034
 # (모든 상수가 source caller 측에서만 소비되므로 SC2034 unused 경고를 비활성화한다.)

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -539,6 +539,30 @@ assert len(sub) == 1
 cmd = sub[0].get("command", "")
 assert cmd == expected_stop_cmd, f"command={cmd!r} expected={expected_stop_cmd!r}"
 PY
+
+  # ── E: PostToolUse template-owned (issue #603) ──
+  # PostToolUse도 template이 declare한 array이므로 사용자가 동일 event에 별도 entry를 추가하면
+  # template-owned leaf 정책에 따라 손실된다. scenario-B의 UserPromptSubmit 변형으로,
+  # PostToolUse에도 동일 정책이 적용됨을 강제한다.
+  target=$(_sync_preservation_run_one \
+    "$FIXTURE_DIR/sync-preservation/scenario-E-posttooluse-template-owned.toml" "scenario-E")
+  python3 - "$target" "$EXPECTED_POST_TOOL_USE_PINNING_COMMAND" <<'PY' \
+    || fail "scenario-E: PostToolUse 사용자 entry가 손실되어야 하지만 보존됨 (template-owned leaf 정책 위반)"
+import sys, tomllib
+with open(sys.argv[1], "rb") as f:
+    d = tomllib.load(f)
+expected_post_cmd = sys.argv[2]
+post = d.get("hooks", {}).get("PostToolUse", [])
+assert isinstance(post, list) and len(post) == 1, f"PostToolUse len={len(post)} (expected 1)"
+sub = post[0].get("hooks", [])
+assert len(sub) == 1, f"PostToolUse.hooks len={len(sub)}"
+cmd = sub[0].get("command", "")
+assert cmd == expected_post_cmd, f"command={cmd!r} expected={expected_post_cmd!r}"
+# 사용자 marker는 손실되어야 함
+all_commands = [h.get("command", "") for entry in post for h in entry.get("hooks", [])]
+assert all("USER-POSTTOOLUSE-LOST" not in c for c in all_commands), \
+    f"user marker still present: {all_commands}"
+PY
 }
 
 # ─── 카테고리 6: stop-notification reliability/security ───
@@ -790,7 +814,7 @@ run_test "dispatcher recovers from sub-script failures" \
   test_dispatcher_recovers_from_subscript_failures
 run_test "noise-guard env variants (cleanup unguarded)" \
   test_noise_guard_env_variants_with_cleanup_unguarded
-run_test "sync-codex-config preservation scenarios A/B/C/D" \
+run_test "sync-codex-config preservation scenarios A/B/C/D/E" \
   test_sync_preservation_scenarios
 
 run_test "stop-notification codex transcript fallback (6.1)" \


### PR DESCRIPTION
## Summary

- LLM 산출물(`.md` / `.sh` / mktemp body tmpfile)에 휘발성 박제 패턴(round counter, bundle finding ID, DA 키워드, partial commit hash)이 들어가면 stderr alert만 출력하는 글로벌 PostToolUse hook을 Claude Code + Codex CLI 양쪽에 동일 spec으로 설치.
- 어떤 surface에서도 차단(`deny`)하지 않으며 `exit 0` + stderr alert만 수행. lefthook commit-msg layer와 idempotent 이중 방어를 구성.
- Codex hook은 0.125 PostToolUse stdin schema 실측을 통해 `apply_patch` envelope 처리 분기를 추가 (matcher alias `Edit|Write|NotebookEdit`로 트리거되지만 stdin `tool_name`은 `apply_patch`로 유지됨).

Closes #603

## 기존 문제/배경

기존 `scripts/ai/commit-msg-pinning.sh`(lefthook commit-msg, repo-local, warn-only)는 `nixos-config` repo의 commit message만 cover한다. 다른 git repo에서 LLM이 만든 `.md` / `.sh` 산출물 또는 mktemp으로 만든 PR/issue body 임시 파일에 박제 패턴이 들어가면 차단/감지하는 layer가 없다.

양쪽 머신(MiniPC + Mac) Claude Code transcript 전수조사(4,986 jsonl, 176,936 assistant entries) 결과, `.md` 317 distinct files + `.sh` 11 + mktemp body tmpfile ~35로 박제 매치의 약 98.5%가 cover된다. fixture/eval(`.json`)과 코드 확장자(`.ts/.nix/.py` 등)는 noise.

본 변경은 모든 git repo · 모든 LLM 세션에서 산출물 단계에 한 layer alert를 추가해 commit-msg layer와 idempotent 이중 방어를 구성한다. PR `#602`(CLOSED, YAGNI/NGMI)가 시도했던 인프라(SSOT JSON · dual adapter · GitHub workflow · pre-push regression · marker syntax · 50+ docs cleanup)를 의도적으로 회피한다.

## CIR (Change Intent Record)

- **v1** (issue `#583`, MERGED): lefthook commit-msg-pinning.sh 도입 — repo-local + warn-only.
- **v2** (PR `#602`, CLOSED): SSOT JSON + shell/JS dual adapter + GitHub Actions + pre-push regression + marker syntax + 50+ docs cleanup으로 한 묶음 시도 → 인프라 무게가 차단 본질 대비 과도하다고 판단되어 close.
- **v3** (issue `#587`, OPEN): PreToolUse hard-fail spec — 더 강한 보장이지만 무게 더 큼. 본 PR과 공존 유지.
- **v4** (이번 변경): PostToolUse + warn-only + inline regex 1 묶음 + 산출물 파일 한정. 즉시 차단 없이 alert만, 사용자가 무시 가능. SSOT는 `scripts/ai/commit-msg-pinning.sh`가 단일 진실 — 본 PR의 두 hook은 inline 사본이며 lockstep 갱신 의무를 verifier(`scripts/ai/verify-ai-compat.sh`)가 강제한다.

**trade-off**: 3-way inline 패턴 중복(commit-msg-pinning + Claude pinning-alert + Codex pinning-alert)을 받아들임. drift 자동 감지 자동화는 없지만 verifier가 변수 라인 동등성을 검증한다. 운영 후 drift 빈도가 높으면 lib SSOT 추출은 후속 PR로 분리.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| commit-msg lefthook only | repo-local commit message만 검사 | 단순, 이미 구현됨 | 다른 repo · `.md`/`.sh` 산출물 미cover | ❌ (선행 작업으로 유지) |
| PreToolUse hard-fail spec | 차단까지 강제 (issue `#587`) | 강한 보장 | 인프라 무게 ↑, false positive 비용 ↑ | ❌ (공존, 별도 trade-off 점) |
| SSOT JSON + dual adapter + workflow | PR `#602` 시도 | 일관성 ↑, automated regression | 인프라 무게 압도적, YAGNI/NGMI | ❌ (close됨) |
| **PostToolUse warn-only inline** | 산출물 파일에 PostToolUse stderr alert | 가벼움, 차단 위험 zero, 운영 시작 가능 | inline 중복, drift 위험 (verifier로 mitigate) | ✅ (본 PR) |
| sync-codex-config identity-merge | PostToolUse 사용자 entry도 보존 | 사용자 확장 경로 유지 | sync-codex-config.py 변경 비용 ↑ | ❌ (별도 follow-up) |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/hooks/pinning-alert.sh` | **신규** — PostToolUse Edit/Write/NotebookEdit warn-only hook |
| `modules/shared/programs/codex/files/hooks/pinning-alert.sh` | **신규** — Codex 사본, apply_patch envelope V4A patch parser (`*** Update/Add/Delete File:` + `*** Move to:` 헤더 처리, added line만 검사) |
| `modules/shared/programs/claude/files/settings.json` | `PostToolUse` array에 `Edit\|Write\|NotebookEdit` matcher entry 추가 (기존 `ExitWorktree` 보존) |
| `modules/shared/programs/codex/files/{config,config.darwin}.toml` | `[[hooks.PostToolUse]]` template-owned entry 추가 + 정책 주석에 PostToolUse template-owned 명시 |
| `modules/shared/programs/{claude,codex}/default.nix` | `home.file ".{claude,codex}/hooks/pinning-alert.sh"` mkOutOfStoreSymlink 등록 |
| `tests/lib/codex-hook-expectations.sh` | `EXPECTED_POST_TOOL_USE_PINNING_COMMAND` oracle entry 추가 + 헤더 주석 갱신 |
| `tests/test-codex-hook-fixtures.sh` | sync-preservation scenario-E (PostToolUse template-owned) 추가 |
| `tests/fixtures/codex-hooks/sync-preservation/scenario-E-posttooluse-template-owned.toml` | **신규** fixture |
| `tests/fixtures/codex-hooks/README.md` | scenario-E 문서화 |
| `scripts/ai/verify-ai-compat.sh` | PostToolUse managed entry/executable 검사 + PATTERN_A/B/C/D + HASH_MIN/MAX 12개 lockstep 검사 추가 |

### 핵심 코드: Codex hook의 apply_patch 분기

```bash
case ""$"TOOL_NAME" in
  Edit | Write | NotebookEdit | apply_patch) ;;
  *) exit 0 ;;  # Bash 등 비대상 tool은 SCAN_DIR 생성 비용 없이 즉시 종료
esac
# ...
case ""$"TOOL_NAME" in
  apply_patch)
    # V4A patch envelope를 awk로 파일 섹션별로 분해 — added line만 추출
    awk '
      /^\*\*\* (Update|Add|Delete) File: / { ... }
      /^\*\*\* Move to: / { ... }   # rename 케이스: effective path를 새 경로로 갱신
      /^\*\*\* End Patch/ { path = ""; next }
      path != "" && /^\+/ && !/^\*\*\*/ { ... }  # added line만 (삭제/context 제외)
    ' "$"PATCH_FILE" > "$"SECTIONS_FILE"
    ;;
esac
```

## 참고 레퍼런스

- `#603` — 본 PR의 issue
- `#587` (OPEN) — PreToolUse hard-fail spec, 본 PR과 공존
- `#602` (CLOSED) — close 사유와 정합 (인프라 무게 회피)
- `#582` (CLOSED) — 박제 패턴 enum/측정 SSOT
- `#583` (MERGED) — lefthook commit-msg-pinning.sh 선행 작업
- `#585` / `#586` (MERGED) — Codex 0.124+ stable hooks 인프라
- [openai/codex#18391](https://github.com/openai/codex/pull/18391) — apply_patch hook stdin schema (matcher alias `Write`/`Edit`로 트리거되지만 stdin `tool_name`은 `apply_patch` 유지)
- [openai/codex#16226](https://github.com/openai/codex/issues/16226) — Codex 0.124+ stable hook event 종류
- [Claude Code Hooks reference](https://code.claude.com/docs/en/hooks) — PostToolUse 공식 spec

## Human Test Plan

1. **새 Claude Code 세션 시작**: 임시 `.md` 파일에 `Round 2 deadbeef foo.sh:42 Correctness-1 DA for_pr` 라인을 한 번 Edit/Write로 작성한다.
   - **기대**: stderr에 `[pinning-alert] Edit on /tmp/...md 매치:`로 시작하는 alert 출력 (4종 패턴 매치).
   - **실패 시**: `ls -la ~/.claude/hooks/pinning-alert.sh`로 symlink 존재 확인 → `nrs` 재실행 → `jq '.hooks.PostToolUse' ~/.claude/settings.json`로 entry 확인.

2. **새 Codex CLI 세션 시작**: 임시 `.md` 파일을 apply_patch로 한 줄 추가하여 박제 패턴을 넣는다.
   - **기대**: stderr에 `[pinning-alert] apply_patch on /tmp/...md 매치:` 출력.
   - **실패 시**: `grep -A3 'PostToolUse' ~/.codex/config.toml`로 entry 확인 → `command -v jq`로 jq 존재 확인.

3. **Negative case**: 정상 텍스트 한 줄 Edit/Write → alert 없이 조용해야 함.

4. **Self-exclude case**: `scripts/ai/commit-msg-pinning.sh` 또는 `modules/.../skills/run-da/SKILL.md` Edit → alert 발생 안 해야 함.

5. **Code 확장자 case**: `.nix`, `.ts`, `.py` 파일 Edit → alert 발생 안 해야 함 (확장자 한정 검증).

6. **macOS host에서 동일 검증**: `ssh mac` 후 1-5번 반복. BSD grep 2.6.0-FreeBSD가 `\b` word boundary를 GNU compatible로 지원함을 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```bash
# Hook 파일 + symlink + executable
ls -la \
  modules/shared/programs/claude/files/hooks/pinning-alert.sh \
  modules/shared/programs/codex/files/hooks/pinning-alert.sh \
  ~/.claude/hooks/pinning-alert.sh \
  ~/.codex/hooks/pinning-alert.sh

# Settings/config entry
jq -e '.hooks.PostToolUse | map(select(.matcher == "Edit|Write|NotebookEdit"))[0].hooks[0].command == "~/.claude/hooks/pinning-alert.sh"' \
  modules/shared/programs/claude/files/settings.json
grep -A3 '\[\[hooks.PostToolUse\]\]' modules/shared/programs/codex/files/config.toml
grep -A3 '\[\[hooks.PostToolUse\]\]' modules/shared/programs/codex/files/config.darwin.toml

# default.nix home.file 등록
grep 'pinning-alert.sh' modules/shared/programs/claude/default.nix modules/shared/programs/codex/default.nix
```

기대: 모든 명령이 0 exit + 매치 출력.

### Phase 1 — Linter / formatter / fixture self-test

```bash
shellcheck -S warning \
  modules/shared/programs/claude/files/hooks/pinning-alert.sh \
  modules/shared/programs/codex/files/hooks/pinning-alert.sh
nixfmt --check modules/shared/programs/claude/default.nix modules/shared/programs/codex/default.nix
tests/test-codex-hook-fixtures.sh --no-live
scripts/ai/verify-ai-compat.sh
```

기대: 모두 exit 0. fixture self-test에서 `sync-codex-config preservation scenarios A/B/C/D/E` 라벨 확인. verify-ai-compat에서 `pinning PATTERN_A/B/C/D + HASH_MIN/MAX lockstep OK` 12개 PASS 라인 확인.

### Phase 2 — 기능 검증 (live trigger)

```bash
# Positive: Claude Edit + 4 패턴
jq -n --arg fp "/tmp/test603.md" --arg ns 'Round 2 with deadbeef hash and Correctness-1 finding from DA for_pr' \
  '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: "x", new_string: $ns}}' \
  | ~/.claude/hooks/pinning-alert.sh
# 기대: stderr에 4종 박제 모두 매치 alert.

# Codex apply_patch positive (multi-file, .ts excluded + .md pinning)
jq -n --arg cmd '*** Begin Patch
*** Update File: /tmp/code.ts
@@
+normal code line
*** Update File: /tmp/notes.md
@@
+Round 7 with abcdef1 hex finding
*** End Patch
' '{tool_name: "apply_patch", tool_input: {command: $cmd}}' \
  | ~/.codex/hooks/pinning-alert.sh
# 기대: /tmp/notes.md만 alert 보고.

# Codex apply_patch Move to (.txt → .md)
jq -n --arg cmd '*** Begin Patch
*** Update File: /tmp/old.txt
*** Move to: /tmp/new.md
@@
+Round 3 with deadbeef
*** End Patch
' '{tool_name: "apply_patch", tool_input: {command: $cmd}}' \
  | ~/.codex/hooks/pinning-alert.sh
# 기대: /tmp/new.md에 alert 발생 (effective path 기준).
```

### Phase 3 — Regression / negative

```bash
# Self-exclude
jq -n --arg fp "/x/scripts/ai/commit-msg-pinning.sh" --arg ns 'Round 5 deadbeef Correctness-1' \
  '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: "x", new_string: $ns}}' \
  | ~/.claude/hooks/pinning-alert.sh
# 기대: 출력 없음, exit 0.

# Code 확장자 mktemp (.ts in /tmp)
jq -n --arg fp "/tmp/test.ts" --arg ns 'Round 2 deadbeef Correctness-1' \
  '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: "x", new_string: $ns}}' \
  | ~/.claude/hooks/pinning-alert.sh
# 기대: 출력 없음 (확장자 + body substring 한정).

# Backtick 5자 token (false positive 회피)
jq -n --arg fp "/tmp/test-bt.md" --arg ns 'short token \`abcde\` only' \
  '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: "x", new_string: $ns}}' \
  | ~/.claude/hooks/pinning-alert.sh
# 기대: 출력 없음.

# apply_patch remove-only (박제 패턴 제거 시 alert 안 함)
jq -n --arg cmd '*** Begin Patch
*** Update File: /tmp/cleanup.md
@@
-Round 1 outdated
+Reviewed without session metadata
*** End Patch
' '{tool_name: "apply_patch", tool_input: {command: $cmd}}' \
  | ~/.codex/hooks/pinning-alert.sh
# 기대: 출력 없음.

# Bash tool (PostToolUse 발화하지만 비대상 tool)
jq -n --arg c "Round 5 deadbeef in bash" \
  '{tool_name: "Bash", tool_input: {command: $c}}' \
  | ~/.codex/hooks/pinning-alert.sh
# 기대: 출력 없음, exit 0, SCAN_DIR 미생성.
```

### Phase 4 — 큰 payload pipefail safety

```bash
SCRATCH=$(mktemp -d /tmp/pre-merge-XXXXXX)
{ echo "Round 1"; head -c 300000 /dev/urandom | base64; } > "$SCRATCH/large.txt"
jq -n --rawfile c "$SCRATCH/large.txt" --arg fp "/tmp/large603.md" \
  '{tool_name: "Write", tool_input: {file_path: $fp, content: $c}}' \
  | ~/.claude/hooks/pinning-alert.sh
# 기대: 'Round counter 박제' alert 출력 (SIGPIPE silent miss 회피).
rm -rf "$SCRATCH"
```

### 결과 보고 형식

각 Phase의 매치/실패를 boolean으로 기록 후 모든 Phase가 PASS이면 머지 가능.

| Phase | 결과 |
|---|---|
| 0 정적 검증 | ✅/❌ |
| 1 linter/fixture | ✅/❌ |
| 2 기능 (positive) | ✅/❌ |
| 3 negative/regression | ✅/❌ |
| 4 pipefail safety | ✅/❌ |

## Follow-up (별도 이슈 등록 예정)

본 PR DA for_pr 3 라운드 + parallel-audit 6 bundle 결과 분리:

- **Design (PostToolUse identity-merge)**: `sync-codex-config.py`에 hook entry identity merge 정책 도입 — 사용자 PostToolUse 확장 경로 보존. Arbiter는 본 PR이 정책 명시 문서화한 점을 들어 LOW severity로 조정.
- **Maintainability (verifier 확장)**: `_should_check_path` / `_scan_file` / awk 후처리까지 lockstep 검사 확장. 본 PR은 PATTERN_A/B/C/D + HASH_MIN/MAX 변수 라인까지만.
- **Maintainability (behavioral fixture)**: `tests/fixtures/codex-hooks/pinning/` 디렉토리에 stdin/expected output fixture 추가 (Move to / multi-file / delete-only / backtick / large payload 등 케이스).
- **Security (apply_patch path tab)**: V4A path에 탭 포함 시 TSV attribution 깨짐 (실용 영향 매우 낮음, 운영 데이터 후 검토).
- **Performance (multi-file F*L)**: SECTIONS_FILE을 파일 수만큼 재스캔 → awk 단일 패스로 최적화 가능. 일반적 F<5라 영향 미미.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a post-tool-use hook for Claude that alerts via stderr after certain operations.
  * Added a post-tool-use hook for Codex that alerts via stderr after certain operations.

* **Tests**
  * Added test fixtures and validation suite to verify hook behavior and template-owned configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->