### PR TITLE
fix(skills): fail fast on missing MCP sources

### DIFF
--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md
@@ -28,7 +28,7 @@ Codex CLI 호환 구조(`.agents/`, `.codex/`)로 프로젝션한다.
 
 ### MCP 섹션 가드 예시
 
-`mcp-config`는 source 파일 부재 시 기존 `[mcp_servers.*]`를 silent 삭제하므로 호출 전 존재 가드가 필수다. 가드는 `if [ -f X ]; then ...; fi` 형태로 작성한다 — `set -e` 환경에서도 안전하다.
+`mcp-config`는 source 옵션 없이 호출하거나 `--project-mcp`/`--plugin-mcp`/`--user-mcp` source 파일이 없으면 fail-fast한다. 선택적 source를 다루는 호출자는 불필요한 실패를 피하기 위해 `if [ -f X ]; then ...; fi` 가드를 사용한다 — `set -e` 환경에서도 안전하다.
 
 ```bash
 # 프로젝트 MCP 섹션만
@@ -43,7 +43,7 @@ fi
 ```
 
 > 추가 동작 노트:
-> - `mcp-config`는 source 옵션 (`--project-mcp` / `--plugin-mcp` / `--user-mcp`) 중 적어도 하나가 필요하다. source 없이 호출하거나 `--project-mcp=<path>`의 path 파일이 없으면 새 MCP TOML이 비어 `replace_mcp_sections`가 기존 `[mcp_servers.*]` 섹션을 모두 제거한다 (`references/sync.sh`의 mcp-config 경로 참조). `sync.sh`는 source 부재를 오류로 처리하지 않으므로 호출자(또는 위 가드)가 책임진다.
+> - `mcp-config`는 source 옵션 (`--project-mcp` / `--plugin-mcp` / `--user-mcp`) 중 적어도 하나가 필요하다. source 없이 호출하거나 source path 파일이 없으면 `sync.sh`가 non-zero로 종료하며 기존 `[mcp_servers.*]` 섹션을 건드리지 않는다. `--plugin-mcp`는 `PATH:INSTALL_PATH:NAME` 형식이어야 한다.
 > - `all` 경로는 인자 조립 시점에 `[ -f .mcp.json ]` 가드를 두어 이 문제를 피한다.
 > - `project-skills`는 `<source-skills-dir> <target-skills-dir>` 두 인자를 모두 명시해야 한다. `sync.sh`는 `set -u` 아래에서 동작하므로 한 인자만 넘기면 즉시 `unbound variable`로 실패하고 종료한다 (투영이 0개로 끝나는 게 아니라 실행 자체가 멈춘다).
 > - **`set -e` 가드 패턴 (단일 SoT)**: 위 if 가드 형태가 본 SKILL의 표준이다. 이전 `test -f X && cmd` 형태는 standalone statement 위치(함수/스크립트 마지막 또는 단독 실행)에서 false 평가 시 exit 1을 propagate해 `set -e` caller를 abort시킨다. `if` 조건 *내부*의 `[ ... ] && [ ... ]`은 단일 평가식이므로 안전하며 본 가이드의 금지 대상이 아니다.

--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
@@ -368,6 +368,7 @@ mcp_config() {
     local plugin_mcp_install="${plugin_mcp_rest%%:*}"
     local plugin_mcp_name="${plugin_mcp_rest#*:}"
     if [ "$plugin_mcp_rest" = "$pm" ] || [ "$plugin_mcp_name" = "$plugin_mcp_rest" ] \
+      || [[ "$plugin_mcp_name" == *:* ]] \
       || [ -z "$plugin_mcp_path" ] || [ -z "$plugin_mcp_install" ] || [ -z "$plugin_mcp_name" ]; then
       echo "sync.sh mcp-config: malformed --plugin-mcp source: ${pm:-<empty>} (expected PATH:INSTALL_PATH:NAME)" >&2
       return 1

--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
@@ -332,16 +332,53 @@ mcp_config() {
 
   # Collect MCP source args
   local project_mcp=""
+  local project_mcp_set=0
   local plugin_mcps=()
+  local plugin_mcp_paths=()
+  local plugin_mcp_installs=()
+  local plugin_mcp_names=()
   local user_mcp=""
+  local user_mcp_set=0
   local user_codex_config=""
   for arg in "$@"; do
     case "$arg" in
-      --project-mcp=*) project_mcp="${arg#--project-mcp=}" ;;
+      --project-mcp=*) project_mcp="${arg#--project-mcp=}"; project_mcp_set=1 ;;
       --plugin-mcp=*)  plugin_mcps+=("${arg#--plugin-mcp=}") ;;
