### PR TITLE
fix(pinning): expose match line and token for all categories + DA scratch whitelist

### DIFF
--- a/modules/shared/programs/claude/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-guard.sh
@@ -142,9 +142,10 @@ case "$TOOL_NAME" in
     _targeted_bash_command "$COMMAND_TEXT" || exit 0
 
     _scan_text_file "$COMMAND_TEXT" "$SCAN_DIR/new.txt"
-    findings="$(pinning_findings_text "$SCAN_DIR/new.txt")"
     if _allow_partial_hash_exception "$COMMAND_TEXT"; then
-      findings="$(pinning_strip_partial_hash_finding "$findings")"
+      findings="$(pinning_findings_text "$SCAN_DIR/new.txt" 1)"
+    else
+      findings="$(pinning_findings_text "$SCAN_DIR/new.txt")"
     fi
     [ -n "$findings" ] || exit 0
     _deny "$TOOL_NAME" "durable shell command" "$findings"

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -7,10 +7,22 @@
 HASH_MIN=7
 HASH_MAX=12
 
+# Named indent constant for line:token report rendering. Single SSOT for all
+# rendered output (partial-hash report and findings_text wrapper).
+PINNING_REPORT_INDENT='         '
+
 # partial-hash finding 라벨 식별 substring. 라벨 출력과 hooks의 partial-hash exception
 # 필터(`pinning_strip_partial_hash_finding`)가 동일 정의를 단일 SSOT로 공유한다.
 # 라벨 텍스트가 바뀌면 이 변수 한 곳만 갱신하면 출력과 helper grep이 동시에 동기화된다.
 PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR='짧은 임시 hex 식별자 박제'
+
+# Category labels (per-PATTERN). pinning_findings_records emits the label as
+# a stable field so callers can map by category code (A/B/C/D) instead of
+# substring-matching the human-readable text.
+PINNING_PATTERN_A_LABEL="Round counter 박제: 'Round N'"
+PINNING_PATTERN_B_LABEL="Bundle finding ID 박제: 'Bundle-N'"
+PINNING_PATTERN_C_LABEL="DA 실행 키워드 박제"
+PINNING_PATTERN_D_LABEL="${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} (${HASH_MIN}~${HASH_MAX}자)"
 
 # Pattern A: progress counters.
 PATTERN_A='\b[Rr][Oo][Uu][Nn][Dd] [0-9]+\b'
@@ -31,8 +43,37 @@ PATTERN_D='\b[a-f0-9]{7,40}\b|`[a-f0-9]+`'
 # Sentence punctuation is only accepted before another delimiter or EOL.
 PATTERN_GITHUB_ATTACHMENT_ASSET_URL="https://github\.com/user-attachments/assets/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}([][:space:])}>\"'\`]|\$|[.,;:!?]([][:space:])}>\"'\`]|\$))"
 
+# Canonicalize a path for whitelist comparison. Returns the canonical path on
+# stdout, or the original path if no canonicalizer is available. Callers must
+# additionally reject paths whose original or canonical form contains `..`,
+# because path traversal can mask durable repo paths as DA scratch paths
+# (e.g. `/tmp/da-x/../../repo/file.md` matches `/tmp/da-*` raw).
+pinning_canonicalize_path() {
+  local raw="$1"
+  local canon=""
+  if command -v realpath >/dev/null 2>&1; then
+    canon=$(realpath -m "$raw" 2>/dev/null) || canon=""
+  fi
+  if [ -z "$canon" ] && command -v readlink >/dev/null 2>&1; then
+    canon=$(readlink -f "$raw" 2>/dev/null) || canon=""
+  fi
+  [ -n "$canon" ] || canon="$raw"
+  printf '%s\n' "$canon"
+}
+
 pinning_should_check_path() {
-  local path="$1"
+  local raw="$1"
+  # Reject path traversal at the raw layer so callers cannot smuggle
+  # durable repo paths through DA workspace whitelist via `..`.
+  case "$raw" in
+    *..* ) return 0 ;;
+  esac
+  local path
+  path="$(pinning_canonicalize_path "$raw")"
+  case "$path" in
+    *..* ) return 0 ;;
+  esac
+
   case "$path" in
     *.md | *.sh | *.ipynb) ;;
     /tmp/*body* | /var/folders/*/T/*body*) ;;
@@ -49,6 +90,8 @@ pinning_should_check_path() {
     tests/fixtures/* | */tests/fixtures/*) return 1 ;;
     evals/queries.json | */evals/queries.json) return 1 ;;
     eval-workspace/* | */eval-workspace/*) return 1 ;;
+    /tmp/da-*) return 1 ;;
+    /var/folders/*/T/da-*) return 1 ;;
   esac
 
   return 0
@@ -59,59 +102,81 @@ pinning_sanitize_partial_hash_input() {
   sed -E "s#${PATTERN_GITHUB_ATTACHMENT_ASSET_URL}#__GITHUB_ATTACHMENT_ASSET_URL__\\1#g" "$scan_file"
 }
 
