### PR TITLE
refactor(skills): clarify parallel-audit args parsing

### DIFF
--- a/modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-audit
-argument-hint: "[agent-count]"
+argument-hint: "[agent-count] [context]"
 description: |
   Exhaustive side-effect/regression audit via parallel agents.
   Trigger: '전수조사', '사이드이펙트 조사', '회귀 조사', '병렬 감사', '에이전트 N개 조사'.

--- a/modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
@@ -18,9 +18,9 @@ description: |
 |------|-----|
 | 기본 에이전트 수 | 6 |
 | open thread cap | current session의 `agents.max_threads` (unset 기본 6) |
-| args 첫 토큰 (정수) | 에이전트 수. 비어있으면 기본값 6 사용. 예: `parallel-audit 6` (정수 단독) 또는 `parallel-audit 6 <컨텍스트>` (정수 + 컨텍스트). |
-| args 그 외 (자유 텍스트) | 메인 에이전트가 변경 컨텍스트로 활용 (Step 1 `git diff` 결과와 결합). 정수 없이도 가능: `parallel-audit <컨텍스트>` (기본 6). |
-| exhaustive override | `parallel-audit 10` |
+| args 첫 토큰 (정수) | 에이전트 수. 비어있으면 기본값 6 사용. 예: `parallel-audit 6` (정수 단독) 또는 `parallel-audit 6 <컨텍스트>` (첫 토큰 뒤 나머지 토큰이 컨텍스트). |
+| args 그 외 (자유 텍스트) | 첫 토큰이 정수가 아니면 전체 args를 컨텍스트로 활용 (Step 1 `git diff` 결과와 결합). 예: `parallel-audit <컨텍스트>` (기본 6). |
+| exhaustive override | `parallel-audit 10` 또는 `parallel-audit 10 <컨텍스트>` (10개 세부 관점 강제 + trailing 컨텍스트 보존) |
 | 에이전트 권한 | 읽기 전용. codex exec 경로(Claude Code/headless)는 Layer 1(`codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules`)으로 구조적 강제. Codex 세션(`spawn_agent`)은 정책 + 프롬프트 + self-report로 운영 (Non-goals 참조) |
 
 ## 용어 정책
