### PR TITLE
docs(skills): clarify codex isolation and playwright cache-only tests

### DIFF
--- a/modules/shared/programs/claude/files/skills/playwright-cli/references/playwright-tests.md
+++ b/modules/shared/programs/claude/files/skills/playwright-cli/references/playwright-tests.md
@@ -1,18 +1,18 @@
 # Running Playwright Tests
 
-To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+To run Playwright tests, prefer a package manager script from the target project. If no script exists, use the cache-only `npx --offline playwright test` path so the agent never fetches from the registry. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
 
 ```bash
-# Run all tests
-PLAYWRIGHT_HTML_OPEN=never npx playwright test
-
 # Run all tests through a custom npm script
 PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+
+# Run all tests through npx without registry fetch/install
+PLAYWRIGHT_HTML_OPEN=never npx --offline playwright test
 ```
 
 # Debugging Playwright Tests
 
-To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions. Use the same package-manager-script or cache-only npx rule as normal test runs.
 
 **IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed.
 
@@ -20,7 +20,7 @@ Once instructions containing a session name are printed, use `playwright-cli` to
 
 ```bash
 # Run the test
-PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+PLAYWRIGHT_HTML_OPEN=never npx --offline playwright test --debug=cli
 # ...
 # ... debugging instructions for "tw-abcdef" session ...
 # ...

--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -182,7 +182,7 @@ Codex 세션에서 `spawn_agent`가 정책상 거부되면(예: `multi_agent=fal
 1. **BLOCKED + 사용자 승인 대기** (기본): `spawn_agent` 거부 감지 시 현재 DA 라운드 중단, 사용자에게 "delegation 거부 감지 — codex exec subprocess fallback 승인?"을 보고한다. 승인 수단은 런타임별로 다음과 같이 취한다:
    - 질문 도구 지원 런타임 (Claude Code 세션, Codex 세션): 질문 도구로 즉시 승인 요청. 승인 시 **같은 턴에서 바로** fallback 단계 진행.
    - 질문 도구 미지원 런타임 (headless 세션 등): plain-text로 상황 보고 후 DA 루프 종료한다. 사용자는 새 메시지에서 "fallback 진행"으로 명시 승인하거나 `run-da <mode>`를 다시 실행하여 **새 라운드로** 재개한다 (이전 라운드 상태는 복원하지 않음, 깨끗한 fresh round로 시작). 명시 승인 없이 자동 재개하지 않는다.
