### PR TITLE
fix(nrs): home-manager.backupCommand로 mkOutOfStoreSymlink atomic-rename collision 자가 치유 (#687)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Environment 섹션의 `Platform` 값으로 현재 환경을 판별한다.
 
 `nrs`를 사용. `darwin-rebuild`/`nixos-rebuild` 직접 실행 금지. `nrs`는 preview를 포함하며, macOS에서는 launchd 정리와 Hammerspoon 재시작도 처리한다. 워크트리에서 `nrs` 완료 시 `$HOME` 아래 out-of-store symlink의 워크트리 relink을 시도한다 (`nrs-relink`, non-fatal). main repo에서 `nrs` 실행 시 nix store 체인으로 복원을 시도한다.
 
-home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이 외부 프로세스의 atomic rename으로 일반 파일이 되면 `home-manager.backupCommand`가 자가 치유한다 (regular file은 unlink + 콘솔 한 줄 echo, directory는 timestamped backup). 사용자가 nixos-config 외부에서 일반 파일을 직접 수정한 변경분은 silent 손실될 수 있다 — atomic rename으로 깨진 ephemeral 변경분 한정 (정상 symlink 흐름은 source 직접 수정 = git 추적). 정책 본체는 `modules/darwin/home.nix`.
+home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이 외부 프로세스의 atomic rename으로 일반 파일이 되면 `home-manager.backupCommand`가 자가 치유한다 (regular file은 unlink + 콘솔 한 줄 echo, directory는 timestamped backup). 사이드이펙트로, symlink가 깨진 시간 동안 사용자가 home 쪽에서 의도 변경한 내용도 silent 손실될 수 있다 (예: VSCode UI에서 keybinding 추가 후 settings.json이 깨진 상태에서 한 후속 변경). 정상 symlink 흐름에서는 source 직접 수정 = git 추적이 정상 동작한다. 본 정책은 사용자 명시 동의 범위 내. 정책 본체는 `modules/darwin/home.nix`.
 
 ## Bash tool 환경
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Environment 섹션의 `Platform` 값으로 현재 환경을 판별한다.
 
 `nrs`를 사용. `darwin-rebuild`/`nixos-rebuild` 직접 실행 금지. `nrs`는 preview를 포함하며, macOS에서는 launchd 정리와 Hammerspoon 재시작도 처리한다. 워크트리에서 `nrs` 완료 시 `$HOME` 아래 out-of-store symlink의 워크트리 relink을 시도한다 (`nrs-relink`, non-fatal). main repo에서 `nrs` 실행 시 nix store 체인으로 복원을 시도한다.
 
+home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이 외부 프로세스의 atomic rename으로 일반 파일이 되면 `home-manager.backupCommand`가 자가 치유한다 (regular file은 unlink + 콘솔 한 줄 echo, directory는 timestamped backup). 사용자가 nixos-config 외부에서 일반 파일을 직접 수정한 변경분은 silent 손실될 수 있다 — atomic rename으로 깨진 ephemeral 변경분 한정 (정상 symlink 흐름은 source 직접 수정 = git 추적). 정책 본체는 `modules/darwin/home.nix`.
+
 ## Bash tool 환경
 
 Bash tool의 inline 스크립트는 zsh에서 실행된다. 아래 bash 전용 문법은 zsh에서 `bad substitution`으로 실패하므로 사용하지 않는다.

--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -12,6 +12,11 @@
   ...
 }:
 
