### PR TITLE
fix(claude/statusline): worktree display 단축 + cwd vscode:// (Cmd+Shift+클릭)

### DIFF
--- a/modules/darwin/programs/vscode/default.nix
+++ b/modules/darwin/programs/vscode/default.nix
@@ -227,6 +227,8 @@ in
 
     register_public_uti public.plain-text
     register_public_uti public.source-code
+    # NB: public.folder default는 macOS가 Apple-protected (Finder 고정) — duti가 error -50
+    # 반환하여 등록 불가. 따라서 statusline.sh의 cwd Cmd+클릭은 Finder가 열리는 동작 수용.
 
     if [ "$skipped" -gt 0 ]; then
       echo "  ⚠️  Skipped $skipped of $total extensions rejected by duti (first: $first_failure → $first_failure_err)"

--- a/modules/darwin/programs/vscode/files/settings.json
+++ b/modules/darwin/programs/vscode/files/settings.json
@@ -39,6 +39,7 @@
   "workbench.iconTheme": "a-file-icon-vscode", // 파일 아이콘 테마
   "workbench.activityBar.orientation": "vertical", // 액티비티 바 세로 배치
   "window.commandCenter": true, // 타이틀 바에 커맨드 센터(검색창) 표시
+  "window.openFoldersInNewWindow": "default", // 폴더 열기 휴리스틱 — 단일 폴더 열려있으면 새 창, 다중/빈 창이면 기존. statusline cwd 클릭의 멀티태스킹 지원
 
   // ============================================================================
   // 파일 관리

--- a/modules/darwin/programs/vscode/files/settings.json
+++ b/modules/darwin/programs/vscode/files/settings.json
@@ -39,7 +39,6 @@
   "workbench.iconTheme": "a-file-icon-vscode", // 파일 아이콘 테마
   "workbench.activityBar.orientation": "vertical", // 액티비티 바 세로 배치
   "window.commandCenter": true, // 타이틀 바에 커맨드 센터(검색창) 표시
-  "window.openFoldersInNewWindow": "default", // 폴더 열기 휴리스틱 — 단일 폴더 열려있으면 새 창, 다중/빈 창이면 기존. statusline cwd 클릭의 멀티태스킹 지원
 
   // ============================================================================
   // 파일 관리

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -515,11 +515,10 @@ if [ -n "$CWD_CANONICAL" ]; then
   CWD_URL=""
   if ! $IS_SSH; then
     CWD_URL_PATH=$(percent_encode_segment "$CWD_CANONICAL")
-    # CWD URL — vscode://file/<path>/ 진단 검증용 임시 복귀.
-    # 가설: Claude Code TUI(CLAUDE_CODE_NO_FLICKER fullscreen 모드)가 mouse capture로
-    # 일반 Cmd+클릭을 가로챔. Cmd+Shift+클릭이 escape hatch → Ghostty가 OSC 8 dispatch.
-    # 사용자 Cmd+Shift+클릭 시 VSCode 열리면 가설 확정 → Fix A/B 결정.
-    CWD_URL="vscode://file${CWD_URL_PATH}/"
+    # ?windowId=_blank — vscode:// URL handler는 window.openFoldersInNewWindow 설정을
+    # 따르지 않고 기본적으로 마지막 활성 창을 덮어쓴다. query param이 공식 해결책으로
+    # 항상 새 창을 강제한다 (microsoft/vscode#141548, 머지 commit bcc2da6).
+    CWD_URL="vscode://file${CWD_URL_PATH}/?windowId=_blank"
   fi
 else
   # 검증 실패: 텍스트만 표시. control 문자가 들어와 fallback으로 escape 주입되는 것 방지

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -515,10 +515,13 @@ if [ -n "$CWD_CANONICAL" ]; then
   CWD_URL=""
   if ! $IS_SSH; then
     CWD_URL_PATH=$(percent_encode_segment "$CWD_CANONICAL")
