### PR TITLE
fix(codex): expose macOS Codex CLI in login shell

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -31,9 +31,6 @@ let
     (import ../../../../libraries/python-runtimes.nix { inherit pkgs; }).pythonWithTomlkit;
   # Claude 파일 경로 (공유 소스)
   claudeFilesPath = "${nixosConfigPath}/modules/shared/programs/claude/files";
-  # Homebrew uses /opt/homebrew on Apple Silicon and /usr/local on Intel macOS.
-  homebrewCodexPrefix =
-    if pkgs.stdenv.hostPlatform.system == "x86_64-darwin" then "/usr/local" else "/opt/homebrew";
 
   # ─── Shared skill 노출 정책 (direct Codex 글로벌, #486) ───
   # SoT: 아래 두 리스트. 독립 감사는 scripts/ai/verify-ai-compat.sh가 수행한다.
@@ -101,7 +98,7 @@ in
     # unrelated command resolution such as notification hook `timeout` behavior.
     ".local/bin/codex" = lib.mkIf (pkgs.stdenv.isDarwin && hostType == "personal") {
       source = pkgs.writeShellScript "codex-homebrew-wrapper" ''
-        exec ${homebrewCodexPrefix}/bin/codex "$@"
+        exec /opt/homebrew/bin/codex "$@"
       '';
       executable = true;
     };

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -31,6 +31,9 @@ let
     (import ../../../../libraries/python-runtimes.nix { inherit pkgs; }).pythonWithTomlkit;
   # Claude 파일 경로 (공유 소스)
   claudeFilesPath = "${nixosConfigPath}/modules/shared/programs/claude/files";
+  # Homebrew uses /opt/homebrew on Apple Silicon and /usr/local on Intel macOS.
+  homebrewCodexPrefix =
+    if pkgs.stdenv.hostPlatform.system == "x86_64-darwin" then "/usr/local" else "/opt/homebrew";
 
   # ─── Shared skill 노출 정책 (direct Codex 글로벌, #486) ───
   # SoT: 아래 두 리스트. 독립 감사는 scripts/ai/verify-ai-compat.sh가 수행한다.
@@ -98,7 +101,7 @@ in
     # unrelated command resolution such as notification hook `timeout` behavior.
     ".local/bin/codex" = lib.mkIf (pkgs.stdenv.isDarwin && hostType == "personal") {
       source = pkgs.writeShellScript "codex-homebrew-wrapper" ''
-        exec /opt/homebrew/bin/codex "$@"
+        exec ${homebrewCodexPrefix}/bin/codex "$@"
       '';
       executable = true;
     };

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -11,6 +11,7 @@
   pkgs,
   lib,
   nixosConfigPath,
+  hostType ? null,
   ...
 }:
 
@@ -90,6 +91,17 @@ in
     # 런타임에서 사용 가능하게 한다.
     ".codex/scripts/fleiss-kappa.py".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/scripts/fleiss-kappa.py";
+
+    # macOS personal hosts install Codex via the Homebrew cask, but login/non-interactive
+    # shells only get the Home Manager session PATH. Expose a narrow wrapper in
+    # ~/.local/bin instead of prepending the whole Homebrew prefix and changing
+    # unrelated command resolution such as notification hook `timeout` behavior.
+    ".local/bin/codex" = lib.mkIf (pkgs.stdenv.isDarwin && hostType == "personal") {
+      source = pkgs.writeShellScript "codex-homebrew-wrapper" ''
+        exec /opt/homebrew/bin/codex "$@"
+      '';
+      executable = true;
+    };
 
     # Codex 0.124+ stable hooks (issue #585 / epic #584).
     # Claude `~/.claude/hooks/*` 무변경 보장이 필요하므로 Codex 전용 사본을 분리한다.


### PR DESCRIPTION
## Summary
- Personal macOS hosts now expose the Homebrew-installed Codex CLI through the Home Manager session PATH.
- The fix is intentionally Codex-only and personal-Darwin-only, so unrelated Homebrew tools do not enter login/non-interactive shell command resolution.

