### PR TITLE
fix(codex): prune stale user hook artifacts

### DIFF
--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -1,9 +1,9 @@
 # PRD: Codex User Legacy Hooks
 
 ## Document Status
-- Status: In Progress
+- Status: Complete
 - File Mode: Split
-- Current Phase: Phase 4
+- Current Phase: Complete
 - Active Phase File: [Phase 4](./prd-codex-user-legacy-hooks/phase-04-validation-handoff.md)
 - Last Updated: 2026-05-02
 - PRD File: `.claude/prds/prd-codex-user-legacy-hooks.md`
@@ -116,7 +116,7 @@ DA for_plan corrected an important boundary: `~/.codex/hooks.json` is still an o
 | Phase 1: Scope Lock | Complete | Resolve issue evidence, PRD routing, DA findings, and scope boundary | PRD/DA consistency | [phase-01-scope-lock.md](./prd-codex-user-legacy-hooks/phase-01-scope-lock.md) |
 | Phase 2: Cleanup Implementation | Complete | Implement safe user-level stale cleanup without deleting valid hooks | Shell behavior, parser safety | [phase-02-cleanup-implementation.md](./prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md) |
 | Phase 3: Verifier And Tests | Complete | Add verifier stale guard and regression tests | Sandbox HOME tests, verifier messages | [phase-03-verifier-tests.md](./prd-codex-user-legacy-hooks/phase-03-verifier-tests.md) |
-| Phase 4: Validation And Handoff | In Progress | Run validation, update PRD closeout, and prepare PR handoff | nrs/verify/DA/audit evidence | [phase-04-validation-handoff.md](./prd-codex-user-legacy-hooks/phase-04-validation-handoff.md) |
+| Phase 4: Validation And Handoff | Complete | Run validation, update PRD closeout, and prepare PR handoff | nrs/verify/DA/audit evidence | [phase-04-validation-handoff.md](./prd-codex-user-legacy-hooks/phase-04-validation-handoff.md) |
 
 ## Final Multi-Pass Review After All Phases
 Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical checklist, with review-impl overlay where applicable.
@@ -134,3 +134,4 @@ Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical c
 - 2026-05-02: DA for_pr Round 2 confirmed symlinked user `hooks.json` clobber risk; fixed by leaving symlinks unchanged, making verifier fail for manual inspection, and adding symlink preservation coverage.
 - 2026-05-02: DA for_pr Round 3 confirmed verifier over-failed valid symlinked `hooks.json`; fixed verifier to inspect symlink targets and fail only malformed/stale cases.
 - 2026-05-02: parallel-audit found stale matcher substring false positives and master PRD symlink repair wording drift; fixed matcher to exact direct hook commands and documented symlink manual-repair carveout.
+- 2026-05-02: Phase 4 completed after final `nrs`, post-activation verifier, and multi-pass review; PR handoff is ready.

--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -131,3 +131,4 @@ Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical c
 - 2026-05-02: Phase 3 verifier/tests completed, including mixed user-hook preservation and malformed user `hooks.json` preservation.
 - 2026-05-02: Phase 4 validation started; `nrs` and post-`nrs` `verify-ai-compat.sh` passed on this machine.
 - 2026-05-02: DA for_pr Round 1 confirmed mixed-version shim and duplicated jq matcher issues; fixed with shared `codex-legacy-hooks.sh`, old-helper fixture coverage, `nrs`, and post-`nrs` verifier pass.
+- 2026-05-02: DA for_pr Round 2 confirmed symlinked user `hooks.json` clobber risk; fixed by leaving symlinks unchanged, making verifier fail for manual inspection, and adding symlink preservation coverage.

--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -132,3 +132,4 @@ Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical c
 - 2026-05-02: Phase 4 validation started; `nrs` and post-`nrs` `verify-ai-compat.sh` passed on this machine.
 - 2026-05-02: DA for_pr Round 1 confirmed mixed-version shim and duplicated jq matcher issues; fixed with shared `codex-legacy-hooks.sh`, old-helper fixture coverage, `nrs`, and post-`nrs` verifier pass.
 - 2026-05-02: DA for_pr Round 2 confirmed symlinked user `hooks.json` clobber risk; fixed by leaving symlinks unchanged, making verifier fail for manual inspection, and adding symlink preservation coverage.
+- 2026-05-02: DA for_pr Round 3 confirmed verifier over-failed valid symlinked `hooks.json`; fixed verifier to inspect symlink targets and fail only malformed/stale cases.

--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -31,8 +31,8 @@ DA for_plan corrected an important boundary: `~/.codex/hooks.json` is still an o
 ## Success Criteria
 - SC-1: `nrs` cleanup removes repo-local retired `.codex/hooks*.json` exactly as before.
 - SC-2: `nrs` cleanup removes user-level `~/.codex/hooks.compatibility.json` when present.
-- SC-3: `nrs` cleanup prunes only known stale managed legacy entries from user-level `~/.codex/hooks.json`, preserving unrelated user hooks.
-- SC-4: `verify-ai-compat.sh` fails on stale user-level legacy state and tells the user how to repair it with `nrs`, but does not fail merely because `~/.codex/hooks.json` exists.
+- SC-3: `nrs` cleanup prunes only known stale managed legacy entries from non-symlinked user-level `~/.codex/hooks.json`, preserving unrelated user hooks and symlinked user hook files.
+- SC-4: `verify-ai-compat.sh` fails on stale user-level legacy state and tells the user how to repair it with `nrs` or, for symlinked user-owned hook files, manual stale-entry removal; it does not fail merely because `~/.codex/hooks.json` exists.
 - SC-5: Shell tests prove stale user-level cleanup for NixOS force, Darwin force, and Darwin no-change paths.
 - SC-6: Existing Codex hook fixture tests still pass without adding `PreToolUse` as a managed template event.
 
@@ -69,9 +69,9 @@ DA for_plan corrected an important boundary: `~/.codex/hooks.json` is still an o
 ### Functional Requirements
 - FR-1: Keep existing repo-local retired artifact cleanup unchanged.
 - FR-2: Add user-level cleanup for `~/.codex/hooks.compatibility.json`.
-- FR-3: Add user-level `~/.codex/hooks.json` stale-entry pruning based on known managed legacy script commands, not file existence.
+- FR-3: Add user-level `~/.codex/hooks.json` stale-entry pruning based on exact known managed legacy script commands, not file existence or substring mentions.
 - FR-4: Preserve non-stale entries in user-level `hooks.json`.
-- FR-5: If `hooks.json` is malformed or cannot be safely parsed, do not destructively rewrite it; verifier should fail with manual repair guidance.
+- FR-5: If `hooks.json` is malformed, symlinked, or cannot be safely parsed, do not destructively rewrite it; verifier should inspect readable symlink targets and fail stale/malformed states with manual repair guidance where `nrs` intentionally preserves ownership.
 - FR-6: Add verifier checks for user-level compatibility artifact and stale known legacy entries.
 - FR-7: Add shell tests for cleanup and preservation behavior.
 - FR-8: Document in PR/issue handoff that actual native `PreToolUse` implementation and ownership are delegated to #587.
@@ -133,3 +133,4 @@ Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical c
 - 2026-05-02: DA for_pr Round 1 confirmed mixed-version shim and duplicated jq matcher issues; fixed with shared `codex-legacy-hooks.sh`, old-helper fixture coverage, `nrs`, and post-`nrs` verifier pass.
 - 2026-05-02: DA for_pr Round 2 confirmed symlinked user `hooks.json` clobber risk; fixed by leaving symlinks unchanged, making verifier fail for manual inspection, and adding symlink preservation coverage.
 - 2026-05-02: DA for_pr Round 3 confirmed verifier over-failed valid symlinked `hooks.json`; fixed verifier to inspect symlink targets and fail only malformed/stale cases.
+- 2026-05-02: parallel-audit found stale matcher substring false positives and master PRD symlink repair wording drift; fixed matcher to exact direct hook commands and documented symlink manual-repair carveout.

--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -130,3 +130,4 @@ Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical c
 - 2026-05-02: Phase 2 cleanup implemented for repo-local retired artifacts, user-level `hooks.compatibility.json`, and known stale user hook entries while preserving user hooks.
 - 2026-05-02: Phase 3 verifier/tests completed, including mixed user-hook preservation and malformed user `hooks.json` preservation.
 - 2026-05-02: Phase 4 validation started; `nrs` and post-`nrs` `verify-ai-compat.sh` passed on this machine.
+- 2026-05-02: DA for_pr Round 1 confirmed mixed-version shim and duplicated jq matcher issues; fixed with shared `codex-legacy-hooks.sh`, old-helper fixture coverage, `nrs`, and post-`nrs` verifier pass.

--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -1,0 +1,132 @@
+# PRD: Codex User Legacy Hooks
+
+## Document Status
+- Status: In Progress
+- File Mode: Split
+- Current Phase: Phase 4
+- Active Phase File: [Phase 4](./prd-codex-user-legacy-hooks/phase-04-validation-handoff.md)
+- Last Updated: 2026-05-02
+- PRD File: `.claude/prds/prd-codex-user-legacy-hooks.md`
+- Purpose: Living PRD / execution source of truth for issue #637. Work is checked off here and in phase files; new implementation facts must update this PRD before later phases continue.
+
+## Problem
+Codex can still load user-level hook configuration from `~/.codex/hooks.json`. A stale Claude-era legacy file there can invoke missing scripts such as session icon or old guard scripts, causing repeated hook failures at session/tool boundaries. The repo already removes repo-local retired `.codex/hooks*.json` artifacts, but it does not detect or clean stale user-level legacy entries.
+
+DA for_plan corrected an important boundary: `~/.codex/hooks.json` is still an official Codex hook source, so file existence alone is not stale. This PRD therefore removes or fails only on known stale legacy entries/artifacts, not on valid user-owned hooks.
+
+## Goals
+- G-1: Prevent recurrence of known stale user-level Claude-era Codex hook entries.
+- G-2: Preserve valid user-owned `~/.codex/hooks.json` hooks.
+- G-3: Keep actual Codex-native `PreToolUse` implementation and ownership decisions in issue #587.
+- G-4: Make verifier output actionable when stale user-level hook state reappears.
+- G-5: Cover common, Darwin, and NixOS nrs wrapper paths with sandboxed tests.
+
+## Non-Goals
+- NG-1: Do not revive legacy JSON projection as a Codex hook source of truth.
+- NG-2: Do not implement native `PreToolUse` guards in #637.
+- NG-3: Do not change Codex hook templates, hook provisioning, or hook oracle for `PreToolUse` in #637.
+- NG-4: Do not store full machine-local `~/.codex/hooks*.json` contents in repo.
+- NG-5: Do not delete valid user-owned `~/.codex/hooks.json` merely because the file exists.
+
+## Success Criteria
+- SC-1: `nrs` cleanup removes repo-local retired `.codex/hooks*.json` exactly as before.
+- SC-2: `nrs` cleanup removes user-level `~/.codex/hooks.compatibility.json` when present.
+- SC-3: `nrs` cleanup prunes only known stale managed legacy entries from user-level `~/.codex/hooks.json`, preserving unrelated user hooks.
+- SC-4: `verify-ai-compat.sh` fails on stale user-level legacy state and tells the user how to repair it with `nrs`, but does not fail merely because `~/.codex/hooks.json` exists.
+- SC-5: Shell tests prove stale user-level cleanup for NixOS force, Darwin force, and Darwin no-change paths.
+- SC-6: Existing Codex hook fixture tests still pass without adding `PreToolUse` as a managed template event.
+
+## Key Scenarios
+### Scenario 1: Fully Stale User Legacy File
+- Actor: developer running `nrs`
+- Trigger: `~/.codex/hooks.json` contains only known stale legacy commands owned by old projection.
+- Expected outcome: stale handlers are removed; if no handlers remain, the file may be removed or reduced to an empty safe state. Output explains what was cleaned.
+
+### Scenario 2: Mixed User File
+- Actor: developer with a valid custom Codex hook plus stale legacy entries.
+- Trigger: `nrs`
+- Expected outcome: stale legacy entries are pruned and valid custom hook entries remain.
+
+### Scenario 3: Stale State Reappears
+- Actor: developer or old tool recreates `~/.codex/hooks.compatibility.json` or stale known entries.
+- Trigger: `./scripts/ai/verify-ai-compat.sh`
+- Expected outcome: verifier fails with specific user-level stale-state guidance.
+
+### Scenario 4: Native PreToolUse Work
+- Actor: developer implementing #587.
+- Trigger: native `PreToolUse` guard work is needed.
+- Expected outcome: #637 does not implement it; PR/issue notes point to #587.
+
+## Discovery Summary
+- Reviewed: issue #637, issue #587, `modules/shared/scripts/lib/rebuild/common.sh`, `modules/darwin/scripts/nrs.sh`, `modules/nixos/scripts/nrs.sh`, `scripts/ai/verify-ai-compat.sh`, `tests/shell-script-tests.sh`, Codex config templates, `pinning-alert.sh`, sync-preservation fixtures, OpenAI Codex hooks docs.
+- Current system: repo-local `.codex/hooks.json` and `.codex/hooks.compatibility.json` are removed before rebuild; user-level equivalents are not cleaned or verified.
+- Current machine: `~/.codex/hooks.json` and `~/.codex/hooks.compatibility.json` are absent; active `~/.codex/config.toml` has `UserPromptSubmit`, `Stop`, `PostToolUse` only.
+- Validation surface: shell wrapper tests, Codex hook fixture tests, verifier, `nrs` activation, and post-`nrs` verifier.
+- Design implications: official Codex docs list `~/.codex/hooks.json` as a current hook source, so the implementation must parse and preserve valid user hooks.
+- Confidence / gaps: exact stale-entry matcher is limited to known old managed hook script basenames; native `PreToolUse` ownership remains intentionally out of scope for #637.
+
+## Requirements
+### Functional Requirements
+- FR-1: Keep existing repo-local retired artifact cleanup unchanged.
+- FR-2: Add user-level cleanup for `~/.codex/hooks.compatibility.json`.
+- FR-3: Add user-level `~/.codex/hooks.json` stale-entry pruning based on known managed legacy script commands, not file existence.
+- FR-4: Preserve non-stale entries in user-level `hooks.json`.
+- FR-5: If `hooks.json` is malformed or cannot be safely parsed, do not destructively rewrite it; verifier should fail with manual repair guidance.
+- FR-6: Add verifier checks for user-level compatibility artifact and stale known legacy entries.
+- FR-7: Add shell tests for cleanup and preservation behavior.
+- FR-8: Document in PR/issue handoff that actual native `PreToolUse` implementation and ownership are delegated to #587.
+
+### Non-Functional Requirements
+- NFR-1: Cleanup must be deterministic and fail closed on unsafe write/delete failures.
+- NFR-2: User-owned hooks must not be silently dropped.
+- NFR-3: Repeated path strings must be grouped through named variables/helpers where practical.
+- NFR-4: Tests must use sandboxed HOME and avoid touching the real user `~/.codex`.
+
+## Assumptions
+- A-1: `~/.codex/hooks.compatibility.json` is not an official current Codex hook source in the checked docs and can be treated as retired.
+- A-2: Known stale legacy commands can be identified by command path/basename from issue #637 evidence.
+- A-3: `jq` is available in the target user environments where existing rebuild scripts already rely on it.
+- A-4: #587 remains the owner for native `PreToolUse` guard implementation.
+
+## Dependencies / Constraints
+- Official Codex hooks docs: https://developers.openai.com/codex/hooks
+- Related issue: #587 for native `PreToolUse`.
+- Existing PostToolUse pinning alert and apply_patch parser remain unchanged.
+- Main-agent-only commands: `nrs`, commits, GitHub writes.
+
+## Risks / Edge Cases
+- Valid user hook entry accidentally matches stale pattern.
+- Stale entry command is wrapped in shell syntax not covered by initial matcher.
+- Malformed `hooks.json` cannot be safely edited.
+- `verify-ai-compat.sh` may fail for unrelated active symlink mismatch when run from a worktree before `nrs`.
+
+## Execution Rules
+- 본 PRD가 명시적으로 수정되지 않는 한 phase는 순서대로 완료한다.
+- 어떤 phase든 시작 전에 master PRD + active phase file을 읽는다.
+- PRD 파일만 active plan으로 사용한다. 경쟁하는 별도 체크리스트를 만들지 않는다.
+- 목표를 만족하는 최소 가역적 변경을 선호한다.
+- 기존 repo patterns를 보존한다.
+- 검증은 risk에 맞는 최소 충분 조합으로 선택한다.
+- 각 phase 종료 시 master PRD와 phase 파일을 갱신한다.
+- Post-Implementation 1~7 자동 수행 (default): 구현, 구현 커밋, `/run-da for_pr`, `/parallel-audit`, Final Multi-Pass Review, 반영 커밋, `/create-pr`.
+
+## Phase Index
+| Phase | Status | Objective | Validation Focus | File |
+|---|---|---|---|---|
+| Phase 1: Scope Lock | Complete | Resolve issue evidence, PRD routing, DA findings, and scope boundary | PRD/DA consistency | [phase-01-scope-lock.md](./prd-codex-user-legacy-hooks/phase-01-scope-lock.md) |
+| Phase 2: Cleanup Implementation | Complete | Implement safe user-level stale cleanup without deleting valid hooks | Shell behavior, parser safety | [phase-02-cleanup-implementation.md](./prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md) |
+| Phase 3: Verifier And Tests | Complete | Add verifier stale guard and regression tests | Sandbox HOME tests, verifier messages | [phase-03-verifier-tests.md](./prd-codex-user-legacy-hooks/phase-03-verifier-tests.md) |
+| Phase 4: Validation And Handoff | In Progress | Run validation, update PRD closeout, and prepare PR handoff | nrs/verify/DA/audit evidence | [phase-04-validation-handoff.md](./prd-codex-user-legacy-hooks/phase-04-validation-handoff.md) |
+
+## Final Multi-Pass Review After All Phases
+Use `plan-with-questions/references/prd/multi-pass-review.md` as the canonical checklist, with review-impl overlay where applicable.
+
+## Open Questions
+- None. Confirmed DA findings have been reflected into the PRD scope.
+
+## Change Log
+- 2026-05-02: Initial PRD created from issue #637. User selected PRD mode and delegated all native `PreToolUse` implementation to #587.
+- 2026-05-02: DA for_plan HIGH findings reflected: `~/.codex/hooks.json` file existence is not stale; cleanup/verifier must target known stale entries only.
+- 2026-05-02: Phase 2 cleanup implemented for repo-local retired artifacts, user-level `hooks.compatibility.json`, and known stale user hook entries while preserving user hooks.
+- 2026-05-02: Phase 3 verifier/tests completed, including mixed user-hook preservation and malformed user `hooks.json` preservation.
+- 2026-05-02: Phase 4 validation started; `nrs` and post-`nrs` `verify-ai-compat.sh` passed on this machine.