-    # CWD URL은 vscode://file/<path>/ (D-2).
-    # Ghostty source 분석상 OSC 8 scheme 필터 없음 — macOS NSWorkspace.open이 dispatch.
-    # 사용자 검증: hover tooltip `vscode://file/...` 정상, `open vscode://...` VSCode 정상 동작.
-    CWD_URL="vscode://file${CWD_URL_PATH}/"
+    # CWD URL은 file:// (실측 — Ghostty 1.3.1이 vscode:// OSC 8 click을 silently drop.
+    # file://는 Plan/Memory와 동일하게 정상 dispatch).
+    # macOS LaunchServices가 폴더(public.folder) default app으로 dispatch.
+    # 폴더 default를 VSCode로 등록(duti -s com.microsoft.VSCode public.folder all)하면
+    # cwd 클릭 → VSCode 폴더 열기 (D-2 의도 충족).
+    # nix-darwin home-manager에 duti activation script로 영구 등록.
+    CWD_URL="file://${CWD_URL_PATH}"
   fi
 else
   # 검증 실패: 텍스트만 표시. control 문자가 들어와 fallback으로 escape 주입되는 것 방지

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -381,14 +381,22 @@ fi
 # -- Worktree detection (D-14)
 #    Primary: stdin.workspace.git_worktree (위 jq 통합에서 추출)
 #    Fallback: git rev-parse --path-format=absolute --git-dir/--git-common-dir
