### PR TITLE
fix(skills): guard DA reviewers from nested codex exec

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
@@ -85,7 +85,7 @@ tracked workspace write, branch mutation, commit/push, GitHub write, main-agent-
 
 | reviewer bundle | 세부 관점 | 핵심 질문 | 집중 대상 |
 |-----------------|----------|----------|----------|
-| **Correctness** | `HALLUCINATION`, `SECURITY` | "이 변경이 실제로 존재하는 동작인가, 그리고 안전한가?"를 검증하라 | 존재하지 않는 API/CLI 플래그/경로, 잘못된 시그니처/인자, trust boundary 오판, 인증/인가 우회, 입력 검증 부재, 과도한 네트워크 노출 |
+| **Correctness** | `HALLUCINATION`, `SECURITY` | "이 변경이 실제로 존재하는 동작인가, 그리고 안전한가?"를 검증하라 | 존재하지 않는 API/CLI 플래그/경로, 잘못된 시그니처/인자, trust boundary 오판, 인증/인가 우회, 입력 검증 부재, 과도한 네트워크 노출. **Self-verification 제약**: nested `codex exec` 또는 `codex-exec-supervised` 호출을 통한 self-verification을 수행하지 않는다. parent가 read-only sandbox에서 실행될 수 있어 nested codex session write가 차단되어 issue #638 회귀를 유발한다. 검증이 필요하면 fallback `codex exec` 경로에서는 read-only 파일 읽기/검색, 문서 인용, diff 확인을 사용하고, repo 밖 private scratch PoC는 native subagent 경로 또는 sandbox가 out-of-repo write를 허용하는 경우에만 사용한다. |
 | **Design** | `YAGNI`, `NGMI` | "지금 필요하지 않은 복잡성을 만들거나, 구조적 막다른 길을 만들지 않는가?"를 판단하라 | 사용처 없는 인터페이스/추상화, 미래 대비 과설계, 가정 붕괴 시 전면 재작성 필요한 구조, 잘못된 책임 분리, 확장 경로 차단된 데이터/모듈 경계 |
 | **Regression** | `SIDE_EFFECT`, `CONSISTENCY` | "기존 동작이나 프로젝트 관례를 조용히 깨지 않는가?"를 추적하라 | 공유 상태의 암묵적 변경, 인터페이스 계약 변경, 환경 변수/경로/포트 변경, import/export 파급, 네이밍/디렉토리/설정 규칙 위반, 기존 패턴 무시 재구현 |
 | **Maintainability** | `READABILITY`, `CLEAN_CODE` | "다음 개발자(LLM 포함)가 이 변경을 빠르게 이해하고 안전하게 수정할 수 있는가?"를 판단하라 | 함수/변수명과 동작 불일치, why 주석 부재, 복잡한 제어 흐름, 복사-붙여넣기 중복, 매직넘버/매직스트링, 죽은 코드, 방치된 TODO/HACK |

--- a/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
@@ -71,7 +71,9 @@
 집중 대상:
 {FOCUS_TARGETS}
 
-PoC가 필요하면 `umask 077` 아래에서 `mktemp -d`로 만든 repo 밖 private scratch 디렉토리에서만 수행하라.
+Self-verification을 위해 nested `codex exec` 또는 `codex-exec-supervised`를 호출하지 마라.
+codex exec fallback 경로처럼 read-only sandbox에서 실행 중이면 파일 증거, 문서 인용, diff 확인만 사용하라.
+PoC가 필요하고 현재 런타임이 out-of-repo write를 허용하면 `umask 077` 아래에서 `mktemp -d`로 만든 repo 밖 private scratch 디렉토리에서만 수행하라.
 tracked workspace write, branch mutation, commit/push, GitHub write, main-agent-only command, host mutation은 explicit delegation 없이는 금지다.
 위 규칙을 위반했거나 금지된 작업이 필요하면 finding 대신 `VIOLATION` 형식으로 반환하라.
 
@@ -85,7 +87,7 @@ tracked workspace write, branch mutation, commit/push, GitHub write, main-agent-
 
 | reviewer bundle | 세부 관점 | 핵심 질문 | 집중 대상 |
 |-----------------|----------|----------|----------|
