### PR TITLE
fix(claude/statusline): /set-icons cwd 격리 lineage 복원 + STATE_FILE 보존

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -156,6 +156,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/worktree-path-guard.sh";
     ".claude/hooks/session-init-icons.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/session-init-icons.sh";
+    ".claude/hooks/record-last-session.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-last-session.sh";
     ".claude/hooks/log-skill.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/log-skill.sh";
     ".claude/hooks/fragile-hardcoding-guard.sh".source =

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -170,6 +170,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/pinning-guard.sh";
     ".claude/lib/pinning-patterns.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/lib/pinning-patterns.sh";
+    ".claude/lib/session-state.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/lib/session-state.sh";
     # Cache TTL tracking hooks
     ".claude/hooks/record-last-stop.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-last-stop.sh";

--- a/modules/shared/programs/claude/files/hooks/record-last-session.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-session.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Claude Code Stop Hook - cwd 단위 last-session 마커 기록
+#
+# /clear는 새 session_id를 발급하지만 Claude Code의 SessionStart hook stdin
+# schema에는 previous_session_id 류 필드가 없다. 그래서 SessionStart 시점에는
+# 직전 sid를 알 수 없다. Stop hook을 매 turn 종료에 발동시켜 cwd-encoded
+# 마커 파일에 last_session_id를 누적 갱신해두면, /clear 직후 SessionStart hook이
+# "같은 cwd의 직전 sid"를 정확히 식별할 수 있다.
+#
+# cwd 단위 격리이므로 동시 진행 중인 다른 워크트리/프로젝트 세션과 마커가
+# 섞이지 않는다.
+
+set -euo pipefail
+umask 077
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=""
+if [ ! -t 0 ]; then
+  INPUT=$(cat)
+fi
+
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+# subagent 내부 Stop은 무시 (메인 턴만 추적)
+AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null) || true
+[ -n "$AGENT_ID" ] && exit 0
+
+SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || true
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || true
+
+if [ -z "$SESSION_ID" ] || [ -z "$CWD" ]; then
+  exit 0
+fi
+
+# session_id allowlist (path traversal 방어 — 마커 파일/sidecar 경로에 사용됨)
+case "$SESSION_ID" in
+  *[!A-Za-z0-9._-]*) exit 0 ;;
+  *..*) exit 0 ;;
+esac
+
+STATE_DIR="$HOME/.claude/status-icons"
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR" 2>/dev/null || true
+
+# cwd 인코딩 — sha1 hash. macOS는 shasum 우선, Linux는 sha1sum.
+# 둘 다 부재하면 graceful skip (lineage 복원 자체가 비활성).
+hash_cwd() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum | awk '{print $1}'
+  elif command -v sha1sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha1sum | awk '{print $1}'
+  fi
+}
+ENCODED_CWD=$(hash_cwd "$CWD")
+if [ -z "$ENCODED_CWD" ]; then
+  exit 0
+fi
+MARKER_FILE="$STATE_DIR/.last-session-${ENCODED_CWD}"
+
+# atomic write — 같은 디렉토리의 mktemp로 cross-device rename 회피
+tmp=$(mktemp "$STATE_DIR/.last-session-XXXXXX")
+printf '%s\n' "$SESSION_ID" > "$tmp"
+mv "$tmp" "$MARKER_FILE"
+chmod 600 "$MARKER_FILE" 2>/dev/null || true
+
+# optional debug log — CLAUDE_HOOK_DEBUG=1 일 때만 활성화
+if [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ]; then
+  LOG_DIR="$HOME/.claude/logs"
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+  chmod 700 "$LOG_DIR" 2>/dev/null || true
+  printf '%s stop sid=%s cwd=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SESSION_ID" "$CWD" \
+    >> "$LOG_DIR/session-hooks.log" 2>/dev/null || true
+fi
+
+exit 0

--- a/modules/shared/programs/claude/files/hooks/record-last-session.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-session.sh
@@ -62,6 +62,6 @@ printf '%s\n' "$SESSION_ID" > "$tmp"
 mv "$tmp" "$MARKER_FILE"
 chmod 600 "$MARKER_FILE" 2>/dev/null || true
 
-session_hook_log stop "sid=$SESSION_ID cwd=$CWD"
+session_hook_log stop "sid=$SESSION_ID cwd=$CWD marker=$MARKER_FILE"
 
 exit 0

--- a/modules/shared/programs/claude/files/hooks/record-last-session.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-session.sh
@@ -13,6 +13,16 @@
 set -euo pipefail
 umask 077
 
+# 공유 helper. marker 규약·session_id allowlist·debug 로그가 SSOT.
+# pinning-guard.sh와 동일 패턴: 설치된 $HOME/.claude/lib 우선, repo fallback.
+SESSION_STATE_LIB="${SESSION_STATE_LIB:-$HOME/.claude/lib/session-state.sh}"
+if [ ! -f "$SESSION_STATE_LIB" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  SESSION_STATE_LIB="$SCRIPT_DIR/../lib/session-state.sh"
+fi
+# shellcheck source=../lib/session-state.sh disable=SC1091
+. "$SESSION_STATE_LIB"
+
 if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
@@ -37,44 +47,21 @@ if [ -z "$SESSION_ID" ] || [ -z "$CWD" ]; then
   exit 0
 fi
 
-# session_id allowlist (path traversal 방어 — 마커 파일/sidecar 경로에 사용됨)
-case "$SESSION_ID" in
-  *[!A-Za-z0-9._-]*) exit 0 ;;
-  *..*) exit 0 ;;
-esac
+is_safe_session_id "$SESSION_ID" || exit 0
 
-STATE_DIR="$HOME/.claude/status-icons"
-mkdir -p "$STATE_DIR"
-chmod 700 "$STATE_DIR" 2>/dev/null || true
+mkdir -p "$SESSION_STATE_DIR"
+chmod 700 "$SESSION_STATE_DIR" 2>/dev/null || true
 
-# cwd 인코딩 — sha1 hash. macOS는 shasum 우선, Linux는 sha1sum.
-# 둘 다 부재하면 graceful skip (lineage 복원 자체가 비활성).
-hash_cwd() {
-  if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$1" | shasum | awk '{print $1}'
-  elif command -v sha1sum >/dev/null 2>&1; then
-    printf '%s' "$1" | sha1sum | awk '{print $1}'
-  fi
-}
-ENCODED_CWD=$(hash_cwd "$CWD")
-if [ -z "$ENCODED_CWD" ]; then
-  exit 0
-fi
-MARKER_FILE="$STATE_DIR/.last-session-${ENCODED_CWD}"
+MARKER_FILE=$(marker_path_for_cwd "$CWD") || exit 0
 
-# atomic write — 같은 디렉토리의 mktemp로 cross-device rename 회피
-tmp=$(mktemp "$STATE_DIR/.last-session-XXXXXX")
+# atomic write — 같은 디렉토리의 mktemp로 cross-device rename 회피.
+# mktemp template은 retention cleanup pattern과 동일 prefix를 공유하므로
+# 정리 누락 위험 없음.
+tmp=$(mktemp "$SESSION_STATE_DIR/${SESSION_MARKER_PREFIX}XXXXXX")
 printf '%s\n' "$SESSION_ID" > "$tmp"
 mv "$tmp" "$MARKER_FILE"
 chmod 600 "$MARKER_FILE" 2>/dev/null || true
 
-# optional debug log — CLAUDE_HOOK_DEBUG=1 일 때만 활성화
-if [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ]; then
-  LOG_DIR="$HOME/.claude/logs"
-  mkdir -p "$LOG_DIR" 2>/dev/null || true
-  chmod 700 "$LOG_DIR" 2>/dev/null || true
-  printf '%s stop sid=%s cwd=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SESSION_ID" "$CWD" \
-    >> "$LOG_DIR/session-hooks.log" 2>/dev/null || true
-fi
+session_hook_log stop "sid=$SESSION_ID cwd=$CWD"
 
 exit 0

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -1,9 +1,26 @@
 #!/usr/bin/env bash
 # Claude Code SessionStart Hook - Status bar icons 초기화/복원
-# stdin: JSON (session_id, transcript_path, source 등)
+# stdin: JSON (session_id, transcript_path, source, cwd 등)
 # stdout: JSON (hookSpecificOutput with additionalContext)
+#
+# 권한 정책:
+# - umask 077 + chmod 700 디렉토리 / 600 파일. status JSON에는 Jira/Slack/Figma
+#   private URL이, memo MD에는 세션 메모가 담길 수 있어 동일 사용자만 접근 가능.
+#
+# Lineage 복원 (cwd-encoded marker):
+# - Stop hook(record-last-session.sh)이 매 턴 종료에 cwd-encoded 마커 파일에
+#   last_session_id를 기록한다. /clear가 새 session_id를 발급해 STATE_FILE이
+#   부재할 때, 같은 cwd 마커의 sid에서 sidecar/memo를 deep clone 복원한다.
+# - 글로벌 mtime 기반 탐색은 cross-cwd 누수를 일으키므로 사용하지 않는다.
+#
+# Retention 정책:
+# - SESSION_ARTIFACT_RETENTION_DAYS=30: status-icons JSON, memo MD, marker 파일에
+#   동일 적용. 변경 시 storage 누적 영향 검토.
 
 set -euo pipefail
+umask 077
+
+SESSION_ARTIFACT_RETENTION_DAYS=30
 
 # jq 필수 — 없으면 graceful skip
 if ! command -v jq >/dev/null 2>&1; then
@@ -23,6 +40,7 @@ fi
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || true
 TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null) || true
 SOURCE=$(printf '%s' "$INPUT" | jq -r '.source // empty' 2>/dev/null) || true
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || true
 
 # session_id resolution — statusline.sh와 동일 fallback (D-8)
 # stdin.session_id 우선, 비어있으면 transcript basename — 단, transcript는
@@ -38,6 +56,7 @@ fi
 # 패턴 검증 — sidecar 파일명에 사용되므로 safe filename 보장
 case "$SESSION_ID" in
   *[!A-Za-z0-9._-]*) SESSION_ID="" ;;
+  *..*) SESSION_ID="" ;;
 esac
 if [ -z "$SESSION_ID" ]; then
   exit 0
@@ -49,71 +68,113 @@ STATE_FILE="$STATE_DIR/$SESSION_ID.json"
 MEMO_FILE="$MEMO_DIR/$SESSION_ID.md"
 
 mkdir -p "$STATE_DIR" "$MEMO_DIR"
+chmod 700 "$STATE_DIR" "$MEMO_DIR" 2>/dev/null || true
+
+# cwd-encoded marker lookup helper (Stop hook과 동일 인코딩)
+hash_cwd() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum | awk '{print $1}'
+  elif command -v sha1sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha1sum | awk '{print $1}'
+  fi
+}
+
+# 같은 cwd의 직전 sid sidecar를 deep clone 복원 (성공 시 RESTORED=true)
+# - LAST_SID 검증 (allowlist + 자기 자신 제외)
+# - memo 파일은 원본 내용을 새 sid 파일로 cp (참조 충돌 방지)
+# - status JSON은 통째 복사 + .memo.path만 새 경로로 rewrite
+# - jq 실패 시 fallback은 호출부에서 처리
+restore_from_cwd_lineage() {
+  [ -z "$CWD" ] && return 1
+  local encoded marker last_sid last_state old_memo
+  encoded=$(hash_cwd "$CWD")
+  [ -z "$encoded" ] && return 1
+  marker="$STATE_DIR/.last-session-${encoded}"
+  [ -f "$marker" ] || return 1
+  last_sid=$(head -1 "$marker" 2>/dev/null | tr -d '[:space:]') || return 1
+  [ -z "$last_sid" ] && return 1
+  case "$last_sid" in
+    *[!A-Za-z0-9._-]*) return 1 ;;
+    *..*) return 1 ;;
+  esac
+  [ "$last_sid" = "$SESSION_ID" ] && return 1
+  last_state="$STATE_DIR/${last_sid}.json"
+  [ -f "$last_state" ] || return 1
+
+  old_memo=$(jq -r '.memo.path // empty' "$last_state" 2>/dev/null) || old_memo=""
+  if [ -n "$old_memo" ] && [ -f "$old_memo" ]; then
+    cp "$old_memo" "$MEMO_FILE"
+  else
+    touch "$MEMO_FILE"
+  fi
+  jq --arg new_memo "$MEMO_FILE" \
+    'if .memo then .memo.path = $new_memo else . end' \
+    "$last_state" > "$STATE_FILE" 2>/dev/null
+}
+
+# optional debug log — CLAUDE_HOOK_DEBUG=1 일 때만 활성화
+# 실제 source 라벨링/cwd 동작을 실측하기 위한 진단 인프라.
+if [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ]; then
+  LOG_DIR="$HOME/.claude/logs"
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+  chmod 700 "$LOG_DIR" 2>/dev/null || true
+  printf '%s session-start src=%s sid=%s cwd=%s state_exists=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SOURCE" "$SESSION_ID" "$CWD" \
+    "$([ -f "$STATE_FILE" ] && echo y || echo n)" \
+    >> "$LOG_DIR/session-hooks.log" 2>/dev/null || true
+fi
 
 case "$SOURCE" in
   startup)
-    touch "$MEMO_FILE"
+    # STATE_FILE 존재 시 보존 (어떤 source가 startup으로 라벨되어도 기존 아이콘
+    # 유실 방지). 부재 시에만 lineage 복원을 시도하고, 실패하면 빈 객체로 시작.
+    if [ ! -f "$STATE_FILE" ]; then
+      if ! restore_from_cwd_lineage; then
+        echo '{}' > "$STATE_FILE"
+        [ ! -f "$MEMO_FILE" ] && touch "$MEMO_FILE"
+      fi
+    fi
+    [ ! -f "$MEMO_FILE" ] && touch "$MEMO_FILE"
+    chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
 