-if [ -n "${WS_WORKTREE:-}" ]; then
-  IS_WORKTREE=true
-elif [ -d "$CWD" ]; then
+#    워크트리일 때 메인 repo 경로(MAIN_REPO_DIR)도 함께 추출 — D-4 display용
+MAIN_REPO_DIR=""
+if [ -d "$CWD" ]; then
   GIT_DIR_ABS=$(git -C "$CWD" rev-parse --path-format=absolute --git-dir 2>/dev/null) || true
   GIT_COMMON_ABS=$(git -C "$CWD" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || true
-  if [ -n "$GIT_DIR_ABS" ] && [ -n "$GIT_COMMON_ABS" ] && [ "$GIT_DIR_ABS" != "$GIT_COMMON_ABS" ]; then
-    IS_WORKTREE=true
-  fi
+fi
+
+if [ -n "${WS_WORKTREE:-}" ]; then
+  IS_WORKTREE=true
+elif [ -n "${GIT_DIR_ABS:-}" ] && [ -n "${GIT_COMMON_ABS:-}" ] && [ "$GIT_DIR_ABS" != "$GIT_COMMON_ABS" ]; then
+  IS_WORKTREE=true
+fi
+
+# 워크트리면 메인 repo 경로 = git_common_dir의 부모 (= .git의 부모 = repo root)
+if $IS_WORKTREE && [ -n "${GIT_COMMON_ABS:-}" ]; then
+  MAIN_REPO_DIR=$(dirname "$GIT_COMMON_ABS")
 fi
 
 # -- Branch 추출 (D-14: worktree.branch || git branch --show-current)
@@ -399,8 +407,8 @@ fi
 
 # -- Heavy 결과 저장 (D-15: CACHED_CWD 포함). SIDECAR_IO_ENABLED 가드
 if $SIDECAR_IO_ENABLED; then
-  printf 'PLAN_FILE=%q\nMEMORY_LINK=%q\nMEMORY_LABEL=%q\nCACHE_TTL=%q\nIS_WORKTREE=%q\nGIT_BRANCH=%q\nCACHED_CWD=%q\n' \
-    "$PLAN_FILE" "$MEMORY_LINK" "$MEMORY_LABEL" "$CACHE_TTL" "$IS_WORKTREE" "$GIT_BRANCH" "$CWD" \
+  printf 'PLAN_FILE=%q\nMEMORY_LINK=%q\nMEMORY_LABEL=%q\nCACHE_TTL=%q\nIS_WORKTREE=%q\nGIT_BRANCH=%q\nMAIN_REPO_DIR=%q\nCACHED_CWD=%q\n' \
+    "$PLAN_FILE" "$MEMORY_LINK" "$MEMORY_LABEL" "$CACHE_TTL" "$IS_WORKTREE" "$GIT_BRANCH" "$MAIN_REPO_DIR" "$CWD" \
     > "${HEAVY_STATE}.vars"
   echo "$NOW" > "$HEAVY_STATE"
 fi
@@ -493,17 +501,24 @@ if [ -n "$SESSION_ID" ]; then
 fi
 
 # cwd canonical 검증 + display + URL
+# D-4 update: 워크트리일 때 display는 `<메인 repo ~ 단축>:<worktree 폴더명>` 형식
+#   (사용자 요청 — 풀 경로는 너무 길어 잘림). URL은 항상 canonical 풀 path (VSCode 정확 dispatch)
 CWD_CANONICAL=$(canonicalize_cwd_check "$CWD")
 if [ -n "$CWD_CANONICAL" ]; then
-  CWD_DISPLAY=$(tilde_shorten "$CWD_CANONICAL")
+  if $IS_WORKTREE && [ -n "${MAIN_REPO_DIR:-}" ]; then
+    MAIN_REPO_SHORT=$(tilde_shorten "$MAIN_REPO_DIR")
+    WORKTREE_NAME=$(basename "$CWD_CANONICAL")
+    CWD_DISPLAY="${MAIN_REPO_SHORT}:${WORKTREE_NAME}"
+  else
+    CWD_DISPLAY=$(tilde_shorten "$CWD_CANONICAL")
+  fi
   CWD_URL=""
   if ! $IS_SSH; then
     CWD_URL_PATH=$(percent_encode_segment "$CWD_CANONICAL")
-    # CWD URL은 file:// 로 단일화 (Plan/Memory와 동일 패턴).
-    # vscode://file/<path>/ scheme은 Ghostty OSC 8 hyperlink dispatch에서 클릭 동작 안 함이
-    # 실측 확인되어 file://로 변경. macOS LaunchServices가 폴더(public.folder) default app을
-    # 호출 — VSCode가 폴더 default면 VSCode 열림, Finder면 Finder 열림.
-    CWD_URL="file://${CWD_URL_PATH}"
+    # CWD URL은 vscode://file/<path>/ (D-2).
+    # Ghostty source 분석상 OSC 8 scheme 필터 없음 — macOS NSWorkspace.open이 dispatch.
+    # 사용자 검증: hover tooltip `vscode://file/...` 정상, `open vscode://...` VSCode 정상 동작.
+    CWD_URL="vscode://file${CWD_URL_PATH}/"
   fi
 else
   # 검증 실패: 텍스트만 표시. control 문자가 들어와 fallback으로 escape 주입되는 것 방지

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -499,7 +499,11 @@ if [ -n "$CWD_CANONICAL" ]; then
   CWD_URL=""
   if ! $IS_SSH; then
     CWD_URL_PATH=$(percent_encode_segment "$CWD_CANONICAL")
-    CWD_URL="vscode://file${CWD_URL_PATH}/"
+    # CWD URL은 file:// 로 단일화 (Plan/Memory와 동일 패턴).
+    # vscode://file/<path>/ scheme은 Ghostty OSC 8 hyperlink dispatch에서 클릭 동작 안 함이
+    # 실측 확인되어 file://로 변경. macOS LaunchServices가 폴더(public.folder) default app을
+    # 호출 — VSCode가 폴더 default면 VSCode 열림, Finder면 Finder 열림.
+    CWD_URL="file://${CWD_URL_PATH}"
   fi
 else
   # 검증 실패: 텍스트만 표시. control 문자가 들어와 fallback으로 escape 주입되는 것 방지

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -515,13 +515,11 @@ if [ -n "$CWD_CANONICAL" ]; then
   CWD_URL=""
   if ! $IS_SSH; then
     CWD_URL_PATH=$(percent_encode_segment "$CWD_CANONICAL")
-    # CWD URL은 file:// (실측 — Ghostty 1.3.1이 vscode:// OSC 8 click을 silently drop.
-    # file://는 Plan/Memory와 동일하게 정상 dispatch).
-    # macOS LaunchServices가 폴더(public.folder) default app으로 dispatch.
-    # 폴더 default를 VSCode로 등록(duti -s com.microsoft.VSCode public.folder all)하면
-    # cwd 클릭 → VSCode 폴더 열기 (D-2 의도 충족).
-    # nix-darwin home-manager에 duti activation script로 영구 등록.
-    CWD_URL="file://${CWD_URL_PATH}"
+    # CWD URL — vscode://file/<path>/ 진단 검증용 임시 복귀.
+    # 가설: Claude Code TUI(CLAUDE_CODE_NO_FLICKER fullscreen 모드)가 mouse capture로
+    # 일반 Cmd+클릭을 가로챔. Cmd+Shift+클릭이 escape hatch → Ghostty가 OSC 8 dispatch.
+    # 사용자 Cmd+Shift+클릭 시 VSCode 열리면 가설 확정 → Fix A/B 결정.
+    CWD_URL="vscode://file${CWD_URL_PATH}/"
   fi
 else
   # 검증 실패: 텍스트만 표시. control 문자가 들어와 fallback으로 escape 주입되는 것 방지

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -170,6 +170,10 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 5. **SessionStart hook 동작 (source별)**:
    - `startup` (새 세션): 빈 상태 파일 + 메모 파일 생성. 아이콘 없음
    - `clear` / `resume` / `compact` (기존 세션 재진입): 상태 파일 없으면 가장 최근 상태 파일을 복사하여 아이콘/메모 경로 보존
+6. **OSC 8 hyperlink 클릭 UX (macOS Ghostty + Claude Code fullscreen)**:
+   - **일반 Cmd+클릭** — Plan/Memo/Memory 같은 `file://` link는 Ghostty plain-text URL fallback detector로 동작 (Jira/Slack/Figma 같은 `https://`도 동작)
+   - **Cmd+Shift+클릭** — Claude Code TUI(`CLAUDE_CODE_NO_FLICKER` fullscreen 모드)가 mouse capture로 일반 Cmd+클릭을 가로채는 영역에서 escape hatch. cwd (`vscode://file/<path>/`) 처럼 fallback detector가 인식 못 하는 scheme은 **Cmd+Shift+클릭으로만 동작**
+   - 관련 upstream issue: anthropics/claude-code#26356, #37216, #45173 (mouse capture 회귀 미해결)
 
 ## 주의사항
 


### PR DESCRIPTION
## Summary

- **worktree cwd display 단축** (D-4 update) — 워크트리 환경에서 풀 경로 잘림 해소: `~/Workspace/nixos-config:fix_plan-with-questions-complexity` 형식
- **cwd URL을 `vscode://file/<percent-encoded>/?windowId=_blank` 로 확정** — Cmd+Shift+클릭 시 VSCode가 항상 새 창에서 폴더 열기 (멀티태스킹 보장). 같은 폴더가 이미 열려있으면 그 창으로 포커스. 진짜 원인 격리 + `?windowId=_blank` 공식 해결책까지 두 단계 결론
- **set-icons SKILL.md에 OSC 8 클릭 UX 안내 추가** — 일반 Cmd+클릭과 Cmd+Shift+클릭 동작 차이 명시

## 진짜 원인 확정 — 두 단계

### 1단계 — Claude Code TUI mouse capture (왜 클릭 자체가 안 갔나)

PR #733 머지 후 사용자 실측에서 cwd Cmd+클릭이 동작 안 함. 6개 Opus 에이전트 병렬 리서치로 root cause 격리:

| 사실 | 확인 출처 |
|---|---|
| `CLAUDE_CODE_NO_FLICKER=1` = fullscreen rendering = **alternate screen + mouse capture** | [code.claude.com/docs/en/fullscreen](https://code.claude.com/docs/en/fullscreen) |
| mouse capture 활성 시 Ghostty는 일반 클릭을 Claude Code TUI에 forward (OSC 8 handler 우회) | [ghostty-org/ghostty#9514](https://github.com/ghostty-org/ghostty/discussions/9514) |
| **Shift modifier는 mouse capture escape hatch** (Ghostty `mouse-shift-capture` config default) | Ghostty docs |
| Ghostty + LaunchServices의 `vscode://` scheme dispatch 자체는 정상 | source 분석 + 사용자 실측 (`open vscode://...` OK) |
| Plan 등 `file://` link가 일반 Cmd+클릭으로 동작하는 이유 | Ghostty plain-text URL fallback detector가 `file:` scheme만 인식. `vscode:` 미인식 → mouse capture에 의해 가로채짐 |
| 관련 OPEN upstream issues | anthropics/claude-code#26356, #27047, #37216, #45173 |

**사용자 검증 확정**: Cmd+Shift+hover → `vscode://file/...` tooltip 정상 표시 + Cmd+Shift+클릭 → VSCode 폴더 열기 ✓

### 2단계 — `?windowId=_blank` 필요 (왜 기존 창이 덮어씌워졌나)

1단계로 Cmd+Shift+클릭은 동작하게 됐으나, VSCode가 **기존 창의 폴더를 새 폴더로 덮어씌워서 멀티태스킹 불가**. 처음에 settings.json `window.openFoldersInNewWindow="default"` 휴리스틱으로 시도했으나 사용자 실측에서 무효함이 드러남:

- 실험 1 (`open "vscode://file/<path>/"` 직접 실행) — 기존 창 있으면 silently noop
- 실험 2 (VSCode 내부 Cmd+Shift+P → Open Folder) — 단일 폴더 창에서도 기존 창 덮어씌움. "default" 휴리스틱 자체가 의도대로 작동 안 함

공식 해결책은 **URL에 `?windowId=_blank` query param**. microsoft/vscode#141548 + 머지 commit bcc2da6에서 메인테이너가 직접 verify: *"If you set this in a URI and give it to be handled by Code, it will always do it in a brand new window."* 사용자 실측 — 같은 cwd가 이미 열려있으면 그 창으로 포커스 회수, 새 cwd면 새 창. 정확히 멀티태스킹 의도.

## 진단 churn 정리

본 PR 흐름에 잘못된 진단 누적 (PR squash merge로 main에는 단일 commit):

1. 첫 시도 — `file://` 변경 (폴더 default가 Finder인 환경 무지로 false fix)
2. 두번째 시도 — `vscode://` 복귀 (Ghostty source 분석 추정)
3. 세번째 시도 — `file://` 재확정 + 옵션 A (`duti -s ... public.folder`) 시도 → macOS Apple-protected (error -50)로 차단
4. 네번째 시도 — 5+1 Opus 에이전트 리서치로 Claude Code TUI mouse capture 원인 격리 → `vscode://` 최종 확정 (1단계 결론)
5. 다섯번째 시도 — settings.json `window.openFoldersInNewWindow="default"`로 멀티태스킹 시도 → 사용자 실측에서 URL handler에 무효함 드러남 → 공식 해결책 `?windowId=_blank` 발견 + revert (2단계 결론)
6. **확정** — `vscode://file/.../?windowId=_blank` (1+2단계 통합)

진단 과정 자체는 추적 가치 있으므로 commit history 유지. squash merge 시 main에 단일 commit으로 정리.

## ADR — 채택 가능했던 fix 옵션 비교

| 옵션 | 설명 | 결정 |
|---|---|---|
| **G. `?windowId=_blank` + Cmd+Shift+클릭 UX 수용** | 1단계는 Cmd+Shift modifier, 2단계는 URL query param. 멀티태스킹 + 같은 cwd 시 포커스 회수까지 작동 | ✅ |
| A. Cmd+Shift+클릭만 + plain `vscode://` | URL query 없음. 기존 창 덮어씌움 → 멀티태스킹 불가 | ❌ 2단계 미해결 |
| B. `CLAUDE_CODE_DISABLE_MOUSE=1` + vscode:// | env 변수 1줄. 일반 Cmd+클릭으로 통일 | ❌ Claude Code 마우스 기반 다른 UX(scroll, drag) 영향 가능성 |
| C. file:// + duti로 public.folder default 변경 | 폴더 default를 VSCode로 등록 | ❌ macOS Apple-protected (error -50) |
| D. Hammerspoon hotkey | TUI 무관. tmux `pane_current_path` 또는 cookie file + hotkey로 폴더 열기 | ❌ 본 PR scope 외. follow-up 가치 있음 |
| E. localhost HTTPS bridge | `http://127.0.0.1:7777/open?path=...` + launchd 서비스로 `code <path>` 실행 | ❌ 본 PR scope 외. follow-up 가치 |
| F. Ghostty `cmd+shift+o` keybind | Ghostty config의 keybind action으로 명령 실행 | ❌ Ghostty 1.3.1에 `exec_shell` 같은 action 없음 ([ghostty 5244](https://github.com/ghostty-org/ghostty/discussions/5244)) |
| H. settings.json `window.openFoldersInNewWindow="default"` 휴리스틱 | 일반 폴더 열기 동작에 휴리스틱 적용 | ❌ URL handler가 설정을 따르지 않음을 사용자 실측에서 확인. 휴리스틱 자체도 의도대로 작동 안 함 |

## 구현 상세

| File | Role | Change |
|------|------|--------|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | statusline 렌더링 | (1) cwd URL을 `vscode://file/<percent-encoded>/?windowId=_blank` 확정 (microsoft/vscode#141548). (2) 워크트리 display를 `<MAIN_REPO_SHORT>:<WORKTREE_NAME>`. (3) HEAVY_STATE.vars에 `MAIN_REPO_DIR` 필드 추가 |
| `modules/shared/programs/claude/files/skills/set-icons/SKILL.md` | set-icons 문서 | OSC 8 클릭 UX 섹션 추가 — 일반 Cmd+클릭 vs Cmd+Shift+클릭 동작 차이 명시 |
| `modules/darwin/programs/vscode/default.nix` | nix-darwin VSCode 설정 | duti `public.folder` 등록 한계 주석 (Apple-protected, error -50) — 미래 재시도 방지 |
| `modules/darwin/programs/vscode/files/settings.json` | VSCode user settings | (churn 5단계의 `window.openFoldersInNewWindow="default"` 시도는 사용자 실측에서 URL handler에 무효함이 드러나 revert) — 본 PR에 최종 변경 없음 |

## 참고 레퍼런스

- 이슈 #734 (Claude Code v2.1.139 폭 측정 회귀, OPEN) — 별개 이슈, upstream 대기
- 이슈 #735 (flex-wrap layout 검토, OPEN) — #734 선행 조건
- PR #733 (cwd/branch/session-id 라인 추가 base)
- anthropics/claude-code OPEN issues: [#26356](https://github.com/anthropics/claude-code/issues/26356), [#27047](https://github.com/anthropics/claude-code/issues/27047), [#37216](https://github.com/anthropics/claude-code/issues/37216), [#45173](https://github.com/anthropics/claude-code/issues/45173) — Claude Code TUI mouse capture 회귀 미해결
- ghostty-org/ghostty: [#9514](https://github.com/ghostty-org/ghostty/discussions/9514) (Shift escape hatch), [#11907](https://github.com/ghostty-org/ghostty/issues/11907), [#11913](https://github.com/ghostty-org/ghostty/issues/11913) (user-configurable link patterns not planned)
- microsoft/vscode: [#141548](https://github.com/microsoft/vscode/issues/141548) (URL Protocol opens existing window — `?windowId=_blank` 공식 해결책), 머지 commit bcc2da6
- [Claude Code Fullscreen docs](https://code.claude.com/docs/en/fullscreen)
- [Ghostty Hyperlink System (DeepWiki)](https://deepwiki.com/ghostty-org/ghostty/3.7-hyperlink-system)

## Human Test Plan

사용자 환경(macOS Ghostty + Claude Code fullscreen)에서:

1. **worktree display 단축**
   - 워크트리 안에서 statusline 확인
   - 기대: `📁 ~/Workspace/nixos-config:<worktree_folder>` 형식
   - 메인 repo에서는 `📁 ~/Workspace/nixos-config`

2. **cwd Cmd+Shift+클릭 → VSCode 새 창** (확정된 UX)
   - statusline 📁 cwd 아이콘에 **Cmd+Shift+hover** → tooltip `vscode://file/...?windowId=_blank` 표시
   - **Cmd+Shift+클릭 (새 cwd)** → 기존 창 유지하면서 새 VSCode 창에 cwd 폴더 열기 ✓
   - **Cmd+Shift+클릭 (이미 열려있는 cwd)** → 새 창 생성 없이 그 창으로 포커스 회수 ✓

3. **일반 Cmd+클릭 동작** (참고)
   - 📝 Plan, 🧠 Memory(file://) 등은 일반 Cmd+클릭으로도 동작 (fallback detector)
   - 📁 cwd(vscode://)는 일반 Cmd+클릭으로 silently no-op — Shift 필수

4. **regression — 기존 OSC 8 클릭**
   - Jira/Slack/Figma/Memo (외부 https://), Plan/Memory (file://) 모두 일반 Cmd+클릭 정상 동작 확인

## Pre-Merge E2E

### Phase 0: 정적 검증

```bash
# cwd URL 형태 = vscode://file/...?windowId=_blank
grep -c 'CWD_URL="vscode://file' modules/shared/programs/claude/files/scripts/statusline.sh  # 기대 1
grep -c 'windowId=_blank' modules/shared/programs/claude/files/scripts/statusline.sh  # 기대 1
grep -c 'CWD_URL="file://' modules/shared/programs/claude/files/scripts/statusline.sh  # 기대 0

# worktree display 분기
grep -c 'MAIN_REPO_SHORT' modules/shared/programs/claude/files/scripts/statusline.sh  # 기대 ≥ 1
grep -c 'MAIN_REPO_DIR' modules/shared/programs/claude/files/scripts/statusline.sh  # 기대 ≥ 3

# vscode/default.nix duti 한계 주석
grep -c 'Apple-protected' modules/darwin/programs/vscode/default.nix  # 기대 1

# set-icons SKILL.md OSC 8 UX 섹션
grep -c 'CLAUDE_CODE_NO_FLICKER' modules/shared/programs/claude/files/skills/set-icons/SKILL.md  # 기대 1

# settings.json에 openFoldersInNewWindow 자취 없음 (revert 확인)
grep -c 'openFoldersInNewWindow' modules/darwin/programs/vscode/files/settings.json  # 기대 0

shellcheck modules/shared/programs/claude/files/scripts/statusline.sh
echo "exit=$?"  # 기대 1 (기존 SC2001/SC2012 info-only, 본 변경 finding 0)
```

### Phase 1: Mock 검증

```bash
ACTUAL_SID="$(uuidgen | tr 'A-Z' 'a-z')"
STATUSLINE=modules/shared/programs/claude/files/scripts/statusline.sh

# Worktree — display 단축 + URL은 풀 path + ?windowId=_blank
jq -n --arg sid "$ACTUAL_SID" \
      --arg t "$HOME/.claude/projects/-Users-glen-Workspace-nixos-config--claude-worktrees-feat-x/$ACTUAL_SID.jsonl" \
      --arg cwd "$HOME/Workspace/nixos-config/.claude/worktrees/feat-x" \
  '{session_id:$sid, transcript_path:$t, cwd:$cwd, workspace:{git_worktree:"feat-x"}, worktree:{branch:"feat/x"}}' \
  | bash "$STATUSLINE" 2>&1 | head -2
# 기대: 📁 ~/Workspace/nixos-config:feat-x + URL vscode://file/Users/.../worktrees/feat-x/?windowId=_blank
```

### Phase 2: 사용자 실측 (Human Test Plan 참조)

Cmd+Shift+클릭 동작은 mock 검증 불가 — 사용자 실세션 검증 필수. 본 PR에서 1단계(클릭 자체) + 2단계(새 창) 모두 사용자 실측 확정.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified macOS folder registration behavior in default editor configuration
  * Added keyboard shortcut guidance for hyperlink interaction in fullscreen mode

* **Improvements**
  * Enhanced display of repository paths when working with git worktrees
  * Added configurable folder-opening behavior setting for VS Code workspace management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/736)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
