### PR TITLE
chore(inputs): flake.lock 주간 동기화 (nixpkgs/home-manager/nix-darwin/disko/vscode-ext)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776613567,
-        "narHash": "sha256-gC9Cp5ibBmGD5awCA9z7xy6MW6iJufhazTYJOiGlCUI=",
+        "lastModified": 1777713215,
+        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "32f4236bfc141ae930b5ba2fb604f561fed5219d",
+        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777000050,
-        "narHash": "sha256-SnungQ8w1+5Mz+axhxZJKzj3OawvwXfqhGyeFFUJnYU=",
+        "lastModified": 1778444552,
+        "narHash": "sha256-f18pIiR9q/p1vHY93gmAum7aHhQOG49oGvAB9+lptRo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4bf1f0bcd156d1f1b23f46902a170c93cd197b88",
+        "rev": "dcebe66f958673729896eec2de4abfd86ef22d21",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775037210,
-        "narHash": "sha256-KM2WYj6EA7M/FVZVCl3rqWY+TFV5QzSyyGE2gQxeODU=",
+        "lastModified": 1777780666,
+        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "06648f4902343228ce2de79f291dd5a58ee12146",
+        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777692448,
-        "narHash": "sha256-Kw6lyQXuxUF93UkHLcQAaB/JGWnDDxnJLtPJNpz/z6g=",
+        "lastModified": 1778384975,
+        "narHash": "sha256-+27MJizhdJGXTl3jzNKnGU3C+fJJBcTsBQb6PtS5vBE=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "c3c77b098f7a0c1116ad2943dfa2564cbd3bc09b",
+        "rev": "5d9f84ecc813690afdd4b35c896904fc02ab6cac",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- 주간 flake inputs 갱신: `nixpkgs`, `home-manager`, `nix-darwin`, `disko`, `nix-vscode-extensions` 5종을 동시 lock 갱신.
- 평가/빌드 영향: `darwin-system` rev 변경, `nix` 2.34.6+1 → 2.34.7+1, neovim 0.12.1 → 0.12.2 등 75개 갱신·2개 추가·9개 제거, closure paths -7 / 디스크 +139.9MiB.

## 기존 문제/배경
`flake.lock`이 최신 upstream 대비 약 일주일 뒤처졌다. nixpkgs와 home-manager 26.05 채널이 빠르게 회전 중이라 같은 채널을 따르는 inputs(nix-darwin/disko)도 함께 갱신해서 follow drift를 줄이는 것이 본 저장소의 관행이다.