-      --user-mcp=*) user_mcp="${arg#--user-mcp=}" ;;
+      --user-mcp=*) user_mcp="${arg#--user-mcp=}"; user_mcp_set=1 ;;
       --user-codex-config=*) user_codex_config="${arg#--user-codex-config=}" ;;
     esac
+  done
+
+  if [ "$project_mcp_set" -eq 0 ] && [ "$user_mcp_set" -eq 0 ] && [ "${#plugin_mcps[@]}" -eq 0 ]; then
+    echo "sync.sh mcp-config: at least one source option (--project-mcp/--plugin-mcp/--user-mcp) required" >&2
+    echo "Usage: sync.sh mcp-config <project-root> [--project-mcp=PATH] [--plugin-mcp=PATH:INSTALL_PATH:NAME]... [--user-mcp=PATH] [--user-codex-config=PATH]" >&2
+    return 1
+  fi
+  if [ "$project_mcp_set" -eq 1 ] && [ ! -f "$project_mcp" ]; then
+    echo "sync.sh mcp-config: --project-mcp source missing: ${project_mcp:-<empty>} (create the file or omit --project-mcp)" >&2
+    return 1
+  fi
+  if [ "$user_mcp_set" -eq 1 ] && [ ! -f "$user_mcp" ]; then
+    echo "sync.sh mcp-config: --user-mcp source missing: ${user_mcp:-<empty>} (create the file or omit --user-mcp)" >&2
+    return 1
+  fi
+  for pm in "${plugin_mcps[@]}"; do
+    local plugin_mcp_path="${pm%%:*}"
+    local plugin_mcp_rest="${pm#*:}"
+    local plugin_mcp_install="${plugin_mcp_rest%%:*}"
+    local plugin_mcp_name="${plugin_mcp_rest#*:}"
+    if [ "$plugin_mcp_rest" = "$pm" ] || [ "$plugin_mcp_name" = "$plugin_mcp_rest" ] \
+      || [ -z "$plugin_mcp_path" ] || [ -z "$plugin_mcp_install" ] || [ -z "$plugin_mcp_name" ]; then
+      echo "sync.sh mcp-config: malformed --plugin-mcp source: ${pm:-<empty>} (expected PATH:INSTALL_PATH:NAME)" >&2
+      return 1
+    fi
+    if [ ! -f "$plugin_mcp_path" ]; then
+      echo "sync.sh mcp-config: --plugin-mcp source missing: $plugin_mcp_path (create the file or omit --plugin-mcp)" >&2
+      return 1
+    fi
+    plugin_mcp_paths+=("$plugin_mcp_path")
+    plugin_mcp_installs+=("$plugin_mcp_install")
+    plugin_mcp_names+=("$plugin_mcp_name")
   done
 
   if [ -n "$user_mcp" ]; then
