### PR TITLE
perf(skills): analyzing-da-sessions SSH multiplexing + worker pool로 양 호스트 5분 회복

### DIFF
--- a/modules/darwin/programs/ssh/default.nix
+++ b/modules/darwin/programs/ssh/default.nix
@@ -40,6 +40,11 @@ in
         hostname = constants.network.minipcTailscaleIP;
         user = "greenhead";
         identityFile = sshKeyPath;
+        extraOptions = {
+          ControlMaster = "auto";
+          ControlPath = "~/.ssh/cm-%h-%p-%r";
+          ControlPersist = "600";
+        };
       };
     };
   };

--- a/modules/nixos/programs/ssh-client/default.nix
+++ b/modules/nixos/programs/ssh-client/default.nix
@@ -20,6 +20,11 @@ in
         hostname = constants.network.macbookTailscaleIP;
         user = "green";
         identityFile = sshKeyPath;
+        extraOptions = {
+          ControlMaster = "auto";
+          ControlPath = "~/.ssh/cm-%h-%p-%r";
+          ControlPersist = "600";
+        };
       };
     };
   };

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/SKILL.md
@@ -92,6 +92,6 @@ pytest tests/
 
 - 사용자 명시 호출 전용. Claude Code는 자연어 trigger로 자동 호출되지 않는다 (frontmatter `disable-model-invocation: true`). Codex는 동등 메커니즘이 없어 자동 trigger 차단이 best-effort이다.
 - `--hosts` 값은 `{mac, minipc}` whitelist 외에는 reject-fast.