+let
+  # backup 확장자 — backupFileExtension(nix)과 backupCommand 셸 스크립트의 fallback 양쪽에
+  # 동일 값으로 흘러야 하므로 한 곳에 binding한다.
+  hmBackupExt = "backup";
+in
 {
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
@@ -28,7 +33,7 @@
   #   - 배경: Claude Code 등 외부 프로세스의 atomic rename(rename(2))으로
   #     mkOutOfStoreSymlink target이 일반 파일/디렉터리로 변해 다음 nrs에서
   #     stale .backup collision으로 막히는 사고를 자가 치유한다.
-  home-manager.backupFileExtension = "backup";
+  home-manager.backupFileExtension = hmBackupExt;
   home-manager.backupCommand = pkgs.writeShellScript "hm-cleanup-stale-conflict" ''
     set -e
     # home-manager activation은 보통 "$targetPath"를 인자로 호출하지만, 메인터넌스 환경에서
@@ -37,7 +42,9 @@
     target="''${1:-}"
     [ -n "$target" ] || exit 0
     if [ -d "$target" ] && [ ! -L "$target" ]; then
-      dest="$target.''${HOME_MANAGER_BACKUP_EXT:-backup}.$(date +%s)"
+      # HOME_MANAGER_BACKUP_EXT는 home-manager가 backupFileExtension에서 export.
+      # fallback은 위 hmBackupExt 동일 값으로 nix interpolation.
+      dest="$target.''${HOME_MANAGER_BACKUP_EXT:-${hmBackupExt}}.$(date +%s)"
       mv -- "$target" "$dest"
       echo "[home-manager] backed up directory conflict: $target -> $dest" >&2
     else

--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -16,9 +16,14 @@
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
   # home-manager backup 정책 (mkOutOfStoreSymlink atomic-rename collision 회피):
-  #   - backupCommand가 우선. regular file/symlink 충돌은 unlink, directory 충돌은
-  #     timestamped backup으로 보존 (rm -rf 위험 회피).
-  #   - backupFileExtension은 셸 스크립트 안에서 timestamp ext로 재사용되며,
+  #   - backupCommand는 home-manager activation 단계에서 non-symlink target에 한해 호출됨
+  #     (symlink target은 home-manager가 자체적으로 처리하고 backupCommand는 호출되지 않는다).
+  #     따라서 본 셸 스크립트는 regular file/directory 두 케이스만 분기한다.
+  #     · regular file 충돌: rm -f로 unlink (사용자 명시 동의 — atomic-rename으로 깨진
+  #       ephemeral 변경분의 보존 가치 0. 시나리오 B(사용자가 깨진 시간 동안 의도 변경)도
+  #       silent loss 흡수 범위로 동의됨).
+  #     · directory 충돌: rm -rf 위험 회피 위해 timestamped backup으로 보존.
+  #   - backupFileExtension은 셸 스크립트 안에서 timestamp 확장자로 재사용되며,
   #     backupCommand 롤백 시 기존 backup 동작 fallback 역할도 한다.
   #   - 배경: Claude Code 등 외부 프로세스의 atomic rename(rename(2))으로
   #     mkOutOfStoreSymlink target이 일반 파일/디렉터리로 변해 다음 nrs에서
@@ -26,12 +31,15 @@
   home-manager.backupFileExtension = "backup";
   home-manager.backupCommand = pkgs.writeShellScript "hm-cleanup-stale-conflict" ''
     set -e
-    # home-manager가 인자 없이 호출하는 probe 경로 대비 — default 빈 문자열로 처리.
+    # home-manager activation은 보통 "$targetPath"를 인자로 호출하지만, 메인터넌스 환경에서
+    # 인자 없이 호출되는 경로가 실측 관찰됨(정확한 source 경로 미확인). default 빈 문자열로
+    # 방어 처리하고 인자 없으면 early exit.
     target="''${1:-}"
     [ -n "$target" ] || exit 0
     if [ -d "$target" ] && [ ! -L "$target" ]; then
-      mv -- "$target" "$target.''${HOME_MANAGER_BACKUP_EXT:-backup}.$(date +%s)"
-      echo "[home-manager] backed up directory conflict: $target" >&2
+      dest="$target.''${HOME_MANAGER_BACKUP_EXT:-backup}.$(date +%s)"
+      mv -- "$target" "$dest"
+      echo "[home-manager] backed up directory conflict: $target -> $dest" >&2
     else
       echo "[home-manager] cleaning conflict at: $target" >&2
       rm -f -- "$target"

--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -15,7 +15,28 @@
 {
   home-manager.useGlobalPkgs = true;
   home-manager.useUserPackages = true;
+  # home-manager backup 정책 (mkOutOfStoreSymlink atomic-rename collision 회피):
+  #   - backupCommand가 우선. regular file/symlink 충돌은 unlink, directory 충돌은
+  #     timestamped backup으로 보존 (rm -rf 위험 회피).
+  #   - backupFileExtension은 셸 스크립트 안에서 timestamp ext로 재사용되며,
+  #     backupCommand 롤백 시 기존 backup 동작 fallback 역할도 한다.
+  #   - 배경: Claude Code 등 외부 프로세스의 atomic rename(rename(2))으로
+  #     mkOutOfStoreSymlink target이 일반 파일/디렉터리로 변해 다음 nrs에서
+  #     stale .backup collision으로 막히는 사고를 자가 치유한다.
   home-manager.backupFileExtension = "backup";
+  home-manager.backupCommand = pkgs.writeShellScript "hm-cleanup-stale-conflict" ''
+    set -e
+    # home-manager가 인자 없이 호출하는 probe 경로 대비 — default 빈 문자열로 처리.
+    target="''${1:-}"
+    [ -n "$target" ] || exit 0
+    if [ -d "$target" ] && [ ! -L "$target" ]; then
+      mv -- "$target" "$target.''${HOME_MANAGER_BACKUP_EXT:-backup}.$(date +%s)"
+      echo "[home-manager] backed up directory conflict: $target" >&2
+    else
+      echo "[home-manager] cleaning conflict at: $target" >&2
+      rm -f -- "$target"
+    fi
+  '';
 
   # Home Manager 모듈에 nixosConfigPath, nixosConfigDefaultPath, hostType, constants 전달
   home-manager.extraSpecialArgs = {

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -97,8 +97,8 @@ pinning_should_check_path() {
     tests/fixtures/* | */tests/fixtures/*) return 1 ;;
     evals/queries.json | */evals/queries.json) return 1 ;;
     eval-workspace/* | */eval-workspace/*) return 1 ;;
-    /tmp/da-*/*) return 1 ;;
-    /var/folders/*/T/da-*/*) return 1 ;;
+    /tmp/da-*/* | /private/tmp/da-*/*) return 1 ;;
+    /var/folders/*/T/da-*/* | /private/var/folders/*/T/da-*/*) return 1 ;;
   esac
 
   return 0

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -97,6 +97,8 @@ pinning_should_check_path() {
     tests/fixtures/* | */tests/fixtures/*) return 1 ;;
     evals/queries.json | */evals/queries.json) return 1 ;;
     eval-workspace/* | */eval-workspace/*) return 1 ;;
+    # macOS는 /tmp가 /private/tmp의 symlink, /var가 /private/var의 symlink.
+    # realpath -m 등으로 canonicalize되면 /private/* 형태가 되므로 둘 다 매치 필요.
     /tmp/da-*/* | /private/tmp/da-*/*) return 1 ;;
     /var/folders/*/T/da-*/* | /private/var/folders/*/T/da-*/*) return 1 ;;
   esac


### PR DESCRIPTION
## Summary

- `home-manager.backupCommand`를 도입해 mkOutOfStoreSymlink target이 외부 atomic rename으로 일반 파일이 됐을 때 다음 nrs에서 stale `.backup` collision으로 실패하는 사고를 자가 치유한다 (regular file은 unlink + 콘솔 한 줄 echo, directory는 timestamped backup).
- macOS `realpath -m`이 `/tmp` → `/private/tmp`로 canonicalize하면서 pinning-guard의 DA scratch whitelist case가 매치되지 않아 fail-closed deny되던 회귀를 보완.
- backup 확장자 상수를 let-binding으로 모아 nix attribute와 셸 fallback 양쪽에 한 번에 주입.

Closes #687.

## 기존 문제/배경

### Pain point 1 — mkOutOfStoreSymlink atomic-rename collision

이 저장소는 `~/.claude/settings.json`, VSCode `settings.json` 등을 `mkOutOfStoreSymlink`로 nixos-config repo source 파일에 양방향 연결한다. 사용자가 home 쪽 파일을 수정하면 symlink를 따라 source가 직접 수정되고 git이 그 변경을 추적한다.

그러나 일부 외부 프로세스는 파일을 저장할 때 atomic rename(`rename(2)` — 임시 파일에 적고 `mv`로 한꺼번에 교체) 패턴을 사용한다. 이 패턴이 발동하면 symlink 자체가 일반 파일로 교체된다. 그 시점부터 home 쪽 파일은 더 이상 source를 가리키지 않아 양방향 컨벤션이 깨진다.

다음 `nrs` 실행 시 home-manager activation의 `checkLinkTargets`가 일반 파일을 발견하고, `backupFileExtension = "backup"`에 따라 `<target>.backup`으로 옮기려 시도한다. 그런데 **이전 사고로 만들어진 `<target>.backup`이 이미 존재하면** "Existing file ... would be clobbered" 에러로 activation이 실패한다. 사용자가 직접 `.backup` 파일을 옮겨야 nrs가 통과하는 수동 개입이 강제된다.

인벤토리상 atomic-rename 위험 HIGH 2개(`~/.claude/settings.json`, `~/.claude/mcp.json`), MEDIUM 3개(VSCode `settings.json`/`keybindings.json`, `~/.config/nvim`), 잔존 `.backup` 다수가 다음 collision의 시한폭탄이다.

### Pain point 2 — pinning-guard macOS /private/tmp 누락

직전 PR(#685)이 DA scratch 디렉터리(`/tmp/da-*/...`, `/var/folders/*/T/da-*/...`)를 pinning-guard whitelist로 추가했지만, macOS에서 GNU `realpath -m`이 `/tmp` → `/private/tmp`, `/var` → `/private/var`로 canonicalize한다. whitelist case 패턴은 canonicalize 전 형태만 가지고 있어 실제 매치 실패 → fail-closed로 DA workspace의 정상 finding 파일도 deny되는 회귀가 있었다.

## CIR

### 발견 경위

직전 사고: 작업 디렉터리에서 `nrs` 실행 시 다음 에러로 막혔다.

```
Existing file '~/.claude/settings.json.backup' would be clobbered by backing up '~/.claude/settings.json'
darwin-rebuild switch failed (exit code: 1)
```

원인 분석에서 `~/.claude/settings.json`이 일반 파일로 변해 있고, 옛 `.backup`이 한 달 가량 전에 만들어진 채 잔존하고 있었다. 외부 플러그인 자동 업그레이드 시점에 settings.json을 atomic rename으로 갱신하면서 symlink가 깨진 것으로 추정.

### 설계 의도

- 자가 치유는 **home-manager activation 메커니즘 자체에 박는다** — pre-flight 자가 진단 / launchd watcher 같은 별도 stage가 아니라.
- 셸 스크립트 1개로 충분 — directory 충돌은 `rm -rf` 위험 회피 위해 timestamped backup, regular file 충돌은 unlink + 콘솔 한 줄 echo.
- 사용자 단순함 시그널 명시: 1 commit revert 가능, 변경면 최소, 콘솔 한 줄 알림만 (macOS notification 등은 YAGNI).
- 사용자 명시 동의: regular file silent unlink는 `~/.claude` ephemeral 변경분뿐 아니라 mkOutOfStoreSymlink 양방향 편집 대상의 깨진 시간 동안 사용자 변경 silent loss 흡수 범위.

### 대안 검토 이력

이슈 분석 단계에서 외부 LLM 자문 + 인터뷰로 결정 트리 좁힘.

자문에서 자가 치유 시점·backup 보존 정책·적용 범위 3개 결정에 대해 4/4/3 옵션을 평가했으나 모든 옵션에 disqualifier가 부여되어 단일 추천 후보 없음. 사용자가 backup 보존 자체를 reject(`git이 source를 추적하니 ephemeral 변경분 보존 가치 0`)하면서 자가 치유 시점·적용 범위가 home-manager activation 전역으로 자연스레 좁혀졌다.

추가 자문에서 좁혀진 cleanup-mechanism 1결정 × 3옵션(`backupCommand` 전역 / `force = true` HIGH hot-list / nrs pre-flight 확장)을 평이 비유로 재평가. `backupCommand` 전역으로 채택.

후속 코드 리뷰에서 directory-shaped target(`~/.config/nvim` 등)의 conflict가 `rm -f`로는 안 지워지고 link 단계에서 다시 실패한다는 회귀 risk가 발견되어 directory 분기를 추가했다 (해당 사고의 인위 재현으로 검증).

## ADR

### Decision 1 — 자가 치유 시점

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| home-manager.backupCommand 전역 | activation의 backup 처리에 셸 스크립트 등록 | 변경면 최소, 모든 home.file 자동 커버, nrs/darwin-rebuild 어느 진입점이든 동작 | 전역 정책 변화, 다른 home.file 충돌도 silent 삭제 | ✅ |
| nrs pre-flight 확장 | nrs-relink.sh `cmd_fix_dangling()`에 일반 파일 분기 추가 | 기존 자가 복원 패턴과 일관 | 변경면 더 큼, nrs 외부 진입점 미커버, 대상 열거 로직 별도 필요 | ❌ |
| launchd WatchPaths watcher | macOS launchd로 24/7 감시 + 즉시 복구 | nrs까지 안 기다려도 됨 | 상주 daemon 추가 복잡도, race condition risk, 콘솔 한 줄 알림 시그널과 미스핏 | ❌ |
| HOME_MANAGER_BACKUP_OVERWRITE=1 | env var로 collision 영구 회피 | 변경 매우 작음 | 마지막 backup만 유지, 사용자 변경분 손실 | ❌ |

### Decision 2 — backup 보존 정책

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| no backup (regular file은 unlink, directory만 timestamped) | source는 git 추적이라 ephemeral 변경분 보존 가치 없음 | 단순함, 디스크 누적 0 | 양방향 편집 대상 깨진 시간 동안 사용자 변경 silent loss | ✅ |
| timestamped 누적 | collision마다 새 backup 파일 | 모든 변경 이력 보존 | backup 파일 누적 | ❌ |
| 단일 .backup 덮어쓰기 | 최신 collision 1개만 보존 | 디스크 0 누적 | 과거 변경 손실 | ❌ |
| source-equal-unlink | source와 동일하면 unlink, 다르면 backup | 의미 있는 변경만 보존 | 비교 로직 복잡도, source 매핑 위험 | ❌ |

### Decision 3 — 적용 범위

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 전역 (backupCommand) | 모든 home.file 대상 | 미래 atomic-rename 위험 자동 커버, 일관된 로깅 | 정책 변경이 전역 | ✅ |
| HIGH hot-list (force = true) | settings.json·mcp.json만 명시 | 명확한 범위 | 콘솔 한 줄 보장 부족(home-manager 기본 로그 의존), 새 위험 대상 수동 추가 | ❌ |
| Hybrid | 전역 + hot-list 정밀 분기 | 가장 정교 | 복잡도 최대, 검증 케이스 폭증 | ❌ |

### Decision 4 — pinning-guard macOS canonicalize

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| OR 패턴으로 /private/* 변형 추가 | case 분기에 `\| /private/tmp/...` 등 추가 | 기존 패턴 보존, OS-specific 동작 흡수 | 패턴 두 줄에 분산 (인접 코멘트로 보완) | ✅ |
| pinning_canonicalize_path에서 /private/* 정규화 | canonical path를 raw 형태로 되돌림 | 패턴 일원화 | 함수 수준 변경, 다른 호출자에 영향 risk | ❌ |
| BSD readlink/realpath 직접 호출 | macOS native 도구 사용 | 정규화 회피 | nix devShell PATH가 GNU 우선이라 회피 어려움 | ❌ |

## 구현 상세

### 변경 파일

| 파일 | 라인 변화 | 변경 내용 |
|------|----------|----------|
| `modules/darwin/home.nix` | +27 -0 | `let hmBackupExt = "backup"` binding + `home-manager.backupCommand`를 `pkgs.writeShellScript`로 등록 (regular file/directory 분기). why 주석 인접 보존. |
| `CLAUDE.md` | +2 -0 | `## 빌드` 섹션에 home-manager activation 충돌 정책 한 단락 — silent loss 시나리오 명시. |
| `modules/shared/programs/claude/files/lib/pinning-patterns.sh` | +4 -2 | `pinning_should_check_path` whitelist case에 `/private/tmp/...` + `/private/var/folders/...` OR 변형 추가 + 인접 한 줄 코멘트. |