@@ -358,8 +395,10 @@ mcp_config() {
   [ -n "$project_mcp" ] && env_args+=("PROJECT_MCP=$project_mcp")
   [ -n "$user_mcp" ] && env_args+=("USER_MCP=$user_mcp")
   local idx=0
-  for pm in "${plugin_mcps[@]}"; do
-    env_args+=("PLUGIN_MCP_${idx}=$pm")
+  while [ "$idx" -lt "${#plugin_mcp_paths[@]}" ]; do
+    env_args+=("PLUGIN_MCP_PATH_${idx}=${plugin_mcp_paths[$idx]}")
+    env_args+=("PLUGIN_MCP_INSTALL_${idx}=${plugin_mcp_installs[$idx]}")
+    env_args+=("PLUGIN_MCP_NAME_${idx}=${plugin_mcp_names[$idx]}")
     idx=$((idx + 1))
   done
 
@@ -445,15 +484,17 @@ if user_mcp and os.path.isfile(user_mcp):
 
 i = 0
 while True:
-    pm = os.environ.get(f'PLUGIN_MCP_{i}', '')
-    if not pm:
+    mcp_path = os.environ.get(f'PLUGIN_MCP_PATH_{i}', '')
+    if not mcp_path:
         break
-    parts = pm.split(':', 2)
-    if len(parts) == 3:
-        mcp_path, ipath, pname = parts
-        if os.path.isfile(mcp_path):
-            for name, cfg in load_mcp(mcp_path, ipath).items():
-                all_servers.append((name, cfg, pname))
+    ipath = os.environ.get(f'PLUGIN_MCP_INSTALL_{i}', '')
+    pname = os.environ.get(f'PLUGIN_MCP_NAME_{i}', '')
+    if not ipath or not pname:
+        sys.exit(f"sync.sh mcp-config: malformed normalized plugin MCP source at index {i}")
+    if not os.path.isfile(mcp_path):
+        sys.exit(f"sync.sh mcp-config: --plugin-mcp source missing after validation: {mcp_path}")
+    for name, cfg in load_mcp(mcp_path, ipath).items():
+        all_servers.append((name, cfg, pname))
     i += 1
 
 # Collision-based prefixing: only prefix when names collide
@@ -533,6 +574,11 @@ sync_all() {
       --user-codex-config=*) user_codex_config="${arg#--user-codex-config=}" ;;
     esac
   done
+
+  if [ -n "$user_mcp" ] && [ ! -f "$user_mcp" ]; then
+    echo "sync.sh all: --user-mcp source missing: $user_mcp (create the file or omit --user-mcp)" >&2
+    return 1
+  fi
 
   echo "=== syncing-codex-harness: Full Sync ===" >&2
 

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -698,6 +698,16 @@ test_sync_sh_mcp_config_failfast() {
 
   _write_existing_mcp_config "$config_file"
   rc=0
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" \
+    --plugin-mcp="$project_root/plugin/.mcp.json:$project_root/plugin:plugin-name:extra" \
+    >"$sandbox/malformed-plugin-extra.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[malformed-plugin-extra] extra field --plugin-mcp가 non-zero로 실패해야 함"
+  grep -Fq "sync.sh mcp-config: malformed --plugin-mcp source:" "$stderr_log" \
+    || fail "[malformed-plugin-extra] stderr에 malformed plugin source 진단이 있어야 함"
+  _assert_existing_mcp_preserved "$config_file" "malformed-plugin-extra"
+
+  _write_existing_mcp_config "$config_file"
+  rc=0
   bash "$SYNC_HARNESS_SH" mcp-config "$project_root" >"$sandbox/no-source.stdout" 2>"$stderr_log" || rc=$?
   [[ "$rc" -ne 0 ]] || fail "[no-source] source 옵션 없는 mcp-config가 non-zero로 실패해야 함"
   grep -Fq "at least one source option" "$stderr_log" \

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -2,7 +2,7 @@
 # tests/test-codex-hook-fixtures.sh
 # Codex 0.124+ stable hook 회귀 차단 fixture runner.
 #
-# 7 카테고리:
+# 8 카테고리:
 #   1. stdin schema baseline 0.124       — fixtures/codex-hooks/stdin/{userpromptsubmit-codex-0.124,stop-codex-0.124,stop-no-last-message}.json
 #   2. dispatcher ordering / failure recovery — runner 내부 mock subscript
 #   3. noise-guard env 변형              — runner 내부 helper (4 env 조합)
@@ -10,6 +10,7 @@
 #   5. env propagation (live opt-in)      — CODEX_HOOK_LIVE=1 / --live
 #   6. stop-notification reliability/security — transcripts/ + stdin secret/transcript fixtures
 #   7. pinning-alert behavioral          — fixtures/codex-hooks/stdin/pinning-{claude,codex}-*.json
+#   8. sync.sh mcp-config fail-fast      — missing/no source가 기존 MCP 섹션을 지우지 않음
 #
 # nrs-session-cleanup.sh는 NRS_LOCK_FILE을 하드코딩하므로 (host /tmp/nrs-state 누수 위험)
 # fixture는 real script를 직접 호출하지 않고 mock subscript로 대체한다.
@@ -69,6 +70,7 @@ else
   TEMPLATE_REPO_FILE="$REPO_ROOT/modules/shared/programs/codex/files/config.toml"
 fi
 SYNC_SCRIPT="$REPO_ROOT/modules/shared/programs/codex/files/sync-codex-config.py"
+SYNC_HARNESS_SH="$REPO_ROOT/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh"
 
 # ─── CLI 인자 / opt-in 모드 ───
 # Precedence: CODEX_HOOK_LIVE env가 default를 set하고, CLI 인자가 그 위에 적용된다.
@@ -579,6 +581,144 @@ assert all("USER-POSTTOOLUSE-LOST" not in c for c in all_commands), \
 PY
 }
 
+# ─── 카테고리 8: syncing-codex-harness mcp-config fail-fast (#609) ───
+_write_existing_mcp_config() {
+  local target="$1"
+  mkdir -p "$(dirname "$target")"
+  cat > "$target" <<'EOF'
+model = "gpt-5.5"
+
+[mcp_servers.existing]
+command = "/tmp/existing-mcp"
+EOF
+}
+
+_assert_existing_mcp_preserved() {
+  local target="$1" scenario="$2"
+  grep -Fqx '[mcp_servers.existing]' "$target" \
+    || fail "[$scenario] 기존 mcp_servers.existing 섹션이 보존되어야 함"
+  grep -Fqx 'command = "/tmp/existing-mcp"' "$target" \
+    || fail "[$scenario] 기존 MCP command가 보존되어야 함"
+}
+
+test_sync_sh_mcp_config_valid_sources() {
+  local sandbox project_root config_file plugin_dir
+  sandbox=$(new_hook_sandbox)
+  project_root="$sandbox/project"
+  config_file="$project_root/.codex/config.toml"
+  plugin_dir="$project_root/plugin"
+  mkdir -p "$project_root/.codex" "$plugin_dir"
+
+  cat > "$project_root/.mcp.json" <<'EOF'
+{
+  "mcpServers": {
+    "project-server": {
+      "command": "/tmp/project-server"
+    }
+  }
+}
+EOF
+  cat > "$plugin_dir/.mcp.json" <<'EOF'
+{
+  "mcpServers": {
+    "plugin-server": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/plugin-server",
+      "args": ["--root", "${CLAUDE_PLUGIN_ROOT}"]
+    }
+  }
+}
+EOF
+
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" \
+    --project-mcp="$project_root/.mcp.json" \
+    --plugin-mcp="$plugin_dir/.mcp.json:$plugin_dir:test-plugin" \
+    >"$sandbox/valid-sources.stdout" 2>"$sandbox/valid-sources.stderr" \
+    || fail "[valid-sources] valid MCP sources should succeed: $(cat "$sandbox/valid-sources.stderr" 2>/dev/null || true)"
+
+  grep -Fqx '[mcp_servers.project-server]' "$config_file" \
+    || fail "[valid-sources] project MCP server missing"
+  grep -Fqx 'command = "/tmp/project-server"' "$config_file" \
+    || fail "[valid-sources] project MCP command missing"
+  grep -Fqx '[mcp_servers.plugin-server]' "$config_file" \
+    || fail "[valid-sources] plugin MCP server missing"
+  grep -Fqx "command = \"$plugin_dir/bin/plugin-server\"" "$config_file" \
+    || fail "[valid-sources] plugin MCP command did not substitute CLAUDE_PLUGIN_ROOT"
+  grep -Fqx "args = [\"--root\", \"$plugin_dir\"]" "$config_file" \
+    || fail "[valid-sources] plugin MCP args did not substitute CLAUDE_PLUGIN_ROOT"
+}
+
+test_sync_sh_mcp_config_failfast() {
+  local sandbox project_root config_file stderr_log rc
+  sandbox=$(new_hook_sandbox)
+  project_root="$sandbox/project"
+  config_file="$project_root/.codex/config.toml"
+  stderr_log="$sandbox/sync-sh.stderr"
+  mkdir -p "$project_root/.codex"
+
+  _write_existing_mcp_config "$config_file"
+  rc=0
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" \
+    --project-mcp="$project_root/.mcp.json" >"$sandbox/missing-project.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[missing-project] missing --project-mcp가 non-zero로 실패해야 함"
+  grep -Fq "sync.sh mcp-config: --project-mcp source missing:" "$stderr_log" \
+    || fail "[missing-project] stderr에 missing source 진단이 있어야 함"
+  _assert_existing_mcp_preserved "$config_file" "missing-project"
+
+  _write_existing_mcp_config "$config_file"
+  rc=0
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" \
+    --user-mcp="$project_root/missing-user-mcp.json" \
+    --user-codex-config="$config_file" >"$sandbox/missing-user.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[missing-user] missing --user-mcp가 non-zero로 실패해야 함"
+  grep -Fq "sync.sh mcp-config: --user-mcp source missing:" "$stderr_log" \
+    || fail "[missing-user] stderr에 missing user source 진단이 있어야 함"
+  _assert_existing_mcp_preserved "$config_file" "missing-user"
+
+  _write_existing_mcp_config "$config_file"
+  rc=0
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" \
+    --plugin-mcp="$project_root/missing-plugin-mcp.json:$project_root/plugin:missing-plugin" \
+    >"$sandbox/missing-plugin.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[missing-plugin] missing --plugin-mcp가 non-zero로 실패해야 함"
+  grep -Fq "sync.sh mcp-config: --plugin-mcp source missing:" "$stderr_log" \
+    || fail "[missing-plugin] stderr에 missing plugin source 진단이 있어야 함"
+  _assert_existing_mcp_preserved "$config_file" "missing-plugin"
+
+  mkdir -p "$project_root/plugin"
+  printf '{}\n' > "$project_root/plugin/.mcp.json"
+  _write_existing_mcp_config "$config_file"
+  rc=0
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" \
+    --plugin-mcp="$project_root/plugin/.mcp.json:$project_root/plugin" \
+    >"$sandbox/malformed-plugin.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[malformed-plugin] malformed --plugin-mcp가 non-zero로 실패해야 함"
+  grep -Fq "sync.sh mcp-config: malformed --plugin-mcp source:" "$stderr_log" \
+    || fail "[malformed-plugin] stderr에 malformed plugin source 진단이 있어야 함"
+  _assert_existing_mcp_preserved "$config_file" "malformed-plugin"
+
+  _write_existing_mcp_config "$config_file"
+  rc=0
+  bash "$SYNC_HARNESS_SH" mcp-config "$project_root" >"$sandbox/no-source.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[no-source] source 옵션 없는 mcp-config가 non-zero로 실패해야 함"
+  grep -Fq "at least one source option" "$stderr_log" \
+    || fail "[no-source] stderr에 source option 필수 진단이 있어야 함"
+  _assert_existing_mcp_preserved "$config_file" "no-source"
+
+  local all_project_root="$sandbox/all-project"
+  mkdir -p "$all_project_root"
+  rc=0
+  bash "$SYNC_HARNESS_SH" all "$all_project_root" \
+    --user-mcp="$all_project_root/missing-user-mcp.json" \
+    >"$sandbox/all-missing-user.stdout" 2>"$stderr_log" || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "[all-missing-user] sync all missing --user-mcp가 non-zero로 실패해야 함"
+  grep -Fq "sync.sh all: --user-mcp source missing:" "$stderr_log" \
+    || fail "[all-missing-user] stderr에 sync all missing user source 진단이 있어야 함"
+  [[ ! -e "$all_project_root/.agents" ]] \
+    || fail "[all-missing-user] source preflight 전에 .agents를 생성하면 안 됨"
+  [[ ! -e "$all_project_root/.codex" ]] \
+    || fail "[all-missing-user] source preflight 전에 .codex를 생성하면 안 됨"
+}
+
 # ─── 카테고리 6: stop-notification reliability/security ───
 # 6.1 Codex JSONL transcript fallback 추출 검증.
 # fixture stdin은 last_assistant_message=null + transcript_path를 sandbox 안의 Codex schema
