### PR TITLE
chore(claude): remove codex-plugin-cc plugin and marketplace

### DIFF
--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -188,18 +188,8 @@
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": false,
     "slack@claude-plugins-official": true,
-    "codex@openai-codex": true,
     "atlassian@claude-plugins-official": true,
     "figma@claude-plugins-official": true
-  },
-  "extraKnownMarketplaces": {
-    "openai-codex": {
-      "source": {
-        "source": "github",
-        "repo": "openai/codex-plugin-cc"
-      },
-      "autoUpdate": true
-    }
   },
   "language": "Korean",
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
## Summary

- `enabledPlugins["codex@openai-codex"]`와 `extraKnownMarketplaces.openai-codex`를 `modules/shared/programs/claude/files/settings.json`에서 제거.
- 다음 Claude 실행부터 codex-plugin-cc(Codex Companion)가 비활성화·재등록 차단된다.
- 머지 후 사용자 측에서 `claude plugin uninstall codex@openai-codex` + `claude plugin marketplace remove openai-codex`로 런타임 캐시(`~/.claude/plugins/{cache,marketplaces}/openai-codex`, `installed_plugins.json`, `known_marketplaces.json`)를 청소한다.

## 기존 문제 / 배경

codex-plugin-cc는 Claude Code의 Stop hook 시점에 Codex 세션을 자동 트리거하는 형태(`hooks.json`의 Stop → `scripts/stop-review-gate-hook.mjs`)로 작동한다. 사용 중 다음 문제가 누적됨.

- **Codex 사이드바 오염**: 매 Claude turn 종료마다 "Codex Companion Task: <task> Run a stop-gate review of the previous Claude turn …" 세션이 생성되어, 사용자가 직접 띄운 Codex 세션과 시각적으로 구분 불가. 프로젝트별 사이드바가 review-gate 항목으로 도배되며 노이즈가 심함.
- **maintainer 유지보수 정체**: 최신 버전 1.0.4가 약 3주째 동결. 이슈/PR 응답이 느려 단기 개선 가능성이 낮음.
- **활용도 저하**: 초기에는 turn별 자동 리뷰가 유용했으나 최근에는 거의 사용하지 않으며, 같은 역할은 필요 시 `/run-da` 또는 명시적 `codex review` 호출로 대체 가능.

## CIR (Change Intent Record)

이 변경은 "원래의 자동 stop-gate 리뷰 자체"가 더 이상 가치보다 비용(세션 오염·노이즈)이 크다고 판단한 결과다. 일시적 비활성화(`enabledPlugins` 값을 `false`)로 끝낼 수도 있지만, 그러면 마켓플레이스 등록과 자동 업데이트(`autoUpdate: true`)가 살아있어 다음 마켓플레이스 갱신 주기에 캐시가 다시 부풀고, 사용자가 우연히 UI에서 enable로 토글할 위험도 남는다. 따라서 enable 항목과 marketplace 등록을 함께 제거해 "재등록되지 않는 상태"를 선언적으로 보장한다.

저장소 내 `codex@openai-codex`/`codex-plugin-cc` 참조를 전수 조사한 결과 `modules/shared/programs/claude/files/settings.json` 한 곳이 SoT였고, hook 정의는 플러그인 내부(`~/.claude/plugins/marketplaces/openai-codex/plugins/codex/hooks/hooks.json`)에 있어 settings.json에서 플러그인을 빼면 자동으로 사라진다 — 추가 hook 정리 작업 불필요.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 비활성화만 (`enabledPlugins` 값을 `false`) | 마켓플레이스 등록·캐시는 그대로 두고 enable 플래그만 false | 변경 최소, 향후 재활성화 쉬움 | `autoUpdate: true`로 캐시가 계속 갱신될 가능성, UI에서 우발적 enable 위험, 이미 사용 안 할 거라면 캐시 유지 가치 없음 | ❌ |
| enable 제거 + 마켓플레이스 유지 | enable 줄만 삭제, `extraKnownMarketplaces.openai-codex`는 유지 | enable 제거로 hook은 즉시 차단됨 | 같은 마켓플레이스가 등록된 채 남아 다른 플러그인 설치 흐름에서 혼동 유발, 정리가 절반만 끝남 | ❌ |
| **enable + 마켓플레이스 모두 제거** | 두 블록을 settings.json에서 함께 제거 | 선언적 SoT가 깨끗해지고 재등록 경로 차단, hook도 자연스럽게 사라짐 | 다시 사용하고 싶을 때 두 블록을 복원해야 함(낮은 비용) | ✅ |
| nix 모듈에서 플러그인 차단 옵션 추가 | `programs.claude.disablePlugins` 같은 옵션을 nix 레벨에 신설 | 향후 다른 플러그인 제거 시 재사용 | YAGNI — 현재 다른 제거 대상 없음, 단발성 변경에 추상화 과함 | ❌ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claude/files/settings.json` | `enabledPlugins."codex@openai-codex"` 1줄 제거, `extraKnownMarketplaces.openai-codex` 객체 통째 제거 (총 -10줄) |

핵심 diff:

```diff
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": false,
     "slack@claude-plugins-official": true,