-    # 초기 상태 파일 생성 (빈 객체 — 아이콘은 스킬 호출 시 추가)
-    #
-    # === Change Intent Record ===
-    # v1 (PR #263): SessionStart hook에서 AskUserQuestion으로 Jira/Slack/Figma 링크를
-    #    proactive하게 질문 + Memo 아이콘 자동 등록. 매 세션마다 링크를 물어봄.
-    #    AskUserQuestion 호출 방식만 6회 시행착오 (3회개별→1회일괄→탭UI 등).
-    # v2 (d65e7d0): 링크 불필요한 세션이 대다수라 매번 묻는 것이 방해됨.
-    #    AskUserQuestion 지시 제거, /set-icons 스킬 호출 시에만 링크 설정.
-    #    단, Memo는 항상 유용하다고 판단하여 자동 등록 유지 → 상태바에 Memo 노출.
-    # v3 (d3bbb3c, 이번): Memo도 불필요 시 상태바를 차지하므로 자동 등록 제거.
-    #    빈 객체({})로 시작, 모든 아이콘을 스킬 호출 시에만 등록.
-    #    trade-off: 메모를 쓰려면 스킬을 먼저 호출해야 하지만,
-    #              깨끗한 상태바가 대다수 세션에서 더 나은 UX.
-    echo '{}' > "$STATE_FILE"
+    # 30일 초과 파일 정리 (status-icons + memos + lineage 마커)
+    find "$STATE_DIR" -maxdepth 1 -type f -name '*.json' \
+      -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
+    find "$STATE_DIR" -maxdepth 1 -type f -name '.last-session-*' \
+      -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
+    find "$MEMO_DIR" -maxdepth 1 -type f -name '*.md' \
+      -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
 
-    # 30일 초과 파일 정리
-    find "$STATE_DIR" -name "*.json" -mtime +30 -delete 2>/dev/null || true
-    find "$MEMO_DIR" -name "*.md" -mtime +30 -delete 2>/dev/null || true
+    if [ -f "$STATE_FILE" ]; then
+      ACTIVE_ICONS=$(jq -r 'keys | join(", ")' "$STATE_FILE" 2>/dev/null) || ACTIVE_ICONS=""
+      [ -z "$ACTIVE_ICONS" ] && ACTIVE_ICONS="없음"
+    else
+      ACTIVE_ICONS="없음"
+    fi
 
     CONTEXT="Status bar icons 초기화됨.
 상태 파일: $STATE_FILE
 메모: $MEMO_FILE
+활성 아이콘: $ACTIVE_ICONS
 링크 설정: /set-icons 스킬로 Jira, Slack, Figma 링크를 추가할 수 있습니다."
     ;;
 
   clear|resume|compact)
-    # /clear, /branch, /fork 등으로 session_id가 변경되면
-    # 이전 세션의 상태 파일이 새 session_id 경로에 없다.
-    # 가장 최근 수정된 상태 파일에서 복사하여 아이콘 보존.
-    #
-    # === Change Intent Record ===
-    # v4 추가: /clear가 새 transcript(= 새 session_id)를 생성하는 것을
-    # 디버그 로그로 확인. 기존 clear|resume|compact 분기는 STATE_FILE 존재를
-    # 전제했으나, session_id 변경 시 STATE_FILE 미존재.
-    # ls -t로 가장 최근 파일을 찾아 복사하는 방식 채택.
-    # trade-off: 동시 세션에서 다른 세션의 아이콘이 복원될 수 있으나,
-    #           /clear 직후는 대부분 단일 세션이므로 실용적.
+    # /resume과 /compact는 같은 session_id를 유지하므로 STATE_FILE이 보통 존재
+    # → 그대로 사용. /clear는 새 session_id를 발급하여 STATE_FILE이 부재 →
+    # 같은 cwd 마커의 직전 sid에서 lineage 복원. 다른 cwd 마커와는 자연 격리됨.
     if [ ! -f "$STATE_FILE" ]; then
