### PR TITLE
fix(tests): isolate wt fixtures from TMUX

### DIFF
--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -648,13 +648,14 @@ test_wt_cd_by_name_returns_target_path() {
 
   expected_path="$repo_root/.claude/worktrees/feature_one"
   output=$(
-    HOME="$home_dir" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/wt"'" cd feature_one
-    ' 2>&1
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$FIXTURE_DIR/bin:$PATH" \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" cd feature_one
+      ' 2>&1
   )
 
   assert_contains "$output" "$expected_path"
@@ -803,14 +804,15 @@ EOF
   chmod +x "$fallback_dir/codex-sync"
 
   output=$(
-    HOME="$home_dir" \
-    PATH="$fallback_dir:$FIXTURE_DIR/bin:$PATH" \
-    CODEX_SYNC_MARKER="$marker_file" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/wt"'" feature-two
-    ' 2>&1
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$fallback_dir:$FIXTURE_DIR/bin:$PATH" \
+      CODEX_SYNC_MARKER="$marker_file" \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" feature-two
+      ' 2>&1
   )
 
   new_worktree="$repo_root/.claude/worktrees/feature-two"


### PR DESCRIPTION
## Summary
- Make `wt` shell fixtures that assert non-tmux stdout paths clear ambient `TMUX` inside the test subprocess.
- Keep production `wt` tmux behavior unchanged while making pre-push shell tests hermetic from the caller's tmux session.

Closes #620

## 기존 문제/배경

`wt`는 `TMUX`가 설정되어 있으면 tmux window 생성/전환 경로를 먼저 탄다. 그런데 `tests/shell-script-tests.sh`의 일부 fixture는 non-tmux stdout path를 검증하면서도 호출자 환경의 `TMUX`를 그대로 상속하고 있었다.

그 결과 tmux pane 안에서 `git push` 또는 shell test runner를 실행하면, fixture가 의도한 stdout path 대신 tmux branch가 실행되어 테스트 결과가 호출자 세션 상태에 의존할 수 있었다.

## CIR (Change Intent Record)

- **v1** (Issue #620): `wt create uses managed codex-sync path` fixture가 tmux 안 pre-push에서 ambient `TMUX` 때문에 실패할 수 있음을 확인.
- **v2** (이번 변경): production `wt` 동작은 유지하고, non-tmux stdout path를 기대하는 fixture subprocess에서만 `TMUX`를 제거한다.

**trade-off**: 각 fixture에 `env -u TMUX`가 명시되어 약간의 반복은 생기지만, 테스트 의도가 호출자 shell 상태와 분리되어 더 명확해진다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| production `wt`의 tmux 분기 변경 | `TMUX` 처리 자체를 바꾼다 | 테스트 실패 원인을 근본적으로 없앨 수 있음 | 의도된 tmux window 기능을 바꿔 사용자 동작 회귀 가능 | ❌ |
| test runner 전체에서 `TMUX` 제거 | 전체 shell test 실행 환경을 non-tmux로 고정 | 한 곳에서 처리 가능 | 향후 tmux 관련 fixture가 생기면 신호를 잃음 | ❌ |
| stdout path fixture subprocess만 `TMUX` 제거 | non-tmux 동작을 검증하는 fixture 내부에서만 환경 격리 | 범위가 작고 테스트 의도와 직접 일치 | 동일 패턴 fixture에는 명시적으로 적용 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `tests/shell-script-tests.sh` | 수정 | `wt cd feature_one` fixture subprocess에 `env -u TMUX` 추가 |
| `tests/shell-script-tests.sh` | 수정 | `wt feature-two` fixture subprocess에 `env -u TMUX` 추가 |

### 핵심 코드

```bash
output=$(
  env -u TMUX \
    HOME="$home_dir" \
    PATH="$FIXTURE_DIR/bin:$PATH" \
    bash -c '
      set -euo pipefail
      cd "'"$repo_root"'"
      "'"$home_dir/.local/bin/wt"'" cd feature_one
    ' 2>&1
)
```

동일한 격리를 `wt feature-two` fixture에도 적용해 managed `codex-sync` path 검증이 tmux pane 여부와 무관하게 non-tmux stdout path를 검증하도록 했다.

## 참고 레퍼런스

- Issue #620 — tmux 안에서 shell fixture가 ambient `TMUX`에 의해 다른 분기로 실행될 수 있다는 버그 보고.
- `modules/shared/scripts/lib/wt/navigate.sh` — `wt cd`가 `TMUX` 존재 시 tmux path로 분기하고, 없으면 target path를 stdout으로 출력한다.
- `modules/shared/scripts/lib/wt/bootstrap.sh` — worktree 생성 후 `TMUX` 존재 시 tmux open path를, 없으면 worktree path stdout을 사용한다.

## Human Test Plan

### 정상 shell에서 검증

1. `bash tests/run-shell-script-tests.sh`를 실행한다.
   - **기대**: `All shell script tests passed.`가 출력된다.
   - **실패 시**: `wt cd returns target path by name` 또는 `wt create uses managed codex-sync path` fixture 출력이 expected path를 포함하는지 확인한다.

### tmux pane에서 검증

2. 실제 tmux pane 안에서 `bash tests/run-shell-script-tests.sh`를 실행한다.
   - **기대**: 일반 shell과 동일하게 모든 shell fixture가 통과한다.
   - **실패 시**: 해당 fixture subprocess에 `env -u TMUX`가 적용되는지, production `wt`가 아닌 test subprocess 경계에서 환경이 제거되는지 확인한다.

### pre-push 경로 검증

3. `git push --dry-run` 또는 실제 branch push를 실행한다.
   - **기대**: pre-push의 shell test가 ambient `TMUX` 때문에 실패하지 않는다.
   - **실패 시**: pre-push 출력에서 실패한 hook과 fixture 이름을 확인하고, shell test runner가 현재 branch의 `tests/shell-script-tests.sh`를 사용하는지 확인한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

> "non-tmux stdout path fixture에만 `TMUX` 격리가 적용됐는지 확인"

```bash
rg -n 'env -u TMUX' tests/shell-script-tests.sh
# 기대: `wt cd feature_one` fixture와 `wt feature-two` fixture 주변에 2건 존재

rg -n 'env -u TMUX' modules/shared/scripts/lib/wt
# 기대: exit 1. production wt helper는 변경하지 않아야 함
```

- **실패 시**: `env -u TMUX`가 test fixture가 아닌 production helper에 들어갔는지 확인한다.

### Phase 1: Shell Fixture 검증

> "일반 shell에서 전체 shell script fixture가 통과하는지 확인"

```bash
bash -n tests/shell-script-tests.sh
shellcheck -S warning tests/shell-script-tests.sh
bash tests/run-shell-script-tests.sh
```

- **기대**: syntax, shellcheck, shell fixture가 모두 통과한다.
- **실패 시**: 실패 fixture의 stdout/stderr가 expected worktree path를 포함하는지 확인한다.

### Phase 2: tmux Regression 검증

> "실제 `TMUX` 환경에서도 shell fixture가 non-tmux stdout path를 안정적으로 검증하는지 확인"

```bash
if command -v tmux >/dev/null 2>&1; then
  repo_root=$(pwd -P)
  tmp_dir=$(mktemp -d)
  session="wt-fixture-620-$$"
  tmux new-session -d -s "$session" \
    "cd $(printf '%q' "$repo_root") && bash tests/run-shell-script-tests.sh >$(printf '%q' "$tmp_dir/out") 2>&1; printf '%s' \$? >$(printf '%q' "$tmp_dir/rc")"
  while tmux has-session -t "=$session" 2>/dev/null; do sleep 0.2; done
  cat "$tmp_dir/out"
  test "$(cat "$tmp_dir/rc")" -eq 0
fi
```

- **기대**: tmux 내부 실행에서도 `All shell script tests passed.`가 출력된다.
- **실패 시**: `wt cd feature_one` 또는 `wt feature-two` fixture가 tmux branch 출력으로 빠지는지 확인한다.

### Phase 3: 인접 기능 Regression

> "pre-push에서 인접 hook과 shell fixture가 함께 통과하는지 확인"

```bash
git push --dry-run
```

- **기대**: pre-push hook이 통과한다. 변경 파일이 push 대상이면 shell fixture가 실행되고 통과한다.
- **실패 시**: `codex-hook-fixtures`, `flake-check`, `shell-script-tests` 중 어느 hook이 실패했는지 분리해서 확인한다.