-    "codex@openai-codex": true,
     "atlassian@claude-plugins-official": true,
     "figma@claude-plugins-official": true
   },
-  "extraKnownMarketplaces": {
-    "openai-codex": {
-      "source": {
-        "source": "github",
-        "repo": "openai/codex-plugin-cc"
-      },
-      "autoUpdate": true
-    }
-  },
   "language": "Korean",
```

수정하지 않은 항목과 사유:
- `modules/shared/programs/claude/default.nix`: settings.json을 mkOutOfStoreSymlink로 노출만 하므로 플러그인 직접 참조 없음.
- `modules/shared/programs/codex/files/config.toml`: codex-plugin-cc는 Claude Code 전용이며 Codex에 등록된 적 없음.
- 13개 worktree(`.claude/worktrees/issue_*/.../settings.json`)의 동일 항목: 각 브랜치는 main 머지/리베이스 시 자동 동기화되므로 별도 수정하지 않음. 워크트리에서 별도로 Claude를 띄워야 하면 그 시점에 cherry-pick 또는 rebase로 동기화.

## 참고 레퍼런스

- 외부: openai/codex-plugin-cc (현재 1.0.4 동결 상태)
- 플러그인 hook 정의 위치: `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/hooks/hooks.json` (SessionStart/SessionEnd/Stop) — 플러그인 비활성화로 자동 무효화됨.

## Human Test Plan

머지 후 사용자가 직접 수행:

1. main 브랜치 동기화: `git checkout main && git pull`.
2. settings.json은 mkOutOfStoreSymlink라 즉시 반영되지만, 안전하게 `nrs` 한 번 실행해 home-manager activation 일관성 확인.
3. 런타임 캐시 정리:
   ```
   claude plugin uninstall codex@openai-codex
   claude plugin marketplace remove openai-codex
   ```
4. Claude Code 완전 종료 후 새 세션 시작 → 한 turn 진행 후 Stop.
5. Codex 앱 사이드바에서 새로운 "Codex Companion Task: …" 항목이 추가되지 않는지 육안 확인.

실패 시 진단:
- 새 항목이 여전히 생성됨 → `claude plugin list`에 codex@openai-codex가 살아있는지 확인. settings.json의 변경이 ~/.claude/settings.json까지 symlink로 반영됐는지 `readlink ~/.claude/settings.json` + `grep openai-codex ~/.claude/settings.json`로 확인.
- 캐시 디렉토리가 남음 → `claude plugin marketplace remove openai-codex`가 정상 종료했는지, exit code와 stderr 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1) settings.json에 codex-plugin-cc 참조가 모두 제거됐는지
grep -n "codex-plugin-cc\|codex@openai-codex\|openai-codex" \
  modules/shared/programs/claude/files/settings.json
# 기대: 출력 없음 (exit code 1)

# 2) 다른 nix 모듈에 새로 끌려들어온 참조가 없는지
grep -rn "codex-plugin-cc\|codex@openai-codex" \
  modules/ flake.nix 2>/dev/null
# 기대: 출력 없음

# 3) JSON 유효성
python3 -m json.tool < modules/shared/programs/claude/files/settings.json > /dev/null
echo "exit=$?"
# 기대: exit=0

# 4) 다른 enabledPlugins 항목이 보존됐는지(slack/atlassian/figma)
grep -E '"(slack|atlassian|figma)@claude-plugins-official"' \
  modules/shared/programs/claude/files/settings.json
# 기대: 3줄 출력
```

진단:
- (1)(2) 출력이 있으면 grep 결과의 파일/줄을 확인하고 누락된 제거를 마저 적용.
- (3) exit≠0이면 콤마 누락 가능성 → `python3 -m json.tool`의 에러 라인 참고.
- (4) 누락이면 무관한 항목까지 지웠을 수 있음 → diff 재확인.

### Phase 1: nix 빌드 무결성 (선택, 본 PR은 이미 lefthook flake-check 통과)

```bash
nix flake check --no-build
```
기대: 에러 없음. 본 변경은 evaluation 영역이라 build까지 갈 필요 없음.

### Phase 2: 회귀(Regression) — 다른 플러그인이 살아있는지

다음 키가 settings.json에 모두 존재해야 한다 (이번 변경의 사이드이펙트로 사라지면 안 됨):
- `slack@claude-plugins-official`
- `atlassian@claude-plugins-official`
- `figma@claude-plugins-official`
- `skill-creator@claude-plugins-official`

```bash
for k in slack@claude-plugins-official atlassian@claude-plugins-official \
         figma@claude-plugins-official skill-creator@claude-plugins-official; do
  grep -q "\"$k\"" modules/shared/programs/claude/files/settings.json \
    && echo "OK: $k" || echo "MISSING: $k"
done
```
기대: 4줄 모두 OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin configuration settings to adjust which plugins are enabled and their order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->