### PR TITLE
fix(codex): align live hook env fixture contract

### DIFF
--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -526,9 +526,9 @@ cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
 |----------|------|-----------|-----------|---------|-------|--------|--------|
 | `host_home_no_override_stdin_pipe_pass` | host | host | 없음 (host config inline) | read-only | `</dev/null` 또는 pipe | OK 12s, hook fired, "PONG" | OK (wrapper grace 무관 — 이미 정상) |
 | `raw_override_inline_toml_hang` | host/sandbox | host/sandbox | `-c hooks.<event>` override | full-auto/read-only | host inherited 또는 pipe | HANG (timeout 못 죽임) | wrapper의 setsid+kill-after로 timeout 안에 정리되어 PASS |
-| `isolated_codex_home_overrideless_known_hang` | sandbox | sandbox | ephemeral config.toml | read-only | inherited | HANG (PR #595 fixture pattern) | known caveat — 별도 follow-up 이슈로 분리 |
+| `isolated_codex_home_overrideless_retired_self_injection` | sandbox | sandbox | ephemeral config.toml | read-only | inherited | HANG/marker unset in retired PR #595 self-injection assertion | Retired historical context (#634) — local fixture now validates caller-supplied `CODEX_PROGRAMMATIC=1` inheritance with supervised wrapper + stdin pipe EOF |
 
-**`isolated_codex_home_overrideless_known_hang` caveat**: `tests/test-codex-hook-fixtures.sh:940-1030`의 `test_env_propagation_live`(opt-in, `CODEX_HOOK_LIVE=1`)는 `CODEX_HOME=$sandbox/codex-home` + ephemeral config.toml로 hook 등록 + override 없음 + `--sandbox read-only` 패턴이지만 mac 0.128에서 hang이 관측됐다 (`CLAUDECODE=1` 미도달 fail). lefthook은 `--no-live`만 실행하므로 daily gate에서 검증되지 않은 상태다. fix는 issue #593 scope 외 — **follow-up: [issue #634](https://github.com/greenheadHQ/nixos-config/issues/634)**. 보강 시 supervised wrapper + 추가 진단 필요.
+**Retired historical context (#634)**: `tests/test-codex-hook-fixtures.sh`의 기존 PR #595 self-injection assertion은 `CODEX_HOME=$sandbox/codex-home` + ephemeral config.toml + inherited stdin + raw `codex exec`에서 mac 0.128 marker unset/hang 계열 실패를 보였다. #634에서 fixture 계약을 local supported path로 정렬했다: programmatic caller가 `CODEX_PROGRAMMATIC=1`을 codex 프로세스에 붙이고, live fixture는 `codex-exec-supervised` + stdin pipe EOF + sandbox `CODEX_HOME` hook config로 이 marker가 hook subprocess까지 상속되는지만 검증한다. managed hook early-exit 자체는 deterministic noise-guard fixture가 검증한다.
 
 **§14와의 관계**: §14는 stdin EOF 보장을 stdin pipe로 구조적으로 제공한다. §15는 그 위에 process group/SIGKILL grace를 추가해 wrapper PID 종료가 native까지 닿지 않는 시나리오를 차단한다. 두 패턴은 결합 사용한다.
 

--- a/tests/fixtures/codex-hooks/README.md
+++ b/tests/fixtures/codex-hooks/README.md
@@ -38,7 +38,7 @@ runner: `tests/test-codex-hook-fixtures.sh`.
 
 ## 외부 contract만 디렉토리로 노출
 
-dispatcher ordering / noise-guard / env-propagation 시나리오는 runner 내부 helper가
+dispatcher ordering / noise-guard / programmatic env inheritance 시나리오는 runner 내부 helper가
 sandbox 안에서 동적으로 mock script를 작성한다. 디렉토리에 빈 placeholder를 두지 않는다.
 
 ## 실행
@@ -93,6 +93,6 @@ agent_id 키는 0.124 schema에 없으며 hook은 graceful fallback에 의존한
 | `standard_override_devnull_stdin_hang` | `-c hooks.<event>` | read-only | `</dev/null` | HANG (timeout 못 죽임) | known-issues.md §15 |
 | `standard_override_stdin_pipe_hang` | `-c hooks.<event>` | read-only | pipe + `-` | HANG (timeout 못 죽임) | known-issues.md §15 |
 | `host_home_no_override_stdin_pipe_pass` | 없음 | read-only | pipe + `-` 또는 `</dev/null` | OK 12s, hook fired, "PONG" | invocation matrix scenario-1 (wrapper 적용 시 `_supervised_pass`) |
-| `isolated_codex_home_overrideless_known_hang` | 없음 (ephemeral config.toml로 hook 등록) | read-only | inherited | HANG (PR #595 fixture pattern) | known-issues.md §15 caveat + **follow-up: [#634](https://github.com/greenheadHQ/nixos-config/issues/634)** |
+| `isolated_codex_home_overrideless_retired_self_injection` | 없음 (ephemeral config.toml로 hook 등록) | read-only | inherited | HANG/marker unset in retired PR #595 self-injection assertion | Retired historical context: #634 replaces this with `programmatic_env_inheritance_live` using caller-supplied `CODEX_PROGRAMMATIC=1`, supervised wrapper, and stdin pipe EOF |
 
-**`isolated_codex_home_overrideless_known_hang` caveat**: PR #595 fixture `test_env_propagation_live`가 mac 0.128에서 hang/CLAUDECODE 미도달 fail. 본 PR scope 외 — follow-up [#634](https://github.com/greenheadHQ/nixos-config/issues/634)에서 추적.
+**Retired historical context (#634)**: PR #595의 기존 self-injection assertion은 mac 0.128에서 marker unset fail을 보였지만, repo의 지원 계약은 Codex CLI self-injection이 아니라 caller-supplied `CODEX_PROGRAMMATIC=1`이다. 현재 live fixture는 sandbox `CODEX_HOME` hook config + `codex-exec-supervised` + stdin pipe EOF로 해당 marker가 hook subprocess까지 상속되는지만 검증한다. managed hook early-exit 동작은 deterministic noise-guard fixture가 검증한다.

--- a/tests/lib/codex-hook-expectations.sh
+++ b/tests/lib/codex-hook-expectations.sh
@@ -36,7 +36,7 @@ EXPECTED_POST_TOOL_USE_PINNING_COMMAND='$HOME/.codex/hooks/pinning-alert.sh'
 # 본 배열 순서는 dispatcher 호출 순서이며 fixture ordering 검증의 expected.
 EXPECTED_DISPATCHER_SUB_SCRIPTS=(record-last-stop.sh nrs-session-cleanup.sh stop-notification.sh)
 
-# live env propagation fixture에서 codex exec --ephemeral 호출 timeout (hang 방어).
+# live programmatic env inheritance fixture에서 codex-exec-supervised 호출 timeout (hang 방어).
 LIVE_CODEX_TIMEOUT_SECONDS=30
 
 # codex-exec-supervised wrapper kill-after grace (issue #593).

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -7,9 +7,9 @@
 #   2. dispatcher ordering / failure recovery — runner 내부 mock subscript
 #   3. noise-guard env 변형              — runner 내부 helper (4 env 조합)
 #   4. sync-codex-config.py preservation — fixtures/codex-hooks/sync-preservation/*.toml
-#   5. env propagation (live opt-in)      — CODEX_HOOK_LIVE=1 / --live
+#   5. programmatic env inheritance (live opt-in) — CODEX_HOOK_LIVE=1 / --live
 #   5b. codex exec invocation matrix (live opt-in, must-pass-only) — issue #593 supervised wrapper 회귀 차단
-#       (--live 시 invocation matrix를 env propagation보다 먼저 실행)
+#       (--live 시 invocation matrix를 programmatic env inheritance보다 먼저 실행)
 #   6. stop-notification reliability/security — transcripts/ + stdin secret/transcript fixtures
 #   7. pinning-alert behavioral          — fixtures/codex-hooks/stdin/pinning-{claude,codex}-*.json
 #   8. sync.sh mcp-config fail-fast      — missing/no source가 기존 MCP 섹션을 지우지 않음
@@ -33,7 +33,7 @@ for arg in "$@"; do
 Usage: $0 [--live | --no-live]
   default      deterministic fixture만 실행
   --live       live opt-in fixture까지 실행: codex exec invocation matrix(must-pass-only)
-               + env propagation live fixture (실행 순서대로)
+               + programmatic env inheritance live fixture (실행 순서대로)
   --no-live    deterministic 강제 (default와 동일; verify-ai-compat가 사용)
 ENV: CODEX_HOOK_LIVE=1  (--live와 동등; CLI 인자가 env보다 우선하며 마지막 모드 인자가 이긴다)
 EOF
@@ -939,23 +939,26 @@ test_pinning_alert_behavioral() {
   done
 }
 
-# ─── 카테고리 5: env propagation live (opt-in) ───
-# codex exec --ephemeral로 임시 dump-env hook을 실행해 CLAUDECODE/CODEX_PROGRAMMATIC propagation
-# 도달을 검증한다. 환경 결함(timeout 부재 / codex 부재 / hang / session 실패)이면 WARN skip.
-test_env_propagation_live() {
-  local timeout_bin=""
-  if command -v timeout >/dev/null 2>&1; then
-    timeout_bin="timeout"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    timeout_bin="gtimeout"
-  else
-    warn "live env propagation: timeout/gtimeout 부재 — skip"
+# ─── 카테고리 5: programmatic env inheritance live (opt-in) ───
+# programmatic codex exec 호출자가 CODEX_PROGRAMMATIC=1을 codex 프로세스에 붙이면,
+# UserPromptSubmit hook subprocess까지 해당 marker가 상속되는지 검증한다. managed hook
+# early-exit 자체는 deterministic noise-guard fixture(카테고리 3)가 검증한다.
+# 환경 결함(codex/wrapper 부재, wrapper capability-probe 실패, session 실패)이면 WARN skip.
+test_programmatic_env_inheritance_live() {
+  if ! command -v codex >/dev/null 2>&1; then
+    warn "programmatic env inheritance live: codex 바이너리 부재 — skip"
     return 0
   fi
 
-  if ! command -v codex >/dev/null 2>&1; then
-    warn "live env propagation: codex 바이너리 부재 — skip"
-    return 0
+  local supervised
+  if command -v codex-exec-supervised >/dev/null 2>&1; then
+    supervised="codex-exec-supervised"
+  else
+    supervised="$REPO_ROOT/modules/shared/scripts/codex-exec-supervised.sh"
+    if [[ ! -x "$supervised" ]]; then
+      warn "programmatic env inheritance live: codex-exec-supervised 미설치 (~/.local/bin 또는 $supervised) — skip (환경 결함)"
+      return 0
+    fi
   fi
 
   local sandbox dump_log
@@ -988,33 +991,37 @@ type = "command"
 command = "$sandbox/home/.codex/hooks/dump-env.sh"
 EOF
 
-  # 본 fixture의 검증 의도는 "codex CLI가 hook subprocess에 CLAUDECODE/CODEX_PROGRAMMATIC을
-  # 자체 propagate한다"이다. 부모 env에 CODEX_PROGRAMMATIC=1을 미리 set하면 codex CLI가
-  # set하는지가 아니라 부모 값이 inherit되는지를 측정하게 되므로 의도가 약화된다.
-  # CLAUDECODE도 동일 이유로 부모에서 set하지 않고 codex CLI가 propagate하는지를 본다.
-  # cwd는 sandbox로 강제하고 codex exec에 --skip-git-repo-check + --sandbox read-only를 명시해
-  # outside-git 거부가 환경 결함으로 분류되지 않도록 + filesystem 보호가 강제되도록 한다.
+  # 본 fixture의 검증 의도는 "programmatic 호출자가 codex 프로세스에 붙인 CODEX_PROGRAMMATIC=1이
+  # hook subprocess까지 상속되는지"이다. CLAUDECODE는 부모에서 제거해 이 fixture가 Claude nesting
+  # marker에 의존하지 않음을 보인다.
+  #
+  # dump-env hook 등록은 sandbox CODEX_HOME/config.toml에 있으므로 --ignore-user-config를 쓰지 않는다.
+  # 쓰면 sandbox config 자체가 무시되어 hook이 발화하지 않는다. stdin은 wrapper 책임이 아니므로
+  # pipe + '-'로 EOF를 명시해 inherited-stdin hang shape를 차단한다.
   local codex_rc=0
   local codex_stderr="$sandbox/codex-exec.stderr"
-  ( cd "$sandbox" && env -u CLAUDECODE -u CODEX_PROGRAMMATIC \
+  ( cd "$sandbox" && printf 'noop\n' | env -u CLAUDECODE \
+       CODEX_PROGRAMMATIC=1 \
+       CODEX_EXEC_TIMEOUT_SECONDS="$LIVE_CODEX_TIMEOUT_SECONDS" \
+       CODEX_EXEC_KILL_AFTER_SECONDS="$CODEX_EXEC_KILL_AFTER_SECONDS" \
        CODEX_HOME="$sandbox/codex-home" \
        HOME="$sandbox/home" \
        XDG_DATA_HOME="$sandbox/xdg-data" \
        XDG_CONFIG_HOME="$sandbox/xdg-config" \
-       "$timeout_bin" "$LIVE_CODEX_TIMEOUT_SECONDS" \
-       codex exec --ephemeral --skip-git-repo-check --sandbox read-only 'noop' >/dev/null 2>"$codex_stderr" ) \
+       "$supervised" \
+         --ephemeral --skip-git-repo-check --sandbox read-only --ignore-rules \
+         -c model="gpt-5.5" -c model_reasoning_effort="medium" \
+         - >/dev/null 2>"$codex_stderr" ) \
     || codex_rc=$?
 
   # hook이 codex exec 실패 전에 실행되었을 수 있으므로 dump_log를 우선 검사한다. dump_log에
-  # 기록이 있으면 propagation 결과를 직접 확인 (환경 결함으로 가리지 않는다). dump_log가 비어 있고
+  # 기록이 있으면 inheritance 결과를 직접 확인 (환경 결함으로 가리지 않는다). dump_log가 비어 있고
   # codex exec도 실패한 경우에만 환경 결함 WARN skip으로 분류한다.
   if [[ -s "$dump_log" ]]; then
-    grep -qE '^CLAUDECODE=1$' "$dump_log" \
-      || fail "live env propagation: CLAUDECODE=1 미도달 (dump_log=$(cat "$dump_log"))"
     grep -qE '^CODEX_PROGRAMMATIC=1$' "$dump_log" \
-      || fail "live env propagation: CODEX_PROGRAMMATIC=1 미도달 (dump_log=$(cat "$dump_log"))"
+      || fail "programmatic env inheritance live: CODEX_PROGRAMMATIC=1 미도달 (dump_log=$(cat "$dump_log"))"
     if (( codex_rc != 0 )); then
-      warn "live env propagation: hook propagation 도달 확인 + codex exec 후속 비정상(rc=$codex_rc) — propagation 통과"
+      warn "programmatic env inheritance live: hook inheritance 도달 확인 + codex exec 후속 비정상(rc=$codex_rc) — inheritance 통과"
     fi
     return 0
   fi
@@ -1024,12 +1031,12 @@ EOF
     # codex exec stderr 마지막 부분을 진단에 포함해 운영자가 timeout/auth/network 원인을 식별 가능하게.
     local stderr_tail
     stderr_tail=$(tail -c 800 "$codex_stderr" 2>/dev/null | tr '\n' ' ' || true)
-    warn "live env propagation: codex exec 비정상(rc=$codex_rc) 또는 timeout(${LIVE_CODEX_TIMEOUT_SECONDS}s) + dump_log empty — skip (환경 결함). stderr_tail: ${stderr_tail:-<empty>}"
+    warn "programmatic env inheritance live: codex exec 비정상(rc=$codex_rc) 또는 timeout(${LIVE_CODEX_TIMEOUT_SECONDS}s) + dump_log empty — skip (환경 결함). stderr_tail: ${stderr_tail:-<empty>}"
     return 0
   fi
 
-  # codex exec 정상 종료 + dump_log 부재 → hook propagation 미도달 회귀.
-  fail "live env propagation: codex exec 정상 종료했으나 dump_log empty — hook propagation 미도달"
+  # codex exec 정상 종료 + dump_log 부재 → hook inheritance 미도달 회귀.
+  fail "programmatic env inheritance live: codex exec 정상 종료했으나 dump_log empty — hook inheritance 미도달"
 }
 
 # ─── 카테고리 5b: codex exec invocation matrix (live opt-in, must-pass-only — issue #593) ───
@@ -1217,17 +1224,16 @@ run_test "sync.sh mcp-config fail-fast (#609)" \
   test_sync_sh_mcp_config_failfast
 
 if [[ "$LIVE_MODE" == "1" ]]; then
-  # invocation matrix를 env propagation보다 먼저 실행한다 (issue #593):
-  # PR #595의 test_env_propagation_live는 mac 0.128에서 hang으로 fail이 관측되어 별도 follow-up
-  # 이슈로 분리됐다 (vJ caveat). invocation matrix가 먼저 실행되어야 새 fixture가
-  # 회귀 차단 신호를 제공할 수 있다.
+  # invocation matrix를 programmatic env inheritance보다 먼저 실행한다 (issue #593):
+  # wrapper/process-group 회귀 차단 신호를 먼저 확보한 뒤, sandbox CODEX_HOME에 등록한
+  # dump hook이 caller-supplied CODEX_PROGRAMMATIC marker를 상속받는지 확인한다.
   run_test "codex exec invocation matrix (supervised wrapper, must-pass-only)" \
     test_codex_exec_invocation_live_matrix
-  run_test "env propagation live (codex exec --ephemeral)" \
-    test_env_propagation_live
+  run_test "programmatic env inheritance live (codex exec --ephemeral)" \
+    test_programmatic_env_inheritance_live
 else
   echo "==> codex exec invocation matrix  (skip; --live 또는 CODEX_HOOK_LIVE=1로 활성화)"
-  echo "==> env propagation live  (skip; --live 또는 CODEX_HOOK_LIVE=1로 활성화)"
+  echo "==> programmatic env inheritance live  (skip; --live 또는 CODEX_HOOK_LIVE=1로 활성화)"
 fi
 
 echo "All codex hook fixture tests passed."


### PR DESCRIPTION
## 1. Summary

- Reframes the opt-in Codex hook live fixture around the supported local contract: callers supply `CODEX_PROGRAMMATIC=1`, and hook subprocesses inherit it.
- Replaces the old raw `timeout + codex exec` probe with `codex-exec-supervised` plus explicit stdin EOF, while preserving sandbox `CODEX_HOME` hook registration.
- Updates fixture docs and known-issues notes to mark the old self-injection assertion as retired historical context.

Closes #634

## 2. 기존 문제/배경

The old live fixture removed `CLAUDECODE` and `CODEX_PROGRAMMATIC`, then expected Codex CLI itself to inject those markers into hook subprocesses. On macOS Codex 0.128 this produced marker-unset failures when the live path actually ran.

That assertion did not match the repo's supported programmatic execution contract. Local programmatic Codex calls already pass `CODEX_PROGRAMMATIC=1` on the Codex process; managed hook early-exit behavior is covered by deterministic noise-guard fixtures.

## 3. CIR (Change Intent Record)

The fix intentionally narrows the live fixture to the contract this repo owns:

- The fixture now proves caller-supplied `CODEX_PROGRAMMATIC=1` reaches `UserPromptSubmit` hook subprocesses.
- It does not claim Codex CLI self-injects `CLAUDECODE` or `CODEX_PROGRAMMATIC`.
- It keeps sandbox `CODEX_HOME/config.toml` as the source of the temporary dump hook, so the live invocation omits `--ignore-user-config`.
- It uses `codex-exec-supervised` with `printf 'noop\n' | ... -` to keep timeout/process-group protection and explicit stdin EOF.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Keep self-injection assertion | Continue expecting Codex CLI to inject env markers by itself | Preserves upstream-behavior signal | Keeps failing/noisy assertion outside the local contract | ❌ |
| Local contract inheritance | Caller sets `CODEX_PROGRAMMATIC=1`; live fixture verifies hook subprocess inheritance | Matches supported repo behavior and existing programmatic call patterns | Stops checking upstream self-injection | ✅ |
| Documentation-only caveat | Remove or permanently skip executable live coverage | Lowest maintenance cost | Loses live coverage for marker inheritance | ❌ |

## 5. 구현 상세

| 파일 | 변경 내용 |
|------|-----------|
| `tests/test-codex-hook-fixtures.sh` | Renames the live fixture to programmatic env inheritance, uses `codex-exec-supervised`, explicit stdin pipe EOF, sandbox `CODEX_HOME`, and asserts `CODEX_PROGRAMMATIC=1`. |
| `tests/lib/codex-hook-expectations.sh` | Updates the live timeout comment to describe supervised programmatic env inheritance. |
| `tests/fixtures/codex-hooks/README.md` | Updates fixture documentation and marks the old self-injection assertion as retired historical context. |
| `modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md` | Updates the issue #593 variant legend and #634 note to the new local-contract fixture. |

Key command shape:

```bash
printf 'noop\n' | env -u CLAUDECODE CODEX_PROGRAMMATIC=1 \
  CODEX_HOME="$sandbox/codex-home" \
  "$supervised" --ephemeral --skip-git-repo-check --sandbox read-only --ignore-rules -
```

## 6. 참고 레퍼런스

- Issue #634
- Issue #593
- PR #595

## 7. Human Test Plan

1. Run deterministic fixture coverage:
   ```bash
   tests/test-codex-hook-fixtures.sh --no-live
   ```
   Expected: all deterministic fixture tests pass; live cases are skipped.

2. Run live opt-in coverage on a Codex-authenticated host:
   ```bash
   CODEX_HOOK_LIVE=1 tests/test-codex-hook-fixtures.sh
   ```
   Expected: invocation matrix passes, programmatic env inheritance reaches the dump hook, and the runner exits 0. A warning about later Codex exit is acceptable after inheritance is confirmed.

3. Confirm stale wording is either absent or explicitly retired:
   ```bash
   rg -n "env propagation|env-propagation|live env propagation|CLAUDECODE/CODEX_PROGRAMMATIC propagation|self propagate|자체 propagate|CLAUDECODE=1 미도달|known_hang|#634" \
     tests modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
   ```
   Expected: remaining matches are only retired historical context for #634.

## 8. Pre-Merge E2E 테스트 가이드

### Phase 0: Static

```bash
git diff --check origin/main...HEAD
bash -n tests/test-codex-hook-fixtures.sh
bash -n tests/lib/codex-hook-expectations.sh
```

Expected: no whitespace or shell syntax failures.

### Phase 1: Deterministic Regression

```bash
tests/test-codex-hook-fixtures.sh --no-live
```

Expected: deterministic fixture suite passes; live tests are skipped.

### Phase 2: Live Contract

```bash
CODEX_HOOK_LIVE=1 tests/test-codex-hook-fixtures.sh
```

Expected: live suite exits 0 and reports `programmatic env inheritance live`.

### Phase 3: Pre-Push Surface

```bash
nix develop --command git push --dry-run
```

Expected: pre-push hooks evaluate codex fixtures, flake checks, and shell script tests without failures.
