### PR TITLE
chore(skills): SSOT 정합 / 표기 일관성 정비 3건 (#741)

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
@@ -193,7 +193,7 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
 
 ### Codex 세션 경로 (N=3)
 
-1. 동일 Arbiter 프롬프트로 3개의 fresh subagent를 strong review profile로 `spawn_agent` 실행한다. 프롬프트는 first-pass와 동일하다(독립 판정 원칙; 이전 판정 transcript 공유 금지).
+1. 동일 판정 기준 / 템플릿으로 3개의 fresh subagent를 strong review profile로 `spawn_agent` 실행한다. 프롬프트 본문은 위 "프롬프트 축소 규칙"대로 trigger된 finding subset 만 포함해 조립하고, 이전 판정 transcript는 공유하지 않는다 (독립 판정 원칙).
 2. 현재 session의 open-thread slot이 `agents.max_threads`(unset 기본 6)을 넘으면 batch한다. 3개 발사 전에 first-pass Arbiter의 completed thread를 `close_agent`로 닫아 슬롯을 확보한다.
 3. `wait_agent`로 3개 결과를 모두 수신한 뒤 `close_agent`로 닫는다. timeout만으로 failure 처리하거나 self-auditing으로 대체하지 않는다(conservative wait).
 4. 3개 결과 markdown을 각각 파일로 저장(`/tmp/da-${_DA_SID}-arbiter-selective-*/arbiter-{1,2,3}.md`) 후 세션 scope의 `fleiss-kappa.py`(Claude: `~/.claude/scripts/`, Codex: `~/.codex/scripts/`)로 집계한다.

--- a/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/set-icons/SKILL.md
@@ -91,7 +91,7 @@ AskUserQuestion으로 필요한 링크를 물어본다:
 Memo 아이콘도 스킬 호출 시 자동 등록한다 (메모 설정 섹션 참조).
 
 > ⚠️ `jq -n` 사용 금지 — 기존 키가 덮어씌워진다.
-> 반드시 기존 파일을 입력으로 사용: `tmp=$(mktemp) && jq '...' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"`
+> 반드시 기존 파일을 입력으로 사용: `tmp=$(mktemp "$(dirname "$STATE_FILE")/.${STATE_FILE##*/}.XXXXXX") && jq '...' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"`
 
 ### Jira 설정
 
@@ -102,7 +102,7 @@ URL에서 이슈번호를 자동 추출한다:
 JIRA_URL="https://example.atlassian.net/browse/PROJ-123"
 JIRA_LABEL=$(echo "$JIRA_URL" | grep -oE '[A-Z]+-[0-9]+' | tail -1)
 
-tmp=$(mktemp) && jq --arg url "$JIRA_URL" --arg label "$JIRA_LABEL" \
+tmp=$(mktemp "$(dirname "$STATE_FILE")/.${STATE_FILE##*/}.XXXXXX") && jq --arg url "$JIRA_URL" --arg label "$JIRA_LABEL" \
   '.jira = {"url":$url,"label":$label}' \
   "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 ```
@@ -110,7 +110,7 @@ tmp=$(mktemp) && jq --arg url "$JIRA_URL" --arg label "$JIRA_LABEL" \
 ### Slack 설정
 
 ```bash
-tmp=$(mktemp) && jq --arg url "https://app.slack.com/client/T.../C..." \
+tmp=$(mktemp "$(dirname "$STATE_FILE")/.${STATE_FILE##*/}.XXXXXX") && jq --arg url "https://app.slack.com/client/T.../C..." \
   '.slack = {"url":$url,"label":"Slack"}' \
   "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 ```
@@ -118,7 +118,7 @@ tmp=$(mktemp) && jq --arg url "https://app.slack.com/client/T.../C..." \
 ### Figma 설정
 
 ```bash
-tmp=$(mktemp) && jq --arg url "https://www.figma.com/design/..." \
+tmp=$(mktemp "$(dirname "$STATE_FILE")/.${STATE_FILE##*/}.XXXXXX") && jq --arg url "https://www.figma.com/design/..." \
   '.figma = {"url":$url,"label":"Figma"}' \
   "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 ```
@@ -127,7 +127,7 @@ tmp=$(mktemp) && jq --arg url "https://www.figma.com/design/..." \
 
 ```bash
 # 특정 아이콘 제거 (예: figma)
-tmp=$(mktemp) && jq 'del(.figma)' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+tmp=$(mktemp "$(dirname "$STATE_FILE")/.${STATE_FILE##*/}.XXXXXX") && jq 'del(.figma)' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 ```
 
 ### 메모 설정
@@ -136,7 +136,7 @@ tmp=$(mktemp) && jq 'del(.figma)' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FI
 
 ```bash
 # MEMO_FILE은 additionalContext의 "메모:" 뒤 경로
-tmp=$(mktemp) && jq --arg path "$MEMO_FILE" \
+tmp=$(mktemp "$(dirname "$STATE_FILE")/.${STATE_FILE##*/}.XXXXXX") && jq --arg path "$MEMO_FILE" \
   '.memo = {"path":$path,"label":"Memo"}' \
   "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 ```

--- a/modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md
@@ -2,7 +2,7 @@
 name: using-claude-p
 description: |
   Use Claude Code non-interactive (-p/--print) mode for scripting, automation, and headless
-  execution. Trigger: '''claude -p''', '''비대화형 claude''', '''headless claude''', '''스크립트에서 claude'''. Covers: CLI flag usage and gotchas (--output-format, --allowedTools, --resume,
+  execution. Trigger: '''claude -p''', '''비대화형 claude''', '''headless claude''', '''스크립트에서 claude'''. Covers: CLI flag usage and gotchas (--output-format, --allowed-tools, --resume,
   --dangerously-skip-permissions), JSON output parsing, session chaining, saving results to files,
   SSH remote execution of claude, harness self-testing (T1~T8), and known flag interaction bugs. Use
   when users want to run claude programmatically, pipe output, parse results, automate workflows,
@@ -82,7 +82,7 @@ claude -p 실행이 필요한가?
 
 ## 핵심 Gotchas
 
-1. `--allowedTools` + 인라인 프롬프트 = 버그: 인라인 프롬프트가 도구 이름으로 먹힘 → stdin 필수
+1. `--allowed-tools` + 인라인 프롬프트 = 버그: 인라인 프롬프트가 도구 이름으로 먹힘 → stdin 필수
 2. `--max-turns 1`은 도구 실행 불가: 도구 사용에 최소 2턴 필요 (호출 + 결과 수신)
 3. 도구 거부/예산 초과도 exit code 0: 실패를 감지하려면 `--output-format json`의 result subtype 확인 필수
 4. `--cwd`, `--output-file` 플래그 없음: `cd dir && claude -p`, shell redirect `> file` 사용
@@ -132,7 +132,7 @@ ssh minipc 'zsh -li -c "c -p \"...\""'  # → unmatched quote
 
 | 금지 패턴 | 발생 에러 | 올바른 대안 |
 |-----------|----------|------------|
-| `--allowedTools "Bash" "prompt"` | 프롬프트가 도구 이름으로 파싱 | stdin pipe 사용 |
+| `--allowed-tools "Bash" "prompt"` | 프롬프트가 도구 이름으로 파싱 | stdin pipe 사용 |
 | `--max-turns 1` + 도구 실행 기대 | Reached max turns | `--max-turns 2` 이상 |
 | exit code로 실패 판정 | 대부분 에러도 exit 0 | `--output-format json` subtype 확인 |
 | SSH에서 `c -p` alias | command not found | `claude -p` full path |

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/gotchas.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/gotchas.md
@@ -21,7 +21,7 @@
 
 ## 입력 (Input)
 
-### #1. `--allowedTools` 뒤에 인라인 프롬프트가 도구 이름으로 파싱됨
+### #1. `--allowed-tools` 뒤에 인라인 프롬프트가 도구 이름으로 파싱됨
 
 ```bash
 # ❌ 잘못된 사용
@@ -88,7 +88,7 @@ cat skill.md agent.md references.md | claude -p --output-format text > result.md
 
 ⚠️ 극단적 상한은 미확인. CLI → Node.js 런타임 → API context window로 이어지는 다층 파이프라인 중 어느 레이어에서 상한이 걸리는지 미검증. 프로덕션 파이프라인에서는 적절한 청킹 전략을 병행하라. v2.1.81 실측.
 
-### #36. `allowedTools` 패턴에서 공백이 중요
+### #36. `allowed-tools` 패턴에서 공백이 중요
 
 ```bash
 --allowed-tools "Bash(git diff *)"   # git diff 로 시작하는 명령만
@@ -218,7 +218,7 @@ echo "ls /tmp 실행해줘" | claude -p; echo "EXIT: $?"
 
 도구를 못 썼는데도 에러가 아닌 정상 종료. 실패를 감지하려면 출력 내용을 파싱해야 한다.
 
-⚠️ `--dangerously-skip-permissions` + `--allowedTools` 상호작용: `--dangerously-skip-permissions`는 `--allowedTools` 제한을 완전히 무시한다. `--allowedTools "Read"`로 Bash를 제한하더라도 `--dangerously-skip-permissions`가 있으면 Bash가 제한 없이 사용 가능하다. 도구를 실제로 제한하려면 `--dangerously-skip-permissions` 없이 `--allowedTools`를 단독 사용하라. v2.1.81 실측.
+⚠️ `--dangerously-skip-permissions` + `--allowed-tools` 상호작용: `--dangerously-skip-permissions`는 `--allowed-tools` 제한을 완전히 무시한다. `--allowed-tools "Read"`로 Bash를 제한하더라도 `--dangerously-skip-permissions`가 있으면 Bash가 제한 없이 사용 가능하다. 도구를 실제로 제한하려면 `--dangerously-skip-permissions` 없이 `--allowed-tools`를 단독 사용하라. v2.1.81 실측.
 
 ### #7. `--permission-mode bypassPermissions` = `--dangerously-skip-permissions`
 
@@ -256,7 +256,7 @@ echo "현재 디렉토리의 파일 목록을 보여줘" | claude -p --tools ""
 
 ⚠️ `--mcp-servers ""` / `--no-mcp` 플래그는 v2.1.76에 존재하지 않음. MCP 도구를 비활성화하는 공식 방법은 `claude -p --help` 출력을 확인한다.
 
-⚠️ 역방향도 성립: `--allowedTools "mcp__server__tool"`에 MCP 도구명을 명시해도 해당 MCP 서버가 세션에서 초기화되지 않으면 사용 불가. `allowedTools`는 허용 목록이지, 서버 활성화 지시가 아니다. MCP 서버 초기화는 `.mcp.json` 또는 `settings.json`의 MCP 설정에 의존한다 (`.mcp.json`에 미등록이거나 서버 프로세스가 init 단계에서 연결 실패한 경우 "미활성"). `--strict-mcp-config`로 특정 MCP 설정만 로드하는 것도 가능하다 (v2.1.81+). v2.1.81 실측.
+⚠️ 역방향도 성립: `--allowed-tools "mcp__server__tool"`에 MCP 도구명을 명시해도 해당 MCP 서버가 세션에서 초기화되지 않으면 사용 불가. `--allowed-tools`는 허용 목록이지, 서버 활성화 지시가 아니다. MCP 서버 초기화는 `.mcp.json` 또는 `settings.json`의 MCP 설정에 의존한다 (`.mcp.json`에 미등록이거나 서버 프로세스가 init 단계에서 연결 실패한 경우 "미활성"). `--strict-mcp-config`로 특정 MCP 설정만 로드하는 것도 가능하다 (v2.1.81+). v2.1.81 실측.
 
 ### #13. `--disable-slash-commands`로 스킬 비활성화 시 "Unknown skill"
 
@@ -288,9 +288,9 @@ cat skill-content.md agent-instructions.md | claude -p --output-format text > re
 
 ⚠️ 이 동작은 Claude Code의 내부 플러그인 인덱싱 메커니즘에 의존하며, 향후 버전에서 변경될 수 있다. v2.1.81 실측. 상세 우회 패턴: [patterns.md](patterns.md) 패턴 9 참조.
 
-### #35. `allowedTools` 패턴 공백 의미 차이
+### #35. `allowed-tools` 패턴 공백 의미 차이
 
-[#36](#36-allowedtools-패턴에서-공백이-중요) 참조.
+[#36](#36-allowed-tools-패턴에서-공백이-중요) 참조.
 
 ---
 

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/patterns.md
@@ -22,7 +22,7 @@ cat /tmp/prompt.md | claude -p
 핵심 요소:
 - 인라인 프롬프트는 짧은 질의에만 사용 (quote 이슈 방지)
 - 긴 프롬프트는 파일로 작성 후 stdin pipe로 전달
-- ⚠️ `--allowedTools` 사용 시 인라인 프롬프트가 도구 이름으로 먹힘 → stdin 필수 ([gotchas.md](gotchas.md) #1)
+- ⚠️ `--allowed-tools` 사용 시 인라인 프롬프트가 도구 이름으로 먹힘 → stdin 필수 ([gotchas.md](gotchas.md) #1)
 
 ## 패턴 2: 도구 실행 — 권한 우회
 
@@ -248,11 +248,11 @@ cat "${CAT_FILES[@]}" \
 ### 주의사항
 
 - 대용량 stdin도 정상 동작 확인. 극단적 상한은 미확인 ([gotcha #40](gotchas.md) 참조)
-- `--dangerously-skip-permissions`는 `--allowedTools` 제한을 무시함 ([gotcha #3](gotchas.md) 참조)
+- `--dangerously-skip-permissions`는 `--allowed-tools` 제한을 무시함 ([gotcha #3](gotchas.md) 참조)
 - 커스텀 환경변수는 `VAR=val claude -p` 형태로 전달 ([gotcha #39](gotchas.md) 참조)
 - MCP 도구 사용 시 해당 MCP 서버가 세션에서 활성화되어야 함 ([gotcha #5](gotchas.md) 참조)
 
-⚠️ 보안 주의: stdin으로 주입하는 파일 내용이 신뢰할 수 있는 출처인지 확인하라. `--dangerously-skip-permissions`와 결합 시 파일 내 prompt injection이 임의 명령 실행으로 이어질 수 있다. 신뢰할 수 없는 입력에는 `--dangerously-skip-permissions` 없이 `--allowedTools`로 도구를 제한하라:
+⚠️ 보안 주의: stdin으로 주입하는 파일 내용이 신뢰할 수 있는 출처인지 확인하라. `--dangerously-skip-permissions`와 결합 시 파일 내 prompt injection이 임의 명령 실행으로 이어질 수 있다. 신뢰할 수 없는 입력에는 `--dangerously-skip-permissions` 없이 `--allowed-tools`로 도구를 제한하라:
 
 ```bash
 # 신뢰할 수 없는 입력 시 안전한 패턴 (--dangerously-skip-permissions 미사용)


### PR DESCRIPTION
## Summary

PR #739 사후 검토에서 식별된 SSOT 정합 / 표기 일관성 이슈 3건 정정. 모두 PR #739 이전부터 잔존한 의미 정합 / 표기 일관성 문제이며 PR #739 의 mechanical replace scope 와 다른 차원이라 별도 follow-up 으로 분리됨.

### 1. `arbiter-scaling.md` N=3 재판정 wording 모순 해소

- `line 192` 의 "축소 규칙" (trigger 된 finding subset 만 포함) 과 `line 196` 의 "first-pass 와 동일" 진술이 정면 모순.
- `line 196` (Codex 세션 경로 N=3 절차 1번) 의 wording 을 축소 규칙과 일치시켜 PR #543 의 selective consistency 정책 baseline 유지.

### 2. `set-icons/SKILL.md` atomic write 보장

- mktemp 6 위치를 GNU/BSD 호환 template-based 형식 (`mktemp "$(dirname "$STATE_FILE")/.<basename>.XXXXXX"`) 으로 변경.
- set-icons 가 Home Manager 로 user-scope (`~/.claude/skills/set-icons`) 에 배포되는 global skill 이라 devShell 밖 macOS native shell 실행에서도 atomic 보장.
- 초기 plan 은 `mktemp -p "$(dirname "$STATE_FILE")"` (GNU 전용) 로 정정 예정이었으나 plan-mode DA 가 macOS/BSD 호환성 우려를 HIGH 신뢰도로 확인 → template-based 로 supersede.

### 3. `using-claude-p` CLI flag 표기 통일

- `--allowedTools` (camelCase) 를 `--allowed-tools` (kebab-case) 로 정정.
- `patterns.md` 3 위치 + `gotchas.md` 본문/헤딩 9 occurrence (`line 24`, `91` heading, `221` 4건, `259` 2건, `291` heading) + `SKILL.md` 본문 3 위치 (`line 5` frontmatter description 포함).
- `gotchas.md:28` 의 BUG 재현 호출 (#1 gotcha 의 "잘못된 사용 → 버그 발생" 예시) 은 의도적 잘못된 호출이라 camelCase 유지.
- `gotchas.md:91` heading 변경에 동반하여 `line 293` 의 내부 anchor link 도 새 slug 로 동기화.

## Decision Log 요약

본 PR 의 plan 파일 (`.claude/plans/issue-741-ssot-consistency-cleanup.md`, global gitignore 대상이라 push 안 됨) 의 Decision Log:

- D-1: arbiter-scaling.md 정정 범위 = line 196 만 (codex exec 경로 line 200~205 는 모호함만 있고 직접 충돌 없으므로 scope 제외).
- D-2: using-claude-p 정정 범위 = 디렉토리 전체. gotchas.md:28 BUG 재현 호출은 예외.
- D-3: set-icons mktemp 정정 패턴 = GNU/BSD 호환 template-based.
- DL-3: 축소 규칙 (arbiter-scaling.md line 192) baseline 유지. PR #543 (사용자 본인 머지 epic "Arbiter drift 대응 — vote-shape v1 selective consistency") 에서 도입된 정책이며 "축소" = subset 선택이지 정보 압축이 아님을 사용자 확인.
- DL-4 ~ DL-6: plan-mode DA 4건 CONFIRMED_ISSUE 자동 반영 (gotchas.md occurrence 9 정정 / mktemp 패턴 변경 / anchor link 갱신).

## DA 결과

- plan-mode DA (LITE): Correctness 1건 + Regression 2건 + Maintainability 1건 → Arbiter 결과 4건 모두 CONFIRMED_ISSUE HIGH. 모두 자동 반영.
- for_pr DA (LITE, xhigh): Correctness CLEAR + Regression 1건 + Maintainability 1건 (모두 gotchas.md:28 의도된 예외 관련) → Arbiter 결과 2건 모두 NOT_AN_ISSUE HIGH (변경 연관성 FAIL: base main 에서도 동일 상태, plan D-2 + commit message 의 명시적 예외 결정에 부합).

## Test plan

- [x] SC-1: `grep "first-pass와 동일\|first-pass 와 동일" arbiter-scaling.md` → 0건
- [x] SC-2: `grep "tmp=\$(mktemp)" set-icons/SKILL.md` → 0건 (모두 template-based)
- [x] SC-3: `rg "allowedTools" using-claude-p/` → gotchas.md:28 1건만 잔존 (의도된 예외)
- [x] SC-4: `grep "#36-allowedtools" gotchas.md` → 0건 (anchor 갱신 완료)
- [x] SC-5: `./scripts/ai/check-skill-noise.sh` 통과 (본 PR scope 외 사전 잔존 2건 보고, exit 0)
- [x] SC-6: `nrs` (no-op) + `./scripts/ai/verify-ai-compat.sh` (완전 통과) + `lefthook run pre-commit` (통과) + commit-msg pinning hook 통과

Closes #741.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Arbiter scaling documentation with refined session behavior
  * Updated file handling best practices with safer approaches
  * Corrected CLI flag naming from `--allowedTools` to `--allowed-tools`
  * Enhanced security guidelines for tool access restrictions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/744)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->