@@ -68,7 +68,7 @@ Codex 세션의 상세 wait/write/violation 계약은 [run-da/references/hardeni
   예: `Platform (macOS + NixOS)`를 `macOS`, `NixOS`로 분할.
 - **에이전트 수 < 조사 bundle 수**: 연관된 bundle을 하나의 에이전트에 통합한다.
   예: `Docs / Consistency`를 `Adjacent Side Effects`와 함께 묶는다.
-- **명시적 exhaustive override**: `parallel-audit 10`은 기본 6 bundle을 다음 10개 세부 관점으로 확장한다.
+- **명시적 exhaustive override**: `parallel-audit 10` 또는 `parallel-audit 10 <컨텍스트>`는 기본 6 bundle을 다음 10개 세부 관점으로 확장한다. `<컨텍스트>`가 있으면 첫 토큰 `10` 뒤 나머지 토큰을 메인 에이전트의 우선순위 판단 컨텍스트로 보존한다.
   `Security`, `API`, `Performance`, `Dependencies`, `Tests`, `Edge Cases`, `macOS`, `NixOS`, `Adjacent Side Effects`, `Docs / Consistency`
 
 ## 절차
@@ -86,7 +86,8 @@ git log --oneline -5     # 최근 커밋 컨텍스트
 ### Step 2: 조사 bundle 분배
 
 에이전트 수(args 첫 토큰이 정수면 그 값, 아니면 기본값 6)에 맞게 위 6개 bundle을 분배한다.
-메인 에이전트는 args의 자유 텍스트(컨텍스트)를 보존하고 Step 1의 `git diff` 결과와 결합하여 bundle 분배 가중치 결정에 활용한다.
+컨텍스트는 정수-first 형식이면 첫 토큰 뒤 나머지 토큰, context-only 형식이면 전체 args다.
+메인 에이전트는 이 컨텍스트를 보존하고 Step 1의 `git diff` 결과와 결합하여 bundle 분배 가중치 결정에 활용한다.
 변경 내용에 따라 관련도가 높은 bundle에 에이전트를 더 배정할 수 있다.
 
 예: Nix 설정 변경이면 `Platform (macOS + NixOS)`와 `Adjacent Side Effects`에 더 많은 비중을 두고,
@@ -364,7 +365,7 @@ BUG/REGRESSION/EDGECASE가 있으면 요약 테이블 아래에 상세를 추가
 - 에이전트는 읽기 전용이다. 코드/tracked workspace 수정을 금지한다. codex exec 경로(Claude Code/headless)는 Layer 1(supervised wrapper + `--sandbox read-only` + `--ignore-user-config` + `--ignore-rules`)으로 구조적 강제, Codex 세션(`spawn_agent`)은 정책 + 프롬프트 + self-report로 운영한다 (한계는 Non-goals 참조).
 - 조사 결과를 사용자에게 먼저 제시하고, 수정은 사용자 승인 후 진행한다.
 - 변경 범위가 극소한 경우 에이전트 수를 줄여 효율을 높인다.
-- 기본값은 6이며, `parallel-audit 10`만 exhaustive override다. 10은 기본값이 아니다.
+- 기본값은 6이며, `parallel-audit 10`/`parallel-audit 10 <컨텍스트>`만 exhaustive override다. 10은 기본값이 아니고, trailing 컨텍스트는 우선순위 판단용으로 보존한다.
 - Codex 세션 경로에서는 completed audit thread를 다음 batch/retry 전에 명시적으로 `close_agent`로 닫는다.
 - `SAFE`는 유효한 auditor 결과가 모두 확보된 뒤에만 반환한다. `RECOVERABLE VIOLATION` 재디스패치 중이거나 `BLOCKED (VIOLATION)` unit이 남아 있으면 완료로 간주하지 않는다.
 - DA 피드백 루프(run-da)와 목적이 다르다: DA는 설계/코드 품질을 반복 개선하고, 전수조사는 변경의 안전성을 일회성으로 검증한다.

--- a/modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
@@ -18,7 +18,8 @@ description: |
 |------|-----|
 | 기본 에이전트 수 | 6 |
 | open thread cap | current session의 `agents.max_threads` (unset 기본 6) |
-| `$ARGUMENTS` | 에이전트 수 (정수). 비어있으면 기본값 6 사용 (Claude Code 하네스의 인자 치환 메타문법. Codex에서는 호출 래퍼 또는 메인 에이전트가 사용자 입력에서 정수를 파싱한다.) |
+| args 첫 토큰 (정수) | 에이전트 수. 비어있으면 기본값 6 사용. 예: `parallel-audit 6` (정수 단독) 또는 `parallel-audit 6 <컨텍스트>` (정수 + 컨텍스트). |
+| args 그 외 (자유 텍스트) | 메인 에이전트가 변경 컨텍스트로 활용 (Step 1 `git diff` 결과와 결합). 정수 없이도 가능: `parallel-audit <컨텍스트>` (기본 6). |
 | exhaustive override | `parallel-audit 10` |
 | 에이전트 권한 | 읽기 전용. codex exec 경로(Claude Code/headless)는 Layer 1(`codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules`)으로 구조적 강제. Codex 세션(`spawn_agent`)은 정책 + 프롬프트 + self-report로 운영 (Non-goals 참조) |
 
@@ -84,7 +85,8 @@ git log --oneline -5     # 최근 커밋 컨텍스트
 
 ### Step 2: 조사 bundle 분배
 
-에이전트 수(`$ARGUMENTS` 또는 기본값 6)에 맞게 위 6개 bundle을 분배한다.
+에이전트 수(args 첫 토큰이 정수면 그 값, 아니면 기본값 6)에 맞게 위 6개 bundle을 분배한다.
+메인 에이전트는 args의 자유 텍스트(컨텍스트)를 보존하고 Step 1의 `git diff` 결과와 결합하여 bundle 분배 가중치 결정에 활용한다.
 변경 내용에 따라 관련도가 높은 bundle에 에이전트를 더 배정할 수 있다.
 
 예: Nix 설정 변경이면 `Platform (macOS + NixOS)`와 `Adjacent Side Effects`에 더 많은 비중을 두고,
@@ -338,6 +340,10 @@ BUG/REGRESSION/EDGECASE가 있으면 요약 테이블 아래에 상세를 추가
 ```
 
 (근거: 과거 검증 에이전트 5개에 YAGNI 프레이밍을 주입하여 5/5 만장일치 SKIP을 유도한 사례 — 프롬프트 조향 회귀 방지 목적)
+
+## 관련 follow-up
+
+`parallel-audit` + `run-da` + `codex-fan-out` + `plan-with-questions` 4 SKILL의 args 처리 패턴이 서로 다르다 (정수 / mode 토큰 / 텍스트 우선 / 모드 판별 표). 4 SKILL 호출 인터페이스의 mental model 통일은 본 이슈 scope 외 — 별도 메타 이슈에서 다룬다.
 
 ## Non-goals
 


### PR DESCRIPTION
## 1. Summary

- Clarifies `parallel-audit` args parsing as `agent-count` plus optional free-text context.
- Removes direct `$ARGUMENTS` body references so free-text slash-skill args are not rendered inline into the skill text.
- Adds a follow-up note that broader args-interface unification across related skills is separate scope.

Closes #635

## 2. 기존 문제/배경

`parallel-audit/SKILL.md` previously documented the harness argument token directly in the quick reference table and Step 2 prose. When a caller passed free-text context, that token could be replaced inline with the entire args payload, making the rendered skill noisy and obscuring the intended parser contract.

The intended behavior is backward compatible: numeric first token still controls auditor count, and any remaining/free-text args are preserved as context for the main agent.

## 3. CIR (Change Intent Record)

This change keeps the fix in one skill file. The intent is to document the parser contract at the skill boundary without changing runtime fan-out behavior, auditor permissions, baseline mutation detection, or adjacent skill interfaces.

During independent review, the frontmatter hint was also aligned with the newly documented free-text context path so command surfaces that display only metadata do not contradict the body.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Replace body token usages only | Remove direct token references from quick reference and Step 2 prose | Smallest behavioral surface | Metadata would still hide context support | Rejected |
| Update `parallel-audit` body and frontmatter | Document first-token integer plus optional context in both body and `argument-hint` | Keeps visible command contract consistent | Slightly broader than the two original body lines | Chosen |
| Redesign args model across 4 skills | Normalize `parallel-audit`, `run-da`, `codex-fan-out`, `plan-with-questions` together | Long-term consistency | Out of scope for #635 | Rejected for this issue |

## 5. 구현 상세

| 파일 | 변경 내용 |
|------|-----------|
| `modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md` | Updates `argument-hint` to include optional context, replaces direct `$ARGUMENTS` body prose with parser rules, and adds a related follow-up note. |

Key behavior now documented:

```text
parallel-audit                -> default 6 auditors, context from conversation
parallel-audit 6              -> 6 auditors
parallel-audit 6 <context>    -> 6 auditors plus explicit context
parallel-audit <context>      -> default 6 auditors plus explicit context
parallel-audit 10             -> exhaustive override
```

## 6. 참고 레퍼런스

- Issue: #635
- Related origin context: #593 follow-up described in the issue body

## 7. Human Test Plan

1. Open `parallel-audit/SKILL.md` and confirm the frontmatter shows `[agent-count] [context]`.
2. Confirm the quick reference table documents both integer first-token parsing and free-text context handling.
3. Confirm Step 2 says the main agent combines free-text context with Step 1 `git diff` evidence for bundle weighting.
4. Confirm no direct `$ARGUMENTS` body token remains in the file.

## 8. Pre-Merge E2E 테스트 가이드

### Phase 0: Static Checks

```bash
git grep -nF '$ARGUMENTS' -- modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
rg -n 'argument-hint|args 첫 토큰|args 그 외|관련 follow-up' modules/shared/programs/claude/files/skills/parallel-audit/SKILL.md
git diff --check main...HEAD
```

Expected:
- First command has no matches.
- Second command shows the updated hint, parser rows, and follow-up section.
- Diff check exits successfully.

### Phase 1: Hook/Repo Validation

```bash
nix develop -c git commit --dry-run --allow-empty -m 'test: hook smoke'
git push --dry-run
```

Expected:
- Commit-hook path can find `gitleaks` in the Nix dev shell and run skill consistency/eval/codex fixture checks.
- Push-hook path runs codex hook fixtures, flake check, and shell script tests.

### Phase 2: Skill Contract Review

Manually inspect these calls against the skill text:

```text
parallel-audit
parallel-audit 6
parallel-audit 6 issue #635 docs fix
parallel-audit issue #635 docs fix
parallel-audit 10
```

Expected:
- Numeric first token controls auditor count.
- Non-numeric/free-text args are treated as context, not rendered into the skill body.
- `parallel-audit 10` remains the only exhaustive override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated parallel-audit skill documentation to clarify argument handling: the first argument token as an integer specifies the number of agents; remaining text is used as context for the main agent. Defaults to 6 agents if the first token is not an integer.
  * Added follow-up notes regarding argument processing differences across related skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->