-2. **codex exec subprocess fallback** (사용자 승인 후에만): [`arbiter-scaling.md`](references/arbiter-scaling.md)의 "Codex delegation-denied fallback" 섹션이 정의한 role별 명령(standard profile = `model="gpt-5.5"`+medium, strong profile = `model="gpt-5.5"`+high)을 `--sandbox read-only --ignore-user-config --ephemeral`로 실행한다 (MCP/plugin/connector surface 차단을 위해 `--ignore-user-config`가 필수다 — 상세는 SSOT 참조). 각 unit은 독립 subprocess.
+2. **codex exec subprocess fallback** (사용자 승인 후에만): [`arbiter-scaling.md`](references/arbiter-scaling.md)의 "Codex delegation-denied fallback" 섹션이 정의한 role별 명령(standard profile = `model="gpt-5.5"`+medium, strong profile = `model="gpt-5.5"`+high)을 `--sandbox read-only --ignore-user-config --ephemeral`로 실행한다 (user config의 MCP/plugin/connector surface 차단을 위해 `--ignore-user-config`가 필수다. 단, cwd 기반 project config는 차단하지 못하므로 한계는 Non-goals #1 참조). 각 unit은 독립 subprocess.
 
 라운드 요약에는 경로와 sandbox 모드를 명시한다:
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
@@ -76,7 +76,7 @@ Claude Code에서 Codex CLI를 subprocess로 호출할 때, 비대화형 automat
 Codex 세션에서 `spawn_agent`가 정책상 거부될 때(예: `multi_agent=false`, `"delegation not permitted"`·`"multi_agent disabled"` 에러) 사용되는 subprocess 실행 계약이다. SKILL.md의 "Delegation fallback" 섹션은 정책 요약(승인 관문, 자동 우회 금지)만 두고, 실제 명령은 이 섹션이 SSOT다.
 
 **공통**:
-- `--sandbox read-only` + `--ignore-user-config`를 함께 강제한다. `--sandbox read-only`는 model-generated shell command의 파일시스템 쓰기만 막고, user `config.toml`의 MCP server/plugin/connector 로딩은 차단하지 못한다. `--ignore-user-config`로 MCP 등 외부 연결 surface를 함께 차단해야 reviewer/Arbiter/Intensity/Auditor의 no-write 경계가 실효성 있게 보장된다 (N=3 경로와 동일한 방식).
+- `--sandbox read-only` + `--ignore-user-config`를 함께 강제한다. `--sandbox read-only`는 model-generated shell command의 파일시스템 쓰기만 막고, user `config.toml`의 MCP server/plugin/connector 로딩은 차단하지 못한다. `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 user MCP/plugin/connector surface를 차단하지만, cwd 기반 project config (`.codex/config.toml`의 `[mcp_servers.*]`)는 차단하지 못한다. 이 project-config 한계는 `run-da/SKILL.md` Non-goals #1이 canonical이다.
 - `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model`/`model_reasoning_effort`도 차단하므로 role별 표의 `-c model="gpt-5.5"`·`-c model_reasoning_effort="..."` 명시가 필수다 (defensive explicit pin).
 - `--ephemeral`로 세션 히스토리 오염 방지.
 - `exec_command`를 `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec --sandbox read-only --ignore-user-config --ephemeral ... - 2>stderr.log` 형태로 stdin pipe 전달.


### PR DESCRIPTION
## Summary
- Clarify that `--ignore-user-config` only blocks user-scope Codex config and does not suppress cwd project config MCP definitions.
- Update the Playwright test reference to prefer project scripts or `npx --offline` so agent examples stay cache-only.

Closes #618
Closes #610

## 기존 문제/배경

`run-da`의 delegation fallback 문구는 `--sandbox read-only --ignore-user-config` 조합이 MCP/plugin/connector surface를 전부 차단하는 것처럼 읽힐 수 있었다. 실제로는 `$CODEX_HOME/config.toml` 같은 user config만 무시하고, cwd의 project config (`.codex/config.toml`)는 그대로 남을 수 있다.

`playwright-cli` 스킬 본문은 cache-only npx 경로를 명확히 설명하지만, `references/playwright-tests.md`에는 여전히 bare `npx playwright test` 예시가 남아 있었다. 이 예시는 local dependency가 없을 때 npx registry fetch/install로 이어질 수 있어 스킬의 권한 모델과 충돌한다.

## CIR (Change Intent Record)

- **v1** (Issue #618): PR review에서 `--ignore-user-config` 보호 범위가 cwd project config까지 포함되는 것처럼 보일 수 있다는 문서 gap 확인.
- **v2** (Issue #610): cleanup batch follow-up에서 Playwright test reference만 cache-only 정책을 따르지 않는 정합성 gap 확인.
- **v3** (이번 변경): 두 gap 모두 구현 변경 없이 문서 문구를 canonical 정책에 맞게 좁게 정정.

**trade-off**: `run-da` 문구가 조금 길어지지만, isolation 보장 범위를 오해하지 않도록 핵심 caveat를 호출 지점에 직접 둔다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 구현 변경 | `codex exec -C <scratch>` 같은 project config 회피를 즉시 구현 | isolation을 더 강하게 만들 수 있음 | #618 범위를 넘어 subprocess 실행 계약 변경으로 커짐 | ❌ |
| Non-goals만 유지 | 이미 있는 Non-goals #1 설명에 의존 | 중복 문구 최소 | delegation fallback 호출 지점만 읽으면 오해 가능 | ❌ |
| 호출 지점 caveat 추가 | fallback 요약과 arbiter-scaling 공통 블록에 project config 한계 명시 | 작은 변경으로 오해 방지 | 같은 사실을 두 위치에서 짧게 반복 | ✅ |
| bare npx 유지 | 기존 Playwright reference 유지 | 문서 churn 없음 | cache-only 정책과 불일치 | ❌ |
| project script 우선 + `npx --offline` | scripts를 우선하고 npx 예시는 offline으로 제한 | agent 예시가 네트워크 fetch를 유발하지 않음 | cold cache 환경에서는 사용자 setup 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/skills/run-da/SKILL.md` | 수정 | delegation fallback 설명에 user config vs cwd project config 한계 caveat 추가 |
| `modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md` | 수정 | `--ignore-user-config` 공통 계약에서 project config 미차단을 명시하고 Non-goals #1을 canonical로 연결 |
| `modules/shared/programs/claude/files/skills/playwright-cli/references/playwright-tests.md` | 수정 | bare `npx playwright test` 예시를 project script 우선 + `npx --offline playwright test`로 교체 |

### 핵심 코드

```markdown
`--ignore-user-config`는 `$CODEX_HOME/config.toml`의 user MCP/plugin/connector surface를 차단하지만,
cwd 기반 project config (`.codex/config.toml`의 `[mcp_servers.*]`)는 차단하지 못한다.
```

```bash
PLAYWRIGHT_HTML_OPEN=never npx --offline playwright test
PLAYWRIGHT_HTML_OPEN=never npx --offline playwright test --debug=cli
```

## 참고 레퍼런스

- Issue #618 — `run-da` delegation fallback의 `--ignore-user-config` project config caveat 요청.
- Issue #610 — `playwright-tests.md`의 cache-only enforcement follow-up.
- `run-da/SKILL.md` Non-goals #1 — project config MCP 차단 불가 한계의 canonical 설명.
- `playwright-cli/SKILL.md` Installation / runtime prerequisite sections — `@playwright/cli` cache-only path와 user-managed bootstrap 분리.

## Human Test Plan

### run-da caveat 확인

1. `run-da/SKILL.md`의 Delegation fallback 섹션을 읽는다.
   - **기대**: `--ignore-user-config`가 user config surface를 차단하지만 cwd project config는 차단하지 못한다는 caveat가 보인다.
   - **실패 시**: fallback 호출 지점이 Non-goals #1을 참조하는지 확인한다.

2. `run-da/references/arbiter-scaling.md`의 Codex delegation-denied fallback 공통 블록을 읽는다.
   - **기대**: `$CODEX_HOME/config.toml`과 cwd `.codex/config.toml`의 차이가 명시되어 있다.
   - **실패 시**: `--ignore-user-config` 설명이 user-scope와 project-scope를 혼동하는지 확인한다.

### Playwright reference 확인

3. `playwright-cli/references/playwright-tests.md`를 읽는다.
   - **기대**: package manager script가 우선이고, npx 예시는 `npx --offline playwright test`만 사용한다.
   - **실패 시**: bare `npx playwright test`가 남아 있는지 검색한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

> "문서에 필요한 caveat와 cache-only npx 예시가 반영됐는지 확인"

```bash
rg -n 'cwd 기반 project config|Non-goals #1|\$CODEX_HOME/config.toml' \
  modules/shared/programs/claude/files/skills/run-da/SKILL.md \
  modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
# 기대: delegation fallback 요약과 arbiter-scaling 공통 블록에서 project config 한계를 확인할 수 있음

rg -n 'npx playwright test' modules/shared/programs/claude/files/skills/playwright-cli/references/playwright-tests.md
# 기대: exit 1. bare npx 예시는 없어야 함

rg -n 'npx --offline playwright test' modules/shared/programs/claude/files/skills/playwright-cli/references/playwright-tests.md
# 기대: 일반 실행과 debug 실행 예시가 확인됨
```

- **실패 시**: raw npx 예시가 남아 있거나 `--ignore-user-config` 설명이 user/project scope를 구분하지 않는지 확인한다.

### Phase 1: Repository 검증

> "문서 변경이 repo-level guardrail을 깨지 않는지 확인"

```bash
git diff --check
./scripts/ai/verify-ai-compat.sh
```

- **기대**: whitespace check와 AI compatibility 검증이 모두 통과한다.
- **실패 시**: `verify-ai-compat.sh` 출력의 FAIL 섹션에서 skill projection 또는 hook surface drift를 확인한다.

### Phase 2: Provisioning Regression

> "스킬 문서 변경 후 실제 프로비저닝 surface가 일치하는지 확인"

```bash
nrs
./scripts/ai/verify-ai-compat.sh
```

- **기대**: `nrs`가 성공하고, `verify-ai-compat.sh`가 `검증 완전 통과`를 출력한다.
- **실패 시**: `nrs`가 out-of-store symlink를 갱신했는지, `~/.codex/skills/*` projection이 repo-local 변경을 반영했는지 확인한다.
