### PR TITLE
fix(pinning): generalize finding label and decouple grep token via lib helper

### DIFF
--- a/modules/shared/programs/claude/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-guard.sh
@@ -144,7 +144,7 @@ case "$TOOL_NAME" in
     _scan_text_file "$COMMAND_TEXT" "$SCAN_DIR/new.txt"
     findings="$(pinning_findings_text "$SCAN_DIR/new.txt")"
     if _allow_partial_hash_exception "$COMMAND_TEXT"; then
-      findings="$(printf '%b\n' "$findings" | grep -v 'Partial commit hash' || true)"
+      findings="$(pinning_strip_partial_hash_finding "$findings")"
     fi
     [ -n "$findings" ] || exit 0
     _deny "$TOOL_NAME" "durable shell command" "$findings"

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -7,6 +7,11 @@
 HASH_MIN=7
 HASH_MAX=12
 
+# partial-hash finding 라벨 식별 substring. 라벨 출력과 hooks의 partial-hash exception
+# 필터(`pinning_strip_partial_hash_finding`)가 동일 정의를 단일 SSOT로 공유한다.
+# 라벨 텍스트가 바뀌면 이 변수 한 곳만 갱신하면 출력과 helper grep이 동시에 동기화된다.
+PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR='짧은 임시 hex 식별자 박제'
+
 # Pattern A: progress counters.
 PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
 