-- 원격 path는 `HOST_PATH_MAP` base prefix 아래의 `.jsonl` 파일만 허용 (제어문자/shell metacharacter 거부).
+- 원격 path는 `HOST_PATH_MAP` base prefix 아래의 `.jsonl` 파일만 허용 (제어문자/shell metacharacter 거부 + `posixpath.commonpath` boundary 비교로 sibling-prefix 거부 — 상세는 `references/host-handling.md` "Command path vs validation/corpus path 역할 분리" 참조). SSH 명령 인자에는 host-neutral relative tilde 표현 (`~/.claude/projects` 등)을 사용한다.
 - SSH 실패는 silent fallback 금지. partial result + warnings 누적 + 명시적 경고 표시.
 - JSON sidecar 자동 경로(`/tmp/...`)는 재시작 시 휘발. 영구 저장은 `--json out=` 명시.

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md
@@ -7,7 +7,7 @@
 | Mac (`/Users/green`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
 | MiniPC (`/home/greenhead`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
 
-원격 호스트는 `subprocess.run(["ssh", alias, "find", "...", "-name", "*.jsonl", ...])` 고정 argv로 path 목록만 수집한 뒤, 실제 파일 내용은 `subprocess.run(["ssh", alias, "cat", path])`로 한 번에 가져온다 (large repo는 batch).
+원격 호스트는 `subprocess.run(["ssh", alias, "find", "~/.claude/projects", "-name", "*.jsonl", ...])` 고정 argv로 path 목록만 수집한 뒤, 실제 파일 내용은 `subprocess.run(["ssh", alias, "cat", path])`로 가져온다. 호스트당 SSH cat 호출은 ControlMaster 다중화 + `concurrent.futures.ThreadPoolExecutor(max_workers=SSH_FETCH_WORKERS)`로 병렬 처리한다 (host 순차 진행, host당 K=8 fetch 병렬). ControlMaster 비활성 호스트는 K=1로 강등된다.
 
 `/subagents/` 하위 jsonl은 분석에서 제외한다 (parent session에서 spawn된 보조 에이전트의 자체 산출물이 아닌 wrapper output이라 verdict 중복 카운트 위험).
 

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md
@@ -7,7 +7,7 @@
 | Mac (`/Users/green`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
 | MiniPC (`/home/greenhead`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
 
-원격 호스트는 `subprocess.run(["ssh", alias, "find", "~/.claude/projects", "-name", "*.jsonl", ...])` 고정 argv로 path 목록만 수집한 뒤, 실제 파일 내용은 `subprocess.run(["ssh", alias, "cat", path])`로 가져온다. 호스트당 SSH cat 호출은 ControlMaster 다중화 + `concurrent.futures.ThreadPoolExecutor(max_workers=SSH_FETCH_WORKERS)`로 병렬 처리한다 (host 순차 진행, host당 K=8 fetch 병렬). ControlMaster 비활성 호스트는 K=1로 강등된다.
+원격 호스트는 `subprocess.run(["ssh", alias, "find", "~/.claude/projects", "-name", "*.jsonl", ...])` 고정 argv로 path 목록만 수집한 뒤, 실제 파일 내용은 `subprocess.run(["ssh", alias, "cat", path])`로 가져온다. 호스트당 SSH cat 호출은 ControlMaster 다중화 + `concurrent.futures.ThreadPoolExecutor(max_workers=SSH_FETCH_WORKERS)`로 병렬 처리한다 (host 순차 진행, host당 K=8 fetch 병렬). ControlMaster가 비활성인 호스트는 K=1 직렬 fallback이 5분 budget 안에 끝나지 않으므로 fetch 자체를 skip하고 명시적 warning을 누적한다 (사용자가 ControlMaster 활성화 누락을 즉시 인지).
 
 `/subagents/` 하위 jsonl은 분석에서 제외한다 (parent session에서 spawn된 보조 에이전트의 자체 산출물이 아닌 wrapper output이라 verdict 중복 카운트 위험).
 

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
@@ -93,7 +93,7 @@ remote `find` stdout의 path line은 **비신뢰 입력**으로 간주. 각 line
 absolute prefix는 다음 두 용도로만 사용한다:
 
 1. **Validation path**: `_allowed_remote_path`가 SSH find stdout (비신뢰 입력) 각 line을 검증할 때 boundary 비교 기준으로 사용한다. `posixpath.normpath` + `posixpath.commonpath([base_norm, path_norm]) == base_norm` 비교로 sibling-prefix (`/Users/green/.claude/projects-evil/...`), traversal (`../../etc/shadow`), relative path (find stdout이 비정상으로 relative line을 내보낸 경우)를 모두 거부한다.
-2. **Corpus path**: `--corpus manifest.json` 모드에서 host 분류 prefix로도 사용한다 (`HOST_PATH_MAP` base prefix 순회 + 기존 `/Users/` `/home/` simple prefix fallback).
+2. **Corpus path**: `--corpus manifest.json` 모드에서 host 분류 prefix로도 사용한다 (`HOST_PATH_MAP` base prefix 순회). 미매칭 path는 silent host 배정 대신 warning만 누적한다 — 새 host 지원은 `HOST_PATH_MAP`에 명시 추가가 정답이다.
 
 이 역할 분리는 PR review thread의 `HOST_PATH_MAP` fragility 질문에 답한다 — 명령 구성에서는 hardcoded prefix를 제거하지만, 보안 경계와 corpus host inference에는 absolute prefix가 SSOT로 남는다 (host model 중앙화는 별도 PR로 분리, 본 reference의 NG-3 참조).
 
@@ -103,6 +103,7 @@ absolute prefix는 다음 두 용도로만 사용한다:
 - `find <prefix> -type f -name "*.jsonl"` (path glob)
 - `cat <path>` (파일 내용 read)
 - `stat <path>` (파일 메타 — 선택)
+- `true` (ControlMaster master 생성/활성 확인용 transport control). `ssh -O check <host>` 자체는 client 측 multiplex control이며 원격 명령을 실행하지 않는다.
 
 `rm`, `mv`, `mkdir`, `git`, `curl`, `wget` 등은 사용하지 않는다 (read-only 분석 의도).
 

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
@@ -132,4 +132,4 @@ JSON sidecar의 `warnings` 배열에도 같은 메시지가 들어간다.
 | mac | `/Users/green/.claude/projects/` | `/Users/green/.codex/sessions/` |
 | minipc | `/home/greenhead/.claude/projects/` | `/home/greenhead/.codex/sessions/` |
 
-`--corpus manifest.json` 사용 시 path prefix(`/Users/` 또는 `/home/`)로 host 자동 분류.
+`--corpus manifest.json` 사용 시 위 표의 `HOST_PATH_MAP` base prefix를 우선 순회하여 host를 분류한다. 미매칭 path는 `warnings` 누적 후 처리에서 제외 — 새 host 지원은 `HOST_PATH_MAP` 추가가 정답이다 (silent host 배정 회피).

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
@@ -38,9 +38,12 @@ for h in args.hosts:
 shell string 금지. 항상 list argv 형태로 subprocess.run 호출. **단 ssh remote command는 원격 shell이 해석하므로 path 안의 shell metacharacter / 제어문자도 거부해야 명령 인젝션을 차단한다** — argv 고정만으로는 충분하지 않다. `analyze.py`의 `_allowed_remote_path` 검증이 SoT.
 
 검증 조건:
-- path가 `HOST_PATH_MAP[host]["claude"]` 또는 `HOST_PATH_MAP[host]["codex"]` base prefix 아래 (`os.sep` 포함).
+- 다음 문자 부재: space, newline, carriage return, tab, `; | & $ \` ( ) { } [ ] < > * ? " ' \\`.
 - 확장자 `.jsonl`로 종결.
-- 다음 문자 부재: newline, carriage return, tab, `; | & $ \` ( ) { } [ ] < > * ? " ' \\`.
+- `posixpath.normpath`로 traversal(`../`) 정규화.
+- `posixpath.isabs`로 relative path 폐기 (find stdout이 비정상으로 relative line을 내보낸 경우).
+- `posixpath.commonpath([base_norm, path_norm]) == base_norm and path_norm != base_norm` boundary 비교 — sibling-prefix(`/Users/green/.claude/projects-evil/x.jsonl`) 거부, absolute/relative mix는 ValueError로 폐기.
+- 비교 대상 base는 `HOST_PATH_MAP[host]["claude"]` 또는 `HOST_PATH_MAP[host]["codex"]` absolute prefix.
 
 검증 실패 시 `ValueError` 또는 (find stdout 처리에서는) silently 폐기.
 
@@ -48,13 +51,28 @@ shell string 금지. 항상 list argv 형태로 subprocess.run 호출. **단 ssh
 def _allowed_remote_path(host: str, path: str) -> bool:
     if not isinstance(path, str) or not path:
         return False
-    if any(c in path for c in "\n\r\t;|&$`(){}[]<>*?\"'\\"):
+    if any(c in path for c in " \n\r\t;|&$`(){}[]<>*?\"'\\"):
         return False
     if not path.endswith(".jsonl"):
         return False
+    try:
+        path_norm = posixpath.normpath(path)
+    except Exception:
+        return False
+    if not posixpath.isabs(path_norm):
+        return False
     paths = HOST_PATH_MAP.get(host, {})
     bases = (paths.get("claude", ""), paths.get("codex", ""))
-    return any(b and path.startswith(b + os.sep) for b in bases)
+    for base in bases:
+        if not base:
+            continue
+        base_norm = posixpath.normpath(base)
+        try:
+            if posixpath.commonpath([base_norm, path_norm]) == base_norm and path_norm != base_norm:
+                return True
+        except ValueError:
+            continue
+    return False
 ```
 
 **금지**:
@@ -67,6 +85,17 @@ def _allowed_remote_path(host: str, path: str) -> bool:
 - `subprocess.run(["ssh", alias, "cat", path], ...)` — argv 고정. **path는 `_allowed_remote_path` 통과 후에만**.
 
 remote `find` stdout의 path line은 **비신뢰 입력**으로 간주. 각 line을 `_allowed_remote_path`로 다시 검증하여 통과한 line만 수집한다.
+
+## Command path vs validation/corpus path 역할 분리
+
+`HOST_PATH_MAP`의 absolute home prefix (`/Users/green/...`, `/home/greenhead/...`)는 **SSH 명령 인자에 직접 들어가지 않는다**. 명령 인자에는 host-neutral relative tilde 표현 (`~/.claude/projects`, `~/.codex/sessions`)을 사용해 host별 home directory hardcoded를 명령 구성에서 제거한다. 원격 shell이 `~`를 해당 user의 home으로 expansion한다.
+
+absolute prefix는 다음 두 용도로만 사용한다:
+
+1. **Validation path**: `_allowed_remote_path`가 SSH find stdout (비신뢰 입력) 각 line을 검증할 때 boundary 비교 기준으로 사용한다. `posixpath.normpath` + `posixpath.commonpath([base_norm, path_norm]) == base_norm` 비교로 sibling-prefix (`/Users/green/.claude/projects-evil/...`), traversal (`../../etc/shadow`), relative path (find stdout이 비정상으로 relative line을 내보낸 경우)를 모두 거부한다.
+2. **Corpus path**: `--corpus manifest.json` 모드에서 host 분류 prefix로도 사용한다 (`HOST_PATH_MAP` base prefix 순회 + 기존 `/Users/` `/home/` simple prefix fallback).
+
+이 역할 분리는 PR review thread의 `HOST_PATH_MAP` fragility 질문에 답한다 — 명령 구성에서는 hardcoded prefix를 제거하지만, 보안 경계와 corpus host inference에는 absolute prefix가 SSOT로 남는다 (host model 중앙화는 별도 PR로 분리, 본 reference의 NG-3 참조).
 
 ## remote command allowlist
 

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
@@ -29,6 +29,7 @@ Output:
 """
 
 import argparse
+import concurrent.futures
 import datetime
 import glob
 import json
@@ -37,6 +38,7 @@ import platform
 import re
 import subprocess
 import sys
+import threading
 from collections import Counter, defaultdict
 from typing import Any, Iterable
 
@@ -126,6 +128,8 @@ SEVERITY_LOOKAHEAD_CHARS = 1000  # finding_id 등장 위치 기준 뒤쪽 탐색
 SSH_FIND_TIMEOUT_SECONDS = 60  # 원격 호스트의 find 명령 timeout
 SSH_CAT_TIMEOUT_SECONDS = 120  # 원격 호스트의 cat 명령 timeout
 FLEISS_KAPPA_TIMEOUT_SECONDS = 60  # fleiss-kappa.py helper 호출 timeout (현재 v1에서는 미사용)
+SSH_FETCH_WORKERS = 8  # 원격 호스트당 동시 SSH cat worker 수 (host 순차 처리, host당 K=8 병렬)
+SSH_CONTROLMASTER_CHECK_TIMEOUT_SECONDS = 10  # ssh -O check / ssh true preflight timeout
 
 
 def current_host() -> str:
@@ -810,6 +814,62 @@ def fetch_remote_file(host: str, path: str, warnings: list[str]) -> str | None:
     return proc.stdout
 
 
+def check_controlmaster_active(host: str, warnings: list[str]) -> bool:
+    """ControlMaster master socket이 활성인지 확인. 비활성이면 master 생성을 1회 시도 후 재확인.
+
+    `ssh -O check <host>`는 master 부재 시 실패한다. 따라서 실패 시 일반 `ssh <host> true`로
+    master 생성 시도 후 다시 `-O check`로 확인하는 2단계 sequence로 구성한다.
+
+    返回值이 False이면 worker pool은 K=1로 강등된다 (degrade fallback).
+    """
+    _validate_host(host)
+    try:
+        proc = subprocess.run(
+            ["ssh", "-O", "check", host],
+            capture_output=True,
+            text=True,
+            timeout=SSH_CONTROLMASTER_CHECK_TIMEOUT_SECONDS,
+        )
+        if proc.returncode == 0:
+            return True
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    # master 부재로 추정 — `ssh true`로 master 생성 시도
+    try:
+        gen = subprocess.run(
+            ["ssh", host, "true"],
+            capture_output=True,
+            text=True,
+            timeout=SSH_CONTROLMASTER_CHECK_TIMEOUT_SECONDS,
+        )
+        if gen.returncode != 0:
+            warnings.append(
+                f"host {host}: ssh true (ControlMaster 생성 시도) 실패 (rc={gen.returncode}) — degrade to K=1"
+            )
+            return False
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        warnings.append(
+            f"host {host}: ssh true 시간 초과 또는 binary 부재 — degrade to K=1"
+        )
+        return False
+    # 재확인
+    try:
+        re_check = subprocess.run(
+            ["ssh", "-O", "check", host],
+            capture_output=True,
+            text=True,
+            timeout=SSH_CONTROLMASTER_CHECK_TIMEOUT_SECONDS,
+        )
+        if re_check.returncode == 0:
+            return True
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    warnings.append(
+        f"host {host}: ControlMaster 재확인 실패 — degrade to K=1 (handshake 비용 잔존)"
+    )
+    return False
+
+
 def analyze_remote_session(host: str, path: str, warnings: list[str]) -> dict | None:
     """원격 jsonl을 fetch하여 임시 파일에 쓰고 analyze_session 호출."""
     content = fetch_remote_file(host, path, warnings)
@@ -904,19 +964,50 @@ def main() -> int:
                 files_by_host[host] = collect_remote_files(host, warnings)
         corpus_label = "live"
 
-    # 분석
+    # 분석 — host 순차 처리, remote host는 ControlMaster preflight 후 worker pool dispatch
     sessions: list[dict] = []
+    warnings_lock = threading.Lock()
+
+    def _safe_warn(msg: str) -> None:
+        with warnings_lock:
+            warnings.append(msg)
+
     for host, files in files_by_host.items():
-        for path in files:
-            if host == cur_host or args.corpus:
-                # corpus 모드는 절대 path가 현재 머신에서 read 가능한 경우만 처리
-                if args.corpus and host != cur_host:
-                    # corpus의 다른 호스트 파일은 SSH로 fetch
-                    result = analyze_remote_session(host, path, warnings)
-                else:
-                    result = analyze_session(path)
-            else:
-                result = analyze_remote_session(host, path, warnings)
+        is_remote = host != cur_host
+        if not is_remote:
+            # local: 직렬 처리 (파일 read는 빠름, 동시성 이득 미미)
+            for path in files:
+                result = analyze_session(path)
+                if result is not None:
+                    sessions.append(result)
+            continue
+
+        # remote: ControlMaster preflight + worker pool
+        cm_active = check_controlmaster_active(host, warnings)
+        worker_count = SSH_FETCH_WORKERS if cm_active else 1
+        if not cm_active:
+            warnings.append(
+                f"host {host}: ControlMaster 비활성 — worker pool을 K=1로 강등 (성능 저하)"
+            )
+
+        # remote_warnings는 worker별로 따로 받지 않고 동일 list를 lock으로 보호
+        def _fetch_one(p: str) -> tuple[str, dict | None]:
+            res = analyze_remote_session(host, p, warnings)  # warnings는 lock 없이도 누적되나, 안전을 위해 _safe_warn 우회 사용
+            return (p, res)
+
+        host_results: list[tuple[str, dict | None]] = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+            futures = {executor.submit(_fetch_one, p): p for p in files}
+            for fut in concurrent.futures.as_completed(futures):
+                try:
+                    host_results.append(fut.result())
+                except Exception as e:
+                    p = futures[fut]
+                    _safe_warn(f"host {host}: worker exception for {p}: {type(e).__name__}: {e}")
+
+        # path 기준 정렬 후 sessions append (deterministic ordering)
+        host_results.sort(key=lambda pair: pair[0])
+        for _, result in host_results:
             if result is not None:
                 sessions.append(result)
 

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
@@ -39,7 +39,6 @@ import posixpath
 import re
 import subprocess
 import sys
-import threading
 from collections import Counter, defaultdict
 from typing import Any, Iterable
 
@@ -983,8 +982,10 @@ def main() -> int:
             print(f"ERROR: corpus manifest read failed: {e}", file=sys.stderr)
             return 1
         all_files = manifest.get("files", [])
-        # host 분류는 HOST_PATH_MAP base prefix 순회 (D-6) — 호스트 추가 시 한 곳만 수정.
-        # `/Users/` / `/home/` 단순 prefix 분기는 `HOST_PATH_MAP`에 없는 OS의 fallback으로 보존.
+        # host 분류는 HOST_PATH_MAP base prefix 순회 — 호스트 추가 시 한 곳만 수정.
+        # 미매칭 path는 silent host 배정 대신 warning만 누적한다 (예전 단순 /Users/-mac
+        # /home/-minipc fallback은 HOST_PATH_MAP 경계를 우회하는 별도 규칙이라 제거 —
+        # 새 host 지원은 HOST_PATH_MAP에 명시 추가가 정답).
         files_by_host: dict[str, list[str]] = defaultdict(list)
         for f in all_files:
             matched = False
@@ -997,13 +998,7 @@ def main() -> int:
                 if matched:
                     break
             if not matched:
-                # fallback (기존 동작 보존)
-                if f.startswith("/Users/"):
-                    files_by_host["mac"].append(f)
-                elif f.startswith("/home/"):
-                    files_by_host["minipc"].append(f)
-                else:
-                    warnings.append(f"corpus host unclassified: {f}")
+                warnings.append(f"corpus host unclassified (HOST_PATH_MAP 미일치): {f}")
         corpus_label = manifest.get("snapshot_id", "pinned")
     else:
         files_by_host = defaultdict(list)
@@ -1014,13 +1009,10 @@ def main() -> int:
                 files_by_host[host] = collect_remote_files(host, warnings)
         corpus_label = "live"
 
-    # 분석 — host 순차 처리, remote host는 ControlMaster preflight 후 worker pool dispatch
+    # 분석 — host 순차 처리, remote host는 ControlMaster preflight 후 worker pool dispatch.
+    # 각 worker는 local warnings list로 분리 수집한 뒤 main thread에서 path 순으로 merge
+    # 한다 (warning ordering deterministic 보장).
     sessions: list[dict] = []
-    warnings_lock = threading.Lock()
-
-    def _safe_warn(msg: str) -> None:
-        with warnings_lock:
-            warnings.append(msg)
 
     for host, files in files_by_host.items():
         is_remote = host != cur_host
@@ -1032,34 +1024,44 @@ def main() -> int:
                     sessions.append(result)
             continue
 
-        # remote: ControlMaster preflight + worker pool
+        # remote: ControlMaster preflight + worker pool.
+        # ControlMaster 비활성이면 K=1 강등이 5526 파일 직렬 fetch ≈ 37분으로 5분 timeout
+        # 안에 끝나기 어려우므로 fail-fast로 host 전체 fetch를 skip하고 명시적 warning을
+        # 누적한다. 사용자가 ControlMaster 활성화 (mac nrs 등) 누락을 즉시 인지할 수 있다.
         cm_active = check_controlmaster_active(host, warnings)
-        worker_count = SSH_FETCH_WORKERS if cm_active else 1
         if not cm_active:
             warnings.append(
-                f"host {host}: ControlMaster 비활성 — worker pool을 K=1로 강등 (성능 저하)"
+                f"host {host}: ControlMaster 비활성으로 fetch skip — 활성화 후 재실행 필요"
+                f" (직렬 fallback은 5분 budget 안에 완료 불가능). minipc는 nrs, mac은 사용자 수동 nrs."
             )
+            continue
 
-        # remote_warnings는 worker별로 따로 받지 않고 동일 list를 lock으로 보호
-        def _fetch_one(p: str) -> tuple[str, dict | None]:
-            res = analyze_remote_session(host, p, warnings)  # warnings는 lock 없이도 누적되나, 안전을 위해 _safe_warn 우회 사용
-            return (p, res)
+        # remote_warnings는 worker별로 분리 수집 후 main thread에서 path 순으로 merge.
+        # CPython GIL이 list.append를 atomic하게 보장하지만 worker 간 순서가 비결정적이므로
+        # 별도 list로 받아 deterministic ordering을 강제한다.
+        def _fetch_one(p: str) -> tuple[str, dict | None, list[str]]:
+            local_warnings: list[str] = []
+            res = analyze_remote_session(host, p, local_warnings)
+            return (p, res, local_warnings)
 
-        host_results: list[tuple[str, dict | None]] = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as executor:
+        host_results: list[tuple[str, dict | None, list[str]]] = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=SSH_FETCH_WORKERS) as executor:
             futures = {executor.submit(_fetch_one, p): p for p in files}
             for fut in concurrent.futures.as_completed(futures):
                 try:
                     host_results.append(fut.result())
                 except Exception as e:
                     p = futures[fut]
-                    _safe_warn(f"host {host}: worker exception for {p}: {type(e).__name__}: {e}")
+                    host_results.append((p, None, [
+                        f"host {host}: worker exception for {p}: {type(e).__name__}: {e}"
+                    ]))
 
-        # path 기준 정렬 후 sessions append (deterministic ordering)
-        host_results.sort(key=lambda pair: pair[0])
-        for _, result in host_results:
+        # path 기준 정렬 후 sessions append + warnings merge (deterministic ordering).
+        host_results.sort(key=lambda triple: triple[0])
+        for _, result, local_warnings in host_results:
             if result is not None:
                 sessions.append(result)
+            warnings.extend(local_warnings)
 
     # aggregate
     agg = build_aggregate(sessions, args.hosts, corpus_label, warnings)

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
@@ -35,6 +35,7 @@ import glob
 import json
 import os
 import platform
+import posixpath
 import re
 import subprocess
 import sys
@@ -109,7 +110,12 @@ SELECTIVE_LINE = re.compile(
     re.I,
 )
 
-# Host path mapping
+# Host path mapping —
+#   command path:    SSH 명령 인자는 `~/.claude/projects` 등 relative tilde 표현을 사용한다
+#                    (remote shell이 expansion). 본 map은 명령 인자에 직접 들어가지 않는다.
+#   validation path: `_allowed_remote_path` boundary check가 본 absolute prefix와 비교하여
+#                    SSH find stdout 비신뢰 line을 검증한다.
+#   corpus path:     `--corpus manifest.json` 모드에서 host 분류 prefix로도 사용한다 (D-6).
 HOST_PATH_MAP = {
     "mac": {
         "claude": "/Users/green/.claude/projects",
@@ -732,8 +738,17 @@ def _allowed_remote_path(host: str, path: str) -> bool:
 
     SSH remote command는 원격 shell이 해석하므로 shell metacharacter (`;`, `$()`,
     newline, backtick, space 등)가 포함된 경로는 명령 인젝션/word-splitting 위험이
-    있다. 따라서 정확한 HOST_PATH_MAP base prefix + .jsonl 확장자 + 제어문자/공백
-    부재만 통과시킨다.
+    있다. 따라서 다음 검사를 통과시킨다:
+
+    1. 제어문자/shell metacharacter/공백 부재.
+    2. `.jsonl` 확장자.
+    3. `posixpath.normpath`로 traversal(`../`) 정규화.
+    4. `posixpath.isabs`로 relative path 폐기 (find stdout 비신뢰).
+    5. `posixpath.commonpath([base_norm, path_norm]) == base_norm` boundary 비교 —
+       sibling-prefix(`/Users/green/.claude/projects-evil/...`)는 commonpath가
+       base_norm와 다르므로 거부. absolute/relative mix는 ValueError → 폐기.
+    6. `path_norm != base_norm`로 base 자체 통과를 차단 (`.jsonl` 확장자 검사가
+       이미 거부하지만 방어적 명시).
     """
     if not isinstance(path, str) or not path:
         return False
@@ -742,9 +757,25 @@ def _allowed_remote_path(host: str, path: str) -> bool:
         return False
     if not path.endswith(".jsonl"):
         return False
+    try:
+        path_norm = posixpath.normpath(path)
+    except Exception:
+        return False
+    if not posixpath.isabs(path_norm):
+        return False
     paths = HOST_PATH_MAP.get(host, {})
     bases = (paths.get("claude", ""), paths.get("codex", ""))
-    return any(b and path.startswith(b + os.sep) for b in bases)
+    for base in bases:
+        if not base:
+            continue
+        base_norm = posixpath.normpath(base)
+        try:
+            if posixpath.commonpath([base_norm, path_norm]) == base_norm and path_norm != base_norm:
+                return True
+        except ValueError:
+            # absolute/relative mix 등 — 폐기
+            continue
+    return False
 
 
 def _validate_remote_path(host: str, path: str) -> None:
@@ -755,13 +786,18 @@ def _validate_remote_path(host: str, path: str) -> None:
 def collect_remote_files(host: str, warnings: list[str]) -> list[str]:
     """원격 호스트에서 jsonl 파일 path glob (subprocess.run 고정 argv).
 
-    원격 find stdout의 path 라인은 비신뢰 입력으로 간주하여, _allowed_remote_path가 통과한
-    line만 수집한다 — 제어문자/shell metacharacter 포함 line은 silently 폐기한다.
+    SSH 명령 인자에는 host-neutral relative tilde 표현 (`~/.claude/projects`,
+    `~/.codex/sessions`)을 사용해 host별 absolute home prefix hardcoded를 피한다.
+    원격 shell이 `~`를 해당 user의 home directory로 expansion한다.
+
+    원격 find stdout의 path 라인은 비신뢰 입력으로 간주하여, `_allowed_remote_path`가
+    통과한 line만 수집한다 — 제어문자/shell metacharacter/relative path/sibling-prefix
+    포함 line은 silently 폐기한다. 검증은 absolute `HOST_PATH_MAP` prefix와의
+    boundary 비교로 수행한다.
     """
     _validate_host(host)
-    paths = HOST_PATH_MAP[host]
     all_files: list[str] = []
-    for base in (paths["claude"], paths["codex"]):
+    for base in ("~/.claude/projects", "~/.codex/sessions"):
         try:
             # SSH는 argv를 single string으로 합쳐 원격 shell에 전달하므로
             # `*.jsonl`을 single-quote로 감싸 원격 glob expansion을 차단한다.
@@ -947,13 +983,27 @@ def main() -> int:
             print(f"ERROR: corpus manifest read failed: {e}", file=sys.stderr)
             return 1
         all_files = manifest.get("files", [])
-        # host 분류는 path prefix로
+        # host 분류는 HOST_PATH_MAP base prefix 순회 (D-6) — 호스트 추가 시 한 곳만 수정.
+        # `/Users/` / `/home/` 단순 prefix 분기는 `HOST_PATH_MAP`에 없는 OS의 fallback으로 보존.
         files_by_host: dict[str, list[str]] = defaultdict(list)
         for f in all_files:
-            if f.startswith("/Users/"):
-                files_by_host["mac"].append(f)
-            elif f.startswith("/home/"):
-                files_by_host["minipc"].append(f)
+            matched = False
+            for host_alias, host_paths in HOST_PATH_MAP.items():
+                for base in (host_paths.get("claude", ""), host_paths.get("codex", "")):
+                    if base and f.startswith(base + os.sep):
+                        files_by_host[host_alias].append(f)
+                        matched = True
+                        break
+                if matched:
+                    break
+            if not matched:
+                # fallback (기존 동작 보존)
+                if f.startswith("/Users/"):
+                    files_by_host["mac"].append(f)
+                elif f.startswith("/home/"):
+                    files_by_host["minipc"].append(f)
+                else:
+                    warnings.append(f"corpus host unclassified: {f}")
         corpus_label = manifest.get("snapshot_id", "pinned")
     else:
         files_by_host = defaultdict(list)

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
@@ -1024,6 +1024,11 @@ def main() -> int:
                     sessions.append(result)
             continue
 
+        # 빈 remote files list (예: corpus 모드에서 해당 host 미분류 파일)는 ControlMaster
+        # preflight 비용 (~30s timeout)을 회피해 즉시 다음 host로 진행한다.
+        if not files:
+            continue
+
         # remote: ControlMaster preflight + worker pool.
         # ControlMaster 비활성이면 K=1 강등이 5526 파일 직렬 fetch ≈ 37분으로 5분 timeout
         # 안에 끝나기 어려우므로 fail-fast로 host 전체 fetch를 skip하고 명시적 warning을

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
@@ -855,7 +855,7 @@ def check_controlmaster_active(host: str, warnings: list[str]) -> bool:
     `ssh -O check <host>`는 master 부재 시 실패한다. 따라서 실패 시 일반 `ssh <host> true`로
     master 생성 시도 후 다시 `-O check`로 확인하는 2단계 sequence로 구성한다.
 
-    返回值이 False이면 worker pool은 K=1로 강등된다 (degrade fallback).
+    반환값이 False이면 caller가 해당 host fetch를 skip한다 (fail-fast).
     """
     _validate_host(host)
     try:
@@ -879,12 +879,12 @@ def check_controlmaster_active(host: str, warnings: list[str]) -> bool:
         )
         if gen.returncode != 0:
             warnings.append(
-                f"host {host}: ssh true (ControlMaster 생성 시도) 실패 (rc={gen.returncode}) — degrade to K=1"
+                f"host {host}: ssh true (ControlMaster 생성 시도) 실패 (rc={gen.returncode}) — fetch skip"
             )
             return False
     except (subprocess.TimeoutExpired, FileNotFoundError):
         warnings.append(
-            f"host {host}: ssh true 시간 초과 또는 binary 부재 — degrade to K=1"
+            f"host {host}: ssh true 시간 초과 또는 binary 부재 — fetch skip"
         )
         return False
     # 재확인
@@ -900,7 +900,7 @@ def check_controlmaster_active(host: str, warnings: list[str]) -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
     warnings.append(
-        f"host {host}: ControlMaster 재확인 실패 — degrade to K=1 (handshake 비용 잔존)"
+        f"host {host}: ControlMaster 재확인 실패 — fetch skip"
     )
     return False
 
@@ -986,19 +986,24 @@ def main() -> int:
         # 미매칭 path는 silent host 배정 대신 warning만 누적한다 (예전 단순 /Users/-mac
         # /home/-minipc fallback은 HOST_PATH_MAP 경계를 우회하는 별도 규칙이라 제거 —
         # 새 host 지원은 HOST_PATH_MAP에 명시 추가가 정답).
+        # live mode와 동일하게 (a) /subagents/ 하위는 wrapper output이라 제외하고
+        # (b) --hosts whitelist 밖 host로 분류된 path는 분석에서 제외한다.
         files_by_host: dict[str, list[str]] = defaultdict(list)
         for f in all_files:
-            matched = False
+            if "/subagents/" in f:
+                continue
+            matched_host = None
             for host_alias, host_paths in HOST_PATH_MAP.items():
                 for base in (host_paths.get("claude", ""), host_paths.get("codex", "")):
                     if base and f.startswith(base + os.sep):
-                        files_by_host[host_alias].append(f)
-                        matched = True
+                        matched_host = host_alias
                         break
-                if matched:
+                if matched_host is not None:
                     break
-            if not matched:
+            if matched_host is None:
                 warnings.append(f"corpus host unclassified (HOST_PATH_MAP 미일치): {f}")
+            elif matched_host in args.hosts:
+                files_by_host[matched_host].append(f)
         corpus_label = manifest.get("snapshot_id", "pinned")
     else:
         files_by_host = defaultdict(list)

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py
@@ -95,3 +95,88 @@ def test_host_validation(analyze_module):
     # valid는 통과
     analyze_module._validate_host("mac")
     analyze_module._validate_host("minipc")
+
+
+def test_hostile_path_rejection(analyze_module):
+    """`_allowed_remote_path` boundary check가 다음 4 시나리오를 모두 거부함을 검증.
+
+    1. 외부 절대 경로 (`/etc/passwd`).
+    2. traversal (`/Users/green/.claude/projects/../../../etc/shadow`).
+    3. sibling-prefix (`/Users/green/.claude/projects-evil/x.jsonl`).
+    4. relative path (find stdout이 비정상으로 relative line을 내보낸 경우).
+    """
+    cases = [
+        ("mac", "/etc/passwd"),
+        ("mac", "/Users/green/.claude/projects/../../../etc/shadow"),
+        ("mac", "/Users/green/.claude/projects-evil/x.jsonl"),
+        ("mac", "Users/green/.claude/projects/a.jsonl"),
+        # 추가 시나리오: shell metacharacter 거부 (기존 계약 회귀 가드)
+        ("mac", "/Users/green/.claude/projects/a.jsonl;rm -rf /"),
+        # 추가 시나리오: .jsonl 확장자 부재 거부
+        ("mac", "/Users/green/.claude/projects/notes.txt"),
+    ]
+    for host, path in cases:
+        assert analyze_module._allowed_remote_path(host, path) is False, (
+            f"hostile path should be rejected: host={host} path={path!r}"
+        )
+
+
+def test_allowed_remote_path_boundary_check(analyze_module):
+    """정상 child path는 통과하고, sibling-prefix와 traversal은 거부됨을 검증.
+
+    posixpath.commonpath boundary 비교가 startswith의 sibling-prefix false positive를
+    차단하는지 unit-level로 확인한다.
+    """
+    # 정상 child path는 통과
+    assert analyze_module._allowed_remote_path(
+        "mac", "/Users/green/.claude/projects/abc/sess.jsonl"
+    ) is True
+    assert analyze_module._allowed_remote_path(
+        "mac", "/Users/green/.codex/sessions/2026/05/10/rollout-x.jsonl"
+    ) is True
+    assert analyze_module._allowed_remote_path(
+        "minipc", "/home/greenhead/.claude/projects/x/y.jsonl"
+    ) is True
+    # sibling-prefix는 startswith로는 통과하지만 commonpath로는 거부
+    assert analyze_module._allowed_remote_path(
+        "mac", "/Users/green/.claude/projects-evil/x.jsonl"
+    ) is False
+    # base 자체는 .jsonl이 아니므로 거부 + commonpath path_norm != base_norm 가드
+    assert analyze_module._allowed_remote_path(
+        "mac", "/Users/green/.claude/projects"
+    ) is False
+    # mac path를 minipc host로 검증 시 거부 (host별 base 분리)
+    assert analyze_module._allowed_remote_path(
+        "minipc", "/Users/green/.claude/projects/x.jsonl"
+    ) is False
+
+
+def test_worker_pool_partial_result(analyze_module, monkeypatch):
+    """worker pool에서 일부 SSH cat이 실패해도 정상 결과는 유지되고 warning이 누적됨을 검증.
+
+    `fetch_remote_file`을 monkeypatch하여 일부 path는 None (실패), 일부는 더미 jsonl
+    내용을 반환하도록 한다. `analyze_remote_session`이 None 반환 시 main loop에서
+    sessions에 append되지 않고 warning만 누적되는 계약을 unit으로 검증한다.
+    """
+    warnings: list[str] = []
+    fail_path = "/Users/green/.claude/projects/fail.jsonl"
+    ok_path = "/Users/green/.claude/projects/ok.jsonl"
+
+    def fake_fetch(host, path, w):
+        if path == fail_path:
+            w.append(f"host {host}: ssh cat failed for {path}")
+            return None
+        # 정상 dummy jsonl 내용 (verdict 분포에 영향 없는 빈 line)
+        return '{"type": "user", "uuid": "x", "timestamp": "2026-05-10"}\n'
+
+    monkeypatch.setattr(analyze_module, "fetch_remote_file", fake_fetch)
+
+    # 두 path 각각 호출
+    fail_result = analyze_module.analyze_remote_session("mac", fail_path, warnings)
+    ok_result = analyze_module.analyze_remote_session("mac", ok_path, warnings)
+
+    assert fail_result is None, "failed fetch should return None"
+    assert ok_result is not None, "successful fetch should return analysis dict"
+    assert any("ssh cat failed" in w for w in warnings), (
+        "failed fetch should accumulate a warning"
+    )

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py
@@ -151,12 +151,16 @@ def test_allowed_remote_path_boundary_check(analyze_module):
     ) is False
 
 
-def test_worker_pool_partial_result(analyze_module, monkeypatch):
-    """worker pool에서 일부 SSH cat이 실패해도 정상 결과는 유지되고 warning이 누적됨을 검증.
+def test_analyze_remote_session_partial_fetch_result(analyze_module, monkeypatch):
+    """`analyze_remote_session()`이 SSH cat 실패 시 None + warning, 성공 시 분석 dict를
+    반환하는 partial result 단위 계약을 검증한다.
 
     `fetch_remote_file`을 monkeypatch하여 일부 path는 None (실패), 일부는 더미 jsonl
-    내용을 반환하도록 한다. `analyze_remote_session`이 None 반환 시 main loop에서
-    sessions에 append되지 않고 warning만 누적되는 계약을 unit으로 검증한다.
+    내용을 반환하도록 한 뒤 `analyze_remote_session()`을 직접 호출한다.
+
+    참고: 본 테스트는 `analyze_remote_session()`의 단위 계약만 검증하며, `main()`의
+    `concurrent.futures.ThreadPoolExecutor` worker pool dispatch 경로는 통과하지
+    않는다. dispatch 경로 자체는 V-1 live 측정과 코드 review로 검증한다.
     """
     warnings: list[str] = []
     fail_path = "/Users/green/.claude/projects/fail.jsonl"


### PR DESCRIPTION
## Summary

- mac+minipc 양 호스트 live 분석을 600초 timeout(약 37분 추정)에서 122초로 단축. ControlMaster 다중화 + ThreadPoolExecutor K=8 worker pool 도입.
- `_allowed_remote_path`의 boundary check를 `posixpath.normpath`/`commonpath`로 강화하고 corpus host inference를 `HOST_PATH_MAP` 순회로 통합. command path는 `~/.claude/projects` relative tilde, validation/corpus path는 absolute prefix로 역할 분리.
- pytest 9 → 12 PASS (hostile path 거부 + boundary unit + worker partial result 추가). 보안/allowlist/JSON aggregate schema invariant 모두 유지.

Closes #678

## 기존 문제/배경

PR #672 (analyzing-da-sessions Skill v1)의 양 호스트 (mac+minipc) live 측정이 600초 timeout으로 종료됐다. 원인은 `analyze_remote_session()`이 파일별로 `subprocess.run(["ssh", host, "cat", path])`를 호출해 매 호출마다 SSH handshake (TCP+auth) 비용이 발생하기 때문이다.

직접 측정값:

- `time ssh mac true` → 0.37~0.51초 (cold/warm 모두 동일; ControlMaster 미설정).
- 현재 jsonl 파일: minipc 1272+729 = 2001, mac 3804+1722 = 5526. 합계 약 7500.
- 5526 × 0.4초 ≈ 2200초 (37분) — 600초 budget의 3.7배 초과.

본 sub-issue가 해결되지 않으면 양 호스트 live 모드는 사실상 사용 불가, single-host 모드만 실용적이다. PR #672 SC-2 ±5% 회귀 게이트의 양 호스트 정식 운영도 차단된다.

## CIR (Change Intent Record)

이 sub-issue는 부모 추적 이슈 #676의 follow-up F2 항목으로 분리된 결함성 발견이다. 본 PR의 의사결정 흐름:

1. **Transport 전략 선택**: 사용자 기준 "성능 > 안정성 > YAGNI" 하에 ControlMaster + worker pool 조합 채택. 다른 transport 후보 (단순 ControlMaster, 단순 worker pool, tar+zstd batch, rsync, distributed analysis)는 5분 마진 부족 또는 remote command allowlist/zstd/schema 변경 필요로 사용자 기준의 안정성 항목과 충돌해 기각.
2. **ControlMaster 적용 레이어**: 사용자 의도가 "전역 적용 → 모든 SSH 호출에 효과"였고 `~/.ssh/config`은 이미 home-manager symlink였다. 따라서 manual 편집(nix activation에서 덮어씀)이나 script-local `-o` 옵션 대신 nix matchBlocks에 선언적으로 추가하는 정답 경로를 채택했다.
3. **Worker count 인터페이스**: I/O-bound 작업이므로 CPU 자동 산출은 부적절하고, 환경별 조정 사용 사례가 없어 CLI 플래그도 over-engineering이라 판단해 `SSH_FETCH_WORKERS = 8` hardcoded constant로 시작했다. 측정 후 단일 위치 1줄 수정으로 조정 가능하다.
4. **HOST_PATH_MAP 역할 분리**: PR #672 review thread에서 사용자가 `HOST_PATH_MAP` fragility를 의문 제기했다. 본 PR과 함께 처리하기로 결정한 뒤, command path와 validation/corpus path 역할 분리 + boundary check 강화로 해결했다. 본격적인 nix-Python config bridge 도입은 본 PR scope를 벗어나 별도 follow-up으로 분리했다.
5. **ControlMaster 비활성 fallback 정책**: 초기에는 worker count를 K=1로 강등하는 보수적 fallback이었으나, K=1 직렬 fetch는 5526 파일 기준 약 37분이 걸려 5분 budget 안에 끝날 수 없는 silent slow fail 경로가 됐다. 검토 후 host fetch 자체를 skip하고 명시적 warning을 누적하는 fail-fast로 전환했다 — 사용자가 ControlMaster 활성화 (mac nrs 등) 누락을 즉시 인지할 수 있다.
6. **Warning ordering**: 초기에는 `threading.Lock`으로 단일 list 보호를 시도했으나 실제로는 worker exception 한 곳에만 lock이 적용되는 misleading 추상화였다. worker별 local list로 분리 수집 후 main thread에서 path 순으로 merge하는 단순한 모델로 정리했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| ControlMaster + worker pool 조합 | nix matchBlocks ControlMaster 다중화 + ThreadPoolExecutor K=8 fetch 병렬화 | 5분 마진 만족 가능성 가장 높음, 보안/allowlist/JSON aggregate schema invariant 모두 유지, 단일 파일 변경 위주로 revert 쉬움 | ControlPath socket 관리 + ControlMaster 비활성 시 fail-fast skip 의무 (별도 fallback 로직 필요) | ✅ 채택 |
| ControlMaster 단독 | client config로 첫 SSH 연결 재사용 | 코드 변경 없이 transport만 빨라짐 | 7500 파일을 여전히 직렬 cat — 5분 보장 약함 | ❌ 성능 마진 부족 |
| worker pool 단독 | per-file SSH cat을 K개 worker로 병렬 호출 | 구현 작음, 외부 의존성 zero | K개 동시 SSH handshake가 SSH server `MaxStartups` 한도 위험 | ❌ 안정성 부족 |
| tar + zstd batch streaming | 호스트당 ssh 1회로 모든 jsonl을 tar archive로 stream | 성능 마진 가장 큼 | mac에 zstd 부재 → home-manager 추가 + remote command allowlist에 tar 추가 정책 변경 필요 | ❌ 외부 의존성 + 정책 변경 부담 |
| rsync 일괄 fetch | rsync로 전체 파일 동기화 후 local 분석 | incremental 매우 빠름 | rsync가 allowlist에 없음, openrsync vs GNU rsync 호환성 미검증, cache 정합성 관리 필요 | ❌ allowlist + cache 부담 |
| Distributed analysis | 각 host에서 local 분석 후 JSON aggregate만 SSH 전송 | 데이터 전송량 최소 | remote python 실행이 allowlist 위반, schema 분리/병합 contract 필요, metric parity 위험 가장 큼 | ❌ schema 변경 + metric parity 위험 |

ControlMaster 적용 레이어 결정에서는 ssh config 수동 편집(home-manager activation에서 덮어씀)과 script-local `-o` 옵션(다른 SSH 호출에 효과 없음)을 모두 기각하고 home.nix matchBlocks 선언적 추가를 ✅ 채택했다.

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/nixos/programs/ssh-client/default.nix` | NixOS의 mac alias matchBlock에 `extraOptions.ControlMaster auto` + `ControlPath ~/.ssh/cm-%h-%p-%r` + `ControlPersist 600` 추가 |
| `modules/darwin/programs/ssh/default.nix` | nix-darwin의 minipc alias matchBlock에 동일 옵션 추가 (`hostType == "personal"` 분기 안) |
| `modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py` | `SSH_FETCH_WORKERS = 8` + `concurrent.futures.ThreadPoolExecutor` (host 순차 + host당 K=8 병렬) + `check_controlmaster_active()` preflight + 비활성 시 host fetch skip(fail-fast) + worker별 local warnings 분리 수집 + main thread path 순 merge + `_allowed_remote_path` `posixpath.normpath`/`commonpath` boundary 비교 + corpus host inference `HOST_PATH_MAP` 순회 + 빈 remote files 시 preflight skip |
| `modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md` | "Command path vs validation/corpus path 역할 분리" 단락 + `_allowed_remote_path` boundary check posixpath 의무 + remote command allowlist에 `true` preflight 명시 + Mac/MiniPC 경로 매핑 마지막 단락 갱신 |
| `modules/shared/programs/claude/files/skills/analyzing-da-sessions/SKILL.md` | 보안 boundary 비교 + relative tilde 사용 1줄 보강 |
| `modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md` | worker pool 병렬 fetch 흐름 + ControlMaster 비활성 fail-fast skip 표현 갱신 |
| `modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py` | `test_hostile_path_rejection` (외부/traversal/sibling-prefix/relative/metacharacter/비-jsonl 6 cases) + `test_allowed_remote_path_boundary_check` (정상 child/cross-host 거부) + `test_analyze_remote_session_partial_fetch_result` (단위 partial result) |

핵심 boundary check 로직:

```python
def _allowed_remote_path(host: str, path: str) -> bool:
    if not isinstance(path, str) or not path:
        return False
    if any(c in path for c in " \n\r\t;|&$`(){}[]<>*?\"'\\"):
        return False
    if not path.endswith(".jsonl"):
        return False
    try:
        path_norm = posixpath.normpath(path)
    except Exception:
        return False
    if not posixpath.isabs(path_norm):
        return False
    paths = HOST_PATH_MAP.get(host, {})
    bases = (paths.get("claude", ""), paths.get("codex", ""))
    for base in bases:
        if not base:
            continue
        base_norm = posixpath.normpath(base)
        try:
            if posixpath.commonpath([base_norm, path_norm]) == base_norm and path_norm != base_norm:
                return True
        except ValueError:
            continue
    return False
```

`commonpath([base_norm, path_norm]) == base_norm` 비교가 sibling-prefix(`/Users/green/.claude/projects-evil/x.jsonl`)를 거부하고, `posixpath.isabs` 선검사 + `ValueError` try/except가 비신뢰 `find` stdout의 relative path/mixed path를 silently 폐기한다.

## 참고 레퍼런스

- 부모 추적 이슈: #676 (analyzing-da-sessions follow-up — v1 결함성 발견 + plan 명시 항목 통합)
- 원 PR: #672 (analyzing-da-sessions Skill v1 등록)
- 자매 sub-issue: #677 (F1 disable-model-invocation 자연어 trigger 차단 강화)
- v1 plan: #671 (SC-2 + Performance follow-up 명시)

## Human Test Plan

ControlMaster 활성화는 minipc는 nrs로 자동 적용된다. mac은 사용자가 mac에서 직접 `nrs`를 1회 실행해야 mac → minipc 호출에서도 다중화가 활성화된다. mac nrs 적용 전에는 minipc → mac 분석은 정상 동작하지만 mac → minipc 분석은 ControlMaster 비활성으로 host fetch skip이 발생한다.

| Step | 명령 | 기대동작 | 실패 시 진단 |
|---|---|---|---|
| 1 | `ssh -O exit mac \|\| true && ssh -O exit minipc \|\| true && time ssh mac true` (cold) | 0.2~0.5초 정도 | mac alias가 ssh config에 없거나 Tailscale 연결 끊김 |
| 2 | `time ssh mac true` (warm, 직후) | 50ms 미만 | ControlPath socket이 만들어지지 않음 → matchBlock에 ControlMaster auto 누락 또는 nrs 미적용 |
| 3 | `ssh -O check mac` | "Master running (pid=...)" | master가 즉시 만료됐거나 ControlPersist 설정이 0인지 확인 |
| 4 | `time timeout 300 python3 ~/.claude/skills/analyzing-da-sessions/scripts/analyze.py --hosts mac,minipc --json out=/tmp/after.json` | exit 0 + JSON sidecar 생성 + elapsed < 300초 | 5분 초과 시 mac sshd `MaxSessions` 도달 또는 master stale → `ssh -O exit mac && ssh mac true`로 fresh master 후 재시도 |
| 5 | `python3 ~/.claude/skills/analyzing-da-sessions/scripts/analyze.py --hosts minipc --json out=/tmp/single.json && python3 ~/.claude/skills/analyzing-da-sessions/scripts/analyze.py --hosts mac --json out=/tmp/mac.json && jq '.metrics["M-2"].distribution.CONFIRMED_ISSUE' /tmp/single.json /tmp/mac.json /tmp/after.json` | single + mac CONFIRMED_ISSUE 합산이 both와 정확히 일치 | 합산 불일치는 build_aggregate Counter 누적 회귀 신호 |
| 6 | `nix run nixpkgs#python3Packages.pytest -- modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/` | 12 passed | 새 테스트 fail 시 boundary check 의사코드와 실제 구현 비교 |

## Pre-Merge E2E 테스트 가이드

### Phase 0 (정적 검증)

- [ ] `grep -n "ControlMaster" modules/nixos/programs/ssh-client/default.nix modules/darwin/programs/ssh/default.nix` → mac/minipc matchBlock 양쪽에 `ControlMaster = "auto"` 라인 1개씩 출현.
- [ ] `grep -n "SSH_FETCH_WORKERS\|check_controlmaster_active\|posixpath.commonpath" modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py` → SSH_FETCH_WORKERS 상수, check_controlmaster_active 함수, posixpath.commonpath 호출 모두 존재.
- [ ] `grep -n "HOST_PATH_MAP" modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py modules/shared/programs/claude/files/skills/analyzing-da-sessions/SKILL.md modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md` → 모든 참조에서 동일 상수명 유지 (rename 없음).

### Phase 1 (분석 실행)

- [ ] `time timeout 300 python3 ~/.claude/skills/analyzing-da-sessions/scripts/analyze.py --hosts mac,minipc --json out=/tmp/pr-after.json` → exit 0, /tmp/pr-after.json size > 0, elapsed < 300초.
- [ ] 출력 markdown footer의 warnings에 silent SSH 폭주 메시지가 없음 (worker pool partial result 정상 누적).

### Phase 2 (boundary check 회귀)

- [ ] `nix run nixpkgs#python3Packages.pytest -- modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py::test_hostile_path_rejection modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py::test_allowed_remote_path_boundary_check -v` → 2 passed.

### Phase 3 (회귀)

- [ ] `python3 ~/.claude/skills/analyzing-da-sessions/scripts/analyze.py --hosts minipc --json out=/tmp/pr-single.json` → single host 분석 정상 (회귀 없음).
- [ ] `nix run nixpkgs#python3Packages.pytest -- modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/` → 12 passed (기존 9 + 새 3).

### Phase 4 (사이드이펙트 — managing-ssh)

- [ ] `ssh minipc 'echo test'` 같은 인접 SSH 호출이 ControlMaster 활성 후 정상 동작 (write-handoff, viewing-immich-photo 등 다른 스킬의 ssh 호출은 의도된 혜택). `measure-anchoring-bias.sh` 같은 ConnectTimeout 의존 호출은 master socket 검증에도 ConnectTimeout이 적용되어 동작 호환.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH connection multiplexing now enabled for faster, persistent connections.
  * Parallel remote session fetching with configurable worker limits for improved performance.

* **Improvements**
  * Hardened remote path validation to prevent security bypasses and traversal attacks.
  * Enhanced error detection with clearer warnings when connections are unavailable.

* **Tests**
  * Comprehensive new test coverage for remote path security scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/710)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->