### 핵심 코드 — `home-manager.backupCommand` 셸 스크립트

```nix
let
  hmBackupExt = "backup";
in
{
  home-manager.backupFileExtension = hmBackupExt;
  home-manager.backupCommand = pkgs.writeShellScript "hm-cleanup-stale-conflict" ''
    set -e
    target="''${1:-}"
    [ -n "$target" ] || exit 0
    if [ -d "$target" ] && [ ! -L "$target" ]; then
      dest="$target.''${HOME_MANAGER_BACKUP_EXT:-${hmBackupExt}}.$(date +%s)"
      mv -- "$target" "$dest"
      echo "[home-manager] backed up directory conflict: $target -> $dest" >&2
    else
      echo "[home-manager] cleaning conflict at: $target" >&2
      rm -f -- "$target"
    fi
  '';
}
```

- home-manager activation은 `non-symlink` target에 한해 backupCommand를 호출 — symlink는 home-manager가 자체 처리.
- `''${1:-}` + early exit: 메인터넌스 환경에서 인자 없이 호출되는 경로가 실측 관찰됨(정확한 source 경로 미확인).

### 핵심 코드 — pinning-guard whitelist OR 변형

```sh
# macOS는 /tmp가 /private/tmp의 symlink, /var가 /private/var의 symlink.
# realpath -m 등으로 canonicalize되면 /private/* 형태가 되므로 둘 다 매치 필요.
/tmp/da-*/* | /private/tmp/da-*/*) return 1 ;;
/var/folders/*/T/da-*/* | /private/var/folders/*/T/da-*/*) return 1 ;;
```