@@ -81,10 +86,18 @@ pinning_findings_text() {
     findings="${findings}\n  - DA 실행 키워드 박제"
   fi
   if [ -n "$(pinning_partial_hash_report "$scan_file")" ]; then
-    findings="${findings}\n  - Partial commit hash 박제 (${HASH_MIN}~${HASH_MAX}자)"
+    findings="${findings}\n  - ${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} (${HASH_MIN}~${HASH_MAX}자)"
   fi
 
   printf '%b' "$findings"
+}
+
+# revert/cherry-pick 같은 git partial-hash exception에서 호출자(hooks/pinning-guard.sh)가
+# pinning_findings_text 출력에서 partial-hash 라벨 라인만 제거하기 위해 사용한다.
+# 라벨 substring은 PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR이 단일 SSOT다.
+pinning_strip_partial_hash_finding() {
+  local findings="$1"
+  printf '%b\n' "$findings" | grep -v -- "$PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR" || true
 }
 
 pinning_match_count() {

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step.md
@@ -219,6 +219,8 @@ rm -rf -- "$CONSULT_DIR"
 
 **Durable output에 임시 dir path 기록 금지 (회귀 방지)**: 셸 호출 사이에 `CONSULT_DIR` 리터럴 값을 재사용하는 것은 runtime 요구사항이지만, plan/PRD/PR/issue/comment 같은 durable output에는 `/tmp/consult-XXXXXXXX-YYYYYY/result.json` 같은 임시 경로 리터럴을 박지 않는다. 임시 경로는 세션 종료 시 사라지는 ephemeral identifier이며, dir suffix의 hex 토큰이 `pinning-guard.sh` PATTERN_D에 의해 차단된다(라벨: "짧은 임시 hex 식별자 박제"). durable output에는 자문 회차 자연어 요약(예: "1차 자문(전체 N결정)")·`decision_id` list·verdict 요약만 기록한다.
 
+**스코프**: 본 금지는 _agent가 이번 작업으로 새로 생성하는_ generated plan/PRD/PR/issue/comment에만 적용된다. 본 reference 문서 자체의 셸 호출 예시(아래 셸 호출 1/2/3 코드블록의 placeholder hex 값)는 runtime 동작을 가르치는 SSOT 가이드이므로 정책 적용 대상이 아니다 — durable output 차단은 *새 박제 추가*에만 작동하며 기존 SSOT 예시는 보존된다.
+
 for_action 기록 형식:
 
 ```

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step.md
@@ -217,6 +217,8 @@ rm -rf -- "$CONSULT_DIR"
 - **for_action**: plan 파일 `Decision Log`에 ADR 미니 기록.
 - **for_prd**: PRD draft/context에 기록하고, PRD 작성 후 master `Change Log`와 특정 phase가 영향받는 경우 phase `Discoveries / Decisions`에 이관.
 
+**Durable output에 임시 dir path 기록 금지 (회귀 방지)**: 셸 호출 사이에 `CONSULT_DIR` 리터럴 값을 재사용하는 것은 runtime 요구사항이지만, plan/PRD/PR/issue/comment 같은 durable output에는 `/tmp/consult-XXXXXXXX-YYYYYY/result.json` 같은 임시 경로 리터럴을 박지 않는다. 임시 경로는 세션 종료 시 사라지는 ephemeral identifier이며, dir suffix의 hex 토큰이 `pinning-guard.sh` PATTERN_D에 의해 차단된다(라벨: "짧은 임시 hex 식별자 박제"). durable output에는 자문 회차 자연어 요약(예: "1차 자문(전체 N결정)")·`decision_id` list·verdict 요약만 기록한다.
+
 for_action 기록 형식:
 
 ```
@@ -225,7 +227,7 @@ for_action 기록 형식:
 - Context: Step 3에서 메인 LLM이 옵션 A를 후보로 작성. Step 3.5 외부 자문에서 옵션 A의 disqualifier 발견.
 - Decision: 옵션 B 채택.
 - Consequences: <영향>
-- External Consult: <자문 결과 요약 또는 result.json 경로>
+- External Consult: <자문 회차 자연어 요약 + decision_id list + verdict 요약. result.json 같은 임시 경로 리터럴 박제 금지.>
 ```
 
 ## Validation (Phase 2 Exit Criteria 보조)

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/plan-file-template.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/plan-file-template.md
@@ -26,7 +26,7 @@
 | Active Phase File | <split mode일 때 phase 파일 링크> 또는 N/A |
 | Last Updated | YYYY-MM-DD |
 | Baseline | branch=<name>, HEAD=<sha7>, dirty=<clean|hash> |
-| External Consult | <Step 3.5 result.json 경로 또는 요약> |
+| External Consult | <Step 3.5 자문 회차 자연어 요약 + decision_id list + verdict 요약. 임시 경로 리터럴 박제 금지> |
 | DA State | <PRE_DA | RUNNING | APPLYING | CONFIRMED | SKIPPED | BLOCKED | NEEDS_USER> |
 | Pending User Questions | <count> (link to high-impact) |
 ```
@@ -48,7 +48,7 @@
 | Active Phase File | `N/A` |
 | Last Updated | 현재 날짜 (`YYYY-MM-DD`) |
 | Baseline | `branch=<name>, HEAD=<sha7>, dirty=<clean\|hash>` |
-| External Consult | Step 3.5 result path/요약 또는 `N/A` |
+| External Consult | Step 3.5 자문 회차 자연어 요약 + decision_id list + verdict 요약 또는 `N/A` (임시 경로 리터럴 박제 금지) |
 | DA State | `PRE_DA` |
 | Pending User Questions | `0` |
 
@@ -78,7 +78,7 @@
 
 ### External Consult
 
-Step 3.5 자문 결과의 `result.json` 경로 또는 핵심 decision_id list. plan 파일은 자문 raw output을 인라인 복제하지 않는다 (별도 path 또는 git ignored 임시 파일).
+Step 3.5 자문 결과의 자문 회차 자연어 요약(예: "1차 자문(전체 N결정)") + 핵심 `decision_id` list + verdict 요약. plan 파일은 자문 raw output을 인라인 복제하지 않으며, `/tmp/consult-XXXXXXXX-YYYYYY/result.json` 같은 임시 경로 리터럴도 박지 않는다 — 임시 경로는 세션 종료 시 사라지는 ephemeral identifier이며 dir suffix hex 토큰이 `pinning-guard.sh` PATTERN_D에 차단된다(라벨: "짧은 임시 hex 식별자 박제"). 셸 호출 사이의 `CONSULT_DIR` 리터럴 재사용은 runtime 요구이지만 durable plan에는 기록하지 않는다는 경계를 분리해 적용한다.
 
 ### DA State 값
 
@@ -162,7 +162,7 @@ Step 3.5 자문 결과의 `result.json` 경로 또는 핵심 decision_id list. p
 - **Context**: 왜 이 결정이 필요했는가 (1-3 문장).
 - **Decision**: 무엇을 결정했는가 (1-2 문장).
 - **Consequences**: 의도된 영향 + 예측되는 trade-off (2-4 bullet).
-- **External Consult**: <Step 3.5 result.json 경로 또는 요약 — 자문이 결정에 영향을 준 경우만>
+- **External Consult**: <Step 3.5 자문 회차 자연어 요약 + decision_id list + verdict 요약 — 자문이 결정에 영향을 준 경우만. 임시 경로 리터럴 박제 금지>
 - **Superseded By**: DL-M (해당 시)
 ```
 

--- a/modules/shared/programs/codex/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-guard.sh
@@ -93,7 +93,7 @@ case "$TOOL_NAME" in
 
     findings="$(_scan_text "$COMMAND_TEXT" "$SCAN_DIR/bash.txt")"
     if _allow_partial_hash_exception "$COMMAND_TEXT"; then
-      findings="$(printf '%b\n' "$findings" | grep -v 'Partial commit hash' || true)"
+      findings="$(pinning_strip_partial_hash_finding "$findings")"
     fi
     [ -n "$findings" ] || exit 0
     _deny "$TOOL_NAME" "durable shell command" "$findings"

--- a/scripts/ai/commit-msg-pinning.sh
+++ b/scripts/ai/commit-msg-pinning.sh
@@ -70,7 +70,7 @@ check_ere "$PATTERN_C" "DA 키워드 박제 감지. 검토 라운드/모드 표�
 if [[ ! "$FIRST_LINE" =~ ^[Rr]evert ]]; then
   pinning_hash_report=$(pinning_partial_hash_report "$CLEAN_MSG")
   if [ -n "$pinning_hash_report" ]; then
-    warn "Partial commit hash 박제 감지. squash 머지 시 dangling 위험. 안정 식별자(PR 번호, 머지된 SHA)로 대체하라."
+    warn "${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} 감지. squash 머지 시 dangling 위험 (partial commit hash 포함). 안정 식별자(PR 번호, 머지된 SHA)로 대체하라."
     echo "$pinning_hash_report" >&2
     found=1
   fi

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -1429,12 +1429,19 @@ _pinning_hooks=(
   "$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-alert.sh"
   "$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-guard.sh"
 )
-for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX; do
+for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR; do
   _lib_line="$(grep -m1 -E "^${_var}=" "$_pinning_lib" || true)"
   if [ -n "$_lib_line" ]; then
     pass "pinning $_var shared lib 정의 OK"
   else
     fail "pinning $_var 정의 부재 ($_pinning_lib)"
+  fi
+done
+for _fn in pinning_findings_text pinning_match_count pinning_should_check_path pinning_strip_partial_hash_finding; do
+  if grep -m1 -E "^${_fn}\(\)" "$_pinning_lib" >/dev/null 2>&1; then
+    pass "pinning $_fn shared lib 함수 OK"
+  else
+    fail "pinning $_fn 함수 부재 ($_pinning_lib)"
   fi
 done
 for _hook in "${_pinning_hooks[@]}"; do

--- a/tests/fixtures/codex-hooks/README.md
+++ b/tests/fixtures/codex-hooks/README.md
@@ -59,12 +59,14 @@ Claude/Codex missing shared-library fail-closed 분기를 검증한다.
 | `pretooluse-pinning-guard-claude-edit-existing-no-increase.json` | Claude PreToolUse | 기존 pinned text count가 증가하지 않는 Edit | 빈 파일 |
 | `pretooluse-pinning-guard-claude-write-clean.json` | Claude PreToolUse | clean Write | 빈 파일 |
 | `pretooluse-pinning-guard-claude-write-positive.json` | Claude PreToolUse | Write content with volatile metadata | deny reason |
+| `pretooluse-pinning-guard-claude-write-consult-positive.json` | Claude PreToolUse | Write content referencing volatile `/tmp/consult-…/result.json` path | deny reason |
 | `pretooluse-pinning-guard-claude-notebook-positive.json` | Claude PreToolUse | NotebookEdit on `.ipynb` | deny reason |
 | `pretooluse-pinning-guard-claude-bash-positive.json` | Claude PreToolUse | durable `gh` command with volatile metadata | deny reason |
 | `pretooluse-pinning-guard-claude-bash-cherrypick-comment.json` | Claude PreToolUse | durable `gh` comment mentioning cherry-pick plus a short hash | deny reason |
 | `pretooluse-pinning-guard-claude-bash-git-option-commit.json` | Claude PreToolUse | `git` global-option commit command | deny reason |
 | `pretooluse-pinning-guard-claude-bash-revert-hash-pass.json` | Claude PreToolUse | real `git commit` revert message with short hash | 빈 파일 |
 | `pretooluse-pinning-guard-codex-applypatch-positive.json` | Codex PreToolUse | apply_patch adds volatile metadata to `.md` | deny reason |
+| `pretooluse-pinning-guard-codex-applypatch-consult-positive.json` | Codex PreToolUse | apply_patch adds volatile `/tmp/consult-…/result.json` path to `.md` | deny reason |
 | `pretooluse-pinning-guard-codex-applypatch-github-attachment-pass.json` | Codex PreToolUse | apply_patch adds Markdown/inline-code/HTML/raw GitHub attachment URLs to `/tmp/*body*.md` | 빈 파일 |
 | `pretooluse-pinning-guard-codex-applypatch-github-attachment-mixed-positive.json` | Codex PreToolUse | GitHub attachment URL + 별도 short hash on same line | deny reason |
 | `pretooluse-pinning-guard-codex-applypatch-github-attachment-malformed-positive.json` | Codex PreToolUse | GitHub attachment-like URL with malformed UUID | deny reason |

--- a/tests/fixtures/codex-hooks/README.md
+++ b/tests/fixtures/codex-hooks/README.md
@@ -27,15 +27,15 @@ runner: `tests/test-codex-hook-fixtures.sh`.
 
 | 파일 | hook | 입력 의도 | expected stderr |
 |------|------|----------|-----------------|
-| `pinning-claude-edit-positive-4patterns.json` | Claude Edit | 4 패턴 동시 매치 (Round/Bundle/DA keyword/partial hash) on `.md` | `Edit on …` 헤더 + 4 finding 라인 |
+| `pinning-claude-edit-positive-4patterns.json` | Claude Edit | 4 패턴 동시 매치 (Round/Bundle/DA keyword/짧은 임시 hex 식별자) on `.md` | `Edit on …` 헤더 + 4 finding 라인 |
 | `pinning-claude-write-clean.json` | Claude Write | 정상 텍스트 | 빈 파일 (false positive 회피) |
 | `pinning-claude-self-exclude.json` | Claude Edit | path가 `…/scripts/ai/commit-msg-pinning.sh` (self-exclude) | 빈 파일 |
 | `pinning-codex-applypatch-md-positive.json` | Codex apply_patch | 단일 `.md` Update + Round | `apply_patch on …` 헤더 + Round 라인 |
 | `pinning-codex-applypatch-github-attachment-pass.json` | Codex apply_patch | Markdown/inline-code/HTML/raw GitHub attachment URLs in `/tmp/*body*.md` | 빈 파일 (attachment UUID false positive 회피) |
-| `pinning-codex-applypatch-github-attachment-mixed-positive.json` | Codex apply_patch | GitHub attachment URL + 별도 short hash on same line | `apply_patch on …` 헤더 + partial hash 라인 |
-| `pinning-codex-applypatch-github-attachment-malformed-positive.json` | Codex apply_patch | GitHub attachment-like URL with malformed UUID | `apply_patch on …` 헤더 + partial hash 라인 |
-| `pinning-codex-applypatch-github-attachment-nonhex-suffix-positive.json` | Codex apply_patch | GitHub attachment-like URL with non-hex suffix | `apply_patch on …` 헤더 + partial hash 라인 |
-| `pinning-codex-applypatch-github-attachment-punct-suffix-positive.json` | Codex apply_patch | GitHub attachment-like URL with extension/query suffix | `apply_patch on …` 헤더 + partial hash 라인 |
+| `pinning-codex-applypatch-github-attachment-mixed-positive.json` | Codex apply_patch | GitHub attachment URL + 별도 short hash on same line | `apply_patch on …` 헤더 + 짧은 임시 hex 식별자 라인 |
+| `pinning-codex-applypatch-github-attachment-malformed-positive.json` | Codex apply_patch | GitHub attachment-like URL with malformed UUID | `apply_patch on …` 헤더 + 짧은 임시 hex 식별자 라인 |
+| `pinning-codex-applypatch-github-attachment-nonhex-suffix-positive.json` | Codex apply_patch | GitHub attachment-like URL with non-hex suffix | `apply_patch on …` 헤더 + 짧은 임시 hex 식별자 라인 |
+| `pinning-codex-applypatch-github-attachment-punct-suffix-positive.json` | Codex apply_patch | GitHub attachment-like URL with extension/query suffix | `apply_patch on …` 헤더 + 짧은 임시 hex 식별자 라인 |
 | `pinning-codex-applypatch-moveto.json` | Codex apply_patch | `*** Move to:` (`.txt` → `.md`) + Round + hash | Move 후 `.md` path로 보고 (R3 분기) |
 | `pinning-codex-applypatch-multifile.json` | Codex apply_patch | `.ts` 정상 + `.md` 박제 | `.md` path만 보고 (multi-file attribution) |
 | `pinning-codex-applypatch-removeonly.json` | Codex apply_patch | 박제 패턴이 `^-` 라인에만 (제거 patch) | 빈 파일 (added line만 검사) |
@@ -92,8 +92,8 @@ Claude/Codex missing shared-library fail-closed 분기를 검증한다.
 | 파일 | 시나리오 | 기대 |
 |------|----------|------|
 | `attachment-pass.msg` | Markdown/inline-code/HTML/raw GitHub attachment URLs | 빈 파일 |
-| `attachment-mixed-positive.msg` | GitHub attachment URL + 별도 short hash | partial hash warn |
-| `attachment-extended-positive.msg` | GitHub attachment-like URL with extension/query suffix | partial hash warn |
+| `attachment-mixed-positive.msg` | GitHub attachment URL + 별도 short hash | 짧은 임시 hex 식별자 warn |
+| `attachment-extended-positive.msg` | GitHub attachment-like URL with extension/query suffix | 짧은 임시 hex 식별자 warn |
 | `revert-skip.msg` | Revert commit message partial hash skip | 빈 파일 |
 
 ## 외부 contract만 디렉토리로 노출

--- a/tests/fixtures/codex-hooks/commit-msg/attachment-extended-positive.expected
+++ b/tests/fixtures/codex-hooks/commit-msg/attachment-extended-positive.expected
@@ -1,4 +1,4 @@
-[WARN] pinning: Partial commit hash 박제 감지. squash 머지 시 dangling 위험. 안정 식별자(PR 번호, 머지된 SHA)로 대체하라.
+[WARN] pinning: 짧은 임시 hex 식별자 박제 감지. squash 머지 시 dangling 위험 (partial commit hash 포함). 안정 식별자(PR 번호, 머지된 SHA)로 대체하라.
          3: 9c368446
          3: 4307403c4c04
          4: 9c368446

--- a/tests/fixtures/codex-hooks/commit-msg/attachment-mixed-positive.expected
+++ b/tests/fixtures/codex-hooks/commit-msg/attachment-mixed-positive.expected
@@ -1,3 +1,3 @@
-[WARN] pinning: Partial commit hash 박제 감지. squash 머지 시 dangling 위험. 안정 식별자(PR 번호, 머지된 SHA)로 대체하라.
+[WARN] pinning: 짧은 임시 hex 식별자 박제 감지. squash 머지 시 dangling 위험 (partial commit hash 포함). 안정 식별자(PR 번호, 머지된 SHA)로 대체하라.
          3: abc1234
 [WARN] pinning: 위 경고는 차단하지 않습니다 (warn-only). 검토 후 amend로 정정하거나 의도적 사용이면 무시하세요.

--- a/tests/fixtures/codex-hooks/stdin/pinning-claude-edit-positive-4patterns.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-claude-edit-positive-4patterns.expected
@@ -2,4 +2,4 @@
   - Round counter 박제: 'Round N'
   - Bundle finding ID 박제: 'Bundle-N'
   - DA 실행 키워드 박제
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-malformed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-malformed-positive.expected
@@ -1,2 +1,2 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-malformed.md 매치:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-mixed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-mixed-positive.expected
@@ -1,2 +1,2 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-mixed.md 매치:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
@@ -1,2 +1,2 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-nonhex-suffix.md 매치:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-punct-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-punct-suffix-positive.expected
@@ -1,2 +1,2 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-punct-suffix.md 매치:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-moveto.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-moveto.expected
@@ -1,3 +1,3 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-new.md 매치:
   - Round counter 박제: 'Round N'
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-positive.expected
@@ -2,5 +2,5 @@
   - Round counter 박제: 'Round N'
   - Bundle finding ID 박제: 'Bundle-N'
   - DA 실행 키워드 박제
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.expected
@@ -1,3 +1,3 @@
-[pinning-guard] Bash on durable shell command contains volatile review/session metadata:
+[pinning-guard] Write on /tmp/fixture-pretooluse-claude-write-consult.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/tmp/fixture-pretooluse-claude-write-consult.md",
+    "content": "Step 3.5 자문 결과는 /tmp/consult-abc12345-XYZ123/result.json 경로에 저장됐다."
+  }
+}

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.expected
@@ -1,3 +1,3 @@
-[pinning-guard] Bash on durable shell command contains volatile review/session metadata:
+[pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-consult.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.json
@@ -1,0 +1,6 @@
+{
+  "tool_name": "apply_patch",
+  "tool_input": {
+    "command": "*** Begin Patch\n*** Update File: /tmp/fixture-pretooluse-codex-consult.md\n@@\n+자문 결과 path: /tmp/consult-abc12345-XYZ123/result.json\n*** End Patch\n"
+  }
+}

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-malformed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-malformed-positive.expected
@@ -1,3 +1,3 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-malformed.md contains volatile review/session metadata:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-mixed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-mixed-positive.expected
@@ -1,3 +1,3 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-mixed.md contains volatile review/session metadata:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
@@ -1,3 +1,3 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-nonhex-suffix.md contains volatile review/session metadata:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-punct-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-punct-suffix-positive.expected
@@ -1,3 +1,3 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-punct-suffix.md contains volatile review/session metadata:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-cherrypick-comment.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-cherrypick-comment.expected
@@ -1,3 +1,3 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
-  - Partial commit hash 박제 (7~12자)
+  - 짧은 임시 hex 식별자 박제 (7~12자)
 Use stable identifiers or plain natural-language context before retrying.


### PR DESCRIPTION
## Summary

- pinning-guard finding 라벨을 commit hash 한정 표현에서 ephemeral hex 식별자 의미로 일반화하고, hooks의 partial-hash exception 필터를 lib SSOT helper 함수로 위임한다.
- 자문 임시 dir 경로 같은 ephemeral hex 토큰이 plan/PRD/PR 같은 durable output에 박히지 않도록 가이드 문구를 명확화한다.
- ephemeral hex 차단 회귀 보호용 fixture 4개를 신규 추가하고 기존 fixture 15개의 라벨을 일괄 정합한다.

## 기존 문제 / 배경

<img width="1728" height="311" alt="image" src="https://github.com/user-attachments/assets/16b85890-2ae1-4eae-8b17-85f46d789de6" />

<img width="1180" height="233" alt="image" src="https://github.com/user-attachments/assets/3c3f793c-65ce-4144-bc81-933f0f1273bf" />


`plan-with-questions` 스킬의 Step 3.5 외부 자문 단계는 `mktemp -d`로 만든 임시 dir을 사용한다. 이 dir의 8자 hex prefix는 fan-out 세션 식별자(UUID prefix 또는 sha1 stub)이며 commit hash가 아니다. 그러나 plan markdown 작성 중 해당 경로 리터럴을 reference하려 하면 `pinning-guard.sh` PreToolUse hook이 `PATTERN_D`(7~12자 hex 토큰 + a-f 포함)로 매칭하여 deny한다.

사용자는 finding 라벨이 "Partial commit hash 박제"로 표시되어 false positive로 의심했다. 그러나 사용자 글로벌 정책 *"리뷰 실행명, 임시 finding id, 짧은 임시 hash 대신 안정적인 대상 이름과 자연어 근거로 다시 작성한다"* 의 ephemeral identifier 박제 금지 정신과 결과적으로 일치하는 차단이었다. 라벨 표현이 commit hash로 한정되어 사용자 오인을 유발한 것이 핵심 문제이며, hook의 partial-hash exception 필터가 이 라벨 텍스트를 raw `grep -v`로 의존하고 있어 단순한 라벨 일반화도 회귀 위험을 동반했다.

## CIR (Change Intent Record)

1. 사용자가 의심 케이스를 제기 → Step 3.5 외부 자문에 4개 옵션 평가 위임 → 옵션 A(라벨/가이드만 일반화, PATTERN_D 알고리즘 보존) 선택. 옵션 B(path-context 화이트리스트), C(좁은 prefix 화이트리스트), D(commit-hash keyword context 한정)는 운영위험·NFR-1(fail-closed) 보존과 충돌하여 disqualifier 활성화.
2. for_plan DA가 4개 reviewer로 plan 검증 → 단순 export 상수 분리만으로는 hooks의 라벨/필터 결합 해소 불가, fixture 영향 표 plan 내부 불일치, plan-file-template의 result.json 허용 문구가 새 가이드와 충돌 — 모두 first-pass Arbiter unanimous CONFIRMED.
3. plan 결정 변경: 단순 상수 export → lib helper 함수 도입(`pinning_strip_partial_hash_finding`), fixture 영향 정합(13 stdin + 2 commit-msg = 15), plan-file-template의 4개 result.json 허용 문구를 자연어 요약/decision_id list/verdict 요약 권장으로 교체.
4. Post-Implementation parallel-audit + Final 10-pass review에서 추가 EDGECASE 3건 발견 → verify-ai-compat 검사에 새 변수/helper 추가, README 표 자연어 표현 정합, consulting-step 가이드 단락에 reference 예시 스코프 명시.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| A | 라벨/가이드만 일반화 (PATTERN_D 알고리즘 보존) | 운영위험 낮음, 비용 낮음, NFR-1 fail-closed 보존, 기존 fixture deny 의도 그대로 | result.json 박제 의도가 있어도 차단 (정책 의도와 일치) | ✅ |
| B | path-context 화이트리스트 일반화 | path 내부 hex false positive 감소 | path-context 일반화의 음성 회귀를 deterministic fixture로 완전 차단하기 어려움, NFR-1 약화 가능 | ❌ |
| C | hybrid (라벨 일반화 + consult-* exact prefix 화이트리스트) | 디버깅 path 리터럴 박제 허용 | 정책 예외 도입, 기존 ephemeral identifier 금지 정책과 긴장 | ❌ |
| D | PATTERN_D를 commit/sha/git keyword context 한정 | broad false positive 감소 | NFR-1과 가장 멀리, keyword-free short hash 박제 누락 위험, 기존 positive fixture 다수 재설계 필요 | ❌ |

추가 결정 (DA 결과 반영):

| 대안 | 설명 | 결정 |
|------|------|------|
| 새 export 상수 분리 | hooks가 lib export 변수를 grep 토큰으로 reference | ❌ — 라벨 substring과 grep 토큰의 결합 미해결 |
| lib helper 함수 도입 | `pinning_findings_text` 출력에서 partial-hash 라벨 라인을 제거하는 helper. lib-private substring 정의(`PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR`)를 단일 SSOT로 hooks와 lib 출력이 공유 | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/lib/pinning-patterns.sh` | `PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR` 변수 export 추가 + `pinning_strip_partial_hash_finding` helper 함수 신규 추가. `pinning_findings_text`의 라벨 substring을 변수 reference로 전환 |
| `modules/shared/programs/claude/files/hooks/pinning-guard.sh` | Bash 분기의 raw `grep -v` 호출을 helper 호출로 전환 |
| `modules/shared/programs/codex/files/hooks/pinning-guard.sh` | 동일 |
| `scripts/ai/commit-msg-pinning.sh` | warn 메시지를 lib substring 변수 reference로 정합 (warn-only 계약 유지) |
| `scripts/ai/verify-ai-compat.sh` | pinning lib 검사에 새 export 변수 1개와 helper 함수 4개 검사 항목 추가 (provision drift 사전 감지) |
| `tests/fixtures/codex-hooks/stdin/*.expected` (13개) + `tests/fixtures/codex-hooks/commit-msg/*.expected` (2개) | 라벨 텍스트 일괄 갱신 (PreToolUse pinning-guard 출력 + PostToolUse pinning-alert 출력 + commit-msg warn 메시지) |
| `tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-{claude-write,codex-applypatch}-consult-positive.{json,expected}` | 신규 4개 (페어 2쌍, ephemeral consult dir path negative case) |
| `tests/fixtures/codex-hooks/README.md` | 표 자연어 표현 6 위치를 새 라벨에 정합 |
| `modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step.md` | durable output에 임시 dir path 기록 금지 단락 + reference 예시 스코프 명시 + Decision Log 형식의 result.json 허용 문구를 자연어 요약 권장으로 교체 |
| `modules/shared/programs/claude/files/skills/plan-with-questions/references/plan-file-template.md` | 4 위치 result.json 허용 문구 교체 (14 metadata 필드 표, Step 4.5 초기값 표, External Consult 필드 설명, Decision Log ADR 미니 형식) |

핵심 설계 포인트:

- **lib SSOT 단일 substring**: `PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR`이 라벨 출력과 helper grep 패턴의 단일 정의. 라벨 텍스트가 바뀌면 한 곳 갱신으로 helper와 출력이 동기.
- **Helper-via-call**: hooks는 `findings="$(pinning_strip_partial_hash_finding "$findings")"` 호출로 raw text grep을 lib에 위임.
- **fail-closed 보존**: PATTERN_D regex와 길이 컷오프(7~12자), `[a-f]` 포함 awk 후처리는 그대로. detection 의미와 fail-closed 동작 변경 없음.

## 참고 레퍼런스

- 관련 PR: #650 (pinning PreToolUse hard-fail guard 도입 PRD 종료)
- 관련 정책: 사용자 글로벌 CLAUDE.md `Durable output pinning policy` 섹션 (`~/.claude/CLAUDE.md`)
- lib 본체: `modules/shared/programs/claude/files/lib/pinning-patterns.sh` PATTERN_D 정의

## Follow-up Issues

본 PR에서 deferred로 남긴 영역을 Codex 자문(candidate별 keep/drop/defer 분리 권장)에 따라 single-purpose issue로 분리 등록함:

- #666 — `follow-up(pinning): PATTERN_D 별도 클래스 false positive 사례 수집·평가` (priority:medium). PATTERN_D는 commit hash 외에도 7~12자 hex 토큰 + a-f 포함이면 모두 잡는다. hex color 코드, nix store path 첫 부분, 외부 API ID hex, IPv6 segment 결합 같은 클래스가 우연한 false positive로 차단될 가능성. 본 PR에서는 사례 수집 단계가 없어 NG-3로 deferred. broader scope의 인접 이슈 #659와 link.
- #667 — `follow-up(pinning): stale-lib 시나리오 hook fallback 도입 검토` (priority:medium). hooks가 lib helper 함수를 호출하는데 lib과 hook의 stale-version 동기화가 깨지면 helper 부재로 hook이 비정상 종료할 위험. PR #664 parallel-audit에서 같은 EDGECASE를 2 bundle 수렴으로 잡았고 verify-ai-compat 검사 추가로 사전 감지는 가능하지만 runtime fallback은 부재. inline fallback / version pin / 현 상태 유지 트레이드오프 평가 필요.
- #668 — `follow-up(pinning): PATTERN_D detector class 의미 lib 주석 명세` (priority:low). 라벨은 ephemeral hex 식별자로 일반화됐지만 `lib/pinning-patterns.sh` PATTERN_D 정의 위 주석은 여전히 commit hash detector로 적혀 있어 detector class 의미와 어긋남. 주석만 갱신하는 작은 cleanup.

추가로 고려했지만 등록하지 않은 후보 (자문 결정 근거 함께 보존):

- **External Consult line 작성 verbosity mitigation** — defer. `plan-file-template.md`의 result.json 허용 문구를 자연어 요약 권장으로 교체했지만 실제 반복 작성 비용이 검증되지 않음. 다음 Step 3.5 사용 시 마찰이 재발하면 등록.
- **CodeRabbit Docstring Coverage warning 처리** — drop. 본 PR에서 1회성 generic warning으로 관측됐고 반복성 / review 비용이 확인되지 않은 상태에서 repo-level 설정 변경은 anchoring-neutral 기준에서 과함. 같은 warning이 다른 PR에서 반복되면 그때 새 issue로 재등록.
- **Fixture 라벨 SSOT generator** — defer. 본 PR은 partial-hash 라벨만 SSOT 분리. 다른 finding label(Round counter / Bundle finding ID / DA 실행 키워드)도 hardcoded이지만 라벨 변경 빈도가 낮고 generator 도입은 YAGNI 위험. 다음 라벨 변경 발생 시 hardcoded fixture 갱신 비용을 근거로 재평가.

## Human Test Plan

| 단계 | 동작 | 기대 |
|------|------|------|
| 1 | plan markdown에 임시 자문 dir 경로 리터럴을 박는 시도 (Claude Write) | 새 라벨 "짧은 임시 hex 식별자 박제 (7~12자)"로 deny |
| 2 | `git commit -m "Revert ..."` 또는 cherry-pick commit 메시지 안에 짧은 partial hash 포함 | partial hash exception으로 통과 (helper가 라벨 라인을 strip) |
| 3 | `gh pr comment N --body "see commit ..."` 같은 git commit 외 durable Bash command에 짧은 partial hash 포함 | exception 미적용 → deny + 새 라벨 출력 |
| 4 | Round 카운터 / DA finding ID / DA 키워드를 markdown에 박기 | 기존 패턴 deny 정상 (라벨 변경 영향 없음) |
| 5 | GitHub user-attachments asset URL 박기 | 기존 화이트리스트로 통과 (false positive 회피) |

실패 시 진단:
- 1번 통과(deny 안 됨) → lib provisioning 확인 (`~/.claude/lib/pinning-patterns.sh` symlink 갱신, `nrs --force` 후 재시도).
- 2번 deny(통과 안 됨) → helper 함수가 lib에 정의됐는지 `command -v pinning_strip_partial_hash_finding` 확인 (`. ~/.claude/lib/pinning-patterns.sh` 후).
- 4/5번 회귀 → fixture runner로 영향 surface 재확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```sh
# lib export 변수 + helper 함수 정의 확인
grep -E '^PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR=' \
  modules/shared/programs/claude/files/lib/pinning-patterns.sh
grep -E '^pinning_strip_partial_hash_finding\(\)' \
  modules/shared/programs/claude/files/lib/pinning-patterns.sh

# 기존 라벨 텍스트가 fixture에 잔존하지 않음
grep -RE 'Partial commit hash 박제' tests/fixtures/codex-hooks/ \
  && echo FAIL || echo OK

# 새 라벨이 정확히 fixture 15곳에 반영
{
  grep -lE '짧은 임시 hex 식별자 박제 \(7~12자\)' \
    tests/fixtures/codex-hooks/stdin/*.expected
  grep -lE '짧은 임시 hex 식별자 박제 감지' \
    tests/fixtures/codex-hooks/commit-msg/*.expected
} | wc -l   # 15

# 신규 negative fixture 4 파일
ls tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.{json,expected}
ls tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.{json,expected}
```

### Phase 1 — Hook 활성화 + 직접 stdin 스모크

```sh
# nrs 활성화 (lib symlink 갱신)
nrs --force

# A. consult dir path 박는 Claude Write → deny + 새 라벨
echo '{"tool_name":"Write","tool_input":{"file_path":"/tmp/smoke-claude-write.md","content":"path: /tmp/consult-PLACEHOLDER-XYZ/result.json"}}' \
  | ~/.claude/hooks/pinning-guard.sh
# 기대: permissionDecision=deny + "짧은 임시 hex 식별자 박제"

# B. revert exception → 통과
echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"Revert commit PLACEHOLDER applied\""}}' \
  | ~/.claude/hooks/pinning-guard.sh
# 기대: empty output

# C. gh pr comment partial hash → deny (exception 미적용)
echo '{"tool_name":"Bash","tool_input":{"command":"gh pr comment 999 --body \"see commit PLACEHOLDER\""}}' \
  | ~/.claude/hooks/pinning-guard.sh
# 기대: deny + 새 라벨

# D. Codex apply_patch consult dir → deny
printf '%s\n' '{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** Update File: /tmp/smoke-codex.md\n@@\n+path: /tmp/consult-PLACEHOLDER-XYZ/result.json\n*** End Patch\n"}}' \
  | ~/.codex/hooks/pinning-guard.sh
# 기대: deny + 새 라벨
```

`PLACEHOLDER`는 a-f 포함 7~12자 hex 임의 값으로 치환한다. PR 본문에 실제 hex를 박지 않기 위한 placeholder다.

### Phase 2 — 검증 surface 통과

```sh
shellcheck --severity=warning \
  modules/shared/programs/claude/files/lib/pinning-patterns.sh \
  modules/shared/programs/claude/files/hooks/pinning-guard.sh \
  modules/shared/programs/codex/files/hooks/pinning-guard.sh \
  modules/shared/programs/claude/files/hooks/pinning-alert.sh \
  modules/shared/programs/codex/files/hooks/pinning-alert.sh \
  scripts/ai/commit-msg-pinning.sh

./tests/test-codex-hook-fixtures.sh --no-live      # All codex hook fixture tests passed.
./scripts/ai/verify-ai-compat.sh                   # 검증 완전 통과
```

### Phase 3 — Regression 회피

- Round 카운터 / DA finding ID / DA 실행 키워드 박제는 라벨 변경 영향 없이 deny 유지 — 기존 fixture가 negative 회귀 보호.
- GitHub user-attachments asset URL은 기존 화이트리스트로 false positive 회피 유지.
- `pinning-alert.sh`(PostToolUse warn-only)와 `commit-msg-pinning.sh`(commit-msg warn-only)의 warn-only 계약 변경 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved pinning validation by introducing a centralized helper function for filtering partial-hash findings, replacing inline filtering logic.

* **Documentation**
  * Updated external consultation documentation to clarify that durable output must not include temporary file paths; instead include natural-language summaries and decision identifiers.

* **Tests**
  * Updated test fixtures to reflect terminology change: "short temporary hex identifier" now replaces "partial commit hash" in pinning messages and guidance text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