@@ -893,6 +1033,10 @@ run_test "stop-notification helper equivalence (6.4)" \
 
 run_test "pinning-alert behavioral (#606)" \
   test_pinning_alert_behavioral
+run_test "sync.sh mcp-config valid sources (#609)" \
+  test_sync_sh_mcp_config_valid_sources
+run_test "sync.sh mcp-config fail-fast (#609)" \
+  test_sync_sh_mcp_config_failfast
 
 if [[ "$LIVE_MODE" == "1" ]]; then
   run_test "env propagation live (codex exec --ephemeral)" \


### PR DESCRIPTION
## Summary
- `syncing-codex-harness`의 MCP 투영이 source 누락 시 기존 `[mcp_servers.*]`를 조용히 지우지 않도록 fail-fast로 전환합니다.
- project/user/plugin MCP source 검증과 `all` 모드 user MCP 사전 검증을 추가해 직접 호출과 전체 sync 경로를 함께 보호합니다.
- 정상 source와 누락 source 양쪽 fixture를 추가해 기존 설정 보존과 plugin root 치환을 고정합니다.

Closes #609

## 기존 문제/배경

`sync.sh mcp-config`는 source 파일이 없을 때 Python 변환부에서 단순히 skip했습니다. 그 상태로 `replace_mcp_sections`가 실행되면 새 MCP 입력이 빈 값이 되어 기존 `[mcp_servers.*]` 섹션이 제거될 수 있었습니다.