Closes #640

## 기존 문제/배경

Personal macOS hosts install Codex via the Homebrew cask, but login/non-interactive shells used by agent tooling rely on the Home Manager session PATH. That session PATH includes `~/.local/bin`, but it does not necessarily load Homebrew `shellenv`, so `codex-exec-supervised --check` could fail with `codex` missing even though `/opt/homebrew/bin/codex` exists and an interactive shell can use it.

A broad Homebrew PATH addition would fix `codex`, but it would also expose unrelated Homebrew binaries such as `timeout`. That changes adjacent hook behavior that currently treats missing Homebrew `timeout` as a deliberate fail-open condition.

## CIR (Change Intent Record)

- **현재 변경**: Reproduced the dependency check failure from a clean login/non-interactive shell context: `codex` was absent from PATH while the Homebrew binary existed.
- Considered adding Homebrew `bin`/`sbin` to the Darwin session PATH, then rejected it because it changes unrelated command resolution.
- Considered a Darwin-wide wrapper, then rejected it because work Darwin hosts are not guaranteed to install the personal Homebrew cask.
- Adopted a narrow `~/.local/bin/codex` wrapper only for personal Darwin hosts.
- Reviewed and rejected Intel Homebrew prefix handling as out of scope: this repository's active and planned personal macOS target is Apple Silicon, and issue #640 explicitly keeps Intel `/usr/local` handling out of this PR.