--- a/.claude/prds/prd-codex-user-legacy-hooks.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks.md
@@ -111,6 +111,7 @@ DA for_plan corrected an important boundary: `~/.codex/hooks.json` is still an o
 - Post-Implementation 1~7 자동 수행 (default): 구현, 구현 커밋, `/run-da for_pr`, `/parallel-audit`, Final Multi-Pass Review, 반영 커밋, `/create-pr`.
 
 ## Phase Index
+
 | Phase | Status | Objective | Validation Focus | File |
 |---|---|---|---|---|
 | Phase 1: Scope Lock | Complete | Resolve issue evidence, PRD routing, DA findings, and scope boundary | PRD/DA consistency | [phase-01-scope-lock.md](./prd-codex-user-legacy-hooks/phase-01-scope-lock.md) |

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-01-scope-lock.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-01-scope-lock.md
@@ -1,0 +1,77 @@
+# Phase 1: Scope Lock
+
+Parent PRD: [PRD: Codex User Legacy Hooks](../prd-codex-user-legacy-hooks.md)
+Status: Complete
+Last Updated: 2026-05-02
+
+## Objective
+Resolve issue #637 into a bounded PRD scope before code edits. This phase locks the boundary between stale legacy user-level cleanup and native `PreToolUse` implementation owned by #587.
+
+## Context From Master PRD
+- Goals covered: G-1, G-2, G-3
+- Success Criteria: SC-1 through SC-6 shaped
+- Requirements covered: FR-1 through FR-8
+- Key scenarios touched: all scenarios
+
+## Phase Discovery Gate
+- [x] 관련 코드/파일: `modules/shared/scripts/lib/rebuild/common.sh`, `modules/darwin/scripts/nrs.sh`, `modules/nixos/scripts/nrs.sh`, `scripts/ai/verify-ai-compat.sh`
+- [x] 관련 테스트/fixture: `tests/shell-script-tests.sh`, `tests/test-codex-hook-fixtures.sh`, `tests/fixtures/codex-hooks/sync-preservation/scenario-C-user-different-event.toml`
+- [x] 관련 docs/spec/외부 참조: issue #637, issue #587, OpenAI Codex hooks docs
+- [x] 관련 command 또는 도구: `gh issue view 637`, `gh issue view 587`, `./scripts/ai/verify-ai-compat.sh`, `./tests/shell-script-tests.sh`
+- [x] Master PRD의 assumption이 여전히 유효함
+- [x] 발견 사항이 이 phase 또는 후속 phase를 바꾸면, 구현 전에 PRD 파일을 먼저 갱신
+
+## Scope
+### In Scope
+- PRD mode routing and split-file selection.
+- User decision capture: all native `PreToolUse` implementation moves to #587.
+- DA for_plan execution and confirmed finding reflection.
+
+### Out of Scope
+- Code implementation.
+- Native `PreToolUse` scripts/templates/oracle.
+
+## Implementation Checklist
+- [x] Resolve issue #637 and related #587.
+- [x] Verify current repo cleanup/verifier scope.
+- [x] Verify current machine user-level hook state without reading/storing private hook contents.
+- [x] Check official Codex hook docs for current `hooks.json` semantics.
+- [x] Run Step 3.5 external consultation for scope/ownership tradeoffs.
+- [x] Ask user scope decisions through question tool.
+- [x] Run DA for_plan and Arbiter.
+- [x] Reflect confirmed DA findings into PRD scope.
+
+## Validation Strategy
+This phase is planning-only. Validation is evidence review plus mandatory DA for_plan.
+
+## Validation Checklist
+- [x] Static check: relevant files read with `sed`/`rg`.
+- [x] External docs checked: OpenAI Codex hooks docs.
+- [x] Local command: `./tests/shell-script-tests.sh` passed existing shell wrapper tests.
+- [x] Local command: `./scripts/ai/verify-ai-compat.sh` executed; failures recorded as existing worktree/global symlink mismatch, hook section passed.
+- [x] DA for_plan completed and findings applied.
+
+## Exit Criteria
+- [x] Phase objective 달성
+- [x] 위에 열거한 요구사항이 구현되었거나 명시적으로 deferred
+- [x] Validation checklist 완료 또는 gap이 근거와 함께 기록됨
+- [x] 다음 phase를 시작하지 못하게 막는 blocker 없음
+
+## Phase-End Multi-Pass Review
+- [x] 1. Intent/coverage review — 본 phase가 objective와 매핑된 요구사항을 달성했다.
+- [x] 2. Correctness review — happy path, edge case, error, empty state, state transition, 권한이 처리되었다.
+- [x] 3. Simplicity review — 솔루션이 필요 이상으로 복잡하지 않다.
+- [x] 4. Code quality review — 이름/경계/추상화/로컬 일관성이 깔끔하다.
+- [x] 5. Duplication/cleanup review — 중복 로직, dead code, temporary code, 잡음 log, 주석 처리 잔재, 사용되지 않는 파일/의존성이 제거되었다.
+- [x] 6. Security/privacy review — 권한, secret, 민감 데이터, injection risk, 클라이언트 노출, 감사 필요성이 안전하다.
+- [x] 7. Performance/load review — bottleneck, 비싼 query, N+1, 불필요한 재렌더, 불필요한 네트워크 호출이 다루어졌다.
+- [x] 8. Validation review — 선택한 check가 phase risk에 적절하다. 누락 check는 근거와 함께 기록.
+- [x] 9. Future-phase review — 뒤 phase 파일/체크리스트가 여전히 옳다. 구현이 계획을 바꿨다면 수정.
+- [x] 10. PRD sync review — master PRD status, active phase, assumption, risk, validation surface, change log가 갱신되었다.
+
+## Discoveries / Decisions
+- D-1: `~/.codex/hooks.json` is an official current hook source and must not be treated as stale by existence.
+- D-2: Native `PreToolUse` implementation and ownership are delegated to #587.
+
+## Phase Change Log
+- 2026-05-02: Phase completed during PRD initialization.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md
@@ -79,8 +79,9 @@ Phase 2 validation is local shell-level behavior using sandboxed HOME fixtures, 
 - D-1: `~/.codex/hooks.json` remains a valid user-owned Codex hook source; cleanup prunes only known stale commands under `/.codex/hooks/`.
 - D-2: When all handlers under an event are pruned, the implementation leaves a valid rewritten JSON object with empty event groups removed rather than deleting the whole file.
 - D-3: Malformed user-level `hooks.json` is left unchanged and reported for manual repair; verifier fails that state later.
-- D-4: Darwin/NixOS entrypoint shims intentionally duplicate the cleanup so mixed-version deployments can self-heal before the new shared helper is active.
+- D-4: Cleanup logic is centralized in `modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh`; Darwin/NixOS entrypoint shims source that helper and override old repo-local-only cleanup functions so mixed-version deployments still self-heal.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase completed with safe user-level legacy cleanup in common helper and Darwin/NixOS shims.
+- 2026-05-02: DA for_pr Round 1 replaced duplicated shim jq with shared helper-backed cleanup.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md
@@ -80,8 +80,10 @@ Phase 2 validation is local shell-level behavior using sandboxed HOME fixtures, 
 - D-2: When all handlers under an event are pruned, the implementation leaves a valid rewritten JSON object with empty event groups removed rather than deleting the whole file.
 - D-3: Malformed user-level `hooks.json` is left unchanged and reported for manual repair; verifier fails that state later.
 - D-4: Cleanup logic is centralized in `modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh`; Darwin/NixOS entrypoint shims source that helper and override old repo-local-only cleanup functions so mixed-version deployments still self-heal.
+- D-5: Symlinked user-level `hooks.json` is treated as ambiguous user-owned state and left unchanged to avoid replacing dotfile-managed links with regular files.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase completed with safe user-level legacy cleanup in common helper and Darwin/NixOS shims.
 - 2026-05-02: DA for_pr Round 1 replaced duplicated shim jq with shared helper-backed cleanup.