-      LATEST=$(ls -t "$STATE_DIR"/*.json 2>/dev/null | head -1 || true)
-      if [ -n "$LATEST" ] && [ -f "$LATEST" ]; then
-        # Memo 파일: 원본의 복사본 생성 (참조 충돌 방지)
-        OLD_MEMO=$(jq -r '.memo.path // empty' "$LATEST" 2>/dev/null)
-        if [ -n "$OLD_MEMO" ] && [ -f "$OLD_MEMO" ]; then
-          cp "$OLD_MEMO" "$MEMO_FILE"
-        else
-          touch "$MEMO_FILE"
-        fi
-        # icons JSON 복사 + memo 경로를 새 세션 파일로 갱신
-        jq --arg new_memo "$MEMO_FILE" \
-          'if .memo then .memo.path = $new_memo else . end' \
-          "$LATEST" > "$STATE_FILE"
-      else
+      if ! restore_from_cwd_lineage; then
         echo '{}' > "$STATE_FILE"
-        touch "$MEMO_FILE"
+        [ ! -f "$MEMO_FILE" ] && touch "$MEMO_FILE"
       fi
+      chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
     fi
 
     ACTIVE_ICONS="없음"
     if [ -f "$STATE_FILE" ]; then
       ACTIVE_ICONS=$(jq -r 'keys | join(", ")' "$STATE_FILE" 2>/dev/null) || ACTIVE_ICONS="없음"
+      [ -z "$ACTIVE_ICONS" ] && ACTIVE_ICONS="없음"
     fi
 
     CONTEXT="Status icons 복원됨.

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -63,6 +63,9 @@ if [ -z "$SESSION_ID" ] && [ -n "$TRANSCRIPT" ]; then
   esac
 fi
 if ! is_safe_session_id "$SESSION_ID"; then
+  # unsafe sid는 sidecar/marker 파일명에 사용할 수 없어 hook을 즉시 종료한다.
+  # 운영자가 "왜 sidecar가 부재한가"를 추적할 수 있도록 진단 로그를 남긴다.
+  session_hook_log session-start-unsafe "src=$SOURCE sid=$SESSION_ID cwd=$CWD"
   exit 0
 fi
 
@@ -74,10 +77,14 @@ chmod 700 "$SESSION_STATE_DIR" "$SESSION_MEMO_DIR" 2>/dev/null || true
 
 # 같은 cwd의 직전 sid sidecar를 deep clone 복원.
 #
-# Invariant:
-# - 성공 시(return 0): STATE_FILE과 MEMO_FILE이 둘 다 valid 상태로 생성.
-# - 실패 시(return 1): STATE_FILE/MEMO_FILE은 부분 쓰기 흔적까지 모두 제거되어
-#   호출부 fallback(`echo '{}' > STATE_FILE`)이 깨끗하게 덮을 수 있다.
+# Invariant (정확히):
+# - return 0: STATE_FILE은 valid JSON, MEMO_FILE은 last_memo의 정확한 사본 또는
+#   정상 빈 파일(last_memo 부재 시). 둘 다 자기 sid 경로에 있고 호출부는 그대로
+#   사용할 수 있다.
+# - return 1: STATE_FILE도 MEMO_FILE도 부분 쓰기 흔적 없이 제거되어, 호출부
+#   fallback(`echo '{}' > STATE_FILE`)이 깨끗하게 덮을 수 있다.
+# - `if ! restore_from_cwd_lineage` 호출 컨텍스트에서 set -e가 함수 내부에서
+#   비활성화되므로(POSIX/bash 동작) 매 단계의 실패를 명시적으로 처리한다.
 #
 # 보안 정책:
 # - last_state JSON의 .memo.path는 set-icons 스킬을 통해 LLM이 임의로 설정 가능한
@@ -99,9 +106,15 @@ restore_from_cwd_lineage() {
   # memo 경로는 sid로 결정적 재구성 — last_state의 .memo.path 신뢰 안 함.
   last_memo="$SESSION_MEMO_DIR/${last_sid}.md"
   if [ -f "$last_memo" ]; then
-    cp "$last_memo" "$MEMO_FILE"
-  else
-    : > "$MEMO_FILE"
+    # cp 실패(rofs/quota/permission)도 명시적 처리. 부분 쓰기 흔적을 정리하고
+    # return 1으로 호출부 fallback에 위임.
+    if ! cp "$last_memo" "$MEMO_FILE" 2>/dev/null; then
+      rm -f "$MEMO_FILE"
+      return 1
+    fi
+  elif ! : > "$MEMO_FILE" 2>/dev/null; then
+    rm -f "$MEMO_FILE"
+    return 1
   fi
   # status JSON 복사 + .memo.path를 새 sid 경로로 rewrite. jq 실패는 명시적
   # 처리 — 부분 쓰기 STATE_FILE과 새로 만든 MEMO_FILE을 모두 제거하고 return 1.
@@ -114,6 +127,8 @@ restore_from_cwd_lineage() {
   return 0
 }
 
+# 모든 source(unknown 포함)에 대해 진단 로그를 남긴다 — 디버그 활성 시
+# unknown source 라벨의 실측 채집이 본 인프라의 본연 목적.
 session_hook_log session-start "src=$SOURCE sid=$SESSION_ID cwd=$CWD state_exists=$([ -f "$STATE_FILE" ] && echo y || echo n)"
 
 case "$SOURCE" in

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -81,8 +81,13 @@ chmod 700 "$SESSION_STATE_DIR" "$SESSION_MEMO_DIR" 2>/dev/null || true
 # - return 0: STATE_FILE은 valid JSON, MEMO_FILE은 last_memo의 정확한 사본 또는
 #   정상 빈 파일(last_memo 부재 시). 둘 다 자기 sid 경로에 있고 호출부는 그대로
 #   사용할 수 있다.
-# - return 1: STATE_FILE도 MEMO_FILE도 부분 쓰기 흔적 없이 제거되어, 호출부
-#   fallback(`echo '{}' > STATE_FILE`)이 깨끗하게 덮을 수 있다.
+# - return 1:
+#   · 쓰기 시작 전 실패(marker_path_for_cwd 실패, 마커 부재, unsafe last_sid,
+#     last_state 부재, last_sid==SESSION_ID): STATE_FILE/MEMO_FILE은 함수 진입
+#     이전 상태 그대로 — 손대지 않는다.
+#   · 복사/생성 시작 후 실패(cp/truncate/jq 실패): 부분 쓰기 흔적을 명시적
+#     rm -f으로 제거한 뒤 return 1. 호출부 fallback(`echo '{}' > STATE_FILE`)이
+#     깨끗하게 덮을 수 있다.
 # - `if ! restore_from_cwd_lineage` 호출 컨텍스트에서 set -e가 함수 내부에서
 #   비활성화되므로(POSIX/bash 동작) 매 단계의 실패를 명시적으로 처리한다.
 #
@@ -143,6 +148,26 @@ case "$SOURCE" in
     fi
     [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
     chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
+
+    # Migration: 기존 sidecar 사용자에게 cwd 마커가 없으면 1회 seed.
+    # legacy(ls -t | head -1) fallback을 제거했기 때문에, 본 PR 적용 직후
+    # 사용자가 첫 /clear/branch를 하면 마커가 아직 없어 lineage 복원이
+    # silently 끊긴다 (Stop hook이 한 번이라도 실행되어야 마커 생성). startup
+    # 시점에 STATE_FILE이 이미 있고 마커가 없으면 현재 sid를 marker에 즉시
+    # 기록해 첫 lineage 복원도 정상 동작하도록 한다.
+    if [ -n "$CWD" ] && [ -f "$STATE_FILE" ]; then
+      MIGRATION_MARKER=$(marker_path_for_cwd "$CWD" 2>/dev/null) || MIGRATION_MARKER=""
+      if [ -n "$MIGRATION_MARKER" ] && [ ! -f "$MIGRATION_MARKER" ]; then
+        # atomic write — record-last-session.sh와 동일 패턴
+        _migration_tmp=$(mktemp "$SESSION_STATE_DIR/${SESSION_MARKER_PREFIX}XXXXXX" 2>/dev/null) || _migration_tmp=""
+        if [ -n "$_migration_tmp" ]; then
+          printf '%s\n' "$SESSION_ID" > "$_migration_tmp"
+          mv "$_migration_tmp" "$MIGRATION_MARKER" 2>/dev/null || rm -f "$_migration_tmp"
+          chmod 600 "$MIGRATION_MARKER" 2>/dev/null || true
+          session_hook_log session-start "migration-seed-marker sid=$SESSION_ID cwd=$CWD"
+        fi
+      fi
+    fi
 
     # 30일 초과 파일 정리 (status-icons + memos + lineage 마커).
     # -maxdepth 1 -type f: 디렉토리/심볼릭링크는 정리 대상 외(사용자가 명시적으로

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -13,10 +13,8 @@
 #   부재할 때, 같은 cwd 마커의 sid에서 sidecar/memo를 deep clone 복원한다.
 # - 글로벌 mtime 기반 탐색은 cross-cwd 누수를 일으키므로 사용하지 않는다.
 #
-# Retention 정책:
-# - SESSION_ARTIFACT_RETENTION_DAYS=30 (lib/session-state.sh의 단일 상수):
-#   status-icons JSON, memo MD, marker 파일에 동일 적용. 변경 시 storage 누적
-#   영향 검토.
+# Retention 정책: 없음. 아카이빙 우선 — sidecar/memo/marker는 자동 삭제하지
+# 않는다. 사용자가 명시적으로 정리하거나 별도 도구로 처리.
 
 set -euo pipefail
 umask 077
@@ -177,17 +175,11 @@ case "$SOURCE" in
       fi
     fi
 
-    # 30일 초과 파일 정리 (status-icons + memos + lineage 마커).
-    # -maxdepth 1 -type f: 디렉토리/심볼릭링크는 정리 대상 외(사용자가 명시적으로
-    # 둔 외부 관리 자원 보호).
-    find "$SESSION_STATE_DIR" -maxdepth 1 -type f -name '*.json' \
-      -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
-    find "$SESSION_STATE_DIR" -maxdepth 1 -type f -name "${SESSION_MARKER_PREFIX}*" \
-      -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
-    find "$SESSION_MEMO_DIR" -maxdepth 1 -type f -name '*.md' \
-      -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
+    # Retention 정리 없음 — 아카이빙 우선 정책. sidecar/memo/marker는 사용자가
+    # 명시적으로 정리하기 전까지 보존된다. 도입 이유 없이 박혀 있던 30일 자동
+    # 삭제는 제거 (PR #263 본문/CIR 어디에도 30일 정당화 없음).
 
-    if [ -f "$STATE_FILE" ]; then
+if [ -f "$STATE_FILE" ]; then
       ACTIVE_ICONS=$(jq -r 'keys | join(", ")' "$STATE_FILE" 2>/dev/null) || ACTIVE_ICONS=""
       [ -z "$ACTIVE_ICONS" ] && ACTIVE_ICONS="없음"
     else

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -14,13 +14,22 @@
 # - 글로벌 mtime 기반 탐색은 cross-cwd 누수를 일으키므로 사용하지 않는다.
 #
 # Retention 정책:
-# - SESSION_ARTIFACT_RETENTION_DAYS=30: status-icons JSON, memo MD, marker 파일에
-#   동일 적용. 변경 시 storage 누적 영향 검토.
+# - SESSION_ARTIFACT_RETENTION_DAYS=30 (lib/session-state.sh의 단일 상수):
+#   status-icons JSON, memo MD, marker 파일에 동일 적용. 변경 시 storage 누적
+#   영향 검토.
 
 set -euo pipefail
 umask 077
 
-SESSION_ARTIFACT_RETENTION_DAYS=30
+# 공유 helper. marker 규약·session_id allowlist·debug 로그가 SSOT.
+# pinning-guard.sh와 동일 패턴: 설치된 $HOME/.claude/lib 우선, repo fallback.
+SESSION_STATE_LIB="${SESSION_STATE_LIB:-$HOME/.claude/lib/session-state.sh}"
+if [ ! -f "$SESSION_STATE_LIB" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  SESSION_STATE_LIB="$SCRIPT_DIR/../lib/session-state.sh"
+fi
+# shellcheck source=../lib/session-state.sh disable=SC1091
+. "$SESSION_STATE_LIB"
 
 # jq 필수 — 없으면 graceful skip
 if ! command -v jq >/dev/null 2>&1; then
@@ -53,76 +62,59 @@ if [ -z "$SESSION_ID" ] && [ -n "$TRANSCRIPT" ]; then
       ;;
   esac
 fi
-# 패턴 검증 — sidecar 파일명에 사용되므로 safe filename 보장
-case "$SESSION_ID" in
-  *[!A-Za-z0-9._-]*) SESSION_ID="" ;;
-  *..*) SESSION_ID="" ;;
-esac
-if [ -z "$SESSION_ID" ]; then
+if ! is_safe_session_id "$SESSION_ID"; then
   exit 0
 fi
 
-STATE_DIR="$HOME/.claude/status-icons"
-MEMO_DIR="$HOME/.claude/memos"
-STATE_FILE="$STATE_DIR/$SESSION_ID.json"
-MEMO_FILE="$MEMO_DIR/$SESSION_ID.md"
+STATE_FILE="$SESSION_STATE_DIR/$SESSION_ID.json"
+MEMO_FILE="$SESSION_MEMO_DIR/$SESSION_ID.md"
 
-mkdir -p "$STATE_DIR" "$MEMO_DIR"
-chmod 700 "$STATE_DIR" "$MEMO_DIR" 2>/dev/null || true
+mkdir -p "$SESSION_STATE_DIR" "$SESSION_MEMO_DIR"
+chmod 700 "$SESSION_STATE_DIR" "$SESSION_MEMO_DIR" 2>/dev/null || true
 
-# cwd-encoded marker lookup helper (Stop hook과 동일 인코딩)
-hash_cwd() {
-  if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$1" | shasum | awk '{print $1}'
-  elif command -v sha1sum >/dev/null 2>&1; then
-    printf '%s' "$1" | sha1sum | awk '{print $1}'
-  fi
-}
-
-# 같은 cwd의 직전 sid sidecar를 deep clone 복원 (성공 시 RESTORED=true)
-# - LAST_SID 검증 (allowlist + 자기 자신 제외)
-# - memo 파일은 원본 내용을 새 sid 파일로 cp (참조 충돌 방지)
-# - status JSON은 통째 복사 + .memo.path만 새 경로로 rewrite
-# - jq 실패 시 fallback은 호출부에서 처리
+# 같은 cwd의 직전 sid sidecar를 deep clone 복원.
+#
+# Invariant:
+# - 성공 시(return 0): STATE_FILE과 MEMO_FILE이 둘 다 valid 상태로 생성.
+# - 실패 시(return 1): STATE_FILE/MEMO_FILE은 부분 쓰기 흔적까지 모두 제거되어
+#   호출부 fallback(`echo '{}' > STATE_FILE`)이 깨끗하게 덮을 수 있다.
+#
+# 보안 정책:
+# - last_state JSON의 .memo.path는 set-icons 스킬을 통해 LLM이 임의로 설정 가능한
+#   user-controlled 값이라 신뢰하지 않는다. memo 파일 경로는 sid에서 결정적으로
+#   파생되므로 last_sid 기반으로 강제 재구성한다(`SESSION_MEMO_DIR/${last_sid}.md`).
+#   이로써 `.memo.path = "$HOME/.ssh/known_hosts"` 류 임의 user-readable 파일을
+#   새 MEMO_FILE로 cp해 LLM context로 누출시키는 표면을 제거한다.
 restore_from_cwd_lineage() {
   [ -z "$CWD" ] && return 1
-  local encoded marker last_sid last_state old_memo
-  encoded=$(hash_cwd "$CWD")
-  [ -z "$encoded" ] && return 1
-  marker="$STATE_DIR/.last-session-${encoded}"
+  local marker last_sid last_state last_memo
+  marker=$(marker_path_for_cwd "$CWD") || return 1
   [ -f "$marker" ] || return 1
   last_sid=$(head -1 "$marker" 2>/dev/null | tr -d '[:space:]') || return 1
-  [ -z "$last_sid" ] && return 1
-  case "$last_sid" in
-    *[!A-Za-z0-9._-]*) return 1 ;;
-    *..*) return 1 ;;
-  esac
+  is_safe_session_id "$last_sid" || return 1
   [ "$last_sid" = "$SESSION_ID" ] && return 1
-  last_state="$STATE_DIR/${last_sid}.json"
+  last_state="$SESSION_STATE_DIR/${last_sid}.json"
   [ -f "$last_state" ] || return 1
 
-  old_memo=$(jq -r '.memo.path // empty' "$last_state" 2>/dev/null) || old_memo=""
-  if [ -n "$old_memo" ] && [ -f "$old_memo" ]; then
-    cp "$old_memo" "$MEMO_FILE"
+  # memo 경로는 sid로 결정적 재구성 — last_state의 .memo.path 신뢰 안 함.
+  last_memo="$SESSION_MEMO_DIR/${last_sid}.md"
+  if [ -f "$last_memo" ]; then
+    cp "$last_memo" "$MEMO_FILE"
   else
-    touch "$MEMO_FILE"
+    : > "$MEMO_FILE"
   fi
-  jq --arg new_memo "$MEMO_FILE" \
-    'if .memo then .memo.path = $new_memo else . end' \
-    "$last_state" > "$STATE_FILE" 2>/dev/null
+  # status JSON 복사 + .memo.path를 새 sid 경로로 rewrite. jq 실패는 명시적
+  # 처리 — 부분 쓰기 STATE_FILE과 새로 만든 MEMO_FILE을 모두 제거하고 return 1.
+  if ! jq --arg new_memo "$MEMO_FILE" \
+       'if .memo then .memo.path = $new_memo else . end' \
+       "$last_state" > "$STATE_FILE" 2>/dev/null; then
+    rm -f "$STATE_FILE" "$MEMO_FILE"
+    return 1
+  fi
+  return 0
 }
 
-# optional debug log — CLAUDE_HOOK_DEBUG=1 일 때만 활성화
-# 실제 source 라벨링/cwd 동작을 실측하기 위한 진단 인프라.
-if [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ]; then
-  LOG_DIR="$HOME/.claude/logs"
-  mkdir -p "$LOG_DIR" 2>/dev/null || true
-  chmod 700 "$LOG_DIR" 2>/dev/null || true
-  printf '%s session-start src=%s sid=%s cwd=%s state_exists=%s\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SOURCE" "$SESSION_ID" "$CWD" \
-    "$([ -f "$STATE_FILE" ] && echo y || echo n)" \
-    >> "$LOG_DIR/session-hooks.log" 2>/dev/null || true
-fi
+session_hook_log session-start "src=$SOURCE sid=$SESSION_ID cwd=$CWD state_exists=$([ -f "$STATE_FILE" ] && echo y || echo n)"
 
 case "$SOURCE" in
   startup)
@@ -131,18 +123,20 @@ case "$SOURCE" in
     if [ ! -f "$STATE_FILE" ]; then
       if ! restore_from_cwd_lineage; then
         echo '{}' > "$STATE_FILE"
-        [ ! -f "$MEMO_FILE" ] && touch "$MEMO_FILE"
+        [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
       fi
     fi
-    [ ! -f "$MEMO_FILE" ] && touch "$MEMO_FILE"
+    [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
     chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
 
-    # 30일 초과 파일 정리 (status-icons + memos + lineage 마커)
-    find "$STATE_DIR" -maxdepth 1 -type f -name '*.json' \
+    # 30일 초과 파일 정리 (status-icons + memos + lineage 마커).
+    # -maxdepth 1 -type f: 디렉토리/심볼릭링크는 정리 대상 외(사용자가 명시적으로
+    # 둔 외부 관리 자원 보호).
+    find "$SESSION_STATE_DIR" -maxdepth 1 -type f -name '*.json' \
       -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
-    find "$STATE_DIR" -maxdepth 1 -type f -name '.last-session-*' \
+    find "$SESSION_STATE_DIR" -maxdepth 1 -type f -name "${SESSION_MARKER_PREFIX}*" \
       -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
-    find "$MEMO_DIR" -maxdepth 1 -type f -name '*.md' \
+    find "$SESSION_MEMO_DIR" -maxdepth 1 -type f -name '*.md' \
       -mtime "+${SESSION_ARTIFACT_RETENTION_DAYS}" -delete 2>/dev/null || true
 
     if [ -f "$STATE_FILE" ]; then
@@ -166,7 +160,7 @@ case "$SOURCE" in
     if [ ! -f "$STATE_FILE" ]; then
       if ! restore_from_cwd_lineage; then
         echo '{}' > "$STATE_FILE"
-        [ ! -f "$MEMO_FILE" ] && touch "$MEMO_FILE"
+        [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
       fi
       chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
     fi

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -138,40 +138,41 @@ session_hook_log session-start "src=$SOURCE sid=$SESSION_ID cwd=$CWD state_exist
 
 case "$SOURCE" in
   startup)
-    # STATE_FILE 존재 시 보존 (어떤 source가 startup으로 라벨되어도 기존 아이콘
-    # 유실 방지). 부재 시에만 lineage 복원을 시도하고, 실패하면 빈 객체로 시작.
+    # 새 세션은 빈 상태로 시작 — 같은 cwd의 이전 sid 상태를 자동 상속하지 않는다.
+    # STATE_FILE이 이미 존재하면 보존(동일 sid로 startup이 재발화되는 케이스
+    # 방어). 부재면 빈 객체로 시작. lineage 복원은 clear|resume|compact 분기로
+    # 한정 — startup에서 복원하면 새 독립 세션도 이전 세션의 아이콘/메모를
+    # 상속해 "새 세션 = 빈 상태" 관례를 깨뜨린다.
+    #
+    # 만약 Claude Code가 `/clear`를 source=startup으로 라벨링하는 빌드가
+    # 발견되면 CLAUDE_HOOK_DEBUG=1로 채집해 source 라벨 매핑을 확인한 뒤
+    # 별도 follow-up에서 startup-labeled-clear 식별 방법을 도입한다.
     if [ ! -f "$STATE_FILE" ]; then
-      if ! restore_from_cwd_lineage; then
-        echo '{}' > "$STATE_FILE"
-        [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
-      fi
+      echo '{}' > "$STATE_FILE"
+      [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
     fi
     [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
     chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
 
-    # Bootstrap marker: cwd 마커가 없으면 현재 sid로 즉시 기록.
+    # Marker reset: startup 시점에 cwd 마커를 항상 현재 sid로 갱신.
     #
-    # 적용 대상은 두 갈래로 모두 의도된 동작이다:
-    # 1) 본 PR 업그레이드 직후의 기존 sidecar 사용자 — Stop hook이 한 번이라도
-    #    실행되어야 마커가 생성되므로, startup 직후 /clear/branch가 발생하면
-    #    lineage 복원이 silently 끊긴다. legacy(`ls -t | head -1`) fallback을
-    #    제거한 결과 발생하는 migration window를 즉시 닫는다.
-    # 2) 새 cwd 첫 진입 — 같은 turn 안에서 /clear/branch가 발생하면 Stop hook이
-    #    아직 안 돌았을 수 있다. 미리 marker를 seed해두면 첫 lineage 복원이
-    #    빈 객체로 시작해 일관된 동작을 보인다. Stop hook이 곧 같은 sid로 덮어
-    #    쓰므로 부작용 없다.
-    #
-    # 즉 본 블록은 "marker bootstrap" — 두 경우 모두 동일하게 처리.
+    # 의도: "새 세션 = 빈 상태" 정책의 일관성 보장. 같은 cwd에서 며칠 전 작업
+    # 마커가 남아 있다고 해도, 새 세션의 첫 /clear가 그 옛 sid sidecar를
+    # 복원하면 사용자 의도(새 세션 = 빈 상태)가 우회로로 깨진다. startup 시점에
+    # marker를 자기 sid로 reset해 두면 첫 /clear가 자기(빈) sidecar에서 복원
+    # 시도해 결과적으로 빈 상태가 유지된다. Stop hook이 매 턴 marker를
+    # last-writer-wins로 덮어쓰는 정책과 동일선상.
     if [ -n "$CWD" ]; then
       BOOTSTRAP_MARKER=$(marker_path_for_cwd "$CWD" 2>/dev/null) || BOOTSTRAP_MARKER=""
-      if [ -n "$BOOTSTRAP_MARKER" ] && [ ! -f "$BOOTSTRAP_MARKER" ]; then
-        # atomic write — record-last-session.sh와 동일 패턴
+      if [ -n "$BOOTSTRAP_MARKER" ]; then
         _bootstrap_tmp=$(mktemp "$SESSION_STATE_DIR/${SESSION_MARKER_PREFIX}XXXXXX" 2>/dev/null) || _bootstrap_tmp=""
         if [ -n "$_bootstrap_tmp" ]; then
           printf '%s\n' "$SESSION_ID" > "$_bootstrap_tmp"
+          # atomic last-writer-wins. 동시 startup 발생 시 마지막에 도달한 sid가
+          # marker를 갖는다. Stop hook의 갱신 정책과 일치.
           mv "$_bootstrap_tmp" "$BOOTSTRAP_MARKER" 2>/dev/null || rm -f "$_bootstrap_tmp"
           chmod 600 "$BOOTSTRAP_MARKER" 2>/dev/null || true
-          session_hook_log session-start "bootstrap-marker sid=$SESSION_ID cwd=$CWD"
+          session_hook_log session-start "reset-marker sid=$SESSION_ID cwd=$CWD"
         fi
       fi
     fi

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -136,15 +136,15 @@ session_hook_log session-start "src=$SOURCE sid=$SESSION_ID cwd=$CWD state_exist
 
 case "$SOURCE" in
   startup)
-    # 새 세션은 빈 상태로 시작 — 같은 cwd의 이전 sid 상태를 자동 상속하지 않는다.
-    # STATE_FILE이 이미 존재하면 보존(동일 sid로 startup이 재발화되는 케이스
-    # 방어). 부재면 빈 객체로 시작. lineage 복원은 clear|resume|compact 분기로
-    # 한정 — startup에서 복원하면 새 독립 세션도 이전 세션의 아이콘/메모를
-    # 상속해 "새 세션 = 빈 상태" 관례를 깨뜨린다.
+    # 새 세션 startup은 빈 sidecar로 시작하되 cwd 마커는 건드리지 않는다.
+    # marker 관리는 전적으로 Stop hook(record-last-session.sh)의 책임이며,
+    # 결과적으로 같은 cwd에서 동시에 두 인스턴스가 떠 있어도 startup이 다른
+    # 인스턴스의 active marker를 덮어쓰지 않는다.
     #
-    # 만약 Claude Code가 `/clear`를 source=startup으로 라벨링하는 빌드가
-    # 발견되면 CLAUDE_HOOK_DEBUG=1로 채집해 source 라벨 매핑을 확인한 뒤
-    # 별도 follow-up에서 startup-labeled-clear 식별 방법을 도입한다.
+    # STATE_FILE이 이미 존재하면 보존(동일 sid로 startup이 재발화되는 케이스
+    # 방어). 부재면 빈 객체로 시작. lineage 복원은 clear|resume|compact 분기에서만
+    # 수행되며, 사용자 의도("아카이빙 우선")에 따라 같은 cwd 재방문 시 직전
+    # 세션의 jira/slack/figma/memo가 /clear 시점에 자동 복원된다.
     if [ ! -f "$STATE_FILE" ]; then
       echo '{}' > "$STATE_FILE"
       [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
@@ -152,34 +152,7 @@ case "$SOURCE" in
     [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
     chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
 
-    # Marker reset: startup 시점에 cwd 마커를 항상 현재 sid로 갱신.
-    #
-    # 의도: "새 세션 = 빈 상태" 정책의 일관성 보장. 같은 cwd에서 며칠 전 작업
-    # 마커가 남아 있다고 해도, 새 세션의 첫 /clear가 그 옛 sid sidecar를
-    # 복원하면 사용자 의도(새 세션 = 빈 상태)가 우회로로 깨진다. startup 시점에
-    # marker를 자기 sid로 reset해 두면 첫 /clear가 자기(빈) sidecar에서 복원
-    # 시도해 결과적으로 빈 상태가 유지된다. Stop hook이 매 턴 marker를
-    # last-writer-wins로 덮어쓰는 정책과 동일선상.
-    if [ -n "$CWD" ]; then
-      BOOTSTRAP_MARKER=$(marker_path_for_cwd "$CWD" 2>/dev/null) || BOOTSTRAP_MARKER=""
-      if [ -n "$BOOTSTRAP_MARKER" ]; then
-        _bootstrap_tmp=$(mktemp "$SESSION_STATE_DIR/${SESSION_MARKER_PREFIX}XXXXXX" 2>/dev/null) || _bootstrap_tmp=""
-        if [ -n "$_bootstrap_tmp" ]; then
-          printf '%s\n' "$SESSION_ID" > "$_bootstrap_tmp"
-          # atomic last-writer-wins. 동시 startup 발생 시 마지막에 도달한 sid가
-          # marker를 갖는다. Stop hook의 갱신 정책과 일치.
-          mv "$_bootstrap_tmp" "$BOOTSTRAP_MARKER" 2>/dev/null || rm -f "$_bootstrap_tmp"
-          chmod 600 "$BOOTSTRAP_MARKER" 2>/dev/null || true
-          session_hook_log session-start "reset-marker sid=$SESSION_ID cwd=$CWD"
-        fi
-      fi
-    fi
-
-    # Retention 정리 없음 — 아카이빙 우선 정책. sidecar/memo/marker는 사용자가
-    # 명시적으로 정리하기 전까지 보존된다. 도입 이유 없이 박혀 있던 30일 자동
-    # 삭제는 제거 (PR #263 본문/CIR 어디에도 30일 정당화 없음).
-
-if [ -f "$STATE_FILE" ]; then
+    if [ -f "$STATE_FILE" ]; then
       ACTIVE_ICONS=$(jq -r 'keys | join(", ")' "$STATE_FILE" 2>/dev/null) || ACTIVE_ICONS=""
       [ -z "$ACTIVE_ICONS" ] && ACTIVE_ICONS="없음"
     else

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -149,22 +149,29 @@ case "$SOURCE" in
     [ ! -f "$MEMO_FILE" ] && : > "$MEMO_FILE"
     chmod 600 "$STATE_FILE" "$MEMO_FILE" 2>/dev/null || true
 
-    # Migration: 기존 sidecar 사용자에게 cwd 마커가 없으면 1회 seed.
-    # legacy(ls -t | head -1) fallback을 제거했기 때문에, 본 PR 적용 직후
-    # 사용자가 첫 /clear/branch를 하면 마커가 아직 없어 lineage 복원이
-    # silently 끊긴다 (Stop hook이 한 번이라도 실행되어야 마커 생성). startup
-    # 시점에 STATE_FILE이 이미 있고 마커가 없으면 현재 sid를 marker에 즉시
-    # 기록해 첫 lineage 복원도 정상 동작하도록 한다.
-    if [ -n "$CWD" ] && [ -f "$STATE_FILE" ]; then
-      MIGRATION_MARKER=$(marker_path_for_cwd "$CWD" 2>/dev/null) || MIGRATION_MARKER=""
-      if [ -n "$MIGRATION_MARKER" ] && [ ! -f "$MIGRATION_MARKER" ]; then
+    # Bootstrap marker: cwd 마커가 없으면 현재 sid로 즉시 기록.
+    #
+    # 적용 대상은 두 갈래로 모두 의도된 동작이다:
+    # 1) 본 PR 업그레이드 직후의 기존 sidecar 사용자 — Stop hook이 한 번이라도
+    #    실행되어야 마커가 생성되므로, startup 직후 /clear/branch가 발생하면
+    #    lineage 복원이 silently 끊긴다. legacy(`ls -t | head -1`) fallback을
+    #    제거한 결과 발생하는 migration window를 즉시 닫는다.
+    # 2) 새 cwd 첫 진입 — 같은 turn 안에서 /clear/branch가 발생하면 Stop hook이
+    #    아직 안 돌았을 수 있다. 미리 marker를 seed해두면 첫 lineage 복원이
+    #    빈 객체로 시작해 일관된 동작을 보인다. Stop hook이 곧 같은 sid로 덮어
+    #    쓰므로 부작용 없다.
+    #
+    # 즉 본 블록은 "marker bootstrap" — 두 경우 모두 동일하게 처리.
+    if [ -n "$CWD" ]; then
+      BOOTSTRAP_MARKER=$(marker_path_for_cwd "$CWD" 2>/dev/null) || BOOTSTRAP_MARKER=""
+      if [ -n "$BOOTSTRAP_MARKER" ] && [ ! -f "$BOOTSTRAP_MARKER" ]; then
         # atomic write — record-last-session.sh와 동일 패턴
-        _migration_tmp=$(mktemp "$SESSION_STATE_DIR/${SESSION_MARKER_PREFIX}XXXXXX" 2>/dev/null) || _migration_tmp=""
-        if [ -n "$_migration_tmp" ]; then
-          printf '%s\n' "$SESSION_ID" > "$_migration_tmp"
-          mv "$_migration_tmp" "$MIGRATION_MARKER" 2>/dev/null || rm -f "$_migration_tmp"
-          chmod 600 "$MIGRATION_MARKER" 2>/dev/null || true
-          session_hook_log session-start "migration-seed-marker sid=$SESSION_ID cwd=$CWD"
+        _bootstrap_tmp=$(mktemp "$SESSION_STATE_DIR/${SESSION_MARKER_PREFIX}XXXXXX" 2>/dev/null) || _bootstrap_tmp=""
+        if [ -n "$_bootstrap_tmp" ]; then
+          printf '%s\n' "$SESSION_ID" > "$_bootstrap_tmp"
+          mv "$_bootstrap_tmp" "$BOOTSTRAP_MARKER" 2>/dev/null || rm -f "$_bootstrap_tmp"
+          chmod 600 "$BOOTSTRAP_MARKER" 2>/dev/null || true
+          session_hook_log session-start "bootstrap-marker sid=$SESSION_ID cwd=$CWD"
         fi
       fi
     fi

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# SC2034: 본 파일의 상수는 source되는 hook에서만 참조한다. shellcheck는 직접
+# 사용처를 보지 못해 false positive로 unused를 보고. lib 파일 전체에 대해 disable.
+#
+# Session state shared helpers for SessionStart hook(session-init-icons.sh)과
+# Stop hook(record-last-session.sh)이 공유하는 상수·함수.
+#
+# 이 파일이 invariant의 SSOT다 — marker 경로 규약, session_id allowlist,
+# cwd 인코딩, 디버그 로그 포맷을 두 hook이 동일 정의로 공유한다. 한쪽에서
+# 변경하면 lineage 복원이 silently 깨지는 위험을 코드 레벨에서 차단한다.
+#
+# Source 방법:
+#   . "$(dirname "$0")/lib/session-state.sh"
+# pinning-{guard,alert}.sh가 lib/pinning-patterns.sh를 source하는 패턴과 동일.
+
+# 공유 상수
+SESSION_STATE_DIR="$HOME/.claude/status-icons"
+SESSION_MEMO_DIR="$HOME/.claude/memos"
+SESSION_LOG_DIR="$HOME/.claude/logs"
+SESSION_MARKER_PREFIX=".last-session-"
+SESSION_ARTIFACT_RETENTION_DAYS=30
+
+# cwd → sha1 hex. shasum 우선, sha1sum fallback. 둘 다 부재 시 빈 문자열
+# (호출부에서 lineage 복원/마커 기록을 graceful skip).
+hash_cwd() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum | awk '{print $1}'
+  elif command -v sha1sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha1sum | awk '{print $1}'
+  fi
+}
+
+# cwd → marker 파일 절대 경로
+marker_path_for_cwd() {
+  local encoded
+  encoded=$(hash_cwd "$1")
+  [ -z "$encoded" ] && return 1
+  printf '%s/%s%s' "$SESSION_STATE_DIR" "$SESSION_MARKER_PREFIX" "$encoded"
+}
+
+# session_id가 sidecar/marker 파일명에 안전한지 검사 (0=safe, 1=unsafe).
+# 정책: allowlist `[A-Za-z0-9._-]` only + `..` 시퀀스 차단(path traversal 방어).
+# 본 검증의 SSOT — hook과 statusline은 모두 이 함수 또는 동일 정책을 따른다.
+is_safe_session_id() {
+  case "$1" in
+    "") return 1 ;;
+    *[!A-Za-z0-9._-]*) return 1 ;;
+    *..*) return 1 ;;
+  esac
+  return 0
+}
+
+# CLAUDE_HOOK_DEBUG=1일 때만 활성화되는 진단 로그.
+# 실제 source 라벨링/cwd 동작을 실측하기 위한 영구 진단 인프라.
+# 첫 인자는 이벤트명(예: session-start, stop), 나머지는 자유 key=value pair.
+session_hook_log() {
+  [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ] || return 0
+  mkdir -p "$SESSION_LOG_DIR" 2>/dev/null || return 0
+  chmod 700 "$SESSION_LOG_DIR" 2>/dev/null || true
+  printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "${*:2}" \
+    >> "$SESSION_LOG_DIR/session-hooks.log" 2>/dev/null || true
+}

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -82,20 +82,22 @@ is_safe_session_id() {
 # - 두 번째 인자는 단일 message 문자열. 호출자가 `k=v k=v` 형태를 그대로 넘긴다.
 #   reader 측에서 `awk '{ts=$1; ev=$2; rest=$0}'` 형태로 파싱하면 첫 두 토큰만
 #   고정 필드, rest는 free-form. 값에 공백이 들어가도 단일 인자라면 한 줄로 기록.
-# - unsafe sid 진단 로그처럼 message에 control 문자(특히 newline, ESC, CSI)가
-#   포함될 가능성이 있는 호출을 대비해 message를 sanitize한다 — C0(0x00-0x1F)
-#   + DEL(0x7F) + C1(0x80-0x9F) 전체를 `?`로 치환해 단일 라인 invariant 및
-#   terminal escape 차단을 동시에 강제한다. UTF-8 multi-byte의 continuation
-#   byte(0x80-0xBF 일부)도 함께 치환되어 한글 등 UTF-8 cwd 일부가 깨질 수
-#   있으나, unsafe message는 비정상 입력이므로 수용 가능 trade-off다.
+# - 본 함수는 정상 session-start/stop 로그(cwd=$CWD 포함)에도 사용되므로
+#   sanitize 범위는 단일 라인 invariant 유지에 필요한 최소(C0 + DEL)로 한정한다.
+#   ESC(0x1B)는 C0에 포함되어 차단된다. raw C1 byte(0x80-0x9F)는 정상 UTF-8
+#   sequence에서 *단독* 등장이 invalid하므로 정상 cwd에선 발생하지 않는다.
+#   UTF-8 continuation byte는 보존되어 한글 등 cwd가 그대로 기록된다.
+#   unsafe sid 입력처럼 raw C1이 들어올 가능성이 있는 호출자는 자체적으로
+#   추가 sanitize를 적용할 수 있으나, debug 로그를 terminal cat보다 grep/awk
+#   reader로 보는 일반 사용 케이스에선 본 sanitize로 충분하다.
 session_hook_log() {
   [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ] || return 0
   mkdir -p "$SESSION_LOG_DIR" 2>/dev/null || return 0
   chmod 700 "$SESSION_LOG_DIR" 2>/dev/null || true
   local msg
-  # LC_ALL=C로 byte-mode tr. C0 + DEL + C1 모두 처리해 raw CSI(0x9B)나
-  # ESC([(0x1B [) 시퀀스가 terminal에 그대로 노출되지 않도록 한다.
-  msg=$(printf '%s' "$2" | LC_ALL=C tr '\000-\037\177\200-\237' '?')
+  # LC_ALL=C로 byte-mode tr. C0(0x00-0x1F) + DEL(0x7F)만 치환 — UTF-8 continuation
+  # byte(0x80-0xBF)는 보존해 정상 한글/UTF-8 cwd가 깨지지 않게 한다.
+  msg=$(printf '%s' "$2" | LC_ALL=C tr '\000-\037\177' '?')
   printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$msg" \
     >> "$SESSION_LOG_DIR/session-hooks.log" 2>/dev/null || true
 }

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -14,10 +14,8 @@
 #   상수:
 #     SESSION_STATE_DIR              — `~/.claude/status-icons`. status JSON + 마커 위치.
 #     SESSION_MEMO_DIR               — `~/.claude/memos`. 세션 메모 위치.
-#     SESSION_LOG_DIR                — `~/.claude/logs`. 디버그 로그 위치(retention
-#                                       정리 대상 아님 — single append-only file 모델).
+#     SESSION_LOG_DIR                — `~/.claude/logs`. 디버그 로그 위치.
 #     SESSION_MARKER_PREFIX          — `.last-session-`. cwd 마커 파일명 prefix.
-#     SESSION_ARTIFACT_RETENTION_DAYS=30 — status JSON / memo / 마커 공통 retention.
 #   함수:
 #     hash_cwd <path>                — cwd → sha1 hex(macOS shasum 우선, Linux sha1sum
 #                                       fallback). 둘 다 부재 시 빈 문자열 반환.
@@ -38,11 +36,13 @@
 # 공유 상수
 SESSION_STATE_DIR="$HOME/.claude/status-icons"
 SESSION_MEMO_DIR="$HOME/.claude/memos"
-# SESSION_LOG_DIR은 retention 정리 대상이 아니다 — append-only single file이라
-# mtime 기반 정리 모델이 부적합. 누적 우려 시 size-based rotation은 별도 follow-up.
+# SESSION_LOG_DIR은 append-only single file. size-based rotation은 별도 follow-up.
 SESSION_LOG_DIR="$HOME/.claude/logs"
 SESSION_MARKER_PREFIX=".last-session-"
-SESSION_ARTIFACT_RETENTION_DAYS=30
+# Retention 정책 없음 — 명확한 도입 이유가 PR #263 본문/code/CIR 어디에도
+# 기록되지 않은 임의의 30일 정리는 제거. 사용자 의도는 "아카이빙 우선" —
+# sidecar/memo/marker는 사용자가 명시적으로 정리하기 전까지 보존. storage 누적
+# 우려 시 별도 도구로 처리 (이 hook은 자동 삭제하지 않는다).
 
 # cwd → sha1 hex. shasum 우선, sha1sum fallback. 둘 다 부재 시 빈 문자열
 # (호출부에서 lineage 복원/마커 기록을 graceful skip).

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -82,18 +82,20 @@ is_safe_session_id() {
 # - 두 번째 인자는 단일 message 문자열. 호출자가 `k=v k=v` 형태를 그대로 넘긴다.
 #   reader 측에서 `awk '{ts=$1; ev=$2; rest=$0}'` 형태로 파싱하면 첫 두 토큰만
 #   고정 필드, rest는 free-form. 값에 공백이 들어가도 단일 인자라면 한 줄로 기록.
-# - unsafe sid 진단 로그처럼 message에 control 문자(특히 newline)가 포함될
-#   가능성이 있는 호출을 대비해 message를 sanitize한다 — control 문자를
-#   `?`로 치환해 단일 라인 invariant를 강제한다 (tr -d 대신 치환으로 위치
-#   정보를 보존). reader는 한 라인 = 한 이벤트 가정을 안전하게 유지.
+# - unsafe sid 진단 로그처럼 message에 control 문자(특히 newline, ESC, CSI)가
+#   포함될 가능성이 있는 호출을 대비해 message를 sanitize한다 — C0(0x00-0x1F)
+#   + DEL(0x7F) + C1(0x80-0x9F) 전체를 `?`로 치환해 단일 라인 invariant 및
+#   terminal escape 차단을 동시에 강제한다. UTF-8 multi-byte의 continuation
+#   byte(0x80-0xBF 일부)도 함께 치환되어 한글 등 UTF-8 cwd 일부가 깨질 수
+#   있으나, unsafe message는 비정상 입력이므로 수용 가능 trade-off다.
 session_hook_log() {
   [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ] || return 0
   mkdir -p "$SESSION_LOG_DIR" 2>/dev/null || return 0
   chmod 700 "$SESSION_LOG_DIR" 2>/dev/null || true
   local msg
-  # POSIX [:cntrl:]는 \n \r \t \0 등 control 문자 전체를 매치. LC_ALL=C로
-  # multibyte 영향 격리. 치환 후 단일 라인 보장.
-  msg=$(printf '%s' "$2" | LC_ALL=C tr '[:cntrl:]' '?')
+  # LC_ALL=C로 byte-mode tr. C0 + DEL + C1 모두 처리해 raw CSI(0x9B)나
+  # ESC([(0x1B [) 시퀀스가 terminal에 그대로 노출되지 않도록 한다.
+  msg=$(printf '%s' "$2" | LC_ALL=C tr '\000-\037\177\200-\237' '?')
   printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$msg" \
     >> "$SESSION_LOG_DIR/session-hooks.log" 2>/dev/null || true
 }

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -1,22 +1,45 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
-# SC2034: 본 파일의 상수는 source되는 hook에서만 참조한다. shellcheck는 직접
-# 사용처를 보지 못해 false positive로 unused를 보고. lib 파일 전체에 대해 disable.
+# SC2034: 본 파일의 상수는 source되는 hook과 statusline에서만 참조한다.
+# 정적 분석은 직접 사용처를 보지 못해 false positive로 unused를 보고하므로
+# 파일 전체에 대해 disable한다.
 #
-# Session state shared helpers for SessionStart hook(session-init-icons.sh)과
-# Stop hook(record-last-session.sh)이 공유하는 상수·함수.
+# Session state shared helpers — SessionStart hook(session-init-icons.sh), Stop
+# hook(record-last-session.sh), statusline.sh(validate_session_id 정책)가
+# 공유하는 상수·함수의 SSOT. 한쪽에서 변경하면 lineage 복원/sidecar I/O가
+# silently 어긋나는 위험을 코드 레벨에서 차단한다.
 #
-# 이 파일이 invariant의 SSOT다 — marker 경로 규약, session_id allowlist,
-# cwd 인코딩, 디버그 로그 포맷을 두 hook이 동일 정의로 공유한다. 한쪽에서
-# 변경하면 lineage 복원이 silently 깨지는 위험을 코드 레벨에서 차단한다.
+# 공개 API
+# ─────────
+#   상수:
+#     SESSION_STATE_DIR              — `~/.claude/status-icons`. status JSON + 마커 위치.
+#     SESSION_MEMO_DIR               — `~/.claude/memos`. 세션 메모 위치.
+#     SESSION_LOG_DIR                — `~/.claude/logs`. 디버그 로그 위치(retention
+#                                       정리 대상 아님 — single append-only file 모델).
+#     SESSION_MARKER_PREFIX          — `.last-session-`. cwd 마커 파일명 prefix.
+#     SESSION_ARTIFACT_RETENTION_DAYS=30 — status JSON / memo / 마커 공통 retention.
+#   함수:
+#     hash_cwd <path>                — cwd → sha1 hex(macOS shasum 우선, Linux sha1sum
+#                                       fallback). 둘 다 부재 시 빈 문자열 반환.
+#     marker_path_for_cwd <path>     — cwd → 마커 절대경로. encoded 실패 시 return 1.
+#     is_safe_session_id <sid>       — 정책 SSOT (0=safe, 1=unsafe). allowlist
+#                                       `[A-Za-z0-9._-]` + `..` 차단.
+#     session_hook_log <event> <msg> — `CLAUDE_HOOK_DEBUG=1` 게이트. 단일 message
+#                                       문자열만 받는다(공백/특수문자 포함 가능).
+#                                       허용 event: `session-start`, `session-start-unsafe`,
+#                                       `stop`.
 #
-# Source 방법:
-#   . "$(dirname "$0")/lib/session-state.sh"
-# pinning-{guard,alert}.sh가 lib/pinning-patterns.sh를 source하는 패턴과 동일.
+# Source 방법(pinning-{guard,alert}.sh가 lib/pinning-patterns.sh를 source하는
+# 패턴과 동일 — `$HOME/.claude/lib` 우선 + repo fallback):
+#   SESSION_STATE_LIB="${SESSION_STATE_LIB:-$HOME/.claude/lib/session-state.sh}"
+#   [ -f "$SESSION_STATE_LIB" ] || SESSION_STATE_LIB="<script_dir>/../lib/session-state.sh"
+#   . "$SESSION_STATE_LIB"
 
 # 공유 상수
 SESSION_STATE_DIR="$HOME/.claude/status-icons"
 SESSION_MEMO_DIR="$HOME/.claude/memos"
+# SESSION_LOG_DIR은 retention 정리 대상이 아니다 — append-only single file이라
+# mtime 기반 정리 모델이 부적합. 누적 우려 시 size-based rotation은 별도 follow-up.
 SESSION_LOG_DIR="$HOME/.claude/logs"
 SESSION_MARKER_PREFIX=".last-session-"
 SESSION_ARTIFACT_RETENTION_DAYS=30
@@ -41,7 +64,7 @@ marker_path_for_cwd() {
 
 # session_id가 sidecar/marker 파일명에 안전한지 검사 (0=safe, 1=unsafe).
 # 정책: allowlist `[A-Za-z0-9._-]` only + `..` 시퀀스 차단(path traversal 방어).
-# 본 검증의 SSOT — hook과 statusline은 모두 이 함수 또는 동일 정책을 따른다.
+# 본 검증의 SSOT — hook과 statusline은 모두 이 함수를 source해서 호출한다.
 is_safe_session_id() {
   case "$1" in
     "") return 1 ;;
@@ -53,11 +76,16 @@ is_safe_session_id() {
 
 # CLAUDE_HOOK_DEBUG=1일 때만 활성화되는 진단 로그.
 # 실제 source 라벨링/cwd 동작을 실측하기 위한 영구 진단 인프라.
-# 첫 인자는 이벤트명(예: session-start, stop), 나머지는 자유 key=value pair.
+#
+# Invariant:
+# - 첫 인자는 event 라벨(허용 enum: session-start / session-start-unsafe / stop).
+# - 두 번째 인자는 단일 message 문자열. 호출자가 `k=v k=v` 형태를 그대로 넘긴다.
+#   reader 측에서 `awk '{ts=$1; ev=$2; rest=$0}'` 형태로 파싱하면 첫 두 토큰만
+#   고정 필드, rest는 free-form. 값에 공백이 들어가도 단일 인자라면 한 줄로 기록.
 session_hook_log() {
   [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ] || return 0
   mkdir -p "$SESSION_LOG_DIR" 2>/dev/null || return 0
   chmod 700 "$SESSION_LOG_DIR" 2>/dev/null || true
-  printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "${*:2}" \
+  printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" \
     >> "$SESSION_LOG_DIR/session-hooks.log" 2>/dev/null || true
 }

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -82,10 +82,18 @@ is_safe_session_id() {
 # - 두 번째 인자는 단일 message 문자열. 호출자가 `k=v k=v` 형태를 그대로 넘긴다.
 #   reader 측에서 `awk '{ts=$1; ev=$2; rest=$0}'` 형태로 파싱하면 첫 두 토큰만
 #   고정 필드, rest는 free-form. 값에 공백이 들어가도 단일 인자라면 한 줄로 기록.
+# - unsafe sid 진단 로그처럼 message에 control 문자(특히 newline)가 포함될
+#   가능성이 있는 호출을 대비해 message를 sanitize한다 — control 문자를
+#   `?`로 치환해 단일 라인 invariant를 강제한다 (tr -d 대신 치환으로 위치
+#   정보를 보존). reader는 한 라인 = 한 이벤트 가정을 안전하게 유지.
 session_hook_log() {
   [ "${CLAUDE_HOOK_DEBUG:-0}" = "1" ] || return 0
   mkdir -p "$SESSION_LOG_DIR" 2>/dev/null || return 0
   chmod 700 "$SESSION_LOG_DIR" 2>/dev/null || true
-  printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" \
+  local msg
+  # POSIX [:cntrl:]는 \n \r \t \0 등 control 문자 전체를 매치. LC_ALL=C로
+  # multibyte 영향 격리. 치환 후 단일 라인 보장.
+  msg=$(printf '%s' "$2" | LC_ALL=C tr '[:cntrl:]' '?')
+  printf '%s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$msg" \
     >> "$SESSION_LOG_DIR/session-hooks.log" 2>/dev/null || true
 }

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -15,6 +15,16 @@
 
 input=$(cat)
 
+# 공유 helper. SESSION_STATE_DIR / is_safe_session_id 등 SSOT를 hook과 공유.
+# pinning-guard.sh와 동일 패턴: 설치된 $HOME/.claude/lib 우선, repo fallback.
+SESSION_STATE_LIB="${SESSION_STATE_LIB:-$HOME/.claude/lib/session-state.sh}"
+if [ ! -f "$SESSION_STATE_LIB" ]; then
+  STATUSLINE_DIR="$(cd "$(dirname "$0")" && pwd)"
+  SESSION_STATE_LIB="$STATUSLINE_DIR/../lib/session-state.sh"
+fi
+# shellcheck source=../lib/session-state.sh disable=SC1091
+[ -f "$SESSION_STATE_LIB" ] && . "$SESSION_STATE_LIB"
+
 # ============================================================
 # Helper: 입력 검증 + sanitize
 # ============================================================
@@ -96,15 +106,18 @@ validate_transcript_path() {
   printf '%s' "$canonical_dir"
 }
 
-# session_id 패턴 검증 (UUID 또는 safe filename pattern)
-# 통과: exit 0 / 실패: exit 1
-# 정책은 hooks/lib/session-state.sh의 is_safe_session_id와 동일하게 유지한다 —
-# allowlist + `..` path traversal 차단. hook이 거부하고 statusline은 통과시키는
-# 비대칭이 발생하면 동일 세션을 두 컴포넌트가 다르게 인식한다.
+# session_id 패턴 검증 — lib/session-state.sh의 is_safe_session_id를 그대로 위임.
+# lib source 실패 시(개발 환경 부재) 동일 정책의 inline fallback 사용.
+# 정책 SSOT는 lib의 is_safe_session_id이며, 본 wrapper는 statusline 호출 표면만
+# 유지하기 위한 thin alias이다.
 validate_session_id() {
-  local sid=$1
-  [ -z "$sid" ] && return 1
-  case "$sid" in
+  if command -v is_safe_session_id >/dev/null 2>&1; then
+    is_safe_session_id "$1"
+    return $?
+  fi
+  # lib 미로드 fallback — 정책은 is_safe_session_id와 동일하게 유지한다.
+  case "${1:-}" in
+    "") return 1 ;;
     *[!A-Za-z0-9._-]*) return 1 ;;
     *..*) return 1 ;;
   esac
@@ -437,7 +450,9 @@ fi
 #   SESSION_ID 검증 통과 시에만 sidecar I/O
 # ============================================================
 ICONS_FILE=""
-$SIDECAR_IO_ENABLED && ICONS_FILE="$HOME/.claude/status-icons/$SESSION_ID.json"
+# SESSION_STATE_DIR은 lib/session-state.sh의 SSOT. lib 미로드 시 hook과 동일 경로
+# 하드코딩으로 fallback (sidecar 파일은 동일 위치).
+$SIDECAR_IO_ENABLED && ICONS_FILE="${SESSION_STATE_DIR:-$HOME/.claude/status-icons}/$SESSION_ID.json"
 
 JIRA_URL="" JIRA_LABEL=""
 SLACK_URL="" SLACK_LABEL=""

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -98,11 +98,15 @@ validate_transcript_path() {
 
 # session_id 패턴 검증 (UUID 또는 safe filename pattern)
 # 통과: exit 0 / 실패: exit 1
+# 정책은 hooks/lib/session-state.sh의 is_safe_session_id와 동일하게 유지한다 —
+# allowlist + `..` path traversal 차단. hook이 거부하고 statusline은 통과시키는
+# 비대칭이 발생하면 동일 세션을 두 컴포넌트가 다르게 인식한다.
 validate_session_id() {
   local sid=$1
   [ -z "$sid" ] && return 1
   case "$sid" in
     *[!A-Za-z0-9._-]*) return 1 ;;
+    *..*) return 1 ;;
   esac
   return 0
 }

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -110,6 +110,10 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/record-last-session.sh"
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/nrs-session-cleanup.sh"
           }
         ]

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -158,6 +158,8 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 
 Stop hook(`record-last-session.sh`)이 매 턴 종료에 `~/.claude/status-icons/.last-session-<sha1(cwd)>` 마커 파일에 `session_id`를 atomic write한다. SessionStart hook은 새 sid에 sidecar가 없을 때 **같은 cwd의 마커**만 조회하므로, 동시에 진행 중인 다른 워크트리/프로젝트 세션과 아이콘이 섞이지 않는다.
 
+SessionStart hook은 startup 시점에 cwd 마커가 없으면 현재 sid로 마커를 bootstrap한다. 본 변경 적용 직후의 기존 sidecar 사용자(아직 Stop hook이 한 번도 실행되지 않은 상태)와 새 cwd 첫 진입 모두에서 startup 직후 `/clear`/`/branch`가 발생해도 lineage 복원이 끊기지 않도록 보장한다.
+
 Retention 30일은 `~/.claude/lib/session-state.sh`의 `SESSION_ARTIFACT_RETENTION_DAYS` 단일 상수가 status JSON / memo / 마커 세 종류에 동일 적용한다. 마커도 같은 retention의 대상이므로 cwd 활동이 끊긴 후 30일 지나면 자동 청소되어 orphaned cwd가 무한 누적되지 않는다.
 
 ## 자주 발생하는 문제

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -152,11 +152,13 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 | `/clear` | 같은 cwd 마커의 직전 sid에서 sidecar/memo deep clone 복원 |
 | `--resume` / `--continue` | 기존 상태 파일 읽기, 모든 아이콘 유지 |
 | `compact` | 동일하게 상태 재주입 |
-| 30일 초과 | 상태 파일·메모·마커 파일 자동 정리 |
+| 30일 초과 | 상태 파일·메모·마커 파일 자동 정리 (1단계 일반 파일만 — 디렉토리/심볼릭링크는 외부 관리 자원 보호 차원에서 제외) |
 
 ### Lineage 복원 (cwd 격리)
 
 Stop hook(`record-last-session.sh`)이 매 턴 종료에 `~/.claude/status-icons/.last-session-<sha1(cwd)>` 마커 파일에 `session_id`를 atomic write한다. SessionStart hook은 새 sid에 sidecar가 없을 때 **같은 cwd의 마커**만 조회하므로, 동시에 진행 중인 다른 워크트리/프로젝트 세션과 아이콘이 섞이지 않는다.
+
+Retention 30일은 `hooks/lib/session-state.sh`의 `SESSION_ARTIFACT_RETENTION_DAYS` 단일 상수가 status JSON / memo / 마커 세 종류에 동일 적용한다. 마커도 같은 retention의 대상이므로 cwd 활동이 끊긴 후 30일 지나면 자동 청소되어 orphaned cwd가 무한 누적되지 않는다.
 
 ## 자주 발생하는 문제
 

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -158,7 +158,7 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 
 Stop hook(`record-last-session.sh`)이 매 턴 종료에 `~/.claude/status-icons/.last-session-<sha1(cwd)>` 마커 파일에 `session_id`를 atomic write한다. SessionStart hook은 새 sid에 sidecar가 없을 때 **같은 cwd의 마커**만 조회하므로, 동시에 진행 중인 다른 워크트리/프로젝트 세션과 아이콘이 섞이지 않는다.
 
-Retention 30일은 `hooks/lib/session-state.sh`의 `SESSION_ARTIFACT_RETENTION_DAYS` 단일 상수가 status JSON / memo / 마커 세 종류에 동일 적용한다. 마커도 같은 retention의 대상이므로 cwd 활동이 끊긴 후 30일 지나면 자동 청소되어 orphaned cwd가 무한 누적되지 않는다.
+Retention 30일은 `~/.claude/lib/session-state.sh`의 `SESSION_ARTIFACT_RETENTION_DAYS` 단일 상수가 status JSON / memo / 마커 세 종류에 동일 적용한다. 마커도 같은 retention의 대상이므로 cwd 활동이 끊긴 후 30일 지나면 자동 청소되어 orphaned cwd가 무한 누적되지 않는다.
 
 ## 자주 발생하는 문제
 

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -148,7 +148,7 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 
 | 상황 | 동작 |
 |------|------|
-| 새 세션 (cwd 첫 진입) | 빈 상태 파일 + 메모 파일 생성, 아이콘 없음 |
+| 새 세션 (cwd 첫 진입 또는 종료 후 재시작) | 빈 상태로 시작, 아이콘 없음. 같은 cwd의 이전 세션 아이콘은 상속하지 않는다. |
 | `/clear` | 같은 cwd 마커의 직전 sid에서 sidecar/memo deep clone 복원 |
 | `--resume` / `--continue` | 기존 상태 파일 읽기, 모든 아이콘 유지 |
 | `compact` | 동일하게 상태 재주입 |
@@ -177,10 +177,11 @@ Retention 30일은 `~/.claude/lib/session-state.sh`의 `SESSION_ARTIFACT_RETENTI
    - **L_M (heavy state 그룹)**: Plan (📝) → Memory (🧠) → Cache TTL (⏱). Memo는 L1으로 이동, Plan/Memory는 L_M 유지
    - **L_N**: 5h/7d Rate Limits
 5. **SessionStart hook 동작 (source별)**:
-   - 모든 source 분기에서 **STATE_FILE이 이미 존재하면 그대로 보존**. 어떤 source로 라벨이 오더라도 기존 아이콘이 사라지지 않는다.
-   - STATE_FILE이 부재할 때만 다음 순서로 복원 시도: ① 같은 cwd 마커의 직전 sid sidecar에서 deep clone → ② 실패 시 빈 객체 `{}`로 시작.
-   - 마커는 Stop hook이 매 턴 종료에 cwd-sha1로 인코딩된 파일에 sid를 기록해 누적한다. **글로벌 mtime 기반 탐색은 사용하지 않으므로** 동시 실행 중인 다른 cwd 세션과 아이콘이 섞이지 않는다.
-   - 실제 source 라벨링이 의심되면 `CLAUDE_HOOK_DEBUG=1`로 hook을 재기동해 `~/.claude/logs/session-hooks.log` 채집.
+   - 지원 source는 `startup`, `clear`, `resume`, `compact` 네 가지. 그 외 source는 hook이 즉시 `exit 0`로 skip한다 (sidecar/memo는 생성하지 않음).
+   - **startup**: STATE_FILE이 부재하면 빈 객체 `{}`로 시작. 동일 sid로 startup이 재발화되면 STATE_FILE을 보존(아이콘 유실 방지). lineage 복원은 시도하지 않으므로 같은 cwd에서 새 세션을 열면 빈 상태로 시작한다.
+   - **clear / resume / compact**: STATE_FILE이 부재하면 ① 같은 cwd 마커의 직전 sid sidecar에서 deep clone → ② 실패 시 빈 객체 `{}`. STATE_FILE이 이미 존재하면 그대로 사용.
+   - 마커는 Stop hook이 매 턴 종료에 cwd-sha1로 인코딩된 파일에 sid를 기록해 누적한다. startup 시점에도 마커가 없으면 현재 sid로 bootstrap한다(첫 `/clear`에 lineage 복원이 동작하도록). **글로벌 mtime 기반 탐색은 사용하지 않으므로** 동시 실행 중인 다른 cwd 세션과 아이콘이 섞이지 않는다.
+   - 실제 source 라벨링이 의심되면(예: `/clear` 후 아이콘이 사라지는 증상이 재현되면) `CLAUDE_HOOK_DEBUG=1`로 hook을 재기동해 `~/.claude/logs/session-hooks.log`를 채집한 뒤 source 매핑을 확인한다.
 6. **OSC 8 hyperlink 클릭 UX (macOS Ghostty + Claude Code fullscreen)**:
    - **일반 Cmd+클릭** — Plan/Memo/Memory 같은 `file://` link는 Ghostty plain-text URL fallback detector로 동작 (Jira/Slack/Figma 같은 `https://`도 동작)
    - **Cmd+Shift+클릭** — Claude Code TUI(`CLAUDE_CODE_NO_FLICKER` fullscreen 모드)가 mouse capture로 일반 Cmd+클릭을 가로채는 영역에서 escape hatch. cwd (`vscode://file/<path>/`) 처럼 fallback detector가 인식 못 하는 scheme은 **Cmd+Shift+클릭으로만 동작**

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -152,7 +152,7 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 | `/clear` | 같은 cwd 마커의 직전 sid에서 sidecar/memo deep clone 복원 |
 | `--resume` / `--continue` | 기존 상태 파일 읽기, 모든 아이콘 유지 |
 | `compact` | 동일하게 상태 재주입 |
-| 30일 초과 | 상태 파일·메모·마커 파일 자동 정리 (1단계 일반 파일만 — 디렉토리/심볼릭링크는 외부 관리 자원 보호 차원에서 제외) |
+| 자동 정리 | 없음 (아카이빙 우선) — sidecar/memo/마커는 사용자가 명시적으로 정리하기 전까지 보존 |
 
 ### Lineage 복원 (cwd 격리)
 
@@ -160,7 +160,7 @@ Stop hook(`record-last-session.sh`)이 매 턴 종료에 `~/.claude/status-icons
 
 SessionStart hook은 startup 시점에 cwd 마커가 없으면 현재 sid로 마커를 bootstrap한다. 본 변경 적용 직후의 기존 sidecar 사용자(아직 Stop hook이 한 번도 실행되지 않은 상태)와 새 cwd 첫 진입 모두에서 startup 직후 `/clear`/`/branch`가 발생해도 lineage 복원이 끊기지 않도록 보장한다.
 
-Retention 30일은 `~/.claude/lib/session-state.sh`의 `SESSION_ARTIFACT_RETENTION_DAYS` 단일 상수가 status JSON / memo / 마커 세 종류에 동일 적용한다. 마커도 같은 retention의 대상이므로 cwd 활동이 끊긴 후 30일 지나면 자동 청소되어 orphaned cwd가 무한 누적되지 않는다.
+아카이빙 우선 정책으로 자동 정리 로직은 없다. sidecar/메모/마커는 사용자가 명시적으로 정리하기 전까지 그대로 보존된다. storage 누적이 부담이 되면 별도 도구나 수동 정리로 처리한다.
 
 ## 자주 발생하는 문제
 

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -148,8 +148,8 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 
 | 상황 | 동작 |
 |------|------|
-| 새 세션 (cwd 첫 진입 또는 종료 후 재시작) | 빈 상태로 시작, 아이콘 없음. 같은 cwd의 이전 세션 아이콘은 상속하지 않는다. |
-| `/clear` | 같은 cwd 마커의 직전 sid에서 sidecar/memo deep clone 복원 |
+| 새 세션 (cwd 첫 진입 또는 종료 후 재시작) | 빈 sidecar로 시작. 같은 cwd 마커는 startup이 건드리지 않음 (관리 책임은 Stop hook). |
+| `/clear` | 같은 cwd 마커의 직전 sid에서 sidecar/memo deep clone 복원 — 같은 cwd에서 며칠 전 세션의 아이콘도 자동 복원된다(아카이빙 우선). |
 | `--resume` / `--continue` | 기존 상태 파일 읽기, 모든 아이콘 유지 |
 | `compact` | 동일하게 상태 재주입 |
 | 자동 정리 | 없음 (아카이빙 우선) — sidecar/memo/마커는 사용자가 명시적으로 정리하기 전까지 보존 |
@@ -158,9 +158,9 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 
 Stop hook(`record-last-session.sh`)이 매 턴 종료에 `~/.claude/status-icons/.last-session-<sha1(cwd)>` 마커 파일에 `session_id`를 atomic write한다. SessionStart hook은 새 sid에 sidecar가 없을 때 **같은 cwd의 마커**만 조회하므로, 동시에 진행 중인 다른 워크트리/프로젝트 세션과 아이콘이 섞이지 않는다.
 
-SessionStart hook은 startup 시점에 cwd 마커가 없으면 현재 sid로 마커를 bootstrap한다. 본 변경 적용 직후의 기존 sidecar 사용자(아직 Stop hook이 한 번도 실행되지 않은 상태)와 새 cwd 첫 진입 모두에서 startup 직후 `/clear`/`/branch`가 발생해도 lineage 복원이 끊기지 않도록 보장한다.
+marker 관리는 전적으로 Stop hook의 책임이다 — SessionStart hook은 startup에서 marker를 건드리지 않으므로, 같은 cwd에 두 인스턴스가 동시에 떠 있어도 새 인스턴스의 startup이 다른 인스턴스의 active marker를 덮어쓰지 않는다. 결과적으로 같은 cwd에서 며칠 전 세션 종료 후 다시 방문해 `/clear`/`/branch`를 하면 직전 세션의 아이콘이 자동 복원된다(아카이빙 우선).
 
-아카이빙 우선 정책으로 자동 정리 로직은 없다. sidecar/메모/마커는 사용자가 명시적으로 정리하기 전까지 그대로 보존된다. storage 누적이 부담이 되면 별도 도구나 수동 정리로 처리한다.
+자동 정리 로직은 없다. sidecar/메모/마커는 사용자가 명시적으로 정리하기 전까지 그대로 보존된다. storage 누적이 부담이 되면 별도 도구나 수동 정리로 처리한다.
 
 ## 자주 발생하는 문제
 
@@ -178,9 +178,9 @@ SessionStart hook은 startup 시점에 cwd 마커가 없으면 현재 sid로 마
    - **L_N**: 5h/7d Rate Limits
 5. **SessionStart hook 동작 (source별)**:
    - 지원 source는 `startup`, `clear`, `resume`, `compact` 네 가지. 그 외 source는 hook이 즉시 `exit 0`로 skip한다 (sidecar/memo는 생성하지 않음).
-   - **startup**: STATE_FILE이 부재하면 빈 객체 `{}`로 시작. 동일 sid로 startup이 재발화되면 STATE_FILE을 보존(아이콘 유실 방지). lineage 복원은 시도하지 않으므로 같은 cwd에서 새 세션을 열면 빈 상태로 시작한다.
+   - **startup**: STATE_FILE이 부재하면 빈 객체 `{}`로 시작. 동일 sid로 startup이 재발화되면 STATE_FILE을 보존(아이콘 유실 방지). cwd 마커는 startup이 건드리지 않는다 (관리 책임은 Stop hook).
    - **clear / resume / compact**: STATE_FILE이 부재하면 ① 같은 cwd 마커의 직전 sid sidecar에서 deep clone → ② 실패 시 빈 객체 `{}`. STATE_FILE이 이미 존재하면 그대로 사용.
-   - 마커는 Stop hook이 매 턴 종료에 cwd-sha1로 인코딩된 파일에 sid를 기록해 누적한다. startup 시점에도 마커가 없으면 현재 sid로 bootstrap한다(첫 `/clear`에 lineage 복원이 동작하도록). **글로벌 mtime 기반 탐색은 사용하지 않으므로** 동시 실행 중인 다른 cwd 세션과 아이콘이 섞이지 않는다.
+   - 마커는 Stop hook이 매 턴 종료에 cwd-sha1로 인코딩된 파일에 sid를 기록해 누적한다. **글로벌 mtime 기반 탐색은 사용하지 않으므로** 동시 실행 중인 다른 cwd 세션과 아이콘이 섞이지 않는다.
    - 실제 source 라벨링이 의심되면(예: `/clear` 후 아이콘이 사라지는 증상이 재현되면) `CLAUDE_HOOK_DEBUG=1`로 hook을 재기동해 `~/.claude/logs/session-hooks.log`를 채집한 뒤 source 매핑을 확인한다.
 6. **OSC 8 hyperlink 클릭 UX (macOS Ghostty + Claude Code fullscreen)**:
    - **일반 Cmd+클릭** — Plan/Memo/Memory 같은 `file://` link는 Ghostty plain-text URL fallback detector로 동작 (Jira/Slack/Figma 같은 `https://`도 동작)

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -148,10 +148,15 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
 
 | 상황 | 동작 |
 |------|------|
-| 새 세션 / `/clear` | 빈 상태 파일 + 메모 파일 생성, 아이콘 없음 |
+| 새 세션 (cwd 첫 진입) | 빈 상태 파일 + 메모 파일 생성, 아이콘 없음 |
+| `/clear` | 같은 cwd 마커의 직전 sid에서 sidecar/memo deep clone 복원 |
 | `--resume` / `--continue` | 기존 상태 파일 읽기, 모든 아이콘 유지 |
 | `compact` | 동일하게 상태 재주입 |
-| 30일 초과 | 상태 파일 + 메모 파일 자동 정리 |
+| 30일 초과 | 상태 파일·메모·마커 파일 자동 정리 |
+
+### Lineage 복원 (cwd 격리)
+
+Stop hook(`record-last-session.sh`)이 매 턴 종료에 `~/.claude/status-icons/.last-session-<sha1(cwd)>` 마커 파일에 `session_id`를 atomic write한다. SessionStart hook은 새 sid에 sidecar가 없을 때 **같은 cwd의 마커**만 조회하므로, 동시에 진행 중인 다른 워크트리/프로젝트 세션과 아이콘이 섞이지 않는다.
 
 ## 자주 발생하는 문제
 
@@ -168,8 +173,10 @@ tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
    - **L_M (heavy state 그룹)**: Plan (📝) → Memory (🧠) → Cache TTL (⏱). Memo는 L1으로 이동, Plan/Memory는 L_M 유지
    - **L_N**: 5h/7d Rate Limits
 5. **SessionStart hook 동작 (source별)**:
-   - `startup` (새 세션): 빈 상태 파일 + 메모 파일 생성. 아이콘 없음
-   - `clear` / `resume` / `compact` (기존 세션 재진입): 상태 파일 없으면 가장 최근 상태 파일을 복사하여 아이콘/메모 경로 보존
+   - 모든 source 분기에서 **STATE_FILE이 이미 존재하면 그대로 보존**. 어떤 source로 라벨이 오더라도 기존 아이콘이 사라지지 않는다.
+   - STATE_FILE이 부재할 때만 다음 순서로 복원 시도: ① 같은 cwd 마커의 직전 sid sidecar에서 deep clone → ② 실패 시 빈 객체 `{}`로 시작.
+   - 마커는 Stop hook이 매 턴 종료에 cwd-sha1로 인코딩된 파일에 sid를 기록해 누적한다. **글로벌 mtime 기반 탐색은 사용하지 않으므로** 동시 실행 중인 다른 cwd 세션과 아이콘이 섞이지 않는다.
+   - 실제 source 라벨링이 의심되면 `CLAUDE_HOOK_DEBUG=1`로 hook을 재기동해 `~/.claude/logs/session-hooks.log` 채집.
 6. **OSC 8 hyperlink 클릭 UX (macOS Ghostty + Claude Code fullscreen)**:
    - **일반 Cmd+클릭** — Plan/Memo/Memory 같은 `file://` link는 Ghostty plain-text URL fallback detector로 동작 (Jira/Slack/Figma 같은 `https://`도 동작)
    - **Cmd+Shift+클릭** — Claude Code TUI(`CLAUDE_CODE_NO_FLICKER` fullscreen 모드)가 mouse capture로 일반 Cmd+클릭을 가로채는 영역에서 escape hatch. cwd (`vscode://file/<path>/`) 처럼 fallback detector가 인식 못 하는 scheme은 **Cmd+Shift+클릭으로만 동작**


### PR DESCRIPTION
## Summary
- SessionStart hook이 `/clear` 직후 `ls -t | head -1`로 전역 mtime 최신 sidecar를 복원하던 cross-cwd 누수를 차단하고, cwd 단위 lineage 마커를 통해 같은 cwd의 직전 sid sidecar만 복원하도록 교체한다.
- `startup` 분기가 STATE_FILE을 무조건 빈 객체로 덮어쓰던 동작을 "부재 시에만 새로 만들기"로 가드해, source 라벨링 변동(예: `/clear`가 startup으로 라벨되는 경우)에도 기존 아이콘이 유실되지 않게 한다.

## 기존 문제/배경

기존 `hooks/session-init-icons.sh`의 `clear|resume|compact` 분기 복원 로직(`ls -t \"$STATE_DIR\"/*.json | head -1`)은 **프로젝트/cwd 정보를 완전히 무시**한다. 그 결과 두 가지 결함이 사용자 환경에서 재현된다.

**결함 1 — cross-cwd 누수**: 동시에 다른 워크트리/디렉토리에서 진행 중인 세션이 `/set-icons`로 sidecar를 갱신해 mtime이 더 최근이 되면, 현재 cwd에서 `/branch`를 실행했을 때 hook이 *완전히 다른 cwd 세션의 sidecar*를 통째로 복사해온다. 새 sidecar 내용이 직전 외부 sidecar와 byte-identical하고, 사용자 cwd와 무관한 아이콘이 상태바에 표시된다.

**결함 2 — `/clear` 시 아이콘 소실**: `startup` 분기는 STATE_FILE 존재 여부와 무관하게 `echo '{}' > \"\$STATE_FILE\"`를 무조건 실행한다. Claude Code 빌드/버전에 따라 `/clear`가 `source=startup`으로 라벨되는 경우(또는 동일 sid에 startup이 재발화되는 경우) 기존 아이콘이 소실된다. SessionStart `additionalContext` 메시지가 "초기화됨"으로 나오는 것이 startup 분기 실행 증거다.

근본 원인은 hook stdin의 `transcript_path`·`cwd` 필드가 프로젝트 식별 정보를 제공하는데도 복원 로직이 이를 사용하지 않는 점, 그리고 새 sid 발급 시 직전 sid를 추적할 수 있는 메커니즘이 없는 점이다.

## CIR (Change Intent Record)

- **v1** (PR #733): cwd·branch·session-id 라인을 statusline에 추가. sidecar 기반 상태바 인프라 정착.
- **v2** (PR #736): 워크트리 display 단축, cwd vscode:// 처리. sidecar 데이터 모델은 유지.
- **v3** (이번 변경): 같은 cwd에서 `/clear`/`/branch`가 발생할 때 직전 sid를 정확히 식별할 수 있도록 Stop hook에서 cwd-encoded 마커를 누적 기록. 글로벌 `ls -t` 경쟁을 cwd 격리된 marker lookup으로 대체. 추가로 `startup` 분기에 STATE_FILE 존재 가드를 도입해 source 라벨 가정에 대한 의존성을 제거.

**trade-off**: Stop hook이 매 턴 종료에 한 번 더 실행되어 비용이 증가하지만, 실측 0.1초 미만이며 atomic write로 정합성 보장. 마커 파일은 30일 retention 정리 대상에 포함되어 storage 누적도 차단.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 기존 `ls -t \| head -1` | 전역 mtime 최신 sidecar 복원 | 구현 단순 | cross-cwd 누수, 동시 세션 환경에서 사실상 사용 불가 | ❌ |
| `transcript_path` 파싱으로 프로젝트 추출 | `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` 경로에서 encoded cwd 추출, 같은 encoded cwd의 sidecar만 후보로 | 별도 인프라 불필요 | 후보 sidecar 각각에 대해 transcript 위치를 역조회해야 하므로 O(N) 디스크 탐색, 인코딩 형식이 비공식 | ❌ |
| Stop hook + cwd-sha1 마커 | 매 턴 종료에 `.last-session-<sha1(cwd)>` 파일에 sid 기록, SessionStart는 그 파일만 읽음 | O(1) lookup, cwd 단위 자연 격리, subagent agent_id로 분리 추적 | Stop hook 추가 1회 실행 비용 | ✅ |
| sidecar 디렉토리를 cwd별 서브디렉토리로 분리 | `~/.claude/status-icons/<cwd-key>/<sid>.json` 구조 변경 | `ls -t` 자체가 cwd-safe | 기존 sidecar 마이그레이션 필요, statusline.sh 등 다른 컴포넌트의 경로 가정 영향 큼 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/hooks/record-last-session.sh` | 신규 | Stop hook. `~/.claude/status-icons/.last-session-<sha1(cwd)>` 마커에 sid atomic 기록. agent_id 있으면 subagent로 판단해 skip. |
| `modules/shared/programs/claude/files/hooks/session-init-icons.sh` | 수정 | `restore_from_cwd_lineage()` 헬퍼로 cwd 마커 기반 복원. startup 분기에 STATE_FILE 존재 가드 추가. umask 077 + 권한 600/700 강제. `..` path traversal 차단 명시. 마커 파일도 30일 retention 정리에 포함. `CLAUDE_HOOK_DEBUG=1` 게이트로 진단 로그 활성화. |
| `modules/shared/programs/claude/files/settings.json` | 수정 | Stop hook 배열에 `record-last-session.sh` 추가 (기존 `record-last-stop.sh`, `nrs-session-cleanup.sh` 옆). |
| `modules/shared/programs/claude/default.nix` | 수정 | 새 hook 스크립트를 `mkOutOfStoreSymlink`로 `~/.claude/hooks/` 아래 등록. |
| `modules/shared/programs/claude/files/skills/set-icons/SKILL.md` | 수정 | 동작 원리 표에 cwd-격리 lineage 설명 추가. 자주 발생하는 문제 #5의 source 매핑을 STATE_FILE 보존 정책으로 갱신. `CLAUDE_HOOK_DEBUG` 진단 방법 안내. |

### 핵심 코드

**복원 로직 교체** (`session-init-icons.sh`):

```bash
# BEFORE: 전역 mtime 최신 sidecar 복원 (cross-cwd 누수)
LATEST=\$(ls -t \"\$STATE_DIR\"/*.json 2>/dev/null | head -1 || true)
if [ -n \"\$LATEST\" ] && [ -f \"\$LATEST\" ]; then
  jq ... \"\$LATEST\" > \"\$STATE_FILE\"
fi

# AFTER: cwd-encoded 마커의 직전 sid sidecar만 복원
restore_from_cwd_lineage() {
  [ -z \"\$CWD\" ] && return 1
  encoded=\$(hash_cwd \"\$CWD\")
  marker=\"\$STATE_DIR/.last-session-\${encoded}\"
  [ -f \"\$marker\" ] || return 1
  last_sid=\$(head -1 \"\$marker\" | tr -d '[:space:]')
  # allowlist + self 제외 + jq fallback 생략
  jq --arg new_memo \"\$MEMO_FILE\" \\
    'if .memo then .memo.path = \$new_memo else . end' \\
    \"\$STATE_DIR/\${last_sid}.json\" > \"\$STATE_FILE\"
}
```

**STATE_FILE 보존 가드** (`session-init-icons.sh`, startup 분기):

```bash
# BEFORE: 무조건 빈 객체 덮어쓰기
echo '{}' > \"\$STATE_FILE\"

# AFTER: 부재 시에만 새로 만들기
if [ ! -f \"\$STATE_FILE\" ]; then
  if ! restore_from_cwd_lineage; then
    echo '{}' > \"\$STATE_FILE\"
  fi
fi
```

**Stop hook 마커 기록** (`record-last-session.sh`):

```bash
ENCODED_CWD=\$(hash_cwd \"\$CWD\")
MARKER_FILE=\"\$STATE_DIR/.last-session-\${ENCODED_CWD}\"
tmp=\$(mktemp \"\$STATE_DIR/.last-session-XXXXXX\")
printf '%s\\n' \"\$SESSION_ID\" > \"\$tmp\"
mv \"\$tmp\" \"\$MARKER_FILE\"
```

## 참고 레퍼런스

- PR #733 — cwd·branch·session-id 라인을 statusline에 도입한 선행 변경
- PR #736 — 워크트리 display 단축과 vscode:// URL 핸들링
- [Claude Code Hooks 공식 문서](https://docs.claude.com/en/docs/claude-code/hooks) — Stop event 입력 schema (agent_id 필드 포함)
- [shasum(1) macOS man page](https://ss64.com/osx/shasum.html) — sha1 인코딩 대체 도구 우선순위

## Human Test Plan

### 정상 동작 검증 — `/clear` 보존

1. 임의의 nixos-config 워크트리에서 새 Claude Code 세션을 연다.
2. `/set-icons`로 Jira·Slack·Figma 중 1개 이상 설정한다.
   - **기대**: 상태바 L1 라인에 해당 아이콘이 표시된다.
3. `/clear` 명령을 실행한다.
   - **기대**: SessionStart `additionalContext`에 "Status icons 복원됨" + "활성 아이콘: jira, slack, ..." 메시지. 상태바에 동일 아이콘 유지.
   - **실패 시**: `cat ~/.claude/status-icons/.last-session-*` 마커 파일 존재 및 내용 확인. 마커가 없으면 Stop hook이 발화하지 않은 것 — `settings.json`의 Stop 배열 확인.

### 정상 동작 검증 — cross-cwd 격리

4. 두 개의 분리된 워크트리(`A`, `B`)에서 각각 Claude Code 세션을 동시에 띄운다.
5. `A` 세션에서 `/set-icons`로 Jira A 설정 → Stop 발생을 기다린다(턴 종료).
6. `B` 세션에서 `/set-icons`로 Jira B 설정 → 턴 종료.
7. `A` 세션에서 `/branch`를 실행한다.
   - **기대**: `A` 세션 새 sid의 sidecar에 **Jira A**만 들어있다. Jira B가 따라오면 안 된다.
   - **실패 시**: `cat ~/.claude/status-icons/.last-session-<sha1>` 각 cwd 마커에 올바른 sid가 기록됐는지 확인.

### 엣지 케이스

8. `cwd`가 stdin에 없거나 `shasum`/`sha1sum`이 부재한 환경에서 hook을 호출한다.
   - **기대**: graceful skip — hook이 `exit 0`. 빈 sidecar로 시작한다.

9. STATE_FILE이 이미 존재하는 상태에서 source=startup이 들어온다.
   - **기대**: 기존 sidecar가 보존된다. 빈 객체로 덮어쓰지 않는다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 신규 hook 파일 존재 + 실행 권한
test -x modules/shared/programs/claude/files/hooks/record-last-session.sh
echo \$?  # 기대: 0

# 2. settings.json Stop 배열에 record-last-session.sh 등록 확인
jq -e '.hooks.Stop[].hooks[] | select(.command | endswith(\"record-last-session.sh\"))' \\
  modules/shared/programs/claude/files/settings.json
# 기대: exit 0

# 3. default.nix에 새 hook 심링크 등록 확인
grep -q 'hooks/record-last-session.sh' modules/shared/programs/claude/default.nix
# 기대: exit 0

# 4. old 'ls -t ... | head -1' 패턴 부재 확인
! grep -q 'ls -t.*status-icons.*head -1' modules/shared/programs/claude/files/hooks/session-init-icons.sh
# 기대: exit 0

# 5. startup 분기에 STATE_FILE 가드 존재 확인
grep -A 3 'startup)' modules/shared/programs/claude/files/hooks/session-init-icons.sh \\
  | grep -q 'if \\[ ! -f \"\\\$STATE_FILE\"'
# 기대: exit 0

# 6. bash 문법 + shellcheck
bash -n modules/shared/programs/claude/files/hooks/session-init-icons.sh
bash -n modules/shared/programs/claude/files/hooks/record-last-session.sh
```

### Phase 1: end-to-end hook 동작 검증 (격리 HOME)

```bash
TMP=\$(mktemp -d) && export HOME=\"\$TMP\"
HOOK_DIR=modules/shared/programs/claude/files/hooks

# Step 1: startup → 빈 sidecar
echo '{\"session_id\":\"AAA\",\"source\":\"startup\",\"cwd\":\"/proj/alpha\"}' \\
  | bash \"\$HOOK_DIR/session-init-icons.sh\" >/dev/null
jq -e '. == {}' \"\$HOME/.claude/status-icons/AAA.json\"
# 기대: exit 0

# Step 2: 수동 등록
echo '{\"jira\":{\"url\":\"https://e.x/T-1\",\"label\":\"T-1\"}}' \\
  > \"\$HOME/.claude/status-icons/AAA.json\"

# Step 3: Stop hook → 마커 기록
echo '{\"session_id\":\"AAA\",\"cwd\":\"/proj/alpha\"}' \\
  | bash \"\$HOOK_DIR/record-last-session.sh\"
ls \"\$HOME/.claude/status-icons/.last-session-\"* | head -1
# 기대: 마커 파일 존재

# Step 4: /clear → 새 sid에서 cwd 마커 lookup으로 복원
echo '{\"session_id\":\"BBB\",\"source\":\"clear\",\"cwd\":\"/proj/alpha\"}' \\
  | bash \"\$HOOK_DIR/session-init-icons.sh\" >/dev/null
jq -e '.jira.label == \"T-1\"' \"\$HOME/.claude/status-icons/BBB.json\"
# 기대: exit 0

# Step 5: 다른 cwd 세션 시뮬 + 같은 cwd에서 다시 /clear
echo '{\"foreign\":{\"url\":\"https://x\",\"label\":\"X\"}}' \\
  > \"\$HOME/.claude/status-icons/ZZZ.json\"
echo '{\"session_id\":\"ZZZ\",\"cwd\":\"/other/beta\"}' \\
  | bash \"\$HOOK_DIR/record-last-session.sh\"
echo '{\"session_id\":\"CCC\",\"source\":\"clear\",\"cwd\":\"/proj/alpha\"}' \\
  | bash \"\$HOOK_DIR/session-init-icons.sh\" >/dev/null
# CCC에 foreign이 들어오면 안 됨
! jq -e '.foreign' \"\$HOME/.claude/status-icons/CCC.json\"
jq -e '.jira.label == \"T-1\"' \"\$HOME/.claude/status-icons/CCC.json\"
# 기대: 두 검증 모두 exit 0

rm -rf \"\$TMP\"
```

- **기대**: 모든 jq -e 검증이 exit 0. cross-cwd 누수 없음.
- **실패 시**: 마커 파일 내용과 sha1 인코딩(cwd 문자열 → `printf '%s' \"\$CWD\" | shasum | awk '{print \$1}'`)을 직접 비교한다.

### Phase 2: STATE_FILE 보존 (worst-case)

```bash
TMP=\$(mktemp -d) && export HOME=\"\$TMP\"
mkdir -p \"\$HOME/.claude/status-icons\"
echo '{\"jira\":{\"url\":\"https://e.x/X-1\",\"label\":\"X-1\"}}' \\
  > \"\$HOME/.claude/status-icons/SSS.json\"

# /clear가 source=startup으로 라벨되는 worst-case 시뮬
echo '{\"session_id\":\"SSS\",\"source\":\"startup\",\"cwd\":\"/proj/x\"}' \\
  | bash modules/shared/programs/claude/files/hooks/session-init-icons.sh >/dev/null
jq -e '.jira.label == \"X-1\"' \"\$HOME/.claude/status-icons/SSS.json\"
# 기대: exit 0 (기존 sidecar 보존)
rm -rf \"\$TMP\"
```

### Phase 3: Regression — 기존 statusline 라인 정상

statusline.sh가 sidecar JSON을 읽는 방식은 변경하지 않았다(`Section 6: Status icons 읽기` 부분). 다음을 수동으로 확인한다.

- 한 워크트리에서 `/set-icons`로 Jira·Slack 설정 → 상태바 L1 라인에 ⚡·💬 아이콘이 OSC 8 hyperlink로 렌더되는지 확인.
- L_M 라인의 Plan·Memory·Cache TTL 아이콘이 영향 받지 않는지 확인 (sidecar와 무관한 별도 sidecar/git common-dir 유도).
- Rate Limit(L_N) 라인이 정상 렌더되는지 확인.

### Phase 4: 빌드 검증

```bash
# nix-darwin syntax
nix-instantiate --parse modules/shared/programs/claude/default.nix > /dev/null
# 기대: exit 0

# 실제 적용
nrs
# 기대: home-manager activation 성공, ~/.claude/hooks/record-last-session.sh 심링크 생성 확인
test -L ~/.claude/hooks/record-last-session.sh
```

- **실패 시**: `mkOutOfStoreSymlink` source 경로(`\${claudeFilesPath}/hooks/record-last-session.sh`)와 실제 파일 존재 비교, home-manager backup 로그 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stop-hook that records per-working-directory "last session" markers.

* **Improvements**
  * Session start restores from cwd-lineage (replacing global mtime scanning) and preserves existing state when present.
  * Stronger session-ID validation, stricter artifact permissions, atomic marker writes, and 30-day artifact retention.
  * Optional debug logging for session hooks.

* **Documentation**
  * Skill docs renamed/updated to describe lineage restore, permissions, retention, and debug options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/737)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->