PR #599에서 SKILL.md 호출 예시에 `if [ -f X ]; then ...; fi` 가드를 추가했지만, root cause는 `sync.sh` 직접 호출 경로에 남아 있었습니다. 따라서 문서 가드를 복사하지 않은 사용자 호출, activation/CI류 호출, 새 callsite 추가 시 같은 silent deletion 위험이 재발할 수 있었습니다.

## CIR (Change Intent Record)

- **v1** (PR #599): SKILL.md 빠른 참조에 파일 존재 가드를 추가해 문서 예시 경로의 silent deletion을 방지했습니다.
- **v2** (Issue #609): 문서 가드만으로는 직접 호출자를 보호하지 못한다는 점을 확인하고, `sync.sh mcp-config` 안에서 source 입력을 검증하는 방향으로 전환했습니다.
- **v3** (이번 변경): project/user missing source와 no-source 호출뿐 아니라 plugin source 형식/존재 검증, `all --user-mcp` 사전 검증, valid-source fixture까지 포함했습니다.

**trade-off**: 선택적 source를 넘기는 호출자는 존재 여부를 먼저 확인해야 합니다. 대신 잘못된 인자나 누락된 파일이 있을 때 기존 MCP 설정을 변경하지 않고 명시적으로 실패합니다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| SKILL.md 가드만 유지 | 호출 예시에서만 `[ -f X ]`로 보호 | 변경 최소 | 직접 호출자와 새 callsite가 계속 위험 | ❌ |
| `mcp_config` 진입부에서 source 검증 | 쓰기 전에 project/user/plugin source와 no-source 호출을 차단 | root cause 위치에서 기존 설정 보존 | 선택적 source 호출자가 가드를 지켜야 함 | ✅ |
| Python 변환부에서만 검증 | 기존 Python 로딩 흐름에 검증 추가 | 구현 위치가 MCP 파싱과 가까움 | Bash 인자 조립과 plugin metadata 오류를 늦게 발견 | ❌ |
| `all --user-mcp` 사전 검증 포함 | projection 생성 전 user MCP 누락을 차단 | 실패 시 `.agents`/`.codex` 부분 생성도 방지 | `all` 경로에 별도 preflight 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh` | 수정 | `mcp_config` source 옵션 필수화, project/user/plugin missing source fail-fast, malformed plugin tuple 차단, plugin metadata 정규화 |
| `modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh` | 수정 | `sync_all`에서 `--user-mcp` 누락을 projection 생성 전에 preflight |
| `modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md` | 수정 | 빠른 참조 동작 노트를 fail-fast 기준으로 갱신 |
| `tests/test-codex-hook-fixtures.sh` | 수정 | missing project/user/plugin/no-source/malformed plugin/all-user-mcp fixture와 valid source fixture 추가 |

### 핵심 코드

```bash
if [ "$project_mcp_set" -eq 0 ] && [ "$user_mcp_set" -eq 0 ] && [ "${#plugin_mcps[@]}" -eq 0 ]; then
  echo "sync.sh mcp-config: at least one source option (--project-mcp/--plugin-mcp/--user-mcp) required" >&2
  return 1
fi
if [ "$project_mcp_set" -eq 1 ] && [ ! -f "$project_mcp" ]; then
  echo "sync.sh mcp-config: --project-mcp source missing: ${project_mcp:-<empty>} (create the file or omit --project-mcp)" >&2
  return 1
fi
```

```bash
if [ -n "$user_mcp" ] && [ ! -f "$user_mcp" ]; then
  echo "sync.sh all: --user-mcp source missing: $user_mcp (create the file or omit --user-mcp)" >&2
  return 1
fi
```

## 참고 레퍼런스

- Issue #609 — `sync.sh mcp-config` missing-source fail-fast follow-up
- PR #599 — SKILL.md 가드 기반 1차 방어
- Issue #547 — Codex CLI 호환성 캠페인 parent epic

## Human Test Plan

### 정상 source 경로

1. project `.mcp.json`과 plugin `.mcp.json`이 있는 sandbox에서 `sync.sh mcp-config <project> --project-mcp=<path> --plugin-mcp=<path>:<install>:<name>`를 실행합니다.
   - **기대**: project/plugin `[mcp_servers.*]`가 생성되고 `${CLAUDE_PLUGIN_ROOT}`가 plugin install path로 치환됩니다.
   - **실패 시**: `--plugin-mcp` tuple이 `PATH:INSTALL_PATH:NAME` 형식인지, source JSON이 `mcpServers`를 포함하는지 확인합니다.

### 누락 source 경로

2. 기존 `[mcp_servers.existing]`가 있는 config에 missing `--project-mcp`를 넘겨 실행합니다.
   - **기대**: command가 non-zero로 실패하고 stderr에 `--project-mcp source missing`이 출력되며 기존 MCP 섹션은 보존됩니다.
   - **실패 시**: `mcp_config`의 source preflight가 `mkdir`/Python 변환보다 먼저 실행되는지 확인합니다.

3. `sync.sh all <project> --user-mcp=<missing>`을 실행합니다.
   - **기대**: non-zero로 실패하고 `.agents`/`.codex` projection 디렉토리를 만들기 전에 종료합니다.
   - **실패 시**: `sync_all`의 user MCP preflight 위치가 init 단계보다 앞인지 확인합니다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

> "source 검증과 문서 노트가 코드와 함께 반영되어 있는지 확인"

```bash
grep -q "at least one source option" modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
grep -q "malformed --plugin-mcp source" modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
grep -q "기존 \[mcp_servers\.\*\] 섹션을 건드리지 않는다" modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md
```

- **기대**: 세 명령 모두 exit 0입니다.
- **실패 시**: `sync.sh`와 SKILL.md가 같은 fail-fast 정책을 설명하는지 확인합니다.

### Phase 1: MCP fixture 검증

> "valid source와 missing source 동작을 fixture로 검증"

```bash
bash tests/test-codex-hook-fixtures.sh --no-live
```

- **기대**: `sync.sh mcp-config valid sources (#609)`와 `sync.sh mcp-config fail-fast (#609)`가 포함되어 전체 통과합니다.
- **실패 시**: stderr의 source missing/malformed 진단과 기존 config 보존 assertion을 확인합니다.

### Phase 2: Shell/static regression

> "인접 shell script와 format/static 검증이 이번 변경으로 깨지지 않았는지 확인"

```bash
bash -n modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh tests/test-codex-hook-fixtures.sh
shellcheck -S warning modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh tests/test-codex-hook-fixtures.sh
git diff --check main...HEAD
```

- **기대**: 모든 명령이 exit 0입니다.
- **실패 시**: shell syntax, shellcheck warning, trailing whitespace를 우선 확인합니다.

### Phase 3: Runtime surface regression

> "Codex 스킬/하니스 투영 표면이 런타임에서 일관되는지 확인"

```bash
nrs
./scripts/ai/verify-ai-compat.sh
```

- **기대**: `nrs`는 변경 적용 없음 또는 정상 preview를 보고하고, `verify-ai-compat.sh`는 `검증 완전 통과`로 끝납니다.
- **실패 시**: `~/.codex/skills/*`, `~/.codex/scripts/*` projection과 shared skill exposure policy를 확인합니다.

### Phase 4: Pre-push regression

> "pre-push 훅의 인접 테스트까지 통과하는지 확인"

```bash
env -u TMUX git push --dry-run
```

- **기대**: `codex-hook-fixtures`, `flake-check`, `shell-script-tests`가 모두 통과합니다.
- **실패 시**: tmux 세션에서 실행 중이면 `TMUX` 환경이 shell-script fixture에 영향을 주는지 먼저 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `mcp-config` now validates that all specified MCP source files exist before making changes, preventing accidental configuration loss.
  * Improved fail-fast error handling with clearer diagnostics when required files or arguments are missing or malformed.

* **Documentation**
  * Updated guidance clarifying required argument formats and validation behavior for MCP configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->