+- 2026-05-02: DA for_pr Round 2 added symlink preservation behavior.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-02-cleanup-implementation.md
@@ -1,0 +1,86 @@
+# Phase 2: Cleanup Implementation
+
+Parent PRD: [PRD: Codex User Legacy Hooks](../prd-codex-user-legacy-hooks.md)
+Status: Complete
+Last Updated: 2026-05-02
+
+## Objective
+Implement safe cleanup for retired user-level Codex legacy artifacts without deleting valid user-owned hooks.
+
+## Context From Master PRD
+- Goals covered: G-1, G-2, G-3
+- Success Criteria: SC-1, SC-2, SC-3
+- Requirements covered: FR-1, FR-2, FR-3, FR-4, FR-5
+- Key scenarios touched: Scenario 1, Scenario 2, Scenario 4
+
+## Phase Discovery Gate
+코드 편집 전에 재확인한다:
+- [x] 관련 코드/파일: `modules/shared/scripts/lib/rebuild/common.sh`, `modules/darwin/scripts/nrs.sh`, `modules/nixos/scripts/nrs.sh`
+- [x] 관련 테스트/fixture: `tests/shell-script-tests.sh`
+- [x] 관련 docs/spec/외부 참조: OpenAI Codex hooks docs, issue #637 Notes, issue #587
+- [x] 관련 command 또는 도구: `rg -n "hooks\\.json|hooks\\.compatibility|_clear_retired_codex_hook_artifacts" modules scripts tests`
+- [x] Master PRD의 assumption이 여전히 유효함
+- [x] 발견 사항이 이 phase 또는 후속 phase를 바꾸면, 구현 전에 PRD 파일을 먼저 갱신
+
+## Scope
+### In Scope
+- Preserve existing repo-local cleanup.
+- Add user-level cleanup for `~/.codex/hooks.compatibility.json`.
+- Add safe pruning for known stale managed legacy entries in `~/.codex/hooks.json`.
+- Keep Darwin/NixOS compatibility shims aligned.
+
+### Out of Scope
+- Native `PreToolUse` hook implementation.
+- Template ownership changes for `PreToolUse`.
+- Full deletion of valid `~/.codex/hooks.json`.
+
+## Implementation Checklist
+- [x] Define named stale artifact/path variables or helper names instead of scattering raw path strings.
+- [x] In common cleanup, keep repo-local retired artifact deletion unchanged.
+- [x] In common cleanup, remove `$HOME/.codex/hooks.compatibility.json` when present.
+- [x] In common cleanup, parse `$HOME/.codex/hooks.json` only when it exists and is valid JSON.
+- [x] Identify stale managed legacy entries by known command paths/basenames from issue #637, not by file existence.
+- [x] Preserve unrelated user hook entries in `hooks.json`.
+- [x] If all hook handlers are stale and removed, delete the empty `hooks.json` or leave a valid empty safe state; document the chosen behavior in output/tests.
+- [x] If `hooks.json` is malformed or cannot be safely rewritten, do not destructively modify it; surface a clear warning/error for verifier/manual repair.
+- [x] Mirror the same behavior in Darwin and NixOS compatibility shim fallback functions.
+- [x] Ensure deletion/rewrite failures fail closed consistently with existing `set -e` nrs behavior.
+
+## Validation Strategy
+Phase 2 validation is local shell-level behavior using sandboxed HOME fixtures, plus static review of duplicated shim logic. Full test execution is Phase 3.
+
+## Validation Checklist
+- [x] Static check: cleanup paths appear only through named variables/helpers where practical.
+- [x] Manual/sandbox smoke: repo-local artifact cleanup still deletes repo files.
+- [x] Manual/sandbox smoke: user-level `hooks.compatibility.json` is removed.
+- [x] Manual/sandbox smoke: mixed `hooks.json` preserves non-stale hook entries.
+- [x] Manual/sandbox smoke: malformed `hooks.json` is not destructively rewritten.
+- [x] 해당 시 error, empty, permission, rollback 상태 검증
+
+## Exit Criteria
+- [x] Phase objective 달성
+- [x] 위에 열거한 요구사항이 구현되었거나 명시적으로 deferred
+- [x] Validation checklist 완료 또는 gap이 근거와 함께 기록됨
+- [x] 다음 phase를 시작하지 못하게 막는 blocker 없음
+
+## Phase-End Multi-Pass Review
+- [x] 1. Intent/coverage review — 본 phase가 objective와 매핑된 요구사항을 달성했다.
+- [x] 2. Correctness review — happy path, edge case, error, empty state, state transition, 권한이 처리되었다.
+- [x] 3. Simplicity review — 솔루션이 필요 이상으로 복잡하지 않다.
+- [x] 4. Code quality review — 이름/경계/추상화/로컬 일관성이 깔끔하다.
+- [x] 5. Duplication/cleanup review — 중복 로직, dead code, temporary code, 잡음 log, 주석 처리 잔재, 사용되지 않는 파일/의존성이 제거되었다.
+- [x] 6. Security/privacy review — 권한, secret, 민감 데이터, injection risk, 클라이언트 노출, 감사 필요성이 안전하다.
+- [x] 7. Performance/load review — bottleneck, 비싼 query, N+1, 불필요한 재렌더, 불필요한 네트워크 호출이 다루어졌다.
+- [x] 8. Validation review — 선택한 check가 phase risk에 적절하다. 누락 check는 근거와 함께 기록.
+- [x] 9. Future-phase review — 뒤 phase 파일/체크리스트가 여전히 옳다. 구현이 계획을 바꿨다면 수정.
+- [x] 10. PRD sync review — master PRD status, active phase, assumption, risk, validation surface, change log가 갱신되었다.
+
+## Discoveries / Decisions
+- D-1: `~/.codex/hooks.json` remains a valid user-owned Codex hook source; cleanup prunes only known stale commands under `/.codex/hooks/`.
+- D-2: When all handlers under an event are pruned, the implementation leaves a valid rewritten JSON object with empty event groups removed rather than deleting the whole file.
+- D-3: Malformed user-level `hooks.json` is left unchanged and reported for manual repair; verifier fails that state later.
+- D-4: Darwin/NixOS entrypoint shims intentionally duplicate the cleanup so mixed-version deployments can self-heal before the new shared helper is active.
+
+## Phase Change Log
+- 2026-05-02: Phase file created.
+- 2026-05-02: Phase completed with safe user-level legacy cleanup in common helper and Darwin/NixOS shims.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
@@ -1,0 +1,84 @@
+# Phase 3: Verifier And Tests
+
+Parent PRD: [PRD: Codex User Legacy Hooks](../prd-codex-user-legacy-hooks.md)
+Status: Complete
+Last Updated: 2026-05-02
+
+## Objective
+Add verifier coverage and regression tests that catch stale user-level legacy hook state while preserving valid user hooks.
+
+## Context From Master PRD
+- Goals covered: G-1, G-2, G-4, G-5
+- Success Criteria: SC-4, SC-5, SC-6
+- Requirements covered: FR-5, FR-6, FR-7
+- Key scenarios touched: Scenario 1, Scenario 2, Scenario 3
+
+## Phase Discovery Gate
+코드 편집 전에 재확인한다:
+- [x] 관련 코드/파일: `scripts/ai/verify-ai-compat.sh`, `tests/shell-script-tests.sh`
+- [x] 관련 테스트/fixture: existing nrs wrapper tests around repo-local retired artifacts
+- [x] 관련 docs/spec/외부 참조: master PRD stale-entry contract
+- [x] 관련 command 또는 도구: `./tests/shell-script-tests.sh`, `./tests/test-codex-hook-fixtures.sh --no-live`
+- [x] Master PRD의 assumption이 여전히 유효함
+- [x] 발견 사항이 이 phase 또는 후속 phase를 바꾸면, 구현 전에 PRD 파일을 먼저 갱신
+
+## Scope
+### In Scope
+- Verifier fail for user-level `hooks.compatibility.json`.
+- Verifier fail for stale known legacy entries inside user-level `hooks.json`.
+- Verifier non-fail for valid user-owned `hooks.json` with no stale entries.
+- Shell tests for cleanup and preservation.
+
+### Out of Scope
+- Live Codex hook execution.
+- Native `PreToolUse` fixture additions.
+
+## Implementation Checklist
+- [x] Update `verify-ai-compat.sh` hook artifact section to distinguish repo-local retired artifacts from user-level stale legacy state.
+- [x] Do not fail verifier on `~/.codex/hooks.json` existence alone.
+- [x] Fail verifier on `~/.codex/hooks.compatibility.json` existence with `nrs` guidance.
+- [x] Fail verifier on known stale legacy entries in `~/.codex/hooks.json` with `nrs` guidance.
+- [x] Add shell tests for NixOS force user-level cleanup.
+- [x] Add shell tests for Darwin force user-level cleanup.
+- [x] Add shell tests for Darwin no-change user-level cleanup.
+- [x] Add mixed `hooks.json` fixture test that preserves non-stale user entries.
+- [x] Add malformed `hooks.json` behavior test if implementation handles it explicitly.
+- [x] Keep `tests/test-codex-hook-fixtures.sh --no-live` unchanged unless verifier/hook oracle change requires it.
+
+## Validation Strategy
+Use deterministic shell fixtures with sandboxed HOME. The verifier must be tested without touching real `~/.codex`.
+
+## Validation Checklist
+- [x] Static check 통과: `bash -n` relevant shell scripts if practical.
+- [x] 자동 test 추가/갱신 및 통과: `./tests/shell-script-tests.sh`
+- [x] Existing hook fixture test remains green: `./tests/test-codex-hook-fixtures.sh --no-live`
+- [x] Manual smoke check: verifier message wording distinguishes repo-local vs user-level state.
+- [x] 해당 시 error, empty, malformed, permission, rollback 상태 검증
+
+## Exit Criteria
+- [x] Phase objective 달성
+- [x] 위에 열거한 요구사항이 구현되었거나 명시적으로 deferred
+- [x] Validation checklist 완료 또는 gap이 근거와 함께 기록됨
+- [x] 다음 phase를 시작하지 못하게 막는 blocker 없음
+
+## Phase-End Multi-Pass Review
+- [x] 1. Intent/coverage review — 본 phase가 objective와 매핑된 요구사항을 달성했다.
+- [x] 2. Correctness review — happy path, edge case, error, empty state, state transition, 권한이 처리되었다.
+- [x] 3. Simplicity review — 솔루션이 필요 이상으로 복잡하지 않다.
+- [x] 4. Code quality review — 이름/경계/추상화/로컬 일관성이 깔끔하다.
+- [x] 5. Duplication/cleanup review — 중복 로직, dead code, temporary code, 잡음 log, 주석 처리 잔재, 사용되지 않는 파일/의존성이 제거되었다.
+- [x] 6. Security/privacy review — 권한, secret, 민감 데이터, injection risk, 클라이언트 노출, 감사 필요성이 안전하다.
+- [x] 7. Performance/load review — bottleneck, 비싼 query, N+1, 불필요한 재렌더, 불필요한 네트워크 호출이 다루어졌다.
+- [x] 8. Validation review — 선택한 check가 phase risk에 적절하다. 누락 check는 근거와 함께 기록.
+- [x] 9. Future-phase review — 뒤 phase 파일/체크리스트가 여전히 옳다. 구현이 계획을 바꿨다면 수정.
+- [x] 10. PRD sync review — master PRD status, active phase, assumption, risk, validation surface, change log가 갱신되었다.
+
+## Discoveries / Decisions
+- D-1: Verifier now treats repo-local `.codex/hooks*.json` as retired artifacts, user-level `hooks.compatibility.json` as retired, and user-level `hooks.json` as valid unless known stale commands are present.
+- D-2: Shell tests cover mixed user-level hook preservation in NixOS force, Darwin force, and Darwin no-change paths.
+- D-3: A malformed user-level `hooks.json` is not rewritten by cleanup and is left for verifier/manual repair.
+- D-4: `tests/test-codex-hook-fixtures.sh --no-live` remains unchanged because #637 does not add managed native `PreToolUse` fixtures.
+
+## Phase Change Log
+- 2026-05-02: Phase file created.
+- 2026-05-02: Phase completed with verifier stale guards and sandboxed cleanup regression tests.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
@@ -80,6 +80,7 @@ Use deterministic shell fixtures with sandboxed HOME. The verifier must be teste
 - D-4: `tests/test-codex-hook-fixtures.sh --no-live` remains unchanged because #637 does not add managed native `PreToolUse` fixtures.
 - D-5: Shell tests cover symlinked user-level `hooks.json` preservation so cleanup cannot clobber dotfile-managed hook state.
 - D-6: Verifier uses the shared jq stale-count filter on symlink targets too: clean symlinked hooks can pass, while symlinked stale entries fail with manual-removal guidance.
+- D-7: Stale matching is exact for direct managed hook commands and ignores path mentions such as `.backup` suffixes or shell snippets that merely reference a stale filename.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
@@ -87,3 +88,4 @@ Use deterministic shell fixtures with sandboxed HOME. The verifier must be teste
 - 2026-05-02: DA for_pr Round 1 added mixed-version old-helper regression coverage.
 - 2026-05-02: DA for_pr Round 2 added symlink preservation regression coverage.
 - 2026-05-02: DA for_pr Round 3 added clean/stale symlink target stale-count coverage.
+- 2026-05-02: parallel-audit added exact matcher coverage for stale path mentions and exact `$HOME` paths.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
@@ -75,10 +75,11 @@ Use deterministic shell fixtures with sandboxed HOME. The verifier must be teste
 
 ## Discoveries / Decisions
 - D-1: Verifier now treats repo-local `.codex/hooks*.json` as retired artifacts, user-level `hooks.compatibility.json` as retired, and user-level `hooks.json` as valid unless known stale commands are present.
-- D-2: Shell tests cover mixed user-level hook preservation in NixOS force, Darwin force, and Darwin no-change paths.
+- D-2: Shell tests cover mixed user-level hook preservation in NixOS force, Darwin force, and Darwin no-change paths, including old deployed repo-local-only cleanup helper coverage for NixOS force and Darwin no-change.
 - D-3: A malformed user-level `hooks.json` is not rewritten by cleanup and is left for verifier/manual repair.
 - D-4: `tests/test-codex-hook-fixtures.sh --no-live` remains unchanged because #637 does not add managed native `PreToolUse` fixtures.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase completed with verifier stale guards and sandboxed cleanup regression tests.
+- 2026-05-02: DA for_pr Round 1 added mixed-version old-helper regression coverage.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
@@ -79,9 +79,11 @@ Use deterministic shell fixtures with sandboxed HOME. The verifier must be teste
 - D-3: A malformed user-level `hooks.json` is not rewritten by cleanup and is left for verifier/manual repair.
 - D-4: `tests/test-codex-hook-fixtures.sh --no-live` remains unchanged because #637 does not add managed native `PreToolUse` fixtures.
 - D-5: Shell tests cover symlinked user-level `hooks.json` preservation so cleanup cannot clobber dotfile-managed hook state.
+- D-6: Verifier uses the shared jq stale-count filter on symlink targets too: clean symlinked hooks can pass, while symlinked stale entries fail with manual-removal guidance.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase completed with verifier stale guards and sandboxed cleanup regression tests.
 - 2026-05-02: DA for_pr Round 1 added mixed-version old-helper regression coverage.
 - 2026-05-02: DA for_pr Round 2 added symlink preservation regression coverage.
+- 2026-05-02: DA for_pr Round 3 added clean/stale symlink target stale-count coverage.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-03-verifier-tests.md
@@ -78,8 +78,10 @@ Use deterministic shell fixtures with sandboxed HOME. The verifier must be teste
 - D-2: Shell tests cover mixed user-level hook preservation in NixOS force, Darwin force, and Darwin no-change paths, including old deployed repo-local-only cleanup helper coverage for NixOS force and Darwin no-change.
 - D-3: A malformed user-level `hooks.json` is not rewritten by cleanup and is left for verifier/manual repair.
 - D-4: `tests/test-codex-hook-fixtures.sh --no-live` remains unchanged because #637 does not add managed native `PreToolUse` fixtures.
+- D-5: Shell tests cover symlinked user-level `hooks.json` preservation so cleanup cannot clobber dotfile-managed hook state.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase completed with verifier stale guards and sandboxed cleanup regression tests.
 - 2026-05-02: DA for_pr Round 1 added mixed-version old-helper regression coverage.
+- 2026-05-02: DA for_pr Round 2 added symlink preservation regression coverage.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
@@ -1,7 +1,7 @@
 # Phase 4: Validation And Handoff
 
 Parent PRD: [PRD: Codex User Legacy Hooks](../prd-codex-user-legacy-hooks.md)
-Status: In Progress
+Status: Complete
 Last Updated: 2026-05-02
 
 ## Objective
@@ -39,11 +39,11 @@ Validate the implemented cleanup/verifier behavior end to end, then prepare comm
 - [x] Run `nrs` using the alias, not direct rebuild.
 - [x] Run `./scripts/ai/verify-ai-compat.sh` after `nrs`.
 - [x] If worktree/global symlink mismatch remains unrelated to #637, record exact limitation and recovery path.
-- [ ] Commit implementation.
-- [ ] Run `/run-da for_pr`.
-- [ ] Run `/parallel-audit`.
-- [ ] Perform Final Multi-Pass Review and PRD closeout.
-- [ ] Create PR with #637 close and #587 boundary notes.
+- [x] Commit implementation.
+- [x] Run `/run-da for_pr`.
+- [x] Run `/parallel-audit`.
+- [x] Perform Final Multi-Pass Review and PRD closeout.
+- [x] Create PR with #637 close and #587 boundary notes.
 
 ## Validation Strategy
 Combine static checks, shell tests, deterministic hook fixtures, and activation-level smoke because the risk is global user-level state and Home Manager/nrs behavior.
@@ -58,22 +58,22 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - [x] 해당 시 error, empty, malformed, permission, rollback 상태 검증
 
 ## Exit Criteria
-- [ ] Phase objective 달성
-- [ ] 위에 열거한 요구사항이 구현되었거나 명시적으로 deferred
-- [ ] Validation checklist 완료 또는 gap이 근거와 함께 기록됨
-- [ ] 다음 phase를 시작하지 못하게 막는 blocker 없음
+- [x] Phase objective 달성
+- [x] 위에 열거한 요구사항이 구현되었거나 명시적으로 deferred
+- [x] Validation checklist 완료 또는 gap이 근거와 함께 기록됨
+- [x] 다음 phase를 시작하지 못하게 막는 blocker 없음
 
 ## Phase-End Multi-Pass Review
-- [ ] 1. Intent/coverage review — 본 phase가 objective와 매핑된 요구사항을 달성했다.
-- [ ] 2. Correctness review — happy path, edge case, error, empty state, state transition, 권한이 처리되었다.
-- [ ] 3. Simplicity review — 솔루션이 필요 이상으로 복잡하지 않다.
-- [ ] 4. Code quality review — 이름/경계/추상화/로컬 일관성이 깔끔하다.
-- [ ] 5. Duplication/cleanup review — 중복 로직, dead code, temporary code, 잡음 log, 주석 처리 잔재, 사용되지 않는 파일/의존성이 제거되었다.
-- [ ] 6. Security/privacy review — 권한, secret, 민감 데이터, injection risk, 클라이언트 노출, 감사 필요성이 안전하다.
-- [ ] 7. Performance/load review — bottleneck, 비싼 query, N+1, 불필요한 재렌더, 불필요한 네트워크 호출이 다루어졌다.
-- [ ] 8. Validation review — 선택한 check가 phase risk에 적절하다. 누락 check는 근거와 함께 기록.
-- [ ] 9. Future-phase review — 뒤 phase 파일/체크리스트가 여전히 옳다. 구현이 계획을 바꿨다면 수정.
-- [ ] 10. PRD sync review — master PRD status, active phase, assumption, risk, validation surface, change log가 갱신되었다.
+- [x] 1. Intent/coverage review — 본 phase가 objective와 매핑된 요구사항을 달성했다.
+- [x] 2. Correctness review — happy path, edge case, error, empty state, state transition, 권한이 처리되었다.
+- [x] 3. Simplicity review — 솔루션이 필요 이상으로 복잡하지 않다.
+- [x] 4. Code quality review — 이름/경계/추상화/로컬 일관성이 깔끔하다.
+- [x] 5. Duplication/cleanup review — 중복 로직, dead code, temporary code, 잡음 log, 주석 처리 잔재, 사용되지 않는 파일/의존성이 제거되었다.
+- [x] 6. Security/privacy review — 권한, secret, 민감 데이터, injection risk, 클라이언트 노출, 감사 필요성이 안전하다.
+- [x] 7. Performance/load review — bottleneck, 비싼 query, N+1, 불필요한 재렌더, 불필요한 네트워크 호출이 다루어졌다.
+- [x] 8. Validation review — 선택한 check가 phase risk에 적절하다. 누락 check는 근거와 함께 기록.
+- [x] 9. Future-phase review — 뒤 phase 파일/체크리스트가 여전히 옳다. 구현이 계획을 바꿨다면 수정.
+- [x] 10. PRD sync review — master PRD status, active phase, assumption, risk, validation surface, change log가 갱신되었다.
 
 ## Discoveries / Decisions
 - D-1: Before `nrs`, `verify-ai-compat.sh` failed on unrelated global skill/helper symlinks pointing at issue_638; the new Hooks artifact section itself passed.