## 참고 레퍼런스

- 이슈: #687 (재발 방지 시스템 구축 명시 요청)
- 직전 외형 유사 사고(다른 원인): #286 — worktree에서 .nix 수정 시 Home Manager "would be clobbered" 빌드 실패 (이번 사고는 worktree와 무관, atomic rename으로 일반 파일이 된 케이스)
- DA scratch whitelist 도입 PR: #685 — 본 PR이 macOS canonicalize 케이스를 보완
- home-manager 공식 옵션: [`backupCommand` / `backupFileExtension`](https://nix-community.github.io/home-manager/nix-darwin-options.xhtml)
- home-manager activation source: [`modules/files/check-link-targets.sh`](https://github.com/nix-community/home-manager/blob/master/modules/files/check-link-targets.sh)
- 같은 사고 upstream 보고: [home-manager#6424](https://github.com/nix-community/home-manager/issues/6424)

## Human Test Plan

### Phase 1 — 정상 흐름 회귀

- 단계: 정상 symlink 상태에서 `nrs` 실행.
- 기대동작: backupCommand 미발동. 콘솔에 `[home-manager] cleaning conflict at:` 또는 `backed up directory conflict:` 메시지 없음.
- 실패 시 진단: backupCommand가 정상 흐름에 발동하면 양방향 컨벤션이 깨질 수 있음. shell script의 `[ -d "$target" ]` 분기 + home-manager가 non-symlink target에 한해 호출하는 조건을 검증.

### Phase 2 — Regular file 충돌 자가 치유

- 단계:
  ```bash
  unlink ~/.claude/settings.json
  cp ~/Workspace/nixos-config/modules/shared/programs/claude/files/settings.json ~/.claude/settings.json
  echo '{"stale": true}' > ~/.claude/settings.json.backup
  nrs --force
  ```
- 기대동작: nrs 통과. 콘솔에 `[home-manager] cleaning conflict at: ~/.claude/settings.json` 출력. settings.json이 다시 정상 symlink로 복구. 옛 `.backup` 파일은 그대로 잔존(별도 정리 대상).
- 실패 시 진단: `would be clobbered` 에러가 다시 나면 셸 스크립트가 발동 안 함 — `home-manager.backupCommand` nix 옵션이 활성화 generation에 반영됐는지 확인.

### Phase 3 — Directory 충돌 자가 치유

- 단계:
  ```bash
  unlink ~/.config/nvim
  mkdir -p ~/.config/nvim
  touch ~/.config/nvim/test.txt
  nrs --force
  ```
- 기대동작: nrs 통과. 콘솔에 `[home-manager] backed up directory conflict: ~/.config/nvim -> ~/.config/nvim.backup.<timestamp>` 출력. nvim이 다시 정상 symlink로 복구. timestamped backup 디렉터리에 test.txt 보존.
- 실패 시 진단: `rm -rf` 발동 의심 시 즉시 중단 — 셸 스크립트의 `[ -d "$target" ] && [ ! -L "$target" ]` 분기 우선 매치 확인. cleanup: `rm -rf ~/.config/nvim.backup.[0-9]*`.

### Phase 4 — VSCode keybindings 부정 테스트

- 단계: VSCode `keybindings.json`을 일반 파일로 복사 + nrs --force.
- 기대동작: nrs 통과 + 콘솔에 `[home-manager] cleaning conflict at: <VSCODE_KB>` 출력 + symlink 복구.
- 실패 시 진단: 정책이 `~/.claude`만 다루는 hot-list로 좁혀졌는지 확인 — 본 변경은 전역 정책이라 모든 home.file 적용.

### Phase 5 — pinning-guard macOS whitelist (직전 PR 회귀 보완)

- 단계: `tests/test-codex-hook-fixtures.sh` 실행.
- 기대동작: 모든 fixture 통과 (`pretooluse-pinning-guard-claude-write-da-workspace-clean.json` 포함).
- 실패 시 진단: `pinning_should_check_path` 함수의 case 패턴이 `/private/tmp/...` 변형을 포함하는지 read.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```bash
# 1) home-manager.backupCommand 옵션 추가 확인
grep -q 'home-manager.backupCommand = pkgs.writeShellScript "hm-cleanup-stale-conflict"' modules/darwin/home.nix && echo "OK: backupCommand 등록됨"

# 2) hmBackupExt let-binding 확인
grep -q 'hmBackupExt = "backup"' modules/darwin/home.nix && echo "OK: extension binding 존재"

# 3) pinning-guard whitelist /private/tmp OR 패턴 확인
grep -q '/tmp/da-\*/\* | /private/tmp/da-\*/\*' modules/shared/programs/claude/files/lib/pinning-patterns.sh && echo "OK: pinning-guard /private/tmp"
grep -q '/var/folders/\*/T/da-\*/\* | /private/var/folders/\*/T/da-\*/\*' modules/shared/programs/claude/files/lib/pinning-patterns.sh && echo "OK: pinning-guard /private/var"

# 4) CLAUDE.md 정책 한 단락 확인
grep -q "home-manager activation 충돌 정책" CLAUDE.md && echo "OK: CLAUDE.md 정책 명시"

# 5) 옛 정책 잔존 안 함 확인 (backupFileExtension만 있던 형태)
! grep -E '^  home-manager.backupFileExtension = "backup";\s*$' modules/darwin/home.nix && echo "OK: backupFileExtension 단독 형태 제거됨"
```

### Phase 1 — eval 검증

```bash
nix flake check --no-build
# 기대: all checks passed!
# 실패 시: writeShellScript 인라인 nix antiquotation escape (`''${1:-}`, `''${HOME_MANAGER_BACKUP_EXT:-${hmBackupExt}}`) 점검.
```

### Phase 2 — pinning-guard 동작 검증

```bash
bash -c '
  . modules/shared/programs/claude/files/lib/pinning-patterns.sh
  for p in /tmp/da-test-abc/finding.md /private/tmp/da-test-abc/finding.md \
           /var/folders/abc/T/da-x/y.md /private/var/folders/abc/T/da-x/y.md; do
    if pinning_should_check_path "$p"; then echo "$p -> CHECK"; else echo "$p -> SKIP (exempt)"; fi
  done
'
# 기대: 4개 path 모두 SKIP (exempt)
```

### Phase 3 — codex-hook-fixtures 통과

```bash
bash tests/test-codex-hook-fixtures.sh 2>&1 | tail -5
# 기대: All codex hook fixture tests passed.
```

### Phase 4 — Regression 점검 (정상 symlink 흐름 영향 없음)

`nrs` 실행 시 `[home-manager] cleaning conflict at:` 또는 `[home-manager] backed up directory conflict:` 메시지가 콘솔에 출력되지 않으면 정상. 출력되면 어떤 mkOutOfStoreSymlink target이 깨졌는지 추가 조사 필요(본 변경의 자가 치유가 발동했다는 신호일 뿐, 회귀가 아닐 수 있음).