**trade-off**: The wrapper assumes the personal macOS Codex cask path remains `/opt/homebrew/bin/codex`. In return, it keeps the fix local to the actual supported personal host and avoids changing adjacent hook semantics.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Broad Homebrew session PATH | Add Homebrew `bin`/`sbin` to login session PATH | Fixes all Homebrew CLIs at once | Changes unrelated command resolution, including `timeout` behavior | ❌ |
| Helper-local fallback | Teach the supervised helper to call `/opt/homebrew/bin/codex` directly | Very localized to one helper | Other Codex callers still fail when PATH lacks `codex`; hard-codes host path in the helper | ❌ |
| Darwin-wide wrapper | Put a `codex` wrapper in `~/.local/bin` for every Darwin host | Keeps session PATH stable | Assumes every Darwin host has the Homebrew cask | ❌ |
| Intel-aware wrapper | Select `/usr/local` for `x86_64-darwin` and `/opt/homebrew` otherwise | More portable across old Intel Macs | Not needed for current or planned hosts; expands support surface outside issue #640 | ❌ |
| Personal Apple-Silicon wrapper | Put only `codex` in `~/.local/bin`, guarded by `hostType == "personal"`, and exec `/opt/homebrew/bin/codex` | Precise fix; preserves adjacent command resolution; matches actual host policy | Would need a separate decision if Intel personal hosts ever become supported | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/codex/default.nix` | 수정 | Adds `hostType ? null` module argument and a personal-Darwin-only `~/.local/bin/codex` wrapper. |

### 핵심 코드

```nix
".local/bin/codex" = lib.mkIf (pkgs.stdenv.isDarwin && hostType == "personal") {
  source = pkgs.writeShellScript "codex-homebrew-wrapper" ''
    exec /opt/homebrew/bin/codex "$@"
  '';
  executable = true;
};
```

## 참고 레퍼런스

- Issue #640 — Missing Codex CLI PATH in login/non-interactive macOS shell context.
- PR #636 — Supervised Codex exec dependency check that exposed the missing PATH boundary.

## Human Test Plan

### 정상 동작 검증

1. On a personal macOS host, run `nrs`.
   - **기대**: Home Manager activation completes and `~/.local/bin/codex` is executable.
   - **실패 시**: Check whether the host is configured with `hostType = "personal"` and whether `/opt/homebrew/bin/codex` exists.

2. Start a clean shell that only sources Home Manager session variables.

```bash
env -i HOME="$HOME" USER="$USER" SHELL=/bin/zsh PATH=/usr/bin:/bin:/usr/sbin:/sbin /bin/zsh -f -c '. "/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh"; command -v codex; codex --version; codex-exec-supervised --check; if command -v timeout >/dev/null 2>&1; then echo timeout=$(command -v timeout); else echo timeout=absent; fi'
```

- **기대**: `command -v codex` prints `~/.local/bin/codex`, `codex --version` succeeds, `codex-exec-supervised --check` reports dependencies OK, and `timeout=absent` is preserved.
- **실패 시**: Inspect `~/.local/bin/codex`, Home Manager session vars, and `/opt/homebrew/bin/codex` separately to distinguish PATH projection from Homebrew installation problems.

3. Check the work-Darwin guard.
   - **기대**: Personal Darwin has the wrapper; work Darwin does not.
   - **실패 시**: Re-check the `hostType == "personal"` guard in the Codex module.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

> "The wrapper is scoped to the Codex module and broad Homebrew PATH injection is absent."

```bash
grep -q 'hostType ? null' modules/shared/programs/codex/default.nix
grep -q '".local/bin/codex"' modules/shared/programs/codex/default.nix
grep -q 'hostType == "personal"' modules/shared/programs/codex/default.nix
! grep -q 'homebrewCodexPrefix' modules/shared/programs/codex/default.nix
! grep -q 'x86_64-darwin' modules/shared/programs/codex/default.nix
! grep -q '"/opt/homebrew/bin"' modules/shared/programs/shell/darwin.nix
```

- **기대**: All commands exit 0.
- **실패 시**: Confirm the fix did not regress to broad Darwin shell PATH mutation, lose the host guard, or expand into Intel-specific support.

### Phase 1: Formatting and rebuild

> "The Nix module formats and activates on the target host."

```bash
nix develop -c nixfmt --check modules/shared/programs/codex/default.nix modules/shared/programs/shell/darwin.nix
nrs
```

- **기대**: Formatting passes and `nrs` completes.
- **실패 시**: Use the first Nix evaluation or activation error to identify whether the new module argument or Home Manager file declaration is invalid.

### Phase 2: Clean-shell Codex availability

> "A shell with only Home Manager session vars can resolve Codex without gaining unrelated Homebrew commands."

```bash
env -i HOME="$HOME" USER="$USER" SHELL=/bin/zsh PATH=/usr/bin:/bin:/usr/sbin:/sbin /bin/zsh -f -c '. "/etc/profiles/per-user/$USER/etc/profile.d/hm-session-vars.sh"; command -v codex; codex --version; codex-exec-supervised --check; if command -v timeout >/dev/null 2>&1; then echo timeout=$(command -v timeout); else echo timeout=absent; fi'
```

- **기대**: `codex` resolves through `~/.local/bin/codex`, the supervised dependency check passes, and `timeout=absent` remains true.
- **실패 시**: Compare `command -v codex`, `ls -l ~/.local/bin/codex`, and `/opt/homebrew/bin/codex` to isolate PATH projection from binary installation.

### Phase 3: Host guard regression

> "The personal host gets the wrapper and the work host does not."

```bash
nix eval --json --impure --expr '
let
  flake = builtins.getFlake "git+file://${builtins.getEnv "PWD"}";
in {
  personal = flake.darwinConfigurations.greenhead-MacBookPro.config.home-manager.users.green.home.file.".local/bin/codex".executable;
  work = builtins.hasAttr ".local/bin/codex" flake.darwinConfigurations.work-MacBookPro.config.home-manager.users.glen.home.file;
}'
```

- **기대**: `{"personal":true,"work":false}`.
- **실패 시**: Check host module arguments and whether `hostType` is passed consistently to the shared Codex module.

### Phase 4: Adjacent regression

> "Shared Codex harness checks and shell-script tests still pass."

```bash
git diff --check
./scripts/ai/verify-ai-compat.sh
git push --dry-run
```

- **기대**: Whitespace check passes, AI compatibility verification passes, and pre-push hooks pass through the dry run.
- **실패 시**: Treat any Codex hook fixture or flake-check failure as a regression before merging.