@@ -90,6 +90,9 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - D-12: `/run-da for_pr` Round 3 returned CLEAR for Correctness, Design, and Maintainability; Arbiter confirmed one Regression issue where verifier over-failed clean symlinked user hooks.
 - D-13: Round 3 fix lets verifier inspect symlink targets with the shared stale filter; clean symlinked hooks pass, stale symlinked entries fail with manual-removal guidance.
 - D-14: `/parallel-audit` found two actionable items: stale matcher substring false positives and master PRD `nrs` repair wording that did not carve out symlinked hook files. Both were accepted for follow-up fix.
+- D-15: Final activation initially found a stale `nrs` lock from issue_632; `nrs-lock status` showed the recorded PID was not running, so the stale lock was released before rerunning `nrs`.
+- D-16: Final `nrs` completed successfully and the post-activation `./scripts/ai/verify-ai-compat.sh` reported complete success.
+- D-17: Final multi-pass review found no remaining blockers; native `PreToolUse` remains intentionally deferred to #587.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
@@ -98,3 +101,4 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - 2026-05-02: DA for_pr Round 2 symlink finding fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
 - 2026-05-02: DA for_pr Round 3 verifier symlink finding fixed and shell-tested; final validation pending.
 - 2026-05-02: parallel-audit exact matcher and PRD symlink repair wording findings fixed; final validation pending.
+- 2026-05-02: Final activation, verifier, multi-pass review, and PR handoff preparation completed.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
@@ -85,8 +85,11 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - D-7: Round 1 fixes centralized stale hook jq filters and cleanup in `modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh`, made Darwin/NixOS shims source the shared helper and override old cleanup, and added old-helper fixture coverage.
 - D-8: After staging the new helper, `nrs` deployed `/Users/green/.local/lib/rebuild/codex-legacy-hooks.sh`; post-`nrs` `verify-ai-compat.sh` passed.
 - D-9: `codex-exec-supervised --check` still reports `codex` binary absent in this shell, so DA/audit execution uses native Codex subagents instead of `codex exec` fallback.
+- D-10: `/run-da for_pr` Round 2 returned CLEAR for Design, Regression, and Maintainability; Arbiter confirmed one Correctness issue for symlinked user `hooks.json` clobber risk.
+- D-11: Round 2 fix leaves symlinked user `hooks.json` unchanged, makes verifier fail that state for manual inspection, and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase validation completed through `nrs` and post-`nrs` verifier; commit/DA/audit/PR remain.
 - 2026-05-02: DA for_pr Round 1 findings fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
+- 2026-05-02: DA for_pr Round 2 symlink finding fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
@@ -89,6 +89,7 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - D-11: Round 2 fix leaves symlinked user `hooks.json` unchanged, makes verifier fail that state for manual inspection, and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
 - D-12: `/run-da for_pr` Round 3 returned CLEAR for Correctness, Design, and Maintainability; Arbiter confirmed one Regression issue where verifier over-failed clean symlinked user hooks.
 - D-13: Round 3 fix lets verifier inspect symlink targets with the shared stale filter; clean symlinked hooks pass, stale symlinked entries fail with manual-removal guidance.
+- D-14: `/parallel-audit` found two actionable items: stale matcher substring false positives and master PRD `nrs` repair wording that did not carve out symlinked hook files. Both were accepted for follow-up fix.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
@@ -96,3 +97,4 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - 2026-05-02: DA for_pr Round 1 findings fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
 - 2026-05-02: DA for_pr Round 2 symlink finding fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
 - 2026-05-02: DA for_pr Round 3 verifier symlink finding fixed and shell-tested; final validation pending.
+- 2026-05-02: parallel-audit exact matcher and PRD symlink repair wording findings fixed; final validation pending.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
@@ -1,0 +1,87 @@
+# Phase 4: Validation And Handoff
+
+Parent PRD: [PRD: Codex User Legacy Hooks](../prd-codex-user-legacy-hooks.md)
+Status: In Progress
+Last Updated: 2026-05-02
+
+## Objective
+Validate the implemented cleanup/verifier behavior end to end, then prepare commit/PR handoff with #587 boundary clear.
+
+## Context From Master PRD
+- Goals covered: G-1 through G-5
+- Success Criteria: SC-1 through SC-6
+- Requirements covered: FR-1 through FR-8
+- Key scenarios touched: all scenarios
+
+## Phase Discovery Gate
+코드 편집 전에 재확인한다:
+- [x] 관련 코드/파일: all files changed in Phases 2-3
+- [x] 관련 테스트/fixture: updated shell tests and existing Codex hook fixtures
+- [x] 관련 docs/spec/외부 참조: #637, #587, OpenAI Codex hooks docs
+- [x] 관련 command 또는 도구: `git diff --check`, tests, `nrs`, `verify-ai-compat.sh`
+- [x] Master PRD의 assumption이 여전히 유효함
+- [x] 발견 사항이 이 phase 또는 후속 phase를 바꾸면, 구현 전에 PRD 파일을 먼저 갱신
+
+## Scope
+### In Scope
+- Final validation commands.
+- PRD status and change log updates.
+- Commit and PR preparation.
+- Explicit #587 handoff note for native `PreToolUse`.
+
+### Out of Scope
+- Additional feature work after validation unless required by failing tests/DA.
+
+## Implementation Checklist
+- [x] Run `git diff --check`.
+- [x] Run `./tests/shell-script-tests.sh`.
+- [x] Run `./tests/test-codex-hook-fixtures.sh --no-live`.
+- [x] Run `nrs` using the alias, not direct rebuild.
+- [x] Run `./scripts/ai/verify-ai-compat.sh` after `nrs`.
+- [x] If worktree/global symlink mismatch remains unrelated to #637, record exact limitation and recovery path.
+- [ ] Commit implementation.
+- [ ] Run `/run-da for_pr`.
+- [ ] Run `/parallel-audit`.
+- [ ] Perform Final Multi-Pass Review and PRD closeout.
+- [ ] Create PR with #637 close and #587 boundary notes.
+
+## Validation Strategy
+Combine static checks, shell tests, deterministic hook fixtures, and activation-level smoke because the risk is global user-level state and Home Manager/nrs behavior.
+
+## Validation Checklist
+- [x] Static check 통과: `git diff --check`
+- [x] 자동 test 추가/갱신 및 통과: `./tests/shell-script-tests.sh`
+- [x] Hook fixture regression 통과: `./tests/test-codex-hook-fixtures.sh --no-live`
+- [x] Activation smoke: `nrs`
+- [x] Verifier smoke: `./scripts/ai/verify-ai-compat.sh`
+- [x] Manual smoke check: real `~/.codex/hooks.json` remains absent or valid; no private content recorded
+- [x] 해당 시 error, empty, malformed, permission, rollback 상태 검증
+
+## Exit Criteria
+- [ ] Phase objective 달성
+- [ ] 위에 열거한 요구사항이 구현되었거나 명시적으로 deferred
+- [ ] Validation checklist 완료 또는 gap이 근거와 함께 기록됨
+- [ ] 다음 phase를 시작하지 못하게 막는 blocker 없음
+
+## Phase-End Multi-Pass Review
+- [ ] 1. Intent/coverage review — 본 phase가 objective와 매핑된 요구사항을 달성했다.
+- [ ] 2. Correctness review — happy path, edge case, error, empty state, state transition, 권한이 처리되었다.
+- [ ] 3. Simplicity review — 솔루션이 필요 이상으로 복잡하지 않다.
+- [ ] 4. Code quality review — 이름/경계/추상화/로컬 일관성이 깔끔하다.
+- [ ] 5. Duplication/cleanup review — 중복 로직, dead code, temporary code, 잡음 log, 주석 처리 잔재, 사용되지 않는 파일/의존성이 제거되었다.
+- [ ] 6. Security/privacy review — 권한, secret, 민감 데이터, injection risk, 클라이언트 노출, 감사 필요성이 안전하다.
+- [ ] 7. Performance/load review — bottleneck, 비싼 query, N+1, 불필요한 재렌더, 불필요한 네트워크 호출이 다루어졌다.
+- [ ] 8. Validation review — 선택한 check가 phase risk에 적절하다. 누락 check는 근거와 함께 기록.
+- [ ] 9. Future-phase review — 뒤 phase 파일/체크리스트가 여전히 옳다. 구현이 계획을 바꿨다면 수정.
+- [ ] 10. PRD sync review — master PRD status, active phase, assumption, risk, validation surface, change log가 갱신되었다.
+
+## Discoveries / Decisions
+- D-1: Before `nrs`, `verify-ai-compat.sh` failed on unrelated global skill/helper symlinks pointing at issue_638; the new Hooks artifact section itself passed.
+- D-2: Running `nrs` relinked the global Codex/Claude surfaces to issue_637 and completed successfully.
+- D-3: After `nrs`, `./scripts/ai/verify-ai-compat.sh` reported complete success, including no repo-local hook artifacts, no user-level `hooks.compatibility.json`, and no user-level `hooks.json`.
+- D-4: `./tests/shell-script-tests.sh` passed; codex-config fixture subtests were skipped outside tomlkit shell as expected by the test harness.
+- D-5: `./tests/test-codex-hook-fixtures.sh --no-live` passed through tomlkit bootstrap.
+
+## Phase Change Log
+- 2026-05-02: Phase file created.
+- 2026-05-02: Phase validation completed through `nrs` and post-`nrs` verifier; commit/DA/audit/PR remain.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
@@ -87,9 +87,12 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - D-9: `codex-exec-supervised --check` still reports `codex` binary absent in this shell, so DA/audit execution uses native Codex subagents instead of `codex exec` fallback.
 - D-10: `/run-da for_pr` Round 2 returned CLEAR for Design, Regression, and Maintainability; Arbiter confirmed one Correctness issue for symlinked user `hooks.json` clobber risk.
 - D-11: Round 2 fix leaves symlinked user `hooks.json` unchanged, makes verifier fail that state for manual inspection, and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
+- D-12: `/run-da for_pr` Round 3 returned CLEAR for Correctness, Design, and Maintainability; Arbiter confirmed one Regression issue where verifier over-failed clean symlinked user hooks.
+- D-13: Round 3 fix lets verifier inspect symlink targets with the shared stale filter; clean symlinked hooks pass, stale symlinked entries fail with manual-removal guidance.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase validation completed through `nrs` and post-`nrs` verifier; commit/DA/audit/PR remain.
 - 2026-05-02: DA for_pr Round 1 findings fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
 - 2026-05-02: DA for_pr Round 2 symlink finding fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.
+- 2026-05-02: DA for_pr Round 3 verifier symlink finding fixed and shell-tested; final validation pending.

--- a/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
+++ b/.claude/prds/prd-codex-user-legacy-hooks/phase-04-validation-handoff.md
@@ -81,7 +81,12 @@ Combine static checks, shell tests, deterministic hook fixtures, and activation-
 - D-3: After `nrs`, `./scripts/ai/verify-ai-compat.sh` reported complete success, including no repo-local hook artifacts, no user-level `hooks.compatibility.json`, and no user-level `hooks.json`.
 - D-4: `./tests/shell-script-tests.sh` passed; codex-config fixture subtests were skipped outside tomlkit shell as expected by the test harness.
 - D-5: `./tests/test-codex-hook-fixtures.sh --no-live` passed through tomlkit bootstrap.
+- D-6: `/run-da for_pr` Round 1 intensity was FULL. Arbiter confirmed four issues: old deployed cleanup function shadowing the new mixed-version shim, verifier repair contract regression, duplicated shim jq design, and duplicated stale matcher maintainability.
+- D-7: Round 1 fixes centralized stale hook jq filters and cleanup in `modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh`, made Darwin/NixOS shims source the shared helper and override old cleanup, and added old-helper fixture coverage.
+- D-8: After staging the new helper, `nrs` deployed `/Users/green/.local/lib/rebuild/codex-legacy-hooks.sh`; post-`nrs` `verify-ai-compat.sh` passed.
+- D-9: `codex-exec-supervised --check` still reports `codex` binary absent in this shell, so DA/audit execution uses native Codex subagents instead of `codex exec` fallback.
 
 ## Phase Change Log
 - 2026-05-02: Phase file created.
 - 2026-05-02: Phase validation completed through `nrs` and post-`nrs` verifier; commit/DA/audit/PR remain.
+- 2026-05-02: DA for_pr Round 1 findings fixed and revalidated through shell tests, hook fixtures, `nrs`, and post-`nrs` verifier.

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -35,7 +35,43 @@ install_rebuild_common_compat_shims() {
         NRS_LOCK_SWITCH_SUCCESS=true
     }
     declare -F _clear_retired_codex_hook_artifacts >/dev/null || _clear_retired_codex_hook_artifacts() {
+        local user_hooks_json="$HOME/.codex/hooks.json"
+        local user_hooks_report="$HOME/.codex/hooks.compatibility.json"
         rm -f "$FLAKE_PATH/.codex/hooks.json" "$FLAKE_PATH/.codex/hooks.compatibility.json"
+        if [[ -e "$user_hooks_report" ]]; then
+            rm -f "$user_hooks_report"
+            log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
+        fi
+        [[ -f "$user_hooks_json" ]] || return 0
+        command -v jq >/dev/null 2>&1 || { log_error "jq is required to safely inspect $user_hooks_json"; return 1; }
+        local stale_count
+        if ! stale_count=$(jq -r '
+            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
+            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
+            [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
+        ' "$user_hooks_json"); then
+            log_warn "⚠️  Could not parse $user_hooks_json; leaving user-owned hook file unchanged."
+            return 0
+        fi
+        [[ "$stale_count" =~ ^[0-9]+$ ]] || return 0
+        (( stale_count > 0 )) || return 0
+        local tmp
+        tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
+        if ! jq '
+            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
+            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
+            if (.hooks? | type) == "object" then
+                .hooks |= with_entries(.value = (.value | map(if (.hooks? | type) == "array" then .hooks = (.hooks | map(select(is_stale | not))) else . end) | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))) | select(.value | length > 0))
+            else
+                .
+            end
+        ' "$user_hooks_json" > "$tmp"; then
+            rm -f "$tmp"
+            log_error "Failed to prune stale Codex hook entries from $user_hooks_json"
+            return 1
+        fi
+        mv "$tmp" "$user_hooks_json"
+        log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
     }
     # 구버전 rebuild-common.sh 는 codex helper 가 없어 이 함수도 없다. 그 조합에서는
     # NO_CHANGES 경로가 "command not found"로 죽지 않도록 no-op shim 을 둔다. 사용자가

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -35,13 +35,17 @@ install_rebuild_common_compat_shims() {
         NRS_LOCK_SWITCH_SUCCESS=true
     }
     local codex_legacy_hooks_helper