-pinning_partial_hash_report() {
+# Raw matcher for PATTERN_D — emits TSV records (no rendering).
+# Used by pinning_findings_records and the pinning_partial_hash_report wrapper.
+_pinning_partial_hash_records() {
   local scan_file="$1"
   pinning_sanitize_partial_hash_input "$scan_file" 2>/dev/null \
     | grep -noE "$PATTERN_D" 2>/dev/null \
-    | awk -v min="$HASH_MIN" -v max="$HASH_MAX" '
+    | awk -v min="$HASH_MIN" -v max="$HASH_MAX" -v label="$PINNING_PATTERN_D_LABEL" '
         { idx = index($0, ":"); lineno = substr($0, 1, idx - 1); tok = substr($0, idx + 1);
           gsub(/`/, "", tok); n = length(tok);
           if (n < min || n > max) next;
           if (tok !~ /[a-f]/) next;
-          print "         " lineno ": " tok }
+          print "D\t" label "\t" lineno ": " tok }
       ' || true
 }
 
-pinning_findings_text() {
-  local scan_file="$1"
-  local findings=""
-
-  if grep -qE "$PATTERN_A" "$scan_file"; then
-    findings="${findings}\n  - Round counter 박제: 'Round N'"
-  fi
-  if grep -qE "$PATTERN_B" "$scan_file"; then
-    findings="${findings}\n  - Bundle finding ID 박제: 'Bundle-N'"
-  fi
-  if grep -qE "$PATTERN_C" "$scan_file"; then
-    findings="${findings}\n  - DA 실행 키워드 박제"
-  fi
-  if [ -n "$(pinning_partial_hash_report "$scan_file")" ]; then
-    findings="${findings}\n  - ${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} (${HASH_MIN}~${HASH_MAX}자)"
-  fi
-
-  printf '%b' "$findings"
+# Generic raw matcher for A/B/C — emits TSV records.
+_pinning_simple_records() {
+  local scan_file="$1" code="$2" pattern="$3" label="$4"
+  grep -noE "$pattern" "$scan_file" 2>/dev/null \
+    | awk -F: -v code="$code" -v label="$label" '
+        { lineno = $1; tok = substr($0, length(lineno) + 2);
+          print code "\t" label "\t" lineno ": " tok }
+      ' || true
 }
 
-# revert/cherry-pick 같은 git partial-hash exception에서 호출자(hooks/pinning-guard.sh)가
-# pinning_findings_text 출력에서 partial-hash 라벨 라인만 제거하기 위해 사용한다.
-# 라벨 substring은 PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR이 단일 SSOT다.
-pinning_strip_partial_hash_finding() {
-  local findings="$1"
-  printf '%b\n' "$findings" | grep -v -- "$PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR" || true
+# D-10 structured findings API. Output: TSV records, one per match.
+# Format: <category_code>\t<label>\t<line>:<token>
+# - category_code: stable identifier (A/B/C/D)
+# - label: human-readable category label (sourced from PINNING_PATTERN_*_LABEL)
+# - line:token: 1-based line number from grep -n + matched token
+# Second arg `skip_partial_hash` (truthy) suppresses D records.
+pinning_findings_records() {
+  local scan_file="$1"
+  local skip_partial_hash="${2:-}"
+
+  _pinning_simple_records "$scan_file" "A" "$PATTERN_A" "$PINNING_PATTERN_A_LABEL"
+  _pinning_simple_records "$scan_file" "B" "$PATTERN_B" "$PINNING_PATTERN_B_LABEL"
+  _pinning_simple_records "$scan_file" "C" "$PATTERN_C" "$PINNING_PATTERN_C_LABEL"
+  if [ -z "$skip_partial_hash" ]; then
+    _pinning_partial_hash_records "$scan_file"
+  fi
+}
+
+# Compatibility wrapper: render PATTERN_D records as the legacy indented
+# `<line>: <token>` form. Kept so existing callers (tests, observability)
+# that only care about partial-hash output keep working.
+pinning_partial_hash_report() {
+  local scan_file="$1"
+  _pinning_partial_hash_records "$scan_file" \
+    | awk -F'\t' -v indent="$PINNING_REPORT_INDENT" '{ print indent $3 }'
+}
+
+# Render records as human-readable findings text. Output preserves the legacy
+# layout (label line per category followed by indented `<line>: <token>`
+# evidence lines). Second arg `skip_partial_hash` (truthy) suppresses D output.
+pinning_findings_text() {
+  local scan_file="$1"
+  local skip_partial_hash="${2:-}"
+  local records
+  records="$(pinning_findings_records "$scan_file" "$skip_partial_hash")"
+  [ -n "$records" ] || return 0
+  printf '%s\n' "$records" | awk -F'\t' -v indent="$PINNING_REPORT_INDENT" '
+    BEGIN { last_code = "" }
+    {
+      code = $1; label = $2; entry = $3
+      if (code != last_code) {
+        printf "\n  - %s", label
+        last_code = code
+      }
+      printf "\n%s%s", indent, entry
+    }
+  '
 }
 
 pinning_match_count() {
   local scan_file="$1"
-  local total=0 count=0
-
-  count=$({ grep -oE "$PATTERN_A" "$scan_file" 2>/dev/null || true; } | wc -l | tr -d ' ')
-  total=$((total + count))
-  count=$({ grep -oE "$PATTERN_B" "$scan_file" 2>/dev/null || true; } | wc -l | tr -d ' ')
-  total=$((total + count))
-  count=$({ grep -oE "$PATTERN_C" "$scan_file" 2>/dev/null || true; } | wc -l | tr -d ' ')
-  total=$((total + count))
-  count=$(pinning_partial_hash_report "$scan_file" | wc -l | tr -d ' ')
-  total=$((total + count))
-
-  printf '%s\n' "$total"
+  pinning_findings_records "$scan_file" | wc -l | tr -d ' '
 }

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -44,10 +44,10 @@ PATTERN_D='\b[a-f0-9]{7,40}\b|`[a-f0-9]+`'
 PATTERN_GITHUB_ATTACHMENT_ASSET_URL="https://github\.com/user-attachments/assets/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}([][:space:])}>\"'\`]|\$|[.,;:!?]([][:space:])}>\"'\`]|\$))"
 
 # Canonicalize a path for whitelist comparison. Returns the canonical path on
-# stdout, or the original path if no canonicalizer is available. Callers must
-# additionally reject paths whose original or canonical form contains `..`,
-# because path traversal can mask durable repo paths as DA scratch paths
-# (e.g. `/tmp/da-x/../../repo/file.md` matches `/tmp/da-*` raw).
+# stdout when canonicalization succeeds, otherwise prints nothing. Callers
+# must treat an empty result as "do not whitelist" (fail-closed) rather than
+# falling back to the raw path, because a symlink under a whitelisted DA
+# scratch directory could otherwise re-export a repo file as exempt.
 pinning_canonicalize_path() {
   local raw="$1"
   local canon=""
@@ -57,21 +57,28 @@ pinning_canonicalize_path() {
   if [ -z "$canon" ] && command -v readlink >/dev/null 2>&1; then
     canon=$(readlink -f "$raw" 2>/dev/null) || canon=""
   fi
-  [ -n "$canon" ] || canon="$raw"
   printf '%s\n' "$canon"
 }
 
 pinning_should_check_path() {
   local raw="$1"
-  # Reject path traversal at the raw layer so callers cannot smuggle
-  # durable repo paths through DA workspace whitelist via `..`.
+  # Reject path traversal segments at the raw layer so callers cannot
+  # smuggle durable repo paths through the DA workspace whitelist via `..`.
+  # Match only true segment traversal patterns (`/../`, leading `../`,
+  # trailing `/..`) instead of any literal `..` so files whose name happens
+  # to contain `..` (e.g. `README..md`) keep the existing exempt contract.
   case "$raw" in
-    *..* ) return 0 ;;
+    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
   esac
   local path
   path="$(pinning_canonicalize_path "$raw")"
+  if [ -z "$path" ]; then
+    # Canonicalization unavailable: fail-closed and check the path so DA
+    # whitelist cannot apply on a fallback that we cannot trust.
+    return 0
+  fi
   case "$path" in
-    *..* ) return 0 ;;
+    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
   esac
 
   case "$path" in

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -11,9 +11,9 @@ HASH_MAX=12
 # rendered output (partial-hash report and findings_text wrapper).
 PINNING_REPORT_INDENT='         '
 
-# partial-hash finding 라벨 식별 substring. 라벨 출력과 hooks의 partial-hash exception
-# 필터(`pinning_strip_partial_hash_finding`)가 동일 정의를 단일 SSOT로 공유한다.
-# 라벨 텍스트가 바뀌면 이 변수 한 곳만 갱신하면 출력과 helper grep이 동시에 동기화된다.
+# partial-hash finding 라벨 식별 substring. 라벨 텍스트가 바뀌면 이 변수 한 곳만
+# 갱신하면 카테고리 D 라벨 (PINNING_PATTERN_D_LABEL)이 자동 동기화된다. revert/cherry-pick
+# 예외는 record 생성 단계의 skip 옵션으로 처리되며 별도 라벨 substring 매칭이 필요 없다.
 PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR='짧은 임시 hex 식별자 박제'
 
 # Category labels (per-PATTERN). pinning_findings_records emits the label as
@@ -90,8 +90,8 @@ pinning_should_check_path() {
     tests/fixtures/* | */tests/fixtures/*) return 1 ;;
     evals/queries.json | */evals/queries.json) return 1 ;;
     eval-workspace/* | */eval-workspace/*) return 1 ;;
-    /tmp/da-*) return 1 ;;
-    /var/folders/*/T/da-*) return 1 ;;
+    /tmp/da-*/*) return 1 ;;
+    /var/folders/*/T/da-*/*) return 1 ;;
   esac
 
   return 0
@@ -127,12 +127,16 @@ _pinning_simple_records() {
       ' || true
 }
 
-# D-10 structured findings API. Output: TSV records, one per match.
+# Structured findings API. Output: TSV records, one per match.
 # Format: <category_code>\t<label>\t<line>:<token>
-# - category_code: stable identifier (A/B/C/D)
+# - category_code: stable identifier (A/B/C/D) — callers branch on this
+#   without parsing the human-readable label, which keeps display-string
+#   changes from breaking branching logic.
 # - label: human-readable category label (sourced from PINNING_PATTERN_*_LABEL)
 # - line:token: 1-based line number from grep -n + matched token
-# Second arg `skip_partial_hash` (truthy) suppresses D records.
+# Second arg `skip_partial_hash` (truthy) suppresses D records — used by the
+# git revert/cherry-pick exception so callers never need to post-process
+# rendered text to remove partial-hash entries.
 pinning_findings_records() {
   local scan_file="$1"
   local skip_partial_hash="${2:-}"

--- a/modules/shared/programs/codex/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-guard.sh
@@ -73,12 +73,6 @@ _scan_text_file() {
   printf '%s' "$text" > "$scan_file"
 }
 
-_scan_text() {
-  local text="$1" scan_file="$2"
-  _scan_text_file "$text" "$scan_file"
-  pinning_findings_text "$scan_file"
-}
-
 _count_text() {
   local text="$1" scan_file="$2"
   _scan_text_file "$text" "$scan_file"
@@ -91,9 +85,11 @@ case "$TOOL_NAME" in
     [ -n "$COMMAND_TEXT" ] || exit 0
     _targeted_bash_command "$COMMAND_TEXT" || exit 0
 
-    findings="$(_scan_text "$COMMAND_TEXT" "$SCAN_DIR/bash.txt")"
+    _scan_text_file "$COMMAND_TEXT" "$SCAN_DIR/bash.txt"
     if _allow_partial_hash_exception "$COMMAND_TEXT"; then
-      findings="$(pinning_strip_partial_hash_finding "$findings")"
+      findings="$(pinning_findings_text "$SCAN_DIR/bash.txt" 1)"
+    else
+      findings="$(pinning_findings_text "$SCAN_DIR/bash.txt")"
     fi
     [ -n "$findings" ] || exit 0
     _deny "$TOOL_NAME" "durable shell command" "$findings"

--- a/scripts/ai/commit-msg-pinning.sh
+++ b/scripts/ai/commit-msg-pinning.sh
@@ -63,10 +63,11 @@ if [[ "$FIRST_LINE" =~ ^[Rr]evert ]]; then
   SKIP_PARTIAL_HASH=1
 fi
 
-# Single record fetch — D-10 structured API. Loops over TSV records and emits
-# a verbose warn message once per category (when category code transitions),
-# followed by the line:token evidence on subsequent lines indented by the
-# shared PINNING_REPORT_INDENT constant.
+# Loop over the shared structured records. Verbose warn message is emitted
+# once per category (when the category code transitions). For A/B/C the
+# shared category label line is also printed so commit-msg output matches
+# the guard/alert rendering contract; for D the legacy verbose-only output
+# is preserved (existing fixtures do not include the label line).
 records=$(pinning_findings_records "$CLEAN_MSG" "$SKIP_PARTIAL_HASH")
 found=0
 
@@ -77,9 +78,9 @@ if [ -n "$records" ]; then
     [ -n "$code" ] || continue
     if [ "$code" != "$prev_code" ]; then
       case "$code" in
-        A) warn "$WARN_A" ;;
-        B) warn "$WARN_B" ;;
-        C) warn "$WARN_C" ;;
+        A) warn "$WARN_A"; printf '  - %s\n' "$label" >&2 ;;
+        B) warn "$WARN_B"; printf '  - %s\n' "$label" >&2 ;;
+        C) warn "$WARN_C"; printf '  - %s\n' "$label" >&2 ;;
         D) warn "$WARN_D" ;;
         *) warn "$label" ;;
       esac

--- a/scripts/ai/commit-msg-pinning.sh
+++ b/scripts/ai/commit-msg-pinning.sh
@@ -57,7 +57,7 @@ WARN_B="DA finding ID 박제 감지. 라운드/finding ID는 휘발성 보고에
 WARN_C="DA 키워드 박제 감지. 검토 라운드/모드 표기는 commit message에 박지 말고 PR 코멘트 또는 휘발성 작업 노트에 둬라."
 WARN_D="${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} 감지. squash 머지 시 dangling 위험 (partial commit hash 포함). 안정 식별자(PR 번호, 머지된 SHA)로 대체하라."
 
-# revert/cherry-pick prefix → suppress partial-hash (D) records at lib level
+# revert prefix → suppress partial-hash (D) records at lib level
 SKIP_PARTIAL_HASH=""
 if [[ "$FIRST_LINE" =~ ^[Rr]evert ]]; then
   SKIP_PARTIAL_HASH=1

--- a/scripts/ai/commit-msg-pinning.sh
+++ b/scripts/ai/commit-msg-pinning.sh
@@ -48,32 +48,45 @@ warn() {
   echo "[WARN] pinning: $1" >&2
 }
 
-# check_ere — 단순 정규식 검사 흐름 통합 helper (PATTERN_A/B/C 공통 구조).
-# 매치 시 warn + 줄번호 출력 + found=1 설정. found는 셸 전역 변수 (subshell 회피 위해 함수 안 사용).
-# usage: check_ere "$PATTERN" "$WARN_MESSAGE"
-check_ere() {
-  local pattern="$1"
-  local message="$2"
-  if grep -qE "$pattern" "$CLEAN_MSG"; then
-    warn "$message"
-    grep -nE "$pattern" "$CLEAN_MSG" | sed 's/^/         /' >&2
-    found=1
-  fi
-}
+# Category code → user-facing remediation message mapping. category code is
+# the stable ID returned by pinning_findings_records (A/B/C/D); the message
+# stays here in commit-msg context to preserve existing UX wording without
+# embedding it in the shared lib.
+WARN_A="라운드 카운터(\`Round N\`) 박제 감지. 영구 산출물에는 자연어 설명으로 표현하라."
+WARN_B="DA finding ID 박제 감지. 라운드/finding ID는 휘발성 보고에만 사용하고 commit message에는 박지 마라."
+WARN_C="DA 키워드 박제 감지. 검토 라운드/모드 표기는 commit message에 박지 말고 PR 코멘트 또는 휘발성 작업 노트에 둬라."
+WARN_D="${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} 감지. squash 머지 시 dangling 위험 (partial commit hash 포함). 안정 식별자(PR 번호, 머지된 SHA)로 대체하라."
 
+# revert/cherry-pick prefix → suppress partial-hash (D) records at lib level
+SKIP_PARTIAL_HASH=""
+if [[ "$FIRST_LINE" =~ ^[Rr]evert ]]; then
+  SKIP_PARTIAL_HASH=1
+fi
+
+# Single record fetch — D-10 structured API. Loops over TSV records and emits
+# a verbose warn message once per category (when category code transitions),
+# followed by the line:token evidence on subsequent lines indented by the
+# shared PINNING_REPORT_INDENT constant.
+records=$(pinning_findings_records "$CLEAN_MSG" "$SKIP_PARTIAL_HASH")
 found=0
 
-check_ere "$PATTERN_A" "라운드 카운터(\`Round N\`) 박제 감지. 영구 산출물에는 자연어 설명으로 표현하라."
-check_ere "$PATTERN_B" "DA finding ID 박제 감지. 라운드/finding ID는 휘발성 보고에만 사용하고 commit message에는 박지 마라."
-check_ere "$PATTERN_C" "DA 키워드 박제 감지. 검토 라운드/모드 표기는 commit message에 박지 말고 PR 코멘트 또는 휘발성 작업 노트에 둬라."
-
-if [[ ! "$FIRST_LINE" =~ ^[Rr]evert ]]; then
-  pinning_hash_report=$(pinning_partial_hash_report "$CLEAN_MSG")
-  if [ -n "$pinning_hash_report" ]; then
-    warn "${PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR} 감지. squash 머지 시 dangling 위험 (partial commit hash 포함). 안정 식별자(PR 번호, 머지된 SHA)로 대체하라."
-    echo "$pinning_hash_report" >&2
-    found=1
-  fi
+if [ -n "$records" ]; then
+  found=1
+  prev_code=""
+  while IFS=$'\t' read -r code label entry; do
+    [ -n "$code" ] || continue
+    if [ "$code" != "$prev_code" ]; then
+      case "$code" in
+        A) warn "$WARN_A" ;;
+        B) warn "$WARN_B" ;;
+        C) warn "$WARN_C" ;;
+        D) warn "$WARN_D" ;;
+        *) warn "$label" ;;
+      esac
+      prev_code="$code"
+    fi
+    printf '%s%s\n' "$PINNING_REPORT_INDENT" "$entry" >&2
+  done <<< "$records"
 fi
 
 if [ "$found" -eq 1 ]; then

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -1430,7 +1430,7 @@ _pinning_hooks=(
   "$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-alert.sh"
   "$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-guard.sh"
 )
-for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR; do
+for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX PINNING_REPORT_INDENT PINNING_PARTIAL_HASH_FINDING_LABEL_SUBSTR PINNING_PATTERN_A_LABEL PINNING_PATTERN_B_LABEL PINNING_PATTERN_C_LABEL PINNING_PATTERN_D_LABEL; do
   _lib_line="$(grep -m1 -E "^${_var}=" "$_pinning_lib" || true)"
   if [ -n "$_lib_line" ]; then
     pass "pinning $_var shared lib 정의 OK"
@@ -1438,7 +1438,7 @@ for _var in PATTERN_A PATTERN_B PATTERN_C PATTERN_D HASH_MIN HASH_MAX PINNING_PA
     fail "pinning $_var 정의 부재 ($_pinning_lib)"
   fi
 done
-for _fn in pinning_findings_text pinning_match_count pinning_should_check_path pinning_strip_partial_hash_finding; do
+for _fn in pinning_findings_records pinning_findings_text pinning_match_count pinning_should_check_path; do
   if grep -m1 -E "^${_fn}\(\)" "$_pinning_lib" >/dev/null 2>&1; then
     pass "pinning $_fn shared lib 함수 OK"
   else

--- a/tests/fixtures/codex-hooks/commit-msg/line-token-a-positive.expected
+++ b/tests/fixtures/codex-hooks/commit-msg/line-token-a-positive.expected
@@ -1,0 +1,4 @@
+[WARN] pinning: 라운드 카운터(`Round N`) 박제 감지. 영구 산출물에는 자연어 설명으로 표현하라.
+  - Round counter 박제: 'Round N'
+         1: Round 5
+[WARN] pinning: 위 경고는 차단하지 않습니다 (warn-only). 검토 후 amend로 정정하거나 의도적 사용이면 무시하세요.

--- a/tests/fixtures/codex-hooks/commit-msg/line-token-a-positive.msg
+++ b/tests/fixtures/codex-hooks/commit-msg/line-token-a-positive.msg
@@ -1,0 +1,1 @@
+fix: track Round 5 baseline measurement

--- a/tests/fixtures/codex-hooks/commit-msg/line-token-b-positive.expected
+++ b/tests/fixtures/codex-hooks/commit-msg/line-token-b-positive.expected
@@ -1,0 +1,4 @@
+[WARN] pinning: DA finding ID 박제 감지. 라운드/finding ID는 휘발성 보고에만 사용하고 commit message에는 박지 마라.
+  - Bundle finding ID 박제: 'Bundle-N'
+         1: Correctness-1
+[WARN] pinning: 위 경고는 차단하지 않습니다 (warn-only). 검토 후 amend로 정정하거나 의도적 사용이면 무시하세요.

--- a/tests/fixtures/codex-hooks/commit-msg/line-token-b-positive.msg
+++ b/tests/fixtures/codex-hooks/commit-msg/line-token-b-positive.msg
@@ -1,0 +1,1 @@
+fix: address Correctness-1 finding from review

--- a/tests/fixtures/codex-hooks/commit-msg/line-token-c-positive.expected
+++ b/tests/fixtures/codex-hooks/commit-msg/line-token-c-positive.expected
@@ -1,0 +1,4 @@
+[WARN] pinning: DA 키워드 박제 감지. 검토 라운드/모드 표기는 commit message에 박지 말고 PR 코멘트 또는 휘발성 작업 노트에 둬라.
+  - DA 실행 키워드 박제
+         1: DA for_pr
+[WARN] pinning: 위 경고는 차단하지 않습니다 (warn-only). 검토 후 amend로 정정하거나 의도적 사용이면 무시하세요.

--- a/tests/fixtures/codex-hooks/commit-msg/line-token-c-positive.msg
+++ b/tests/fixtures/codex-hooks/commit-msg/line-token-c-positive.msg
@@ -1,0 +1,1 @@
+refactor: simplify after DA for_pr feedback

--- a/tests/fixtures/codex-hooks/stdin/pinning-claude-edit-positive-4patterns.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-claude-edit-positive-4patterns.expected
@@ -1,5 +1,9 @@
 [pinning-alert] Edit on /tmp/fixture-pinning-positive.md 매치:
   - Round counter 박제: 'Round N'
+         1: Round 2
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Correctness-1
   - DA 실행 키워드 박제
+         1: DA for_pr
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: deadbeef

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-malformed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-malformed-positive.expected
@@ -1,2 +1,3 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-malformed.md 매치:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: 9c368446

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-mixed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-mixed-positive.expected
@@ -1,2 +1,3 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-mixed.md 매치:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: abc1234

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
@@ -1,2 +1,3 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-nonhex-suffix.md 매치:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: 9c368446

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-punct-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-github-attachment-punct-suffix-positive.expected
@@ -1,2 +1,6 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-github-attachment-punct-suffix.md 매치:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: 9c368446
+         1: 4307403c4c04
+         2: 9c368446
+         2: 4307403c4c04

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-md-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-md-positive.expected
@@ -1,2 +1,3 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-codex-md.md 매치:
   - Round counter 박제: 'Round N'
+         1: Round 3

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-moveto.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-moveto.expected
@@ -1,3 +1,5 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-new.md 매치:
   - Round counter 박제: 'Round N'
+         1: Round 4
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: deadbeef

--- a/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-multifile.expected
+++ b/tests/fixtures/codex-hooks/stdin/pinning-codex-applypatch-multifile.expected
@@ -1,3 +1,5 @@
 [pinning-alert] apply_patch on /tmp/fixture-pinning-tagged.md 매치:
   - Round counter 박제: 'Round N'
+         1: Round 6
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Maintainability-2

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-bash-cherrypick-comment.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-bash-cherrypick-comment.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: abc1234
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-bash-git-option-commit.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-bash-git-option-commit.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 16
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-bash-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-bash-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Regression-4
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-notebook-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-notebook-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] NotebookEdit on /tmp/fixture-pretooluse-claude.ipynb contains volatile review/session metadata:
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Maintainability-3
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-consult-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Write on /tmp/fixture-pretooluse-claude-write-consult.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: abc12345
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.expected
@@ -6,5 +6,5 @@
   - DA 실행 키워드 박제
          1: DA for_pr
   - 짧은 임시 hex 식별자 박제 (7~12자)
-         1: deadbeef
+         1: a3f8c1d2
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.expected
@@ -1,10 +1,10 @@
-[pinning-guard] Edit on /tmp/fixture-pretooluse-claude-edit.md contains volatile review/session metadata:
+[pinning-guard] Write on /tmp/da-x/../../home/greenhead/Workspace/nixos-config/docs/review.md contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
-         1: Round 4
+         1: Round 5
   - Bundle finding ID 박제: 'Bundle-N'
-         1: Correctness-2
+         1: Correctness-1
   - DA 실행 키워드 박제
          1: DA for_pr
   - 짧은 임시 hex 식별자 박제 (7~12자)
-         1: cafebabe
+         1: deadbeef
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/tmp/da-x/../../home/greenhead/Workspace/nixos-config/docs/review.md",
+    "content": "Round 5 Correctness-1 DA for_pr deadbeef token. Path traversal should not bypass the whitelist."
+  }
+}

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny.json
@@ -2,6 +2,6 @@
   "tool_name": "Write",
   "tool_input": {
     "file_path": "/tmp/da-x/../../home/greenhead/Workspace/nixos-config/docs/review.md",
-    "content": "Round 5 Correctness-1 DA for_pr deadbeef token. Path traversal should not bypass the whitelist."
+    "content": "Round 5 Correctness-1 DA for_pr a3f8c1d2 token. Path traversal should not bypass the whitelist."
   }
 }

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-workspace-clean.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-workspace-clean.json
@@ -2,6 +2,6 @@
   "tool_name": "Write",
   "tool_input": {
     "file_path": "/tmp/da-test-abc/finding.md",
-    "content": "Round 5 Correctness-1 DA for_pr deadbeef token. DA workspace scratch should be exempt."
+    "content": "Round 5 Correctness-1 DA for_pr a3f8c1d2 token. DA workspace scratch should be exempt."
   }
 }

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-workspace-clean.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-workspace-clean.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/tmp/da-test-abc/finding.md",
+    "content": "Round 5 Correctness-1 DA for_pr deadbeef token. DA workspace scratch should be exempt."
+  }
+}

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Write on /tmp/fixture-pretooluse-claude-write-positive.md contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 14
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-consult-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-consult.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: abc12345
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-malformed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-malformed-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-malformed.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: 9c368446
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-mixed-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-mixed-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-mixed.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: abc1234
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-nonhex-suffix-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-nonhex-suffix.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: 9c368446
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-punct-suffix-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-github-attachment-punct-suffix-positive.expected
@@ -1,3 +1,7 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-github-attachment-punct-suffix.md contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: 9c368446
+         1: 4307403c4c04
+         2: 9c368446
+         2: 4307403c4c04
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-moveto.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-moveto.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-new.md contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 7
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-multifile.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-multifile.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-multi.md contains volatile review/session metadata:
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Design-5
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-multimatch.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-multimatch.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex-a.md contains volatile review/session metadata:
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Design-5
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-applypatch-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] apply_patch on /tmp/fixture-pretooluse-codex.md contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 6
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-cherrypick-comment.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-cherrypick-comment.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - 짧은 임시 hex 식별자 박제 (7~12자)
+         1: abc1234
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-gh-api-comment.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-gh-api-comment.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 18
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-git-option-commit.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-git-option-commit.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 17
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-bash-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Bash on durable shell command contains volatile review/session metadata:
   - Bundle finding ID 박제: 'Bundle-N'
+         1: Security-6
 Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-write-positive.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-codex-write-positive.expected
@@ -1,3 +1,4 @@
 [pinning-guard] Write on /tmp/fixture-pretooluse-codex-write-positive.md contains volatile review/session metadata:
   - Round counter 박제: 'Round N'
+         1: Round 15
 Use stable identifiers or plain natural-language context before retrying.


### PR DESCRIPTION
## Summary

- pinning-guard deny / pinning-alert warn 메시지가 모든 패턴 카테고리에 대해 매칭 line:token 증거를 표시하도록 확장. 자식 LLM이 어디서 차단됐는지 한 번에 식별해 다음 액션으로 바로 이어갈 수 있다.
- DA reviewer scratch 디렉토리(`/tmp/da-*/*`, `/var/folders/*/T/da-*/*`)를 화이트리스트에 추가해 reviewer dump가 더 이상 durable artifact 검사를 받지 않도록 한다. path traversal과 canonicalization 실패는 fail-closed로 처리.
- 공유 라이브러리에 구조화 finding record API를 도입해 PreToolUse guard·PostToolUse alert·commit-msg hook이 모두 같은 출력 계약을 사용하게 한다.

Closes #665

## 기존 문제/배경

`~/.claude/hooks/pinning-guard.sh` PreToolUse hook이 Edit/Write/NotebookEdit/Bash deny 시 LLM에 카테고리 라벨만 알려주고 partial-hash를 제외한 다른 패턴은 어디 어떤 토큰이 매칭됐는지 표시하지 않았다. 그 결과 자식 LLM이 같은 자리를 다시 시도하거나, 다른 파일로 회피하거나, grep으로 진단을 시도하며 turn을 낭비했다.

이슈 본문에 박제된 측정 결과(1238 Claude jsonl 전수조사):

| 신호 | 값 |
|------|---|
| 실측 deny 이벤트 | 45건 (6 세션) |
| 차단 surface | Write 32건(71%) / Edit 7건(16%) / Bash 6건(13%) |
| 차단 path | TMP `.md` (DA workspace) 26건 / durable `.md` 10건 / durable shell 6건 / `.sh` 3건 |
| 후속 동작 retry-same / try-different / investigate | 15 / 15 / 10 (총 89%) |
| **추가 turn 낭비율** | **40/45 = 89%** |

추가로 차단 path 26건이 DA reviewer scratch `.md` 파일에 집중되어 있었다. 이는 durable artifact가 아닌 임시 결과 dump이지만 path classifier가 `.md` 확장자만 보고 검사 대상으로 잡았다.

## CIR (Change Intent Record)

- **이번 변경**: deny 메시지가 카테고리 라벨만 노출하던 결함을 line:token 증거 표시로 해소하고, DA reviewer scratch path를 검사 대상에서 제외해 false-positive를 즉시 줄인다.
- **방향 유지**: line:token 표시 형식은 partial-hash 카테고리가 이미 사용하던 9-space indent 포맷을 그대로 다른 카테고리로 확장하여 사용자/LLM에게 일관된 출력 계약을 보존한다.
- **방향 보강**: 단순 텍스트 helper 확장으로 시작했으나, commit-msg hook과의 출력 책임 통합이 라벨 substring 매칭이라는 brittle 분기 API를 만든다는 우려가 검토에서 누적되어 카테고리 코드를 반환하는 구조화 record API로 전환했다. consumer는 사람용 표시 텍스트가 아니라 안정적 카테고리 코드(A/B/C/D)로 분기하므로 라벨 문구 변경이 분기 로직을 깨지 않는다.
- **명시적 trade-off**: DA scratch 화이트리스트는 `gh ... --body-file` / `-F body=@file` 같은 우회 경로를 통한 trust boundary 약화를 동반한다. 본 PR은 26건 false-positive 즉시 해소를 우선하고, body-file 우회는 별도 sub-issue #684로 분리해 추적한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 카테고리 라벨에 line:token 단순 추가 | 기존 `pinning_findings_text`에 매칭 라인을 append만 한다 | 변경 범위 최소 | commit-msg hook은 자체 helper를 가지고 있어 출력 책임 통합 안 됨, partial-hash revert/cherry-pick 예외가 indent 라인까지 함께 제거하지 못해 fixture 깨짐 | ❌ |
| 라벨 substring 상수 노출 + commit-msg가 매핑 | 라벨 문자열 상수를 lib에 노출하고 commit-msg가 substring으로 매칭해 패턴별 안내 prefix를 붙인다 | lib 통합 + 안내 문구 보존 | 사람용 표시 텍스트가 분기 API가 되어 라벨 문구를 다듬으면 commit-msg 매핑이 깨짐, partial-hash revert 예외 처리도 출력 포맷에 결합 | ❌ |
| 카테고리 코드 반환 구조화 record API | lib가 `<code>\t<label>\t<line>:<token>` TSV를 반환, consumer가 코드로 분기 후 자체 렌더 | 표시 텍스트와 분기 API 분리, partial-hash 예외도 record 단계에서 명시 skip 옵션으로 처리, lib 내부 wrapper로 사람용 텍스트 일관 조립 | 변경 범위 1.5-2배 확대 (lib API 신규 + 4 consumer 수정 + verify-ai-compat surface 갱신 + 기존 fixture 일괄 갱신) | ✅ |
| DA scratch 우회 경로 본 PR에 통합 해결 | targeted Bash hook이 `--body-file`/`-F body=@file` 인자를 파싱해 대상 파일도 검사 | trust boundary 약화 즉시 해소 | 본 PR scope이 또 1.5배 확대, gh CLI 옵션 파싱이 별도 결함 표면을 만들 수 있음 | ❌ (sub-issue #684 분리) |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/lib/pinning-patterns.sh` | `PINNING_REPORT_INDENT` named constant 신규 + `pinning_findings_records` 신규 (구조화 TSV API, partial-hash skip 옵션 지원) + `pinning_findings_text` 재구현 (record를 사람용 텍스트로 조립, skip 인자 지원) + `pinning_partial_hash_report` indent 리터럴을 named constant 참조로 교체 + `pinning_should_check_path`에 path canonicalization (실패 시 fail-closed) + segment 기반 traversal 거부 + DA scratch 디렉토리 두 패턴 면제 + 기존 strip helper 제거 (record 단계 skip으로 대체) + 라벨 상수 (`PINNING_PATTERN_*_LABEL`) 신규 노출 |
| Claude `modules/shared/programs/claude/files/hooks/pinning-guard.sh` | Bash 분기에서 기존 strip helper 호출을 `pinning_findings_text "$file" 1` (skip_partial_hash 인자) 단일 호출로 대체 |
| Codex `modules/shared/programs/codex/files/hooks/pinning-guard.sh` | 동일 마이그레이션 + dead helper `_scan_text` 제거 |
| `scripts/ai/commit-msg-pinning.sh` | 자체 `check_ere` helper 제거 + `pinning_findings_records` 호출 후 카테고리 코드별로 verbose remediation 안내 prefix 출력. A/B/C는 라벨 라인 + indent line:token, D는 기존 verbose-only 출력 보존 (기존 fixture 계약) |
| `scripts/ai/verify-ai-compat.sh` | shared lib helper surface 검증 목록에서 기존 strip helper 제거 + `pinning_findings_records` 추가 + 신규 named constant·라벨 상수 검증 추가 |
| `tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-{workspace-clean,traversal-deny}.{json,expected}` | 신규 fixture 2종 — DA scratch dir contents clean pass + path traversal deny 검증 |
| `tests/fixtures/codex-hooks/commit-msg/line-token-{a,b,c}-positive.{msg,expected}` | 신규 fixture 3종 — A/B/C 카테고리에 대한 commit-msg verbose + label + indent line:token 출력 검증 |
| `tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-*-positive.expected` 외 다수 | 기존 positive expected 일괄 갱신 — 모든 카테고리에 line:token 증거 라인 추가에 따른 strict diff 동기화 |

### 핵심 변경 — 구조화 finding record API

```bash
# 라이브러리는 <category_code>\t<label>\t<line>:<token> TSV를 반환
pinning_findings_records() {
  local scan_file="$1"
  local skip_partial_hash="${2:-}"
  _pinning_simple_records "$scan_file" "A" "$PATTERN_A" "$PINNING_PATTERN_A_LABEL"
  _pinning_simple_records "$scan_file" "B" "$PATTERN_B" "$PINNING_PATTERN_B_LABEL"
  _pinning_simple_records "$scan_file" "C" "$PATTERN_C" "$PINNING_PATTERN_C_LABEL"
  if [ -z "$skip_partial_hash" ]; then
    _pinning_partial_hash_records "$scan_file"
  fi
}
```

revert/cherry-pick 예외는 record 생성 단계에서 partial-hash 카테고리를 명시적으로 skip하므로 사용자가 별도로 rendered 텍스트를 사후에 잘라낼 필요가 없다. 호출자(Claude/Codex Bash 분기)는 `pinning_findings_text "$file" 1`만 부르고, lib wrapper가 record와 텍스트 동기화를 보장한다.

### 핵심 변경 — path canonicalization fail-closed

```bash
pinning_should_check_path() {
  local raw="$1"
  case "$raw" in
    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
  esac
  local path
  path="$(pinning_canonicalize_path "$raw")"
  if [ -z "$path" ]; then
    return 0  # 정규화 불가 시 검사 대상으로 처리
  fi
  case "$path" in
    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
  esac
  ...
  case "$path" in
    /tmp/da-*/*) return 1 ;;
    /var/folders/*/T/da-*/*) return 1 ;;
  esac
}
```

화이트리스트는 디렉토리 내부 경로(separator 포함)만 매칭하므로 `/tmp/da-body.md` 같은 단일 임시 마크다운은 계속 검사 대상이다. canonicalization 실패 시 raw path를 신뢰하지 않고 검사 대상으로 fail-closed.

## 참고 레퍼런스

- 정책 SSOT: `~/.claude/CLAUDE.md` Durable output pinning policy 섹션
- 라이브러리 SSOT: `modules/shared/programs/claude/files/lib/pinning-patterns.sh`
- 후속 sub-issue: #684 (targeted Bash hook이 `--body-file` / `-F body=@file` 대상 파일 내용도 재스캔하도록 확장)
- 인접 이슈: #666, #667, #668

## Human Test Plan

1. **deny 메시지 형식 확인**
   - 진행: 임시 마크다운 파일을 만들어 카테고리 A/B/C/D 매칭 텍스트를 Write로 시도
   - 기대: deny reason에 카테고리 라벨 라인 + 9-space indent된 `<line>: <token>` 라인이 카테고리마다 표시됨
   - 실패 시: `pinning_findings_text` 출력을 스모크로 직접 확인. PATTERN regex 매칭 누락 여부와 indent 폭 (정확히 9 spaces) 확인.

2. **DA scratch 디렉토리 면제 확인**
   - 진행: `/tmp/da-test/finding.md` 같은 디렉토리 내부 마크다운에 매칭 텍스트를 Write
   - 기대: deny 발생하지 않음 (clean pass)
   - 실패 시: `pinning_should_check_path` smoke로 디렉토리 내부 path가 `return 1`을 반환하는지 확인. canonicalization이 정상 동작하는지 (`realpath -m` / `readlink -f` 가용성) 함께 확인.

3. **단일 임시 마크다운은 계속 검사**
   - 진행: `/tmp/da-body.md` 같은 단일 임시 파일에 매칭 텍스트를 Write
   - 기대: deny 발생 (`/tmp/da-*/*` 화이트리스트는 디렉토리 내부 경로만 매칭하므로 단일 파일은 검사 대상 유지)
   - 실패 시: 화이트리스트 패턴이 `/tmp/da-*` (single trailing wildcard)로 잘못 변경된 경우. case 분기 형태가 `/tmp/da-*/*`인지 확인.

4. **path traversal 거부**
   - 진행: `/tmp/da-x/../../home/repo/file.md`처럼 traversal 포함 경로를 Write
   - 기대: deny 발생 (traversal 패턴이 raw 단계에서 거부)
   - 실패 시: `pinning_should_check_path` 첫 case 분기가 `*/../*`, `../*`, `*/..`, `..` 패턴을 모두 포함하는지 확인.

5. **literal `..` 파일명은 기존 화이트리스트 유지**
   - 진행: `tests/fixtures/codex-hooks/README..md` 같은 path를 Write
   - 기대: deny 발생하지 않음 (`tests/fixtures/*` 화이트리스트가 그대로 적용)
   - 실패 시: traversal 패턴이 `*..*` raw matching으로 회귀했는지 확인. 정확한 segment 패턴(위 4개)이어야 한다.

6. **commit-msg 카테고리별 출력**
   - 진행: 카테고리 A/B/C/D 매칭 텍스트가 들어간 commit message로 commit 시도
   - 기대: stderr에 카테고리별 verbose 안내 + (A/B/C는 라벨 라인 +) 9-space indent line:token 블록이 출력됨. exit code 0 (warn-only).
   - 실패 시: `commit-msg-pinning.sh`가 `pinning_findings_records` 호출 결과를 카테고리 코드(A/B/C/D)로 분기 처리하는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

> "변경된 hook과 lib 파일이 helper-clean하고 화이트리스트 패턴이 의도대로 좁혀져 있다."

```bash
# 모든 변경 shell이 shellcheck 통과
shellcheck modules/shared/programs/claude/files/lib/pinning-patterns.sh \
           modules/shared/programs/claude/files/hooks/pinning-guard.sh \
           modules/shared/programs/claude/files/hooks/pinning-alert.sh \
           modules/shared/programs/codex/files/hooks/pinning-guard.sh \
           scripts/ai/commit-msg-pinning.sh

# 화이트리스트 패턴이 디렉토리 내부 경로만 매칭하도록 좁혀져 있다 (`/tmp/da-*/*` + `/var/folders/*/T/da-*/*`)
grep -nE '/tmp/da-\*/\*|/var/folders/\*/T/da-\*/\*' \
  modules/shared/programs/claude/files/lib/pinning-patterns.sh

# legacy strip helper와 그 호출은 모두 제거됐다
! grep -rn 'pinning_strip_partial_hash_finding' \
  modules/shared/programs/claude/files/lib/ \
  modules/shared/programs/claude/files/hooks/ \
  modules/shared/programs/codex/files/hooks/ \
  scripts/ai/

# 신규 helper와 named constant가 lib에 정의되어 있다
grep -nE 'pinning_findings_records\(\)|^PINNING_REPORT_INDENT=' \
  modules/shared/programs/claude/files/lib/pinning-patterns.sh
```

- 기대: 첫 번째 명령은 무경고(또는 기존 baseline info만), 두 번째와 마지막 grep은 매칭, 세 번째 grep은 빈 출력.
- 실패 시: 해당 파일을 읽어 변경이 누락된 부분을 확인하고 PR scope에서 빠진 위치를 보강한다.

### Phase 1: hook fixture 전수

> "기존과 신규 fixture 모두 통과한다."

```bash
bash tests/test-codex-hook-fixtures.sh
```

- 기대: `All codex hook fixture tests passed.` exit 0.
- 실패 시: 실패한 fixture의 expected와 hook 출력을 비교한다. 출력 형식이 의도된 변경과 다르면 expected 갱신, 의도와 다른 회귀라면 코드 수정.

### Phase 2: 호환성 검증

> "AI 도구 호환성과 helper surface가 새 API와 일치한다."

```bash
./scripts/ai/verify-ai-compat.sh
```

- 기대: 모든 OK, exit 0. 특히 `pinning pinning_findings_records shared lib 함수 OK`와 신규 named constant 검증이 통과.
- 실패 시: `scripts/ai/verify-ai-compat.sh`의 helper surface 목록과 라이브러리 정의가 동기화됐는지 확인.

### Phase 3: Activation surface

> "Deployed hook이 source 변경을 그대로 반영한다."

```bash
nrs

# Deployed hook과 source의 차이가 없어야 한다
diff -u ~/.claude/lib/pinning-patterns.sh \
        modules/shared/programs/claude/files/lib/pinning-patterns.sh
diff -u ~/.claude/hooks/pinning-guard.sh \
        modules/shared/programs/claude/files/hooks/pinning-guard.sh
diff -u ~/.codex/hooks/pinning-guard.sh \
        modules/shared/programs/codex/files/hooks/pinning-guard.sh
```

- 기대: `nrs` 정상 종료, 모든 diff 빈 출력 (deployed hook이 source와 동일).
- 실패 시: home-manager symlink 경로를 확인하고 `nrs` 로그에서 activation 단계 이슈를 찾는다.

### Phase 4: Smoke - 화이트리스트 동작

> "DA scratch 디렉토리는 면제, 단일 임시 파일과 traversal은 검사."

```bash
bash -c '
  source modules/shared/programs/claude/files/lib/pinning-patterns.sh
  pinning_should_check_path "/tmp/da-test/finding.md" \
    && echo "FAIL: DA dir contents should be exempt" \
    || echo "PASS: DA dir contents exempt"
  pinning_should_check_path "/tmp/da-body.md" \
    && echo "PASS: single da- file checked" \
    || echo "FAIL: single da- file incorrectly excluded"
  pinning_should_check_path "/tmp/da-x/../../home/repo/file.md" \
    && echo "PASS: traversal rejected (checked)" \
    || echo "FAIL: traversal incorrectly excluded"
  pinning_should_check_path "tests/fixtures/codex-hooks/README..md" \
    && echo "FAIL: README..md should remain exempt" \
    || echo "PASS: README..md exempt"
'
```

- 기대: 모든 라인이 `PASS:`.
- 실패 시: `pinning_should_check_path` 분기 순서와 case 패턴을 다시 확인.

### Phase 5: Regression — alert/commit-msg 자동 풍부화

> "PostToolUse alert와 commit-msg가 같은 lib helper를 통해 line:token 증거를 함께 출력한다."

```bash
# Alert (warn-only) — PATTERN_A 매칭 텍스트로 stderr 풍부화 확인
SCAN=$(mktemp /tmp/alert-staging-XXXXXX.txt)
# PATTERN_A regex는 `~/.claude/lib/pinning-patterns.sh`에서 직접 확인하고
# fixture에 들어갈 텍스트는 그 정규식을 보고 즉석 생성 (본 PR 본문은 자기 차단 회피).
echo '<PATTERN_A 매칭 텍스트>' > "$SCAN"
printf '{"tool_name":"Edit","tool_input":{"file_path":"/tmp/test.md","new_string":"%s"}}\n' \
  "$(cat "$SCAN")" \
  | bash modules/shared/programs/claude/files/hooks/pinning-alert.sh 2>&1 >/dev/null \
  | tail -5
rm "$SCAN"
```

- 기대: stderr에 카테고리 라벨 + 9-space indent된 line:token 출력.
- 실패 시: `pinning_findings_text`가 record를 받아 사람용 텍스트로 조립하는 wrapper인지 확인 (간접 호출 경로 동기화).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection and reporting of pinned code values (rounds, bundle findings, keywords, identifiers) with improved categorization
  * Strengthened path security checks to prevent symlink and directory traversal bypass attempts

* **Tests**
  * Updated test fixture expectations to reflect improved detection accuracy and structured warning outputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->