## CIR (Change Intent Record)
- **발견 경위**: 정기적 inputs lock 동기화. 별도 incident 없음.
- **설계 의도**:
  - 한 번의 `nrs` 빌드 + 한 머신에서의 사용성 확인으로 회귀를 잡을 수 있는 범위로 한정한다(전체 inputs를 한 번에 흔들지 않음).
  - 채널을 공유하는 input(`nixpkgs`/`home-manager`/`nix-darwin`/`disko`)은 같은 PR에서 같이 옮긴다. drift 시 빌드 실패를 유발한 전례가 있다(예: #559 home-manager realpath 검사 + nixpkgs `nodePackages` 제거 동시 대응).
- **대안 검토**: 본문 ADR 참조.

## ADR (Architecture Decision Record)
| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 채널 공유 input 일괄 갱신 (현재) | `nixpkgs/home-manager/nix-darwin/disko/nix-vscode-extensions` 동시 lock | drift로 인한 평가 실패 회피, 빌드 1회로 검증 | 회귀 시 어느 input이 원인인지 분리하기가 어려움 | ✅ |
| input별로 PR 분리 | input 1개씩 lock + 빌드 | 회귀 시 원인 분리 명확 | 채널 공유 input은 동시 갱신하지 않으면 자체 빌드가 깨질 수 있음, PR 5개로 검토 비용 증가 | ❌ |
| 자동화 봇이 매일 PR 생성 | 사람 개입 없이 PR을 매일 생성 | 항상 최신 추적 | 본 저장소 1인 운영 환경에서 PR 큐 노이즈가 커짐, 본 작업에서 다룰 범위 아님 | ❌ |

## 구현 상세
| 파일 | 변경 |
|---|---|
| `flake.lock` | `disko`, `home-manager`, `nix-darwin`, `nix-vscode-extensions`, `nixpkgs` 5개 input의 `lastModified`/`narHash`/`rev`를 최신으로 갱신 |

추가 변경 없음. lock 외 파일은 건드리지 않는다.

## 참고 레퍼런스
- #559 — nixpkgs/home-manager 26.05 breaking change 대응(채널 drift로 빌드 실패 사례)
- #333 — 전체 input 일괄 업데이트로 atuin migration 불일치 해결(동시 갱신 패턴 선례)
- #358 — nixpkgs 업데이트로 Go 버전 불일치 해소(단일 input 빌드 영향 사례)

## Human Test Plan
1. macOS에서 `nrs`를 실행한다.
   - 기대: preview 단계 통과 → activation 성공, launchd/Hammerspoon 정리 단계 에러 없음.
   - 실패 시: nrs 출력에서 첫 에러를 캡처하고, `darwin-system` rev(`8c62fba`)·`home-manager` rev(`dcebe66`) 둘 중 어느 단계에서 실패했는지 확인한다.
2. `nrs` 후 새 셸을 열고 `nvim --version`이 `0.12.2`인지 확인한다.
   - 기대: `NVIM v0.12.2` 출력. tree-sitter 0.26.8과 같이 따라 올라와야 한다.
3. (선택) MiniPC에서도 `ssh minipc` 후 `nrs` 실행 — 본 PR은 darwin 영향이 대부분이지만 nixpkgs/home-manager 공통 변경이 있으므로 NixOS 빌드도 1회 확인하면 안전하다.
   - 실패 시: 어떤 service activation에서 실패했는지 `journalctl -xe`로 분리한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증
프롬프트: "flake.lock에서 5개 input(nixpkgs/home-manager/nix-darwin/disko/nix-vscode-extensions)의 rev가 PR diff와 일치하는지, 추가 변경 파일이 없는지 확인하라."

기대 동작:
- `git diff --stat main...HEAD` 결과가 `flake.lock | 30 +++++++++++++++---------------` 1줄.
- `git diff main...HEAD -- flake.lock`에서 위 5개 input 모두 `lastModified`/`narHash`/`rev`가 갱신됨.
- 다른 input(예: `agenix`, `yazi-flavors`)의 rev는 그대로.

실패 시 진단: diff에 `flake.lock` 외 파일이 보이면 PR 범위 위반 → 해당 변경을 별도 PR로 분리한다.

### Phase 1 — Darwin 빌드 검증
프롬프트: "darwin 호스트에서 `nrs`를 실행하고 build/activation 모두 성공하는지 확인하라."

기대 동작:
- `nrs` 종료 코드 0.
- preview 단계에서 `darwin-system 26.05.06648f4 -> 26.05.8c62fba` 출력.
- activation 후 launchd 정리, Hammerspoon 재시작이 에러 없이 끝남.

실패 시 진단:
- evaluation 실패: `nix-darwin` 또는 `home-manager` 업스트림 breaking change. `git log <old>..<new> --oneline` 으로 의심 커밋 식별.
- FOD hash mismatch: `scripts/fix-fod-hashes.sh` 실행 후 재시도(#113 패턴).

### Phase 2 — 런타임 확인
프롬프트: "neovim과 nix 버전이 갱신본을 따라가고 있는지 확인하라."

기대 동작:
- `nvim --version` → `NVIM v0.12.2`.
- `nix --version` → `nix (Nix) 2.34.7`.

실패 시 진단: PATH가 이전 generation을 가리키면 새 셸을 열거나 `exec $SHELL`로 환경을 갱신한다.

### Phase 3 — Regression
프롬프트: "neovim과 home-manager 의존 도구(예: lazygit, delta, atuin)가 정상 기동하는지 확인하라."

기대 동작: 각 도구가 정상 실행되며, atuin 동기화 키 오류·HM activation backup 같은 silent 사이드이펙트가 없음.

실패 시 진단: HM activation 로그(`~/.local/state/nix/profiles/home-manager/activation*`) 또는 `journalctl --user -xe`(linux)에서 원인 분리.