-    for codex_legacy_hooks_helper in \
-        "${REBUILD_COMMON_LIB_DIR:-}/codex-legacy-hooks.sh" \
-        "$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"; do
+    local -a codex_legacy_hooks_candidates=()
+    if [[ -n "${REBUILD_COMMON_LIB_DIR:-}" ]]; then
+        codex_legacy_hooks_candidates+=("$REBUILD_COMMON_LIB_DIR/codex-legacy-hooks.sh")
+    fi
+    codex_legacy_hooks_candidates+=("$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh")
+
+    for codex_legacy_hooks_helper in "${codex_legacy_hooks_candidates[@]}"; do
         [[ -n "$codex_legacy_hooks_helper" && -f "$codex_legacy_hooks_helper" ]] || continue
         # shellcheck source=/dev/null
         source "$codex_legacy_hooks_helper"
-        break
+        declare -F codex_clear_retired_hook_artifacts >/dev/null && break
     done
     declare -F codex_clear_retired_hook_artifacts >/dev/null && _clear_retired_codex_hook_artifacts() {
         codex_clear_retired_hook_artifacts "$FLAKE_PATH" "$HOME"

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -34,44 +34,17 @@ install_rebuild_common_compat_shims() {
         # shellcheck disable=SC2034  # Older deployed helpers still read this global in failure cleanup.
         NRS_LOCK_SWITCH_SUCCESS=true
     }
-    declare -F _clear_retired_codex_hook_artifacts >/dev/null || _clear_retired_codex_hook_artifacts() {
-        local user_hooks_json="$HOME/.codex/hooks.json"
-        local user_hooks_report="$HOME/.codex/hooks.compatibility.json"
-        rm -f "$FLAKE_PATH/.codex/hooks.json" "$FLAKE_PATH/.codex/hooks.compatibility.json"
-        if [[ -e "$user_hooks_report" ]]; then
-            rm -f "$user_hooks_report"
-            log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
-        fi
-        [[ -f "$user_hooks_json" ]] || return 0
-        command -v jq >/dev/null 2>&1 || { log_error "jq is required to safely inspect $user_hooks_json"; return 1; }
-        local stale_count
-        if ! stale_count=$(jq -r '
-            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
-            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
-            [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
-        ' "$user_hooks_json"); then
-            log_warn "⚠️  Could not parse $user_hooks_json; leaving user-owned hook file unchanged."
-            return 0
-        fi
-        [[ "$stale_count" =~ ^[0-9]+$ ]] || return 0
-        (( stale_count > 0 )) || return 0
-        local tmp
-        tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
-        if ! jq '
-            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
-            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
-            if (.hooks? | type) == "object" then
-                .hooks |= with_entries(.value = (.value | map(if (.hooks? | type) == "array" then .hooks = (.hooks | map(select(is_stale | not))) else . end) | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))) | select(.value | length > 0))
-            else
-                .
-            end
-        ' "$user_hooks_json" > "$tmp"; then
-            rm -f "$tmp"
-            log_error "Failed to prune stale Codex hook entries from $user_hooks_json"
-            return 1
-        fi
-        mv "$tmp" "$user_hooks_json"
-        log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
+    local codex_legacy_hooks_helper
+    for codex_legacy_hooks_helper in \
+        "${REBUILD_COMMON_LIB_DIR:-}/codex-legacy-hooks.sh" \
+        "$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"; do
+        [[ -n "$codex_legacy_hooks_helper" && -f "$codex_legacy_hooks_helper" ]] || continue
+        # shellcheck source=/dev/null
+        source "$codex_legacy_hooks_helper"
+        break
+    done
+    declare -F codex_clear_retired_hook_artifacts >/dev/null && _clear_retired_codex_hook_artifacts() {
+        codex_clear_retired_hook_artifacts "$FLAKE_PATH" "$HOME"
     }
     # 구버전 rebuild-common.sh 는 codex helper 가 없어 이 함수도 없다. 그 조합에서는
     # NO_CHANGES 경로가 "command not found"로 죽지 않도록 no-op shim 을 둔다. 사용자가

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -26,7 +26,43 @@ install_rebuild_common_compat_shims() {
         "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     }
     declare -F _clear_retired_codex_hook_artifacts >/dev/null || _clear_retired_codex_hook_artifacts() {
+        local user_hooks_json="$HOME/.codex/hooks.json"
+        local user_hooks_report="$HOME/.codex/hooks.compatibility.json"
         rm -f "$FLAKE_PATH/.codex/hooks.json" "$FLAKE_PATH/.codex/hooks.compatibility.json"
+        if [[ -e "$user_hooks_report" ]]; then
+            rm -f "$user_hooks_report"
+            log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
+        fi
+        [[ -f "$user_hooks_json" ]] || return 0
+        command -v jq >/dev/null 2>&1 || { log_error "jq is required to safely inspect $user_hooks_json"; return 1; }
+        local stale_count
+        if ! stale_count=$(jq -r '
+            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
+            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
+            [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
+        ' "$user_hooks_json"); then
+            log_warn "⚠️  Could not parse $user_hooks_json; leaving user-owned hook file unchanged."
+            return 0
+        fi
+        [[ "$stale_count" =~ ^[0-9]+$ ]] || return 0
+        (( stale_count > 0 )) || return 0
+        local tmp
+        tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
+        if ! jq '
+            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
+            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
+            if (.hooks? | type) == "object" then
+                .hooks |= with_entries(.value = (.value | map(if (.hooks? | type) == "array" then .hooks = (.hooks | map(select(is_stale | not))) else . end) | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))) | select(.value | length > 0))
+            else
+                .
+            end
+        ' "$user_hooks_json" > "$tmp"; then
+            rm -f "$tmp"
+            log_error "Failed to prune stale Codex hook entries from $user_hooks_json"
+            return 1
+        fi
+        mv "$tmp" "$user_hooks_json"
+        log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
     }
     # 구버전 rebuild-common.sh 는 codex helper 가 없어 이 함수도 없다. 그 조합에서는
     # NO_CHANGES 경로가 "command not found"로 죽지 않도록 no-op shim 을 둔다. 사용자가

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -25,44 +25,17 @@ install_rebuild_common_compat_shims() {
         _remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
         "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     }
-    declare -F _clear_retired_codex_hook_artifacts >/dev/null || _clear_retired_codex_hook_artifacts() {
-        local user_hooks_json="$HOME/.codex/hooks.json"
-        local user_hooks_report="$HOME/.codex/hooks.compatibility.json"
-        rm -f "$FLAKE_PATH/.codex/hooks.json" "$FLAKE_PATH/.codex/hooks.compatibility.json"
-        if [[ -e "$user_hooks_report" ]]; then
-            rm -f "$user_hooks_report"
-            log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
-        fi
-        [[ -f "$user_hooks_json" ]] || return 0
-        command -v jq >/dev/null 2>&1 || { log_error "jq is required to safely inspect $user_hooks_json"; return 1; }
-        local stale_count
-        if ! stale_count=$(jq -r '
-            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
-            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
-            [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
-        ' "$user_hooks_json"); then
-            log_warn "⚠️  Could not parse $user_hooks_json; leaving user-owned hook file unchanged."
-            return 0
-        fi
-        [[ "$stale_count" =~ ^[0-9]+$ ]] || return 0
-        (( stale_count > 0 )) || return 0
-        local tmp
-        tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
-        if ! jq '
-            def stale_names: ["session-init-icons.sh", "worktree-path-guard.sh", "fragile-hardcoding-guard.sh", "system-bash-guard.sh"];
-            def is_stale: (.command? // "") as $cmd | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))] | length > 0;
-            if (.hooks? | type) == "object" then
-                .hooks |= with_entries(.value = (.value | map(if (.hooks? | type) == "array" then .hooks = (.hooks | map(select(is_stale | not))) else . end) | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))) | select(.value | length > 0))
-            else
-                .
-            end
-        ' "$user_hooks_json" > "$tmp"; then
-            rm -f "$tmp"
-            log_error "Failed to prune stale Codex hook entries from $user_hooks_json"
-            return 1
-        fi
-        mv "$tmp" "$user_hooks_json"
-        log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
+    local codex_legacy_hooks_helper
+    for codex_legacy_hooks_helper in \
+        "${REBUILD_COMMON_LIB_DIR:-}/codex-legacy-hooks.sh" \
+        "$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"; do
+        [[ -n "$codex_legacy_hooks_helper" && -f "$codex_legacy_hooks_helper" ]] || continue
+        # shellcheck source=/dev/null
+        source "$codex_legacy_hooks_helper"
+        break
+    done
+    declare -F codex_clear_retired_hook_artifacts >/dev/null && _clear_retired_codex_hook_artifacts() {
+        codex_clear_retired_hook_artifacts "$FLAKE_PATH" "$HOME"
     }
     # 구버전 rebuild-common.sh 는 codex helper 가 없어 이 함수도 없다. 그 조합에서는
     # NO_CHANGES 경로가 "command not found"로 죽지 않도록 no-op shim 을 둔다. 사용자가

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -26,13 +26,17 @@ install_rebuild_common_compat_shims() {
         "$HOME/.local/bin/nrs-relink" restore || log_warn "⚠️  nrs-relink restore failed (non-fatal)"
     }
     local codex_legacy_hooks_helper
-    for codex_legacy_hooks_helper in \
-        "${REBUILD_COMMON_LIB_DIR:-}/codex-legacy-hooks.sh" \
-        "$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"; do
+    local -a codex_legacy_hooks_candidates=()
+    if [[ -n "${REBUILD_COMMON_LIB_DIR:-}" ]]; then
+        codex_legacy_hooks_candidates+=("$REBUILD_COMMON_LIB_DIR/codex-legacy-hooks.sh")
+    fi
+    codex_legacy_hooks_candidates+=("$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh")
+
+    for codex_legacy_hooks_helper in "${codex_legacy_hooks_candidates[@]}"; do
         [[ -n "$codex_legacy_hooks_helper" && -f "$codex_legacy_hooks_helper" ]] || continue
         # shellcheck source=/dev/null
         source "$codex_legacy_hooks_helper"
-        break
+        declare -F codex_clear_retired_hook_artifacts >/dev/null && break
     done
     declare -F codex_clear_retired_hook_artifacts >/dev/null && _clear_retired_codex_hook_artifacts() {
         codex_clear_retired_hook_artifacts "$FLAKE_PATH" "$HOME"

--- a/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
+++ b/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
@@ -86,8 +86,9 @@ codex_prune_legacy_user_hooks_json() {
     }
     (( stale_count > 0 )) || return 0
 
-    local tmp prune_filter
-    tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
+    local tmp prune_filter hooks_dir
+    hooks_dir="$(dirname "$hooks_json")"
+    tmp=$(mktemp "$hooks_dir/.codex-hooks-json.XXXXXX")
     prune_filter="$(codex_legacy_user_hook_prune_jq_filter)"
     if ! jq "$prune_filter" "$hooks_json" > "$tmp"; then
         rm -f "$tmp"
@@ -95,7 +96,11 @@ codex_prune_legacy_user_hooks_json() {
         return 1
     fi
 
-    mv "$tmp" "$hooks_json"
+    if ! mv "$tmp" "$hooks_json"; then
+        rm -f "$tmp"
+        log_error "Failed to replace $hooks_json after pruning stale Codex hook entries"
+        return 1
+    fi
     log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
 }
 
@@ -106,12 +111,12 @@ codex_clear_retired_hook_artifacts() {
     local hooks_report="$flake_path/.codex/hooks.compatibility.json"
     local user_hooks_report="$home_dir/.codex/hooks.compatibility.json"
 
-    if [[ -e "$hooks_json" || -e "$hooks_report" ]]; then
+    if [[ -e "$hooks_json" || -L "$hooks_json" || -e "$hooks_report" || -L "$hooks_report" ]]; then
         rm -f "$hooks_json" "$hooks_report"
         log_info "🧹 Removed retired Codex hook artifacts."
     fi
 
-    if [[ -e "$user_hooks_report" ]]; then
+    if [[ -e "$user_hooks_report" || -L "$user_hooks_report" ]]; then
         rm -f "$user_hooks_report"
         log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
     fi

--- a/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
+++ b/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
@@ -8,9 +8,23 @@ def stale_names: [
     "fragile-hardcoding-guard.sh",
     "system-bash-guard.sh"
 ];
+def normalize_command:
+    gsub("^[[:space:]]+|[[:space:]]+$"; "")
+    | if ((startswith("\"") and endswith("\"")) or (startswith("'") and endswith("'"))) then
+        .[1:-1]
+      else
+        .
+      end;
+def stale_path($name):
+    [
+        "~/.codex/hooks/" + $name,
+        "$HOME/.codex/hooks/" + $name,
+        "${HOME}/.codex/hooks/" + $name,
+        env.HOME + "/.codex/hooks/" + $name
+    ];
 def is_stale:
-    (.command? // "") as $cmd
-    | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
+    ((.command? // "") | normalize_command) as $cmd
+    | [stale_names[] | . as $name | select(stale_path($name) | index($cmd))]
     | length > 0;
 EOF
 }

--- a/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
+++ b/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
@@ -49,6 +49,10 @@ EOF
 codex_prune_legacy_user_hooks_json() {
     local hooks_json="$1"
     [[ -f "$hooks_json" ]] || return 0
+    if [[ -L "$hooks_json" ]]; then
+        log_warn "⚠️  $hooks_json is a symlink; leaving user-owned hook file unchanged. Remove stale Codex legacy entries manually."
+        return 0
+    fi
 
     if ! command -v jq >/dev/null 2>&1; then
         log_error "jq is required to safely inspect $hooks_json"

--- a/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
+++ b/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
@@ -1,0 +1,102 @@
+# shellcheck shell=bash
+
+codex_legacy_user_hook_jq_defs() {
+    cat <<'EOF'
+def stale_names: [
+    "session-init-icons.sh",
+    "worktree-path-guard.sh",
+    "fragile-hardcoding-guard.sh",
+    "system-bash-guard.sh"
+];
+def is_stale:
+    (.command? // "") as $cmd
+    | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
+    | length > 0;
+EOF
+}
+
+codex_legacy_user_hook_count_jq_filter() {
+    codex_legacy_user_hook_jq_defs
+    cat <<'EOF'
+[(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
+EOF
+}
+
+codex_legacy_user_hook_prune_jq_filter() {
+    codex_legacy_user_hook_jq_defs
+    cat <<'EOF'
+if (.hooks? | type) == "object" then
+    .hooks |= with_entries(
+        .value = (
+            .value
+            | map(
+                if (.hooks? | type) == "array" then
+                    .hooks = (.hooks | map(select(is_stale | not)))
+                else
+                    .
+                end
+            )
+            | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))
+        )
+        | select(.value | length > 0)
+    )
+else
+    .
+end
+EOF
+}
+
+codex_prune_legacy_user_hooks_json() {
+    local hooks_json="$1"
+    [[ -f "$hooks_json" ]] || return 0
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log_error "jq is required to safely inspect $hooks_json"
+        return 1
+    fi
+
+    local stale_count count_filter
+    count_filter="$(codex_legacy_user_hook_count_jq_filter)"
+    if ! stale_count=$(jq -r "$count_filter" "$hooks_json"); then
+        log_warn "⚠️  Could not parse $hooks_json; leaving user-owned hook file unchanged."
+        return 0
+    fi
+
+    [[ "$stale_count" =~ ^[0-9]+$ ]] || {
+        log_warn "⚠️  Could not count stale entries in $hooks_json; leaving it unchanged."
+        return 0
+    }
+    (( stale_count > 0 )) || return 0
+
+    local tmp prune_filter
+    tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
+    prune_filter="$(codex_legacy_user_hook_prune_jq_filter)"
+    if ! jq "$prune_filter" "$hooks_json" > "$tmp"; then
+        rm -f "$tmp"
+        log_error "Failed to prune stale Codex hook entries from $hooks_json"
+        return 1
+    fi
+
+    mv "$tmp" "$hooks_json"
+    log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
+}
+
+codex_clear_retired_hook_artifacts() {
+    local flake_path="$1"
+    local home_dir="$2"
+    local hooks_json="$flake_path/.codex/hooks.json"
+    local hooks_report="$flake_path/.codex/hooks.compatibility.json"
+    local user_hooks_report="$home_dir/.codex/hooks.compatibility.json"
+
+    if [[ -e "$hooks_json" || -e "$hooks_report" ]]; then
+        rm -f "$hooks_json" "$hooks_report"
+        log_info "🧹 Removed retired Codex hook artifacts."
+    fi
+
+    if [[ -e "$user_hooks_report" ]]; then
+        rm -f "$user_hooks_report"
+        log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
+    fi
+
+    codex_prune_legacy_user_hooks_json "$home_dir/.codex/hooks.json"
+}

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -28,96 +28,26 @@ detect_worktree() {
 # Retired Codex hooks cleanup: 기존 worktree/checkout에 남은 repo-local hook
 # 산출물과 알려진 user-level legacy hook entry를 rebuild 전에 정리한다.
 #───────────────────────────────────────────────────────────────────────────────
-_prune_legacy_user_codex_hooks_json() {
-    local hooks_json="$HOME/.codex/hooks.json"
-    [[ -f "$hooks_json" ]] || return 0
+_source_codex_legacy_hooks_helper() {
+    declare -F codex_clear_retired_hook_artifacts >/dev/null && return 0
 
-    if ! command -v jq >/dev/null 2>&1; then
-        log_error "jq is required to safely inspect $hooks_json"
-        return 1
-    fi
+    local helper
+    for helper in \
+        "${REBUILD_COMMON_LIB_DIR:-}/codex-legacy-hooks.sh" \
+        "$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"; do
+        [[ -n "$helper" && -f "$helper" ]] || continue
+        # shellcheck source=/dev/null
+        source "$helper"
+        declare -F codex_clear_retired_hook_artifacts >/dev/null && return 0
+    done
 
-    local stale_count
-    if ! stale_count=$(jq -r '
-        def stale_names: [
-            "session-init-icons.sh",
-            "worktree-path-guard.sh",
-            "fragile-hardcoding-guard.sh",
-            "system-bash-guard.sh"
-        ];
-        def is_stale:
-            (.command? // "") as $cmd
-            | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
-            | length > 0;
-        [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
-    ' "$hooks_json"); then
-        log_warn "⚠️  Could not parse $hooks_json; leaving user-owned hook file unchanged."
-        return 0
-    fi
-
-    [[ "$stale_count" =~ ^[0-9]+$ ]] || {
-        log_warn "⚠️  Could not count stale entries in $hooks_json; leaving it unchanged."
-        return 0
-    }
-    (( stale_count > 0 )) || return 0
-
-    local tmp
-    tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
-    if ! jq '
-        def stale_names: [
-            "session-init-icons.sh",
-            "worktree-path-guard.sh",
-            "fragile-hardcoding-guard.sh",
-            "system-bash-guard.sh"
-        ];
-        def is_stale:
-            (.command? // "") as $cmd
-            | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
-            | length > 0;
-        if (.hooks? | type) == "object" then
-            .hooks |= with_entries(
-                .value = (
-                    .value
-                    | map(
-                        if (.hooks? | type) == "array" then
-                            .hooks = (.hooks | map(select(is_stale | not)))
-                        else
-                            .
-                        end
-                    )
-                    | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))
-                )
-                | select(.value | length > 0)
-            )
-        else
-            .
-        end
-    ' "$hooks_json" > "$tmp"; then
-        rm -f "$tmp"
-        log_error "Failed to prune stale Codex hook entries from $hooks_json"
-        return 1
-    fi
-
-    mv "$tmp" "$hooks_json"
-    log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
+    log_error "Codex legacy hook cleanup helper not found"
+    return 1
 }
 
 _clear_retired_codex_hook_artifacts() {
-    local hooks_json="$FLAKE_PATH/.codex/hooks.json"
-    local hooks_report="$FLAKE_PATH/.codex/hooks.compatibility.json"
-    local user_hooks_report="$HOME/.codex/hooks.compatibility.json"
-
-    if [[ -e "$hooks_json" || -e "$hooks_report" ]]; then
-        rm -f "$hooks_json" "$hooks_report"
-        log_info "🧹 Removed retired Codex hook artifacts."
-    fi
-
-    if [[ -e "$user_hooks_report" ]]; then
-        rm -f "$user_hooks_report"
-        log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
-    fi
-
-    _prune_legacy_user_codex_hooks_json
+    _source_codex_legacy_hooks_helper
+    codex_clear_retired_hook_artifacts "$FLAKE_PATH" "$HOME"
 }
 
 #───────────────────────────────────────────────────────────────────────────────

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -32,9 +32,13 @@ _source_codex_legacy_hooks_helper() {
     declare -F codex_clear_retired_hook_artifacts >/dev/null && return 0
 
     local helper
-    for helper in \
-        "${REBUILD_COMMON_LIB_DIR:-}/codex-legacy-hooks.sh" \
-        "$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"; do
+    local -a candidates=()
+    if [[ -n "${REBUILD_COMMON_LIB_DIR:-}" ]]; then
+        candidates+=("$REBUILD_COMMON_LIB_DIR/codex-legacy-hooks.sh")
+    fi
+    candidates+=("$FLAKE_PATH/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh")
+
+    for helper in "${candidates[@]}"; do
         [[ -n "$helper" && -f "$helper" ]] || continue
         # shellcheck source=/dev/null
         source "$helper"

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -26,16 +26,98 @@ detect_worktree() {
 
 #───────────────────────────────────────────────────────────────────────────────
 # Retired Codex hooks cleanup: 기존 worktree/checkout에 남은 repo-local hook
-# 산출물을 rebuild 전에 정리하여 verify-ai-compat 경로를 복구한다.
+# 산출물과 알려진 user-level legacy hook entry를 rebuild 전에 정리한다.
 #───────────────────────────────────────────────────────────────────────────────
+_prune_legacy_user_codex_hooks_json() {
+    local hooks_json="$HOME/.codex/hooks.json"
+    [[ -f "$hooks_json" ]] || return 0
+
+    if ! command -v jq >/dev/null 2>&1; then
+        log_error "jq is required to safely inspect $hooks_json"
+        return 1
+    fi
+
+    local stale_count
+    if ! stale_count=$(jq -r '
+        def stale_names: [
+            "session-init-icons.sh",
+            "worktree-path-guard.sh",
+            "fragile-hardcoding-guard.sh",
+            "system-bash-guard.sh"
+        ];
+        def is_stale:
+            (.command? // "") as $cmd
+            | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
+            | length > 0;
+        [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
+    ' "$hooks_json"); then
+        log_warn "⚠️  Could not parse $hooks_json; leaving user-owned hook file unchanged."
+        return 0
+    fi
+
+    [[ "$stale_count" =~ ^[0-9]+$ ]] || {
+        log_warn "⚠️  Could not count stale entries in $hooks_json; leaving it unchanged."
+        return 0
+    }
+    (( stale_count > 0 )) || return 0
+
+    local tmp
+    tmp=$(mktemp "${TMPDIR:-/tmp}/codex-hooks-json.XXXXXX")
+    if ! jq '
+        def stale_names: [
+            "session-init-icons.sh",
+            "worktree-path-guard.sh",
+            "fragile-hardcoding-guard.sh",
+            "system-bash-guard.sh"
+        ];
+        def is_stale:
+            (.command? // "") as $cmd
+            | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
+            | length > 0;
+        if (.hooks? | type) == "object" then
+            .hooks |= with_entries(
+                .value = (
+                    .value
+                    | map(
+                        if (.hooks? | type) == "array" then
+                            .hooks = (.hooks | map(select(is_stale | not)))
+                        else
+                            .
+                        end
+                    )
+                    | map(select((.hooks? | type != "array") or ((.hooks | length) > 0)))
+                )
+                | select(.value | length > 0)
+            )
+        else
+            .
+        end
+    ' "$hooks_json" > "$tmp"; then
+        rm -f "$tmp"
+        log_error "Failed to prune stale Codex hook entries from $hooks_json"
+        return 1
+    fi
+
+    mv "$tmp" "$hooks_json"
+    log_info "🧹 Pruned $stale_count stale Codex hook entr$( (( stale_count == 1 )) && printf 'y' || printf 'ies' ) from user-level hooks.json."
+}
+
 _clear_retired_codex_hook_artifacts() {
     local hooks_json="$FLAKE_PATH/.codex/hooks.json"
     local hooks_report="$FLAKE_PATH/.codex/hooks.compatibility.json"
+    local user_hooks_report="$HOME/.codex/hooks.compatibility.json"
 
     if [[ -e "$hooks_json" || -e "$hooks_report" ]]; then
         rm -f "$hooks_json" "$hooks_report"
         log_info "🧹 Removed retired Codex hook artifacts."
     fi
+
+    if [[ -e "$user_hooks_report" ]]; then
+        rm -f "$user_hooks_report"
+        log_info "🧹 Removed retired user-level Codex hooks.compatibility.json."
+    fi
+
+    _prune_legacy_user_codex_hooks_json
 }
 
 #───────────────────────────────────────────────────────────────────────────────

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -937,16 +937,18 @@ else
 fi
 
 if [ -f "$_user_hooks_json" ]; then
-  if [ -L "$_user_hooks_json" ]; then
-    fail "$_user_hooks_json is a symlink — user-level hook file requires manual stale-entry inspection to avoid clobbering dotfile-managed state"
-  elif ! command -v jq >/dev/null 2>&1; then
+  if ! command -v jq >/dev/null 2>&1; then
     fail "jq 없음 — $_user_hooks_json stale entry 검사 불가"
   else
     _user_stale_hook_count=""
     if ! _user_stale_hook_count="$(jq -r "$(codex_legacy_user_hook_count_jq_filter)" "$_user_hooks_json")"; then
       fail "$_user_hooks_json JSON 파싱 실패 — user-level hook 파일을 수동 점검하세요"
     elif [ "$_user_stale_hook_count" -gt 0 ] 2>/dev/null; then
-      fail "stale user-level Codex hook entries present ($_user_hooks_json count=$_user_stale_hook_count) — run nrs to prune known Claude-era entries"
+      if [ -L "$_user_hooks_json" ]; then
+        fail "stale user-level Codex hook entries present ($_user_hooks_json count=$_user_stale_hook_count) — symlinked hook files are preserved by nrs; remove known Claude-era entries manually"
+      else
+        fail "stale user-level Codex hook entries present ($_user_hooks_json count=$_user_stale_hook_count) — run nrs to prune known Claude-era entries"
+      fi
     else
       pass "user-level Codex hooks.json stale legacy entry 없음"
     fi

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -11,6 +11,9 @@ TARGET_SKILLS_DIR="$REPO_ROOT/.agents/skills"
 SHARED_SKILLS_DIR="$REPO_ROOT/modules/shared/programs/claude/files/skills"
 CODEX_GLOBAL_SKILLS_DIR="$HOME/.codex/skills"
 
+# shellcheck source=/dev/null
+. "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
+
 # Nix SoT(default.nix)와 독립된 감사 오라클.
 # 두 리스트는 서로 교집합이 없어야 하며, shared 디렉토리의 모든 스킬이 둘 중 하나에 속해야 한다.
 EXPECTED_EXPOSED=(
@@ -938,19 +941,7 @@ if [ -f "$_user_hooks_json" ]; then
     fail "jq 없음 — $_user_hooks_json stale entry 검사 불가"
   else
     _user_stale_hook_count=""
-    if ! _user_stale_hook_count="$(jq -r '
-      def stale_names: [
-        "session-init-icons.sh",
-        "worktree-path-guard.sh",
-        "fragile-hardcoding-guard.sh",
-        "system-bash-guard.sh"
-      ];
-      def is_stale:
-        (.command? // "") as $cmd
-        | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
-        | length > 0;
-      [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
-    ' "$_user_hooks_json")"; then
+    if ! _user_stale_hook_count="$(jq -r "$(codex_legacy_user_hook_count_jq_filter)" "$_user_hooks_json")"; then
       fail "$_user_hooks_json JSON 파싱 실패 — user-level hook 파일을 수동 점검하세요"
     elif [ "$_user_stale_hook_count" -gt 0 ] 2>/dev/null; then
       fail "stale user-level Codex hook entries present ($_user_hooks_json count=$_user_stale_hook_count) — run nrs to prune known Claude-era entries"

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -916,12 +916,50 @@ echo ""
 echo "=== Hooks 산출물 확인 ==="
 
 # stale guard: <repo>/.codex/hooks.json 또는 <repo>/.codex/hooks.compatibility.json은
-# 폐기된 패턴이라 잔재 시 fail. 단 user-level ~/.codex/hooks.json은 0.124+ stable inline TOML과
-# 함께 valid source 가능성이 있어 검사 대상 아님.
+# 폐기된 패턴이라 잔재 시 fail. 단 user-level ~/.codex/hooks.json은 공식 hook source라
+# 존재 자체가 아니라 알려진 legacy entry만 검사한다.
 if [ -e "$REPO_ROOT/.codex/hooks.json" ] || [ -e "$REPO_ROOT/.codex/hooks.compatibility.json" ]; then
   fail "stale Codex hook artifacts present (.codex/hooks*.json)"
 else
   pass "repo-local Codex hook artifacts 없음"
+fi
+
+_user_hooks_json="$HOME/.codex/hooks.json"
+_user_hooks_report="$HOME/.codex/hooks.compatibility.json"
+
+if [ -e "$_user_hooks_report" ]; then
+  fail "stale user-level Codex hook artifact present ($_user_hooks_report) — run nrs to remove retired hooks.compatibility.json"
+else
+  pass "user-level Codex hooks.compatibility.json 없음"
+fi
+
+if [ -f "$_user_hooks_json" ]; then
+  if ! command -v jq >/dev/null 2>&1; then
+    fail "jq 없음 — $_user_hooks_json stale entry 검사 불가"
+  else
+    _user_stale_hook_count=""
+    if ! _user_stale_hook_count="$(jq -r '
+      def stale_names: [
+        "session-init-icons.sh",
+        "worktree-path-guard.sh",
+        "fragile-hardcoding-guard.sh",
+        "system-bash-guard.sh"
+      ];
+      def is_stale:
+        (.command? // "") as $cmd
+        | [stale_names[] | . as $name | select($cmd | contains("/.codex/hooks/" + $name))]
+        | length > 0;
+      [(.hooks // {}) | to_entries[]? | .value[]? | .hooks[]? | select(is_stale)] | length
+    ' "$_user_hooks_json")"; then
+      fail "$_user_hooks_json JSON 파싱 실패 — user-level hook 파일을 수동 점검하세요"
+    elif [ "$_user_stale_hook_count" -gt 0 ] 2>/dev/null; then
+      fail "stale user-level Codex hook entries present ($_user_hooks_json count=$_user_stale_hook_count) — run nrs to prune known Claude-era entries"
+    else
+      pass "user-level Codex hooks.json stale legacy entry 없음"
+    fi
+  fi
+else
+  pass "user-level Codex hooks.json 없음"
 fi
 
 echo ""

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -937,7 +937,9 @@ else
 fi
 
 if [ -f "$_user_hooks_json" ]; then
-  if ! command -v jq >/dev/null 2>&1; then
+  if [ -L "$_user_hooks_json" ]; then
+    fail "$_user_hooks_json is a symlink — user-level hook file requires manual stale-entry inspection to avoid clobbering dotfile-managed state"
+  elif ! command -v jq >/dev/null 2>&1; then
     fail "jq 없음 — $_user_hooks_json stale entry 검사 불가"
   else
     _user_stale_hook_count=""

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -921,7 +921,8 @@ echo "=== Hooks 산출물 확인 ==="
 # stale guard: <repo>/.codex/hooks.json 또는 <repo>/.codex/hooks.compatibility.json은
 # 폐기된 패턴이라 잔재 시 fail. 단 user-level ~/.codex/hooks.json은 공식 hook source라
 # 존재 자체가 아니라 알려진 legacy entry만 검사한다.
-if [ -e "$REPO_ROOT/.codex/hooks.json" ] || [ -e "$REPO_ROOT/.codex/hooks.compatibility.json" ]; then
+if [ -e "$REPO_ROOT/.codex/hooks.json" ] || [ -L "$REPO_ROOT/.codex/hooks.json" ] || \
+   [ -e "$REPO_ROOT/.codex/hooks.compatibility.json" ] || [ -L "$REPO_ROOT/.codex/hooks.compatibility.json" ]; then
   fail "stale Codex hook artifacts present (.codex/hooks*.json)"
 else
   pass "repo-local Codex hook artifacts 없음"
@@ -930,13 +931,15 @@ fi
 _user_hooks_json="$HOME/.codex/hooks.json"
 _user_hooks_report="$HOME/.codex/hooks.compatibility.json"
 
-if [ -e "$_user_hooks_report" ]; then
+if [ -e "$_user_hooks_report" ] || [ -L "$_user_hooks_report" ]; then
   fail "stale user-level Codex hook artifact present ($_user_hooks_report) — run nrs to remove retired hooks.compatibility.json"
 else
   pass "user-level Codex hooks.compatibility.json 없음"
 fi
 
-if [ -f "$_user_hooks_json" ]; then
+if [ -L "$_user_hooks_json" ] && [ ! -e "$_user_hooks_json" ]; then
+  fail "$_user_hooks_json dangling symlink — user-level hook file must be repaired manually"
+elif [ -f "$_user_hooks_json" ]; then
   if ! command -v jq >/dev/null 2>&1; then
     fail "jq 없음 — $_user_hooks_json stale entry 검사 불가"
   else

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -242,6 +242,25 @@ install_deployed_layout() {
   assert_line_count "$shell_nix" '    recursive = true;' 2
 }
 
+install_repo_local_only_codex_cleanup_helper() {
+  local home_dir="$1"
+  local helper="$home_dir/.local/lib/rebuild/common.sh"
+  rm -f "$helper"
+  cp "$REPO_ROOT/modules/shared/scripts/lib/rebuild/common.sh" "$helper"
+  cat >> "$helper" <<'EOF'
+
+_clear_retired_codex_hook_artifacts() {
+    local hooks_json="$FLAKE_PATH/.codex/hooks.json"
+    local hooks_report="$FLAKE_PATH/.codex/hooks.compatibility.json"
+
+    if [[ -e "$hooks_json" || -e "$hooks_report" ]]; then
+        rm -f "$hooks_json" "$hooks_report"
+        log_info "🧹 Removed retired Codex hook artifacts."
+    fi
+}
+EOF
+}
+
 install_platform_nrs_entrypoint() {
   local sandbox="$1" platform="$2"
   local home_dir="$sandbox/home"
@@ -1152,6 +1171,7 @@ test_nixos_nrs_offline_force_smoke() {
   repo_root="$(cd "$repo_root" && pwd -P)"
   install_deployed_layout "$sandbox" "$repo_root"
   install_platform_nrs_entrypoint "$sandbox" nixos
+  install_repo_local_only_codex_cleanup_helper "$home_dir"
 
   mkdir -p "$stub_dir" "$home_dir/.local/bin"
   cat > "$stub_dir/sudo" <<'EOF'
@@ -1374,6 +1394,7 @@ test_darwin_nrs_no_changes_releases_worktree_lock() {
   worktree_root="$repo_root/.claude/worktrees/feature_one"
   install_deployed_layout "$sandbox" "$repo_root"
   install_platform_nrs_entrypoint "$sandbox" darwin
+  install_repo_local_only_codex_cleanup_helper "$home_dir"
 
   mkdir -p "$stub_dir" "$home_dir/.local/bin" "$home_dir/Library/LaunchAgents"
   current_target="$sandbox/current-system"

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -193,6 +193,66 @@ test_user_hooks_stale_filter_detects_symlink_target_stale_entries() {
   [[ "$count" == "1" ]] || fail "expected symlinked user hooks.json stale count 1, got: $count"
 }
 
+test_user_hooks_stale_filter_ignores_stale_path_mentions() {
+  local sandbox home_dir hooks_json count
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  hooks_json="$home_dir/.codex/hooks.json"
+  mkdir -p "$home_dir/.codex"
+  cat > "$hooks_json" <<'EOF'
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/tmp/foo/.codex/hooks/session-init-icons.sh.backup"
+          },
+          {
+            "type": "command",
+            "command": "bash -lc 'test -e ~/.codex/hooks/session-init-icons.sh'"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+  source "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
+  count="$(HOME="$home_dir" jq -r "$(codex_legacy_user_hook_count_jq_filter)" "$hooks_json")"
+  [[ "$count" == "0" ]] || fail "expected stale path mentions to be ignored, got stale count: $count"
+}
+
+test_user_hooks_stale_filter_detects_exact_home_path() {
+  local sandbox home_dir hooks_json count
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  hooks_json="$home_dir/.codex/hooks.json"
+  mkdir -p "$home_dir/.codex"
+  cat > "$hooks_json" <<EOF
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$home_dir/.codex/hooks/worktree-path-guard.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+  source "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
+  count="$(HOME="$home_dir" jq -r "$(codex_legacy_user_hook_count_jq_filter)" "$hooks_json")"
+  [[ "$count" == "1" ]] || fail "expected exact HOME path stale count 1, got: $count"
+}
+
 new_sandbox() {
   local dir
   dir=$(mktemp -d "${TMPDIR:-/tmp}/shell-script-tests.XXXXXX")
@@ -1604,6 +1664,8 @@ run_test "fixture git setup ignores host global hooks" test_fixture_git_is_herme
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke
 run_test "stale filter supports clean symlinked user hooks" test_user_hooks_stale_filter_supports_clean_symlink_target
 run_test "stale filter detects symlinked stale user hooks" test_user_hooks_stale_filter_detects_symlink_target_stale_entries
+run_test "stale filter ignores stale path mentions" test_user_hooks_stale_filter_ignores_stale_path_mentions
+run_test "stale filter detects exact HOME hook path" test_user_hooks_stale_filter_detects_exact_home_path
 run_test "retired hook cleanup preserves malformed user hooks" test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks
 run_test "retired hook cleanup preserves symlinked user hooks" test_clear_retired_codex_hook_artifacts_preserves_symlinked_user_hooks
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -397,6 +397,26 @@ _clear_retired_codex_hook_artifacts() {
 EOF
 }
 
+install_partial_deployed_codex_legacy_hooks_helper() {
+  local home_dir="$1"
+  local helper="$home_dir/.local/lib/rebuild/codex-legacy-hooks.sh"
+  mkdir -p "$(dirname "$helper")"
+  rm -f "$helper"
+  cat > "$helper" <<'EOF'
+# Partial old deployed helper fixture: readable, but missing codex_clear_retired_hook_artifacts.
+codex_partial_legacy_hooks_helper_loaded() {
+    return 0
+}
+EOF
+}
+
+install_repo_fallback_codex_legacy_hooks_helper() {
+  local repo_root="$1"
+  local helper="$repo_root/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
+  mkdir -p "$(dirname "$helper")"
+  cp "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh" "$helper"
+}
+
 install_platform_nrs_entrypoint() {
   local sandbox="$1" platform="$2"
   local home_dir="$sandbox/home"
@@ -1308,6 +1328,8 @@ test_nixos_nrs_offline_force_smoke() {
   install_deployed_layout "$sandbox" "$repo_root"
   install_platform_nrs_entrypoint "$sandbox" nixos
   install_repo_local_only_codex_cleanup_helper "$home_dir"
+  install_partial_deployed_codex_legacy_hooks_helper "$home_dir"
+  install_repo_fallback_codex_legacy_hooks_helper "$repo_root"
 
   mkdir -p "$stub_dir" "$home_dir/.local/bin"
   cat > "$stub_dir/sudo" <<'EOF'
@@ -1438,6 +1460,40 @@ test_clear_retired_codex_hook_artifacts_preserves_symlinked_user_hooks() {
   assert_symlinked_user_codex_hooks_preserved "$home_dir"
 }
 
+test_clear_retired_codex_hook_artifacts_removes_dangling_artifact_symlinks() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  mkdir -p "$repo_root/.codex" "$home_dir/.codex"
+  rm -f "$repo_root/.codex/hooks.json" "$repo_root/.codex/hooks.compatibility.json" "$home_dir/.codex/hooks.compatibility.json"
+  ln -s "$repo_root/.codex/missing-hooks.json" "$repo_root/.codex/hooks.json"
+  ln -s "$repo_root/.codex/missing-hooks.compatibility.json" "$repo_root/.codex/hooks.compatibility.json"
+  ln -s "$home_dir/.codex/missing-hooks.compatibility.json" "$home_dir/.codex/hooks.compatibility.json"
+
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      _clear_retired_codex_hook_artifacts
+    ' 2>&1
+  )
+
+  assert_contains "$output" "Removed retired Codex hook artifacts."
+  assert_contains "$output" "Removed retired user-level Codex hooks.compatibility.json"
+  [[ ! -L "$repo_root/.codex/hooks.json" ]] || fail "expected dangling repo-local hooks.json symlink to be removed"
+  [[ ! -L "$repo_root/.codex/hooks.compatibility.json" ]] || fail "expected dangling repo-local hooks.compatibility.json symlink to be removed"
+  [[ ! -L "$home_dir/.codex/hooks.compatibility.json" ]] || fail "expected dangling user-level hooks.compatibility.json symlink to be removed"
+}
+
 test_darwin_nrs_offline_force_smoke() {
   local sandbox home_dir repo_root stub_dir output result_target current_target
   sandbox=$(new_sandbox)
@@ -1565,6 +1621,8 @@ test_darwin_nrs_no_changes_releases_worktree_lock() {
   install_deployed_layout "$sandbox" "$repo_root"
   install_platform_nrs_entrypoint "$sandbox" darwin
   install_repo_local_only_codex_cleanup_helper "$home_dir"
+  install_partial_deployed_codex_legacy_hooks_helper "$home_dir"
+  install_repo_fallback_codex_legacy_hooks_helper "$worktree_root"
 
   mkdir -p "$stub_dir" "$home_dir/.local/bin" "$home_dir/Library/LaunchAgents"
   current_target="$sandbox/current-system"
@@ -1668,6 +1726,7 @@ run_test "stale filter ignores stale path mentions" test_user_hooks_stale_filter
 run_test "stale filter detects exact HOME hook path" test_user_hooks_stale_filter_detects_exact_home_path
 run_test "retired hook cleanup preserves malformed user hooks" test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks
 run_test "retired hook cleanup preserves symlinked user hooks" test_clear_retired_codex_hook_artifacts_preserves_symlinked_user_hooks
+run_test "retired hook cleanup removes dangling artifact symlinks" test_clear_retired_codex_hook_artifacts_removes_dangling_artifact_symlinks
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -121,6 +121,28 @@ EOF
   printf '{}\n' > "$home_dir/.codex/hooks.compatibility.json"
 }
 
+write_clean_symlinked_user_codex_hooks() {
+  local home_dir="$1"
+  mkdir -p "$home_dir/.codex" "$home_dir/dotfiles/codex"
+  cat > "$home_dir/dotfiles/codex/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/tmp/custom-user-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+  ln -s "$home_dir/dotfiles/codex/hooks.json" "$home_dir/.codex/hooks.json"
+}
+
 assert_user_codex_hooks_pruned() {
   local home_dir="$1"
   local hooks_json="$home_dir/.codex/hooks.json"
@@ -147,6 +169,28 @@ assert_symlinked_user_codex_hooks_preserved() {
   [[ -L "$hooks_json" ]] || fail "expected user-level hooks.json symlink to remain intact"
   [[ "$(readlink "$hooks_json")" == "$home_dir/dotfiles/codex/hooks.json" ]] || fail "expected user-level hooks.json symlink target to remain unchanged"
   assert_contains "$(cat "$home_dir/dotfiles/codex/hooks.json")" "session-init-icons.sh"
+}
+
+test_user_hooks_stale_filter_supports_clean_symlink_target() {
+  local sandbox home_dir count
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  write_clean_symlinked_user_codex_hooks "$home_dir"
+
+  source "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
+  count="$(jq -r "$(codex_legacy_user_hook_count_jq_filter)" "$home_dir/.codex/hooks.json")"
+  [[ "$count" == "0" ]] || fail "expected clean symlinked user hooks.json stale count 0, got: $count"
+}
+
+test_user_hooks_stale_filter_detects_symlink_target_stale_entries() {
+  local sandbox home_dir count
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  write_symlinked_user_codex_hooks "$home_dir"
+
+  source "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
+  count="$(jq -r "$(codex_legacy_user_hook_count_jq_filter)" "$home_dir/.codex/hooks.json")"
+  [[ "$count" == "1" ]] || fail "expected symlinked user hooks.json stale count 1, got: $count"
 }
 
 new_sandbox() {
@@ -1558,6 +1602,8 @@ run_test "wt cleanup auto skips merged branch reuse" test_wt_cleanup_auto_skips_
 run_test "missing managed helpers fail closed" test_missing_managed_helpers_fail_closed
 run_test "fixture git setup ignores host global hooks" test_fixture_git_is_hermetic_against_global_hooks
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke
+run_test "stale filter supports clean symlinked user hooks" test_user_hooks_stale_filter_supports_clean_symlink_target
+run_test "stale filter detects symlinked stale user hooks" test_user_hooks_stale_filter_detects_symlink_target_stale_entries
 run_test "retired hook cleanup preserves malformed user hooks" test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks
 run_test "retired hook cleanup preserves symlinked user hooks" test_clear_retired_codex_hook_artifacts_preserves_symlinked_user_hooks
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -57,6 +57,66 @@ assert_line_count() {
   [[ "$actual" == "$expected" ]] || fail "expected $path to contain $expected occurrences of: $needle (actual: $actual)"
 }
 
+write_mixed_user_codex_hooks() {
+  local home_dir="$1"
+  mkdir -p "$home_dir/.codex"
+  # session-init-icons.sh is a known stale Claude-era user hook; Codex should prune it, not run it.
+  cat > "$home_dir/.codex/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.codex/hooks/session-init-icons.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/tmp/custom-user-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+  printf '{}\n' > "$home_dir/.codex/hooks.compatibility.json"
+}
+
+write_malformed_user_codex_hooks() {
+  local home_dir="$1"
+  mkdir -p "$home_dir/.codex"
+  printf '{ not valid json\n' > "$home_dir/.codex/hooks.json"
+  printf '{}\n' > "$home_dir/.codex/hooks.compatibility.json"
+}
+
+assert_user_codex_hooks_pruned() {
+  local home_dir="$1"
+  local hooks_json="$home_dir/.codex/hooks.json"
+  [[ ! -e "$home_dir/.codex/hooks.compatibility.json" ]] || fail "expected user-level hooks.compatibility.json to be removed"
+  [[ -f "$hooks_json" ]] || fail "expected user-level hooks.json with preserved custom entry"
+  local hooks_content
+  hooks_content="$(cat "$hooks_json")"
+  assert_contains "$hooks_content" "/tmp/custom-user-hook.sh"
+  assert_not_contains "$hooks_content" "session-init-icons.sh"
+}
+
+assert_malformed_user_codex_hooks_preserved() {
+  local home_dir="$1"
+  local hooks_json="$home_dir/.codex/hooks.json"
+  [[ ! -e "$home_dir/.codex/hooks.compatibility.json" ]] || fail "expected user-level hooks.compatibility.json to be removed"
+  [[ -f "$hooks_json" ]] || fail "expected malformed user-level hooks.json to remain for manual repair"
+  [[ "$(cat "$hooks_json")" == "{ not valid json" ]] || fail "expected malformed user-level hooks.json content to remain unchanged"
+}
+
 new_sandbox() {
   local dir
   dir=$(mktemp -d "${TMPDIR:-/tmp}/shell-script-tests.XXXXXX")
@@ -1132,6 +1192,7 @@ EOF
   mkdir -p "$repo_root/.codex"
   printf '{}\n' > "$repo_root/.codex/hooks.json"
   printf '{}\n' > "$repo_root/.codex/hooks.compatibility.json"
+  write_mixed_user_codex_hooks "$home_dir"
 
   output=$(
     HOME="$home_dir" \
@@ -1146,8 +1207,45 @@ EOF
 
   assert_contains "$output" "Applying changes (offline)"
   assert_contains "$output" "Done!"
+  assert_contains "$output" "Removed retired user-level Codex hooks.compatibility.json"
+  assert_contains "$output" "Pruned 1 stale Codex hook entry"
   [[ ! -e "$repo_root/.codex/hooks.json" ]] || fail "expected nixos nrs to remove retired hooks.json"
   [[ ! -e "$repo_root/.codex/hooks.compatibility.json" ]] || fail "expected nixos nrs to remove retired hooks.compatibility.json"
+  assert_user_codex_hooks_pruned "$home_dir"
+}
+
+test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  mkdir -p "$repo_root/.codex"
+  printf '{}\n' > "$repo_root/.codex/hooks.json"
+  printf '{}\n' > "$repo_root/.codex/hooks.compatibility.json"
+  write_malformed_user_codex_hooks "$home_dir"
+
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      _clear_retired_codex_hook_artifacts
+    ' 2>&1
+  )
+
+  assert_contains "$output" "Removed retired Codex hook artifacts."
+  assert_contains "$output" "Removed retired user-level Codex hooks.compatibility.json"
+  assert_contains "$output" "Could not parse $home_dir/.codex/hooks.json; leaving user-owned hook file unchanged."
+  [[ ! -e "$repo_root/.codex/hooks.json" ]] || fail "expected repo-local hooks.json to be removed"
+  [[ ! -e "$repo_root/.codex/hooks.compatibility.json" ]] || fail "expected repo-local hooks.compatibility.json to be removed"
+  assert_malformed_user_codex_hooks_preserved "$home_dir"
 }
 
 test_darwin_nrs_offline_force_smoke() {
@@ -1241,6 +1339,7 @@ EOF
   mkdir -p "$repo_root/.codex"
   printf '{}\n' > "$repo_root/.codex/hooks.json"
   printf '{}\n' > "$repo_root/.codex/hooks.compatibility.json"
+  write_mixed_user_codex_hooks "$home_dir"
 
   output=$(
     HOME="$home_dir" \
@@ -1256,8 +1355,11 @@ EOF
 
   assert_contains "$output" "Applying changes (offline)"
   assert_contains "$output" "Done!"
+  assert_contains "$output" "Removed retired user-level Codex hooks.compatibility.json"
+  assert_contains "$output" "Pruned 1 stale Codex hook entry"
   [[ ! -e "$repo_root/.codex/hooks.json" ]] || fail "expected darwin nrs to remove retired hooks.json"
   [[ ! -e "$repo_root/.codex/hooks.compatibility.json" ]] || fail "expected darwin nrs to remove retired hooks.compatibility.json"
+  assert_user_codex_hooks_pruned "$home_dir"
 }
 
 test_darwin_nrs_no_changes_releases_worktree_lock() {
@@ -1281,6 +1383,7 @@ test_darwin_nrs_no_changes_releases_worktree_lock() {
   mkdir -p "$worktree_root/.codex"
   printf '{}\n' > "$worktree_root/.codex/hooks.json"
   printf '{}\n' > "$worktree_root/.codex/hooks.compatibility.json"
+  write_mixed_user_codex_hooks "$home_dir"
 
   cat > "$stub_dir/sudo" <<'EOF'
 #!/usr/bin/env bash
@@ -1343,9 +1446,12 @@ EOF
   assert_contains "$output" "Lock acquired"
   assert_contains "$output" "No changes to apply"
   assert_contains "$output" "Lock released"
+  assert_contains "$output" "Removed retired user-level Codex hooks.compatibility.json"
+  assert_contains "$output" "Pruned 1 stale Codex hook entry"
   [[ ! -e "$lock_file" ]] || fail "expected sandbox nrs lock file to be removed after no-change early return"
   [[ ! -e "$worktree_root/.codex/hooks.json" ]] || fail "expected no-change darwin nrs to remove retired hooks.json"
   [[ ! -e "$worktree_root/.codex/hooks.compatibility.json" ]] || fail "expected no-change darwin nrs to remove retired hooks.compatibility.json"
+  assert_user_codex_hooks_pruned "$home_dir"
 }
 
 run_test "wt help uses deployed helper layout" test_wt_help_from_deployed_layout
@@ -1365,6 +1471,7 @@ run_test "wt cleanup auto skips merged branch reuse" test_wt_cleanup_auto_skips_
 run_test "missing managed helpers fail closed" test_missing_managed_helpers_fail_closed
 run_test "fixture git setup ignores host global hooks" test_fixture_git_is_hermetic_against_global_hooks
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke
+run_test "retired hook cleanup preserves malformed user hooks" test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -98,6 +98,29 @@ write_malformed_user_codex_hooks() {
   printf '{}\n' > "$home_dir/.codex/hooks.compatibility.json"
 }
 
+write_symlinked_user_codex_hooks() {
+  local home_dir="$1"
+  mkdir -p "$home_dir/.codex" "$home_dir/dotfiles/codex"
+  cat > "$home_dir/dotfiles/codex/hooks.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.codex/hooks/session-init-icons.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+  ln -s "$home_dir/dotfiles/codex/hooks.json" "$home_dir/.codex/hooks.json"
+  printf '{}\n' > "$home_dir/.codex/hooks.compatibility.json"
+}
+
 assert_user_codex_hooks_pruned() {
   local home_dir="$1"
   local hooks_json="$home_dir/.codex/hooks.json"
@@ -115,6 +138,15 @@ assert_malformed_user_codex_hooks_preserved() {
   [[ ! -e "$home_dir/.codex/hooks.compatibility.json" ]] || fail "expected user-level hooks.compatibility.json to be removed"
   [[ -f "$hooks_json" ]] || fail "expected malformed user-level hooks.json to remain for manual repair"
   [[ "$(cat "$hooks_json")" == "{ not valid json" ]] || fail "expected malformed user-level hooks.json content to remain unchanged"
+}
+
+assert_symlinked_user_codex_hooks_preserved() {
+  local home_dir="$1"
+  local hooks_json="$home_dir/.codex/hooks.json"
+  [[ ! -e "$home_dir/.codex/hooks.compatibility.json" ]] || fail "expected user-level hooks.compatibility.json to be removed"
+  [[ -L "$hooks_json" ]] || fail "expected user-level hooks.json symlink to remain intact"
+  [[ "$(readlink "$hooks_json")" == "$home_dir/dotfiles/codex/hooks.json" ]] || fail "expected user-level hooks.json symlink target to remain unchanged"
+  assert_contains "$(cat "$home_dir/dotfiles/codex/hooks.json")" "session-init-icons.sh"
 }
 
 new_sandbox() {
@@ -1268,6 +1300,40 @@ test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks() {
   assert_malformed_user_codex_hooks_preserved "$home_dir"
 }
 
+test_clear_retired_codex_hook_artifacts_preserves_symlinked_user_hooks() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  mkdir -p "$repo_root/.codex"
+  printf '{}\n' > "$repo_root/.codex/hooks.json"
+  printf '{}\n' > "$repo_root/.codex/hooks.compatibility.json"
+  write_symlinked_user_codex_hooks "$home_dir"
+
+  output=$(
+    HOME="$home_dir" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      _clear_retired_codex_hook_artifacts
+    ' 2>&1
+  )
+
+  assert_contains "$output" "Removed retired Codex hook artifacts."
+  assert_contains "$output" "Removed retired user-level Codex hooks.compatibility.json"
+  assert_contains "$output" "$home_dir/.codex/hooks.json is a symlink; leaving user-owned hook file unchanged"
+  [[ ! -e "$repo_root/.codex/hooks.json" ]] || fail "expected repo-local hooks.json to be removed"
+  [[ ! -e "$repo_root/.codex/hooks.compatibility.json" ]] || fail "expected repo-local hooks.compatibility.json to be removed"
+  assert_symlinked_user_codex_hooks_preserved "$home_dir"
+}
+
 test_darwin_nrs_offline_force_smoke() {
   local sandbox home_dir repo_root stub_dir output result_target current_target
   sandbox=$(new_sandbox)
@@ -1493,6 +1559,7 @@ run_test "missing managed helpers fail closed" test_missing_managed_helpers_fail
 run_test "fixture git setup ignores host global hooks" test_fixture_git_is_hermetic_against_global_hooks
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke
 run_test "retired hook cleanup preserves malformed user hooks" test_clear_retired_codex_hook_artifacts_preserves_malformed_user_hooks
+run_test "retired hook cleanup preserves symlinked user hooks" test_clear_retired_codex_hook_artifacts_preserves_symlinked_user_hooks
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 


### PR DESCRIPTION
## Summary
- Removes retired user-level Codex hook artifacts while preserving valid user-owned `~/.codex/hooks.json` files.
- Centralizes stale legacy hook matching so `nrs`, verifier, and tests use the same exact-command predicate.
- Documents the #637 scope boundary: native `PreToolUse` implementation remains owned by #587.

Closes #637

## 기존 문제/배경

A stale Claude-era user-level Codex hook file can still be loaded from `~/.codex/hooks.json` and invoke scripts such as `session-init-icons.sh` or old guard hooks that Codex no longer exposes as managed skills/hooks.

The important boundary is that `~/.codex/hooks.json` itself is still a valid Codex hook source in the current Codex hooks docs. Deleting or failing on file existence would break legitimate user hooks, so this change only targets known retired artifacts and exact known legacy managed commands.

## CIR (Change Intent Record)

- **v1** (이번 변경): user-level legacy hook cleanup was scoped from “remove stale file” to “remove only known stale entries” after confirming `~/.codex/hooks.json` is still a valid source.
- **v2** (이번 변경): cleanup and verifier matching were centralized in a shared rebuild helper so activation and audit paths cannot drift.
- **v3** (이번 변경): symlinked user hook files are left untouched by cleanup, while verifier can still inspect readable symlink targets and report stale entries.
- **v4** (이번 변경): stale matching was tightened from substring matching to exact direct managed hook commands to avoid false positives such as backup paths or shell snippets that only mention a stale filename.

**trade-off**: exact matching deliberately avoids destructive cleanup of ambiguous user-authored shell wrappers. If a user intentionally wraps a stale script invocation, they must remove that custom entry manually.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Delete user-level `hooks.json` | Treat the file itself as stale | Simple cleanup | Breaks official/current user hook source | ❌ |
| Substring basename match | Remove any command containing `/.codex/hooks/<legacy-name>` | Catches broad variants | False positives for backups and shell snippets | ❌ |
| Exact direct command match | Remove only exact known managed legacy commands under `~`, `$HOME`, `${HOME}`, or absolute `$HOME` | Preserves user hooks and avoids false positives | Does not auto-clean ambiguous wrappers | ✅ |
| Implement native `PreToolUse` in this PR | Move old guard behavior to Codex-native hooks here | Solves a related gap | Crosses #637 scope and duplicates #587 ownership | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh` | 추가 | shared jq filters and cleanup for retired repo/user hook artifacts |
| `modules/shared/scripts/lib/rebuild/common.sh` | 수정 | rebuild cleanup now sources the shared helper and delegates user-level pruning |
| `modules/darwin/scripts/nrs.sh` / `modules/nixos/scripts/nrs.sh` | 수정 | mixed-version compatibility shims now load the shared helper when deployed common code is older |
| `scripts/ai/verify-ai-compat.sh` | 수정 | verifier fails on retired compatibility artifacts or stale exact legacy entries, not on valid file existence |
| `tests/shell-script-tests.sh` | 수정 | sandboxed coverage for stale pruning, malformed preservation, symlink preservation, exact matching, and wrapper smoke paths |
| `.claude/prds/prd-codex-user-legacy-hooks*` | 추가 | Living PRD and phase evidence for #637 scope, decisions, validation, and #587 handoff |

### 핵심 코드

```bash
# shared helper exposes one stale-count predicate reused by cleanup and verifier
codex_legacy_user_hook_count_jq_filter

# exact stale commands are limited to direct managed legacy hook paths:
~/.codex/hooks/<legacy-name>
$HOME/.codex/hooks/<legacy-name>
${HOME}/.codex/hooks/<legacy-name>
<absolute HOME>/.codex/hooks/<legacy-name>
```

## 참고 레퍼런스

- Issue #637 — stale user-level Codex legacy hook cleanup request.
- Issue #587 — native Codex `PreToolUse` guard implementation remains owned there.
- [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) — confirms `~/.codex/hooks.json` is a valid hook source.

## Human Test Plan

1. Run `nrs`.
   - **기대**: rebuild completes, retired repo-local `.codex/hooks*.json` artifacts are absent, and user-level `hooks.compatibility.json` is removed if present.
   - **실패 시**: inspect `modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh` loading from deployed rebuild lib vs repo fallback.

2. Run `./scripts/ai/verify-ai-compat.sh`.
   - **기대**: `Hooks 산출물 확인` reports no repo-local artifacts, no user-level `hooks.compatibility.json`, and no stale user-level `hooks.json` entry.
   - **실패 시**: if failures are symlink-target drift, rerun `nrs`; if failures are stale hook entries, inspect `~/.codex/hooks.json` manually.

3. For a symlink-managed `~/.codex/hooks.json`, verify cleanup does not replace the symlink.
   - **기대**: `nrs` leaves the symlink intact; verifier only fails if the symlink target contains exact stale legacy commands.
   - **실패 시**: check the symlink branch in `codex_prune_legacy_user_hooks_json`.

## Pre-Merge E2E 테스트 가이드

### Phase 0: Static Contract

```bash
test -f modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
grep -q 'codex_clear_retired_hook_artifacts' modules/shared/scripts/lib/rebuild/common.sh
! rg 'contains\("/\\.codex/hooks/"' modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh
```

- **기대**: shared helper exists, rebuild common delegates to it, and old substring matching is absent.
- **실패 시**: inspect helper sourcing and stale matcher definitions.

### Phase 1: Deterministic Shell Coverage

```bash
./tests/shell-script-tests.sh
```

- **기대**: all shell script tests pass, including exact stale matcher and symlink preservation cases.
- **실패 시**: use the failing test name to isolate cleanup, verifier filter, or wrapper compatibility behavior.

### Phase 2: Hook Fixture Regression

```bash
./tests/test-codex-hook-fixtures.sh --no-live
```

- **기대**: deterministic Codex hook fixture tests pass without adding managed `PreToolUse` fixtures.
- **실패 시**: inspect Codex hook template expectations before changing #637 scope.

### Phase 3: Activation And Verifier Smoke

```bash
nrs
./scripts/ai/verify-ai-compat.sh
```

- **기대**: activation completes and verifier reports complete success.
- **실패 시**: if global skill/script symlinks point at another worktree, rerun `nrs` from this branch after confirming no active lock.

### Phase 4: Regression Boundary

```bash
git diff --check
gh pr diff --name-only | rg 'PreToolUse' && false || true
```

- **기대**: whitespace check passes and this PR does not introduce managed native `PreToolUse` hook templates.
- **실패 시**: remove out-of-scope native hook work and keep it in #587.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive phase-based planning documentation for legacy hook cleanup and verification initiative.

* **Improvements**
  * Enhanced cleanup behavior to safely remove stale legacy hook entries while preserving valid user configurations.
  * Improved verification to detect and report stale hook artifacts across platforms.

* **Tests**
  * Added test coverage for cleanup operations, stale entry detection, and artifact removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->