-| **Correctness** | `HALLUCINATION`, `SECURITY` | "이 변경이 실제로 존재하는 동작인가, 그리고 안전한가?"를 검증하라 | 존재하지 않는 API/CLI 플래그/경로, 잘못된 시그니처/인자, trust boundary 오판, 인증/인가 우회, 입력 검증 부재, 과도한 네트워크 노출. **Self-verification 제약**: nested `codex exec` 또는 `codex-exec-supervised` 호출을 통한 self-verification을 수행하지 않는다. parent가 read-only sandbox에서 실행될 수 있어 nested codex session write가 차단되어 issue #638 회귀를 유발한다. 검증이 필요하면 fallback `codex exec` 경로에서는 read-only 파일 읽기/검색, 문서 인용, diff 확인을 사용하고, repo 밖 private scratch PoC는 native subagent 경로 또는 sandbox가 out-of-repo write를 허용하는 경우에만 사용한다. |
+| **Correctness** | `HALLUCINATION`, `SECURITY` | "이 변경이 실제로 존재하는 동작인가, 그리고 안전한가?"를 검증하라 | 존재하지 않는 API/CLI 플래그/경로, 잘못된 시그니처/인자, trust boundary 오판, 인증/인가 우회, 입력 검증 부재, 과도한 네트워크 노출 |
 | **Design** | `YAGNI`, `NGMI` | "지금 필요하지 않은 복잡성을 만들거나, 구조적 막다른 길을 만들지 않는가?"를 판단하라 | 사용처 없는 인터페이스/추상화, 미래 대비 과설계, 가정 붕괴 시 전면 재작성 필요한 구조, 잘못된 책임 분리, 확장 경로 차단된 데이터/모듈 경계 |
 | **Regression** | `SIDE_EFFECT`, `CONSISTENCY` | "기존 동작이나 프로젝트 관례를 조용히 깨지 않는가?"를 추적하라 | 공유 상태의 암묵적 변경, 인터페이스 계약 변경, 환경 변수/경로/포트 변경, import/export 파급, 네이밍/디렉토리/설정 규칙 위반, 기존 패턴 무시 재구현 |
 | **Maintainability** | `READABILITY`, `CLEAN_CODE` | "다음 개발자(LLM 포함)가 이 변경을 빠르게 이해하고 안전하게 수정할 수 있는가?"를 판단하라 | 함수/변수명과 동작 불일치, why 주석 부재, 복잡한 제어 흐름, 복사-붙여넣기 중복, 매직넘버/매직스트링, 죽은 코드, 방치된 TODO/HACK |


### PR DESCRIPTION
## 1. Summary

- Closes #638.
- Adds a common DA reviewer guard that forbids nested `codex exec` / `codex-exec-supervised` self-verification.
- Aligns read-only fallback guidance with the existing degraded-mode contract: use file evidence, documentation quotes, and diff checks when scratch writes are unavailable.

## 2. 기존 문제/배경

PR #636 moved programmatic reviewer subprocesses onto the supervised Layer 1 path with read-only sandboxing. In that environment, nested Codex self-verification can fail while trying to create session files, which can waste reasoning budget or terminate reviewer output.

The existing common prompt still told reviewers to use repo-outside scratch PoC when needed. That was too broad for read-only fallback reviewers, where scratch writes are unavailable by design.

## 3. CIR (Change Intent Record)

The initial issue framed the deterministic failure around the Correctness reviewer. During validation, the safer boundary became clear: nested Codex self-verification is a reviewer execution constraint, not a domain-specific focus target. The final change therefore keeps the bundle table domain-focused and places the guard in the shared reviewer prompt block that every bundle receives.

The change is intentionally small: prompt policy only. It does not redesign the wrapper, add a writable nested session area, or add new live fixture coverage.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Correctness row only | Put the guard in the Correctness focus target | Minimal issue-local edit | Other reviewer bundles do not receive the runtime constraint | ❌ Rejected |
| Common reviewer prompt | Put the guard near the shared PoC/no-write rules | Applies consistently to all DA reviewer bundles and keeps focus rows readable | Slightly broader than the issue's initial wording | ✅ Selected |
| Wrapper/session redesign | Provide a writable isolated nested Codex session area | Could preserve nested Codex checks | Larger runtime policy change, outside this issue | ❌ Deferred |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/skills/run-da/references/da-domains.md` | Adds shared self-verification/fallback execution guidance to the common DA reviewer prompt block |

Core prompt change:

```text
Self-verification을 위해 nested `codex exec` 또는 `codex-exec-supervised`를 호출하지 마라.
codex exec fallback 경로처럼 read-only sandbox에서 실행 중이면 파일 증거, 문서 인용, diff 확인만 사용하라.
PoC가 필요하고 현재 런타임이 out-of-repo write를 허용하면 ...
```

## 6. 참고 레퍼런스

- #638: Correctness reviewer silent termination regression.
- #636: supervised Layer 1 `codex-exec-supervised` rollout that exposed the known caveat.
- `run-da/references/arbiter-scaling.md`: degraded fallback contract for read-only subprocess reviewers.
- `run-da/references/hardening-contract.md`: role boundary contract for reviewer scratch PoC and no-write roles.

## 7. Human Test Plan

1. Inspect `da-domains.md` and confirm the self-verification guard appears in the common prompt structure, before the reviewer bundle table.
2. Confirm the Correctness row remains a domain focus row and does not carry long runtime policy text.
3. Run a normal DA review path and confirm reviewer guidance discourages nested Codex self-verification.
4. For affected-path validation, run a Layer 1 smoke using `cat prompt | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only ...`.
5. Expected result: reviewer output is non-empty, no `thread/start failed`, and no nested Codex tool invocation occurs.

## 8. Pre-Merge E2E 테스트 가이드

### Phase 0: Static Verification

```bash
rg -n 'Self-verification|nested `codex exec`|codex-exec-supervised|read-only sandbox|out-of-repo write' \
  modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
git diff --check main...HEAD
```

Expected: guard text exists in the common prompt block, and whitespace check passes.

### Phase 1: Skill Projection

```bash
nrs
./scripts/ai/verify-ai-compat.sh
```

Expected: `nrs` relinks the current worktree and compatibility verification fully passes.

### Phase 2: Review Regression

Run the normal DA review flow and the affected Layer 1 smoke described in the Human Test Plan.

Expected: normal review returns clear output, and affected-path smoke returns a non-empty result without nested Codex session creation failure.
