### PR TITLE
chore(skills): check-skill-noise.sh robustness + lefthook pre-commit 통합 (#740)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,9 +20,10 @@ pre-commit:
       run: bash ./tests/test-codex-hook-fixtures.sh --no-live
     skill-noise-check:
       # Agent Skill markdown 의 LLM 노이즈 syntax (bold / excessive empty lines) 잔존 0 검증.
-      # check-skill-noise.sh 는 hardcoded SKILLS_DIR 전체를 검사하므로 glob/staged_files 없이
-      # 항상 실행한다 (전체 corpus invariant — ai-skills-consistency / eval-tests / codex-hook-fixtures
-      # 와 동일 패턴). script 는 stdlib only (re/sys/pathlib) 라 nix shell wrap 불필요.
+      # check-skill-noise.sh 의 기본 검사 경로는 canonical skills corpus 이며, lefthook 에서는
+      # 인자 없이 호출하여 default 경로만 검사한다 (전체 corpus invariant — ai-skills-consistency /
+      # eval-tests / codex-hook-fixtures 와 동일한 항상 실행 패턴). script 는 Python stdlib only 라
+      # nix shell wrap 불필요.
       run: bash ./scripts/ai/check-skill-noise.sh
 
 commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,11 +19,12 @@ pre-commit:
       # wrap이 불필요하다. live propagation 검증은 manual/scheduled에 위임.
       run: bash ./tests/test-codex-hook-fixtures.sh --no-live
     skill-noise-check:
-      # Agent Skill markdown 의 LLM 노이즈 syntax (bold / excessive empty lines) 잔존 0 검증.
-      # check-skill-noise.sh 의 기본 검사 경로는 canonical skills corpus 이며, lefthook 에서는
-      # 인자 없이 호출하여 default 경로만 검사한다 (전체 corpus invariant — ai-skills-consistency /
-      # eval-tests / codex-hook-fixtures 와 동일한 항상 실행 패턴). script 는 Python stdlib only 라
-      # nix shell wrap 불필요.
+      # shared skill projection (modules/shared/programs/claude/files/skills) 의 LLM 노이즈 syntax
+      # (bold / excessive empty lines) 잔존 0 검증. check-skill-noise.sh 의 기본 검사 경로는 본
+      # projection corpus 이며, lefthook 에서는 인자 없이 호출하여 default 경로만 검사한다
+      # (ai-skills-consistency / eval-tests / codex-hook-fixtures 와 동일한 항상 실행 패턴).
+      # script 는 Python stdlib only 라 nix shell wrap 불필요. .claude/skills 의 동일 invariant
+      # 적용은 별도 follow-up 으로 분리 (해당 corpus 의 bold 잔존 대량 cleanup 선행 필요).
       run: bash ./scripts/ai/check-skill-noise.sh
 
 commit-msg:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,6 +18,12 @@ pre-commit:
       # source하여 repo-pinned pythonWithTomlkit으로 self-wrap하므로 lefthook에서 추가 nix shell
       # wrap이 불필요하다. live propagation 검증은 manual/scheduled에 위임.
       run: bash ./tests/test-codex-hook-fixtures.sh --no-live
+    skill-noise-check:
+      # Agent Skill markdown 의 LLM 노이즈 syntax (bold / excessive empty lines) 잔존 0 검증.
+      # check-skill-noise.sh 는 hardcoded SKILLS_DIR 전체를 검사하므로 glob/staged_files 없이
+      # 항상 실행한다 (전체 corpus invariant — ai-skills-consistency / eval-tests / codex-hook-fixtures
+      # 와 동일 패턴). script 는 stdlib only (re/sys/pathlib) 라 nix shell wrap 불필요.
+      run: bash ./scripts/ai/check-skill-noise.sh
 
 commit-msg:
   commands:

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md
@@ -142,8 +142,8 @@ rm -rf -- "$CONSULT_DIR"
 
 위 echo 메시지는 메인 에이전트 내부 진단용 문자열이며 사용자에게 그대로 노출하지 않는다. 자문 실패 시 사용자 노출 평이 문구는 다음 두 경로에서 정의된다:
 
-- **schema fail (raw 결과는 있지만 schema 검증 fail)**: 메인 LLM 이 raw `$RESULT` 를 입력으로 [`consulting-step.md`](./consulting-step.md#user_facing-누락-시-텍스트-복구-4단계) 의 텍스트 복구 4단계 Stage 1-3 를 시도한다. 사용자 노출 문구는 복구 성공 시 user_facing layer 형식, 모두 실패 시 Stage 4 의 "자문 결과 형식이 맞지 않아 옵션 설명을 복구하지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
-- **empty/invalid (result.json 자체가 없거나 비어 있음)**: 텍스트 복구할 raw 가 없으므로 Stage 4 와 동등하게 처리. 사용자 노출 문구는 [`../modes/for_action.md`](../modes/for_action.md) Step 3.5 자문 미수신 fallback 의 "자문이 완료되지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
+- `schema fail` (raw 결과는 있지만 schema 검증 fail) — 메인 LLM 이 raw `$RESULT` 를 입력으로 [`consulting-step.md`](./consulting-step.md#user_facing-누락-시-텍스트-복구-4단계) 의 텍스트 복구 4단계 Stage 1-3 를 시도한다. 사용자 노출 문구는 복구 성공 시 user_facing layer 형식, 모두 실패 시 Stage 4 의 "자문 결과 형식이 맞지 않아 옵션 설명을 복구하지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
+- `empty/invalid` (result.json 자체가 없거나 비어 있음) — 텍스트 복구할 raw 가 없으므로 Stage 4 와 동등하게 처리. 사용자 노출 문구는 [`../modes/for_action.md`](../modes/for_action.md) Step 3.5 자문 미수신 fallback 의 "자문이 완료되지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
 
 `trap` 사용 금지: 셸 호출이 분리되어 있어 trap이 호출 1 종료 시점에 발동하면 호출 2 이전에 디렉토리가 삭제된다. 명시적 `rm -rf` 한 번이 SSOT 다.
 

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md
@@ -142,8 +142,8 @@ rm -rf -- "$CONSULT_DIR"
 
 위 echo 메시지는 메인 에이전트 내부 진단용 문자열이며 사용자에게 그대로 노출하지 않는다. 자문 실패 시 사용자 노출 평이 문구는 다음 두 경로에서 정의된다:
 
-- `schema fail` (raw 결과는 있지만 schema 검증 fail) — 메인 LLM 이 raw `$RESULT` 를 입력으로 [`consulting-step.md`](./consulting-step.md#user_facing-누락-시-텍스트-복구-4단계) 의 텍스트 복구 4단계 Stage 1-3 를 시도한다. 사용자 노출 문구는 복구 성공 시 user_facing layer 형식, 모두 실패 시 Stage 4 의 "자문 결과 형식이 맞지 않아 옵션 설명을 복구하지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
-- `empty/invalid` (result.json 자체가 없거나 비어 있음) — 텍스트 복구할 raw 가 없으므로 Stage 4 와 동등하게 처리. 사용자 노출 문구는 [`../modes/for_action.md`](../modes/for_action.md) Step 3.5 자문 미수신 fallback 의 "자문이 완료되지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
+- `schema fail` (raw 결과는 있지만 schema 검증 fail) : 메인 LLM 이 raw `$RESULT` 를 입력으로 [`consulting-step.md`](./consulting-step.md#user_facing-누락-시-텍스트-복구-4단계) 의 텍스트 복구 4단계 Stage 1-3 를 시도한다. 사용자 노출 문구는 복구 성공 시 user_facing layer 형식, 모두 실패 시 Stage 4 의 "자문 결과 형식이 맞지 않아 옵션 설명을 복구하지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
+- `empty/invalid` (result.json 자체가 없거나 비어 있음) : 텍스트 복구할 raw 가 없으므로 Stage 4 와 동등하게 처리. 사용자 노출 문구는 [`../modes/for_action.md`](../modes/for_action.md) Step 3.5 자문 미수신 fallback 의 "자문이 완료되지 못했어요. 옵션을 그대로 보여드릴게요." 평이 한국어.
 
 `trap` 사용 금지: 셸 호출이 분리되어 있어 trap이 호출 1 종료 시점에 발동하면 호출 2 이전에 디렉토리가 삭제된다. 명시적 `rm -rf` 한 번이 SSOT 다.
 

--- a/scripts/ai/check-skill-noise.sh
+++ b/scripts/ai/check-skill-noise.sh
@@ -5,18 +5,23 @@
 # - bold (`**X**`) 잔존: 0 건이어야 함 (코드 블록 / inline code 외).
 # - excessive empty lines: 0 건이어야 함 (코드 블록 외). 정의는 "3+ consecutive newlines" (`\n{3,}`) —
 #   markdown paragraph break (`\n\n`, 2 consecutive newlines) 는 보존하고, 그 이상은 정규화.
+#   파일 읽기는 Python `Path.read_text(encoding="utf-8-sig")` 의 universal newlines 동작에 의존하므로
+#   `\r\n` 입력도 `\n` 으로 정규화되어 동일 regex 가 CRLF 파일을 정상 검출한다.
 #
 # 보존 대상 (변경 없음):
 # - 코드 블록 (` ``` ... ``` `) 안 모든 syntax.
-# - inline code (`` `X` ``) 안 모든 syntax.
+# - inline code (`` `X` ``) 안 모든 syntax. CommonMark escaped backtick (`` \` ``) 은 inline code
+#   delimiter 가 아닌 literal 로 인식한다.
 # - HTML 태그, HTML comment, italic, strikethrough, emoji 등 본 검증 외.
 #
-# 회귀 차단 시스템 (lefthook hook / CI step) 통합은 별도 follow-up.
+# 회귀 차단:
+# - lefthook pre-commit `skill-noise-check` 항목으로 자동 통합 완료.
+# - CI step (GitHub Actions) 통합은 `.github/workflows/` 부재로 별도 follow-up.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SKILLS_DIR="$REPO_ROOT/modules/shared/programs/claude/files/skills"
+SKILLS_DIR="${SKILLS_DIR:-$REPO_ROOT/modules/shared/programs/claude/files/skills}"
 
 if [ ! -d "$SKILLS_DIR" ]; then
   echo "[FAIL] Skills directory not found: $SKILLS_DIR" >&2
@@ -24,6 +29,7 @@ if [ ! -d "$SKILLS_DIR" ]; then
 fi
 
 python3 - "$SKILLS_DIR" <<'PY'
+import bisect
 import re
 import sys
 from pathlib import Path
@@ -68,29 +74,55 @@ def tokenize_fences(text):
     return sorted(spans)
 
 
+def _in_span(pos, sorted_spans, starts):
+    # sorted_spans 는 start 기준 정렬된 (start, end) 리스트. starts 는 (start, ...) 의 분리 캐시.
+    # bisect_right - 1 로 pos 이하의 가장 큰 start 를 찾고, end 와 비교한다.
+    if not sorted_spans:
+        return False
+    idx = bisect.bisect_right(starts, pos) - 1
+    if idx < 0:
+        return False
+    s, e = sorted_spans[idx]
+    return s <= pos < e
+
+
 def tokenize_inline_code(text, fence_spans):
-    def in_fence(pos):
-        return any(s <= pos < e for s, e in fence_spans)
+    # 같은 길이의 backtick run 두 개로 둘러싸인 inline code span을 paired matching.
+    # CommonMark: 같은 길이 backtick run delimiter, between text 에 두 개 이상의 연속 newline (`\n\n`)
+    # 있으면 inline code 미성립.
+    # Escaped backtick: backtick run 시작 직전 backslash 가 홀수 개면 literal 로 간주하고 delimiter 아닌
+    # 것으로 처리한다. 단 fenced code block 내부에서는 backslash escape 가 적용되지 않으므로 fence_spans
+    # 안 backtick 은 그냥 skip (delimiter 아님으로 처리).
+    fence_starts = [s for s, e in fence_spans]
     spans = []
-    runs = list(re.finditer(r'`+', text))
-    used = [False] * len(runs)
-    for i, m in enumerate(runs):
-        if used[i] or in_fence(m.start()):
+    open_runs = {}  # length -> [Match, ...] (FIFO queue per length)
+    for m in re.finditer(r'`+', text):
+        start = m.start()
+        if _in_span(start, fence_spans, fence_starts):
+            continue
+        # escape 처리 (fence 밖에서만)
+        backslashes = 0
+        i = start - 1
+        while i >= 0 and text[i] == '\\':
+            backslashes += 1
+            i -= 1
+        if backslashes % 2 == 1:
             continue
         run_len = len(m.group())
-        for j in range(i + 1, len(runs)):
-            if used[j]:
-                continue
-            m2 = runs[j]
-            if in_fence(m2.start()) or len(m2.group()) != run_len:
-                continue
-            between = text[m.end():m2.start()]
+        queue = open_runs.get(run_len)
+        if queue:
+            m_open = queue.pop(0)
+            between = text[m_open.end():start]
             if '\n\n' in between:
-                continue
-            spans.append((m.start(), m2.end()))
-            used[i] = True
-            used[j] = True
-            break
+                # multi-line — pairing 미성립. 두 run 모두 다시 open 으로 처리 (FIFO 위치 유지).
+                queue.insert(0, m_open)
+                queue.append(m)
+            else:
+                spans.append((m_open.start(), m.end()))
+            if not queue:
+                del open_runs[run_len]
+        else:
+            open_runs.setdefault(run_len, []).append(m)
     return sorted(spans)
 
 
@@ -107,19 +139,21 @@ def protected_spans(text):
     return out
 
 
-def is_contained(start, end, spans):
-    for s, e in spans:
-        if s <= start and end <= e:
-            return True
-    return False
-
-
 def count_bold_outside(text):
     spans = protected_spans(text)
+    starts = [s for s, e in spans]
     count = 0
     locations = []
     for m in re.finditer(r'\*\*[^*\n]+\*\*', text):
-        if not is_contained(m.start(), m.end(), spans):
+        # bold 매치 전체가 같은 span 안에 contained 되어야 protected.
+        contained = False
+        if spans:
+            idx = bisect.bisect_right(starts, m.start()) - 1
+            if idx >= 0:
+                s, e = spans[idx]
+                if s <= m.start() and m.end() <= e:
+                    contained = True
+        if not contained:
             count += 1
             lineno = text[:m.start()].count('\n') + 1
             locations.append((lineno, m.group()[:60]))
@@ -128,22 +162,28 @@ def count_bold_outside(text):
 
 def count_excessive_empty_outside(text):
     spans = protected_spans(text)
+    starts = [s for s, e in spans]
     count = 0
     locations = []
-    # 3+ consecutive newlines (= 2+ empty lines 이상). markdown paragraph break (\n\n, 2 newlines) 는 보존.
+    # 3+ consecutive newlines (= 2+ empty lines 이상). markdown paragraph break (\n\n) 는 보존.
     for m in re.finditer(r'\n{3,}', text):
-        if not any(s <= m.start() < e for s, e in spans):
+        if not _in_span(m.start(), spans, starts):
             count += 1
             lineno = text[:m.start()].count('\n') + 1
             locations.append((lineno, len(m.group())))
     return count, locations
 
 
+md_files = sorted(base.rglob('*.md'))
+if not md_files:
+    print(f"[FAIL] {base} 하위에 *.md 파일이 0 개 — skill projection 깨짐 또는 잘못된 SKILLS_DIR.", file=sys.stderr)
+    sys.exit(1)
+
 total_bold = 0
 total_empty = 0
 fail = False
-for f in sorted(base.rglob('*.md')):
-    text = f.read_text()
+for f in md_files:
+    text = f.read_text(encoding="utf-8-sig")
     bc, blocs = count_bold_outside(text)
     ec, elocs = count_excessive_empty_outside(text)
     if bc > 0 or ec > 0:

--- a/scripts/ai/check-skill-noise.sh
+++ b/scripts/ai/check-skill-noise.sh
@@ -119,8 +119,9 @@ def tokenize_inline_code(text, fence_spans):
             m_open = queue.pop(0)
             between = text[m_open.end():start]
             if '\n\n' in between:
-                # blank-line 사이에 끼인 opener 는 만료 (R-1 / M-1 정정).
-                # 현재 run 은 opening delimiter 후보로 재시도 — escape 검사 필요.
+                # blank-line 을 사이에 둔 opener 는 만료한다. 그대로 큐에 두면 뒤쪽 문단의
+                # 정상 backtick pair 가 늘 같은 만료 opener 와 매칭되어 inline code span 으로
+                # 등록되지 않는다. 따라서 현재 run 은 새 opening delimiter 후보로 재평가한다.
                 if not queue:
                     del open_runs[run_len]
                 if not is_escaped(start):

--- a/scripts/ai/check-skill-noise.sh
+++ b/scripts/ai/check-skill-noise.sh
@@ -21,7 +21,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SKILLS_DIR="${SKILLS_DIR:-$REPO_ROOT/modules/shared/programs/claude/files/skills}"
+# 첫 positional arg 가 SKILLS_DIR override (PoC / 테스트 전용). 미지정 시 canonical repo 경로.
+# pre-commit hook 은 인자 없이 호출하여 ambient env 와 무관하게 canonical corpus 만 검사한다.
+SKILLS_DIR="${1:-$REPO_ROOT/modules/shared/programs/claude/files/skills}"
 
 if [ ! -d "$SKILLS_DIR" ]; then
   echo "[FAIL] Skills directory not found: $SKILLS_DIR" >&2
@@ -90,38 +92,47 @@ def tokenize_inline_code(text, fence_spans):
     # 같은 길이의 backtick run 두 개로 둘러싸인 inline code span을 paired matching.
     # CommonMark: 같은 길이 backtick run delimiter, between text 에 두 개 이상의 연속 newline (`\n\n`)
     # 있으면 inline code 미성립.
-    # Escaped backtick: backtick run 시작 직전 backslash 가 홀수 개면 literal 로 간주하고 delimiter 아닌
-    # 것으로 처리한다. 단 fenced code block 내부에서는 backslash escape 가 적용되지 않으므로 fence_spans
-    # 안 backtick 은 그냥 skip (delimiter 아님으로 처리).
+    # Escaped backtick: opening delimiter 후보일 때만 escape literal 처리 (backslash 홀수 개면 skip).
+    # closing delimiter 후보 (open queue 에 같은 길이 entry 존재) 일 때는 escape 검사하지 않는다.
+    # CommonMark code span 내부에서는 backslash escape 가 동작하지 않기 때문이다 (Example 338).
+    # Fenced code block 안 backtick 은 fence_spans 로 미리 걸러진다.
     fence_starts = [s for s, e in fence_spans]
     spans = []
     open_runs = {}  # length -> [Match, ...] (FIFO queue per length)
+
+    def is_escaped(pos):
+        backslashes = 0
+        i = pos - 1
+        while i >= 0 and text[i] == '\\':
+            backslashes += 1
+            i -= 1
+        return backslashes % 2 == 1
+
     for m in re.finditer(r'`+', text):
         start = m.start()
         if _in_span(start, fence_spans, fence_starts):
             continue
-        # escape 처리 (fence 밖에서만)
-        backslashes = 0
-        i = start - 1
-        while i >= 0 and text[i] == '\\':
-            backslashes += 1
-            i -= 1
-        if backslashes % 2 == 1:
-            continue
         run_len = len(m.group())
         queue = open_runs.get(run_len)
         if queue:
+            # closing delimiter 후보 — escape 검사 안 함 (code span 내부 escape 미동작)
             m_open = queue.pop(0)
             between = text[m_open.end():start]
             if '\n\n' in between:
-                # multi-line — pairing 미성립. 두 run 모두 다시 open 으로 처리 (FIFO 위치 유지).
-                queue.insert(0, m_open)
-                queue.append(m)
+                # blank-line 사이에 끼인 opener 는 만료 (R-1 / M-1 정정).
+                # 현재 run 은 opening delimiter 후보로 재시도 — escape 검사 필요.
+                if not queue:
+                    del open_runs[run_len]
+                if not is_escaped(start):
+                    open_runs.setdefault(run_len, []).append(m)
             else:
                 spans.append((m_open.start(), m.end()))
-            if not queue:
-                del open_runs[run_len]
+                if not queue:
+                    del open_runs[run_len]
         else:
+            # opening delimiter 후보 — escape 검사
+            if is_escaped(start):
+                continue
             open_runs.setdefault(run_len, []).append(m)
     return sorted(spans)
 


### PR DESCRIPTION
## Summary

- `scripts/ai/check-skill-noise.sh` 의 4건 robustness 정정 + 인터페이스 정리 (escaped backtick / BOM / empty SKILLS_DIR fail-fast + positional arg override / O(n²)→O(n) tokenizer + `protected_spans()` bisect 교체).
- `lefthook.yml` pre-commit 에 `skill-noise-check` hook 추가 — 신규 PR 의 LLM 노이즈 syntax 잠입 자동 차단.
- `consulting-step-shell.md` L145-L146 의 list item bold 2건 cleanup (PR #732 정책 준수 + 현재 main FAIL 해소).

Closes #740.

## 기존 문제 / 배경

PR #739 (Closes #732) 가 14개 Agent Skill markdown 의 LLM 노이즈 syntax 일괄 제거 + `scripts/ai/check-skill-noise.sh` validation owner 를 main 에 commit. 본 검증 도구의 robustness 한계와 회귀 차단 시스템 부재가 사후 검토에서 follow-up 으로 분리됨.

본 작업 직전 baseline:

- `scripts/ai/check-skill-noise.sh` 168 lines, Python stdlib only.
- `lefthook.yml` pre-commit 6 hook 등록, `skill-noise-check` 미통합.
- `.github/workflows/` 부재 — CI step 통합은 별도 follow-up.
- skills projection 79 markdown / 735KB. timing 0.13-0.15s.
- **`main` 이 FAIL 상태** — `consulting-step-shell.md` L145-L146 의 list item bold 2건 잔존 (PR #742 신규 도입 회귀, PR #732 정책 모르고 작성됨).
- escaped backtick `` \` `` 사용: 6+ 파일.
- `tomlkit-bootstrap.sh` 패턴: tomlkit 의존성 있는 script 만 `nix shell .#pythonWithTomlkit` self-wrap. 본 script 는 stdlib only — wrap 비대상.

## CIR (Change Intent Record)

### 발견 경위

이슈 #740 본문 + handoff comment 가 5건 robustness + 회귀 차단 시스템 통합을 follow-up 으로 분리. 본 작업 시작 시 `main` 이 PR #742 머지로 새로 들어온 `consulting-step-shell.md` 의 list item bold 2건 때문에 이미 FAIL 상태 — hook 추가 전 cleanup 이 사전 조건임을 확인.

### 설계 의도

외부 검토 자문 결과 사용자가 "확인된 문제를 한 번에 정리" 옵션 채택. cleanup + 4건 robustness + lefthook hook 통합으로 PR scope 확정. 후속 외부 검토에서 식별된 5건 (CommonMark code span 내부 backslash escape, blank-line opener 만료, SKILLS_DIR env override 문제, hook scope 명시, 임시 finding ID 박제) 모두 자동 반영.

### 대안 검토 이력

- CRLF 별도 regex 정정 (`(?:\r?\n){3,}`) → 외부 검토에서 불필요 확인. Python `Path.read_text()` 기본 universal newlines 동작이 이미 `\r\n` 을 `\n` 으로 정규화하므로 기존 `\n{3,}` regex 가 CRLF 파일을 정상 검출. 항목 제거.
- BOM 처리는 zero-width 리터럴 `text.lstrip('﻿')` 대신 Python 표준 `f.read_text(encoding="utf-8-sig")` 채택. 가독성 + 라인 offset 보존.
- SKILLS_DIR override 는 ambient env 가 아닌 첫 positional arg 로 변경 — pre-commit 환경의 ambient `SKILLS_DIR` 우회 차단.
- lefthook hook 의 glob trigger 제거 + 항상 실행 패턴 (`ai-skills-consistency` / `eval-tests` / `codex-hook-fixtures` 와 동일). `check-skill-noise.sh` 가 인자 없이 호출 시 전체 corpus 검사하는 invariant 와 일치.
- tokenizer 알고리즘 정확성 강화 (backtick 길이별 stack 정확 매칭) 는 본 PR 비포함 (NG-4). O(n²)→O(n) 최적화 자체는 length+first-unused 매칭 정책 유지 (corpus diff 0 검증).

## ADR (Architecture Decision Record)

### Scope 결정 (사용자 옵션 A 채택)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| A | 5건 robustness 전부 + cleanup + hook 통합 | review 분리 5건 종결 + 후속 issue 분리 비용 회피 | PR scope 가 ~45-75분 | ✅ 채택 |
| B | 핵심 2건 (escaped backtick + empty fail-fast) + cleanup + hook | 빠른 차단 장치 (~20-35분) | 드문 상황 follow-up 분리 | ❌ |
| C | 최소 1건 (escaped backtick) + cleanup + hook | 최단 (~10-20분) | edge case 4건 미해소 | ❌ |
| D | 5건 + tokenizer 정확성 강화 (stack 정확 매칭) | 정확성 강화 | 단일 세션 초과 + stdlib 복잡도 증가 | ❌ |

### lefthook hook 패턴 (외부 검토 후속 반영)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| glob + 항상 실행 | `glob` 으로 trigger + 인자 없이 전체 검사 | 변경된 파일이 한 개여도 전체 검증 | `staged_files` 미사용 + glob 혼합형이 기존 패턴과 불일치 | ❌ |
| glob 없이 항상 실행 | 인자 없이 전체 검사 (다른 항상 실행 hook 와 동일 패턴) | 기존 `ai-skills-consistency` / `eval-tests` / `codex-hook-fixtures` 와 일관 + 전체 corpus invariant 명시 | partial staging false negative (별도 follow-up) | ✅ 채택 |
| `{staged_files}` 전달 | 변경 파일만 검사 | partial staging false negative 없음 | script 인터페이스 변경 폭이 큼 + 전체 corpus invariant 깨짐 | ❌ |

### 외부 검토 후 추가 결정 (NG follow-up 분리)

- **NG-5**: raw newline 보존 (`read_text(newline='')`) 정책 변경은 안 함. Python universal newlines 의존 (CRLF 파일 자동 LF 정규화).
- **NG-6**: `.claude/skills` (별도 git-tracked corpus, 78 파일, bold=1056 잔존) 의 동일 invariant 적용은 follow-up. 본 PR 의 검증 경계는 `modules/shared/programs/claude/files/skills` (shared projection) 만.
- **NG-7**: CommonMark whitespace-only blank-line + fence info string backtick corner case 정정은 follow-up. `main` 부터 존재한 동작 — 본 PR 변경 무관.
- **NG-8**: lefthook pre-commit hook 의 partial staging false negative (staged blob vs working tree) 대응은 follow-up. 기존 lefthook 의 다른 always-run hook 와 동일 패턴 — 본 PR 단독 fix 시 lefthook 전반 패턴 검토 + 구조적 폭발이 따라옴.

## 구현 상세

| 파일 | 현재 라인 | 수정 범위 |
|------|----------|-----------|
| `modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md` | 168 | L145-L146 list item bold 2건 → backtick code (`schema fail` / `empty/invalid`) 로 정정. |
| `scripts/ai/check-skill-noise.sh` | 168 → 197 | 4건 robustness + 1 인터페이스 + 1 주석 갱신: positional arg override, `encoding="utf-8-sig"`, escaped backtick (opening 후보만 escape), tokenizer FIFO queue (length별 paired matching + blank-line opener 만료), `protected_spans()` bisect, empty fail-fast, 상단 주석 갱신. `import bisect` 추가 (Python stdlib). |
| `lefthook.yml` | 44 → 52 | pre-commit `commands` 섹션 끝에 `skill-noise-check` 추가 (8 lines). glob 없이 항상 실행. |

### 핵심 코드 스니펫

**SKILLS_DIR override (positional arg)**:

```bash
REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
# 첫 positional arg 가 SKILLS_DIR override (PoC / 테스트 전용). 미지정 시 canonical repo 경로.
# pre-commit hook 은 인자 없이 호출하여 ambient env 와 무관하게 canonical corpus 만 검사한다.
SKILLS_DIR="${1:-$REPO_ROOT/modules/shared/programs/claude/files/skills}"
```

**BOM 처리 (Python 표준)**:

```python
text = f.read_text(encoding="utf-8-sig")
```

**Escaped backtick (opening 후보만 escape)**:

```python
queue = open_runs.get(run_len)
if queue:
    # closing delimiter 후보 — escape 검사 안 함 (code span 내부 escape 미동작)
    ...
else:
    # opening delimiter 후보 — escape 검사
    if is_escaped(start):
        continue
    open_runs.setdefault(run_len, []).append(m)
```

**Tokenizer blank-line opener 만료**:

```python
between = text[m_open.end():start]
if '\n\n' in between:
    # blank-line 을 사이에 둔 opener 는 만료한다. 그대로 큐에 두면 뒤쪽 문단의 정상 backtick pair
    # 가 늘 같은 만료 opener 와 매칭되어 inline code span 으로 등록되지 않는다. 따라서 현재 run
    # 은 새 opening delimiter 후보로 재평가한다.
    if not queue:
        del open_runs[run_len]
    if not is_escaped(start):
        open_runs.setdefault(run_len, []).append(m)
```

**lefthook hook (glob 없이 항상 실행)**:

```yaml
skill-noise-check:
  # shared skill projection (modules/shared/programs/claude/files/skills) 의 LLM 노이즈 syntax
  # (bold / excessive empty lines) 잔존 0 검증. check-skill-noise.sh 의 기본 검사 경로는 본
  # projection corpus 이며, lefthook 에서는 인자 없이 호출하여 default 경로만 검사한다
  # (ai-skills-consistency / eval-tests / codex-hook-fixtures 와 동일한 항상 실행 패턴).
  # script 는 Python stdlib only 라 nix shell wrap 불필요. .claude/skills 의 동일 invariant
  # 적용은 별도 follow-up 으로 분리 (해당 corpus 의 bold 잔존 대량 cleanup 선행 필요).
  run: bash ./scripts/ai/check-skill-noise.sh
```

## 참고 레퍼런스

- 이슈 #740 — 본 PR 가 closes 하는 follow-up 이슈
- 이슈 #732 — Agent Skill markdown 의 LLM 노이즈 syntax 일괄 제거 정책
- PR #739 — `scripts/ai/check-skill-noise.sh` 도입 PR (Closes #732)
- PR #742 — `consulting-step-shell.md` 신규 도입 (cleanup 대상 회귀가 들어온 PR)
- DEV-457 (Linear) — 본 follow-up 의 Linear 대응 이슈

## Human Test Plan

### 단계 1: 본 PR 머지 후 main 상태 확인

1. `git fetch origin && git checkout main && git pull`
2. `bash ./scripts/ai/check-skill-noise.sh` 실행
3. **기대 동작**: `[PASS] bold + excessive empty lines 잔존 0 건 (보호 컨텍스트 외)` 출력 + exit 0.
4. **실패 시 진단**: `[FAIL]` 출력이면 PR 머지가 cleanup 을 빼먹은 경우. `consulting-step-shell.md` L145-L146 확인.

### 단계 2: lefthook pre-commit hook 동작 검증

1. `lefthook run pre-commit` 실행 (staged 변경 없는 상태).
2. **기대 동작**: 모든 hook 이 `skip (no matching staged files)` 표시.
3. 임시 markdown 파일에 `**bold**` 추가: `echo "test **bold**" > modules/shared/programs/claude/files/skills/run-da/dummy-test.md && git add modules/shared/programs/claude/files/skills/run-da/dummy-test.md`
4. `lefthook run pre-commit` 실행.
5. **기대 동작**: `skill-noise-check` hook 이 FAIL — `[FAIL] run-da/dummy-test.md: bold 1 건 잔존` 출력 + lefthook exit 1.
6. **cleanup**: `git reset HEAD modules/shared/programs/claude/files/skills/run-da/dummy-test.md && rm modules/shared/programs/claude/files/skills/run-da/dummy-test.md`

### 단계 3: PoC 3종 확인

1. **BOM PoC**: `python3 -c "from pathlib import Path; import tempfile; p=tempfile.mkstemp(suffix='.md')[1]; open(p,'wb').write(b'\xef\xbb\xbf**X**'); print(Path(p).read_text(encoding='utf-8-sig'))"` → `**X**` 출력 (BOM 제거).
2. **Empty dir PoC**: `tmpdir=$(mktemp -d); bash ./scripts/ai/check-skill-noise.sh "$tmpdir"; echo "exit=$?"; rm -rf "$tmpdir"` → `[FAIL] ... *.md 파일이 0 개` + exit 1.
3. **SKILLS_DIR env 무시**: `SKILLS_DIR=/tmp bash ./scripts/ai/check-skill-noise.sh` → `[PASS]` (canonical corpus 검사, env 무시).

### 단계 4: Timing 회귀 확인

1. `TIMEFMT='%E'; for i in 1 2 3; do { time bash ./scripts/ai/check-skill-noise.sh >/dev/null 2>&1 } 2>&1; done`
2. **기대 동작**: 0.13-0.15s 수준 (baseline 동일 또는 개선).

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증 (파일/주석/import)

- [ ] `git diff main...HEAD --name-only` → 정확히 3개 파일 (`lefthook.yml`, `modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md`, `scripts/ai/check-skill-noise.sh`).
- [ ] `grep -c 'skill-noise-check' lefthook.yml` → 정확히 1 (hook 정의 추가).
- [ ] `grep -n 'import bisect' scripts/ai/check-skill-noise.sh` → 정확히 1줄 추가.
- [ ] `grep -n 'encoding="utf-8-sig"' scripts/ai/check-skill-noise.sh` → 정확히 1줄 (BOM 처리).
- [ ] `grep -c '\*\*schema fail\|\*\*empty/invalid' modules/shared/programs/claude/files/skills/plan-with-questions/references/consulting-step-shell.md` → 0 (정책 위반 bold 잔존 0건).
- [ ] `grep -n 'R-1 / M-1\|R-1\\b\|M-1\\b' scripts/ai/check-skill-noise.sh` → 박제된 임시 finding ID 0건.

### Phase 1: corpus 검증

- [ ] `bash ./scripts/ai/check-skill-noise.sh; echo "exit=$?"` → `[PASS] ... 잔존 0 건` + exit 0.
- [ ] timing 측정 3회 → 모두 1초 이내.

### Phase 2: lefthook E2E

- [ ] `lefthook run pre-commit` (clean state) → 모든 hook `skip (no matching staged files)`.
- [ ] 의도적 노이즈 staging 후 `lefthook run pre-commit` → `skill-noise-check` FAIL + lefthook exit 1.
- [ ] cleanup 후 `lefthook run pre-commit` → PASS.

### Phase 3: PoC

- [ ] BOM PoC → `**X**` 출력.
- [ ] Empty dir PoC → `[FAIL] ... *.md 파일이 0 개` + exit 1.
- [ ] SKILLS_DIR env 무시 PoC → `[PASS]`.
- [ ] Escaped backtick PoC: `` python3 -c "import re; ..." `` 로 `runs` 카운트 검증.

### Phase Regression: 인접 기능 확인

- [ ] `lefthook run pre-commit` 의 다른 6 hook (`ai-skills-consistency`, `gitleaks`, `nixfmt`, `shellcheck`, `eval-tests`, `codex-hook-fixtures`) 모두 정상 동작 (staged 변경 시).
- [ ] `lefthook run pre-push` 의 hook (`shell-script-tests`, `codex-hook-fixtures`, `flake-check`) 모두 정상 PASS.
- [ ] `warn-skill-consistency.sh` 의 `.claude/skills` ↔ `.agents/skills` directory-level 정합성 검증 영향 없음.

### 실패 시 진단

- Phase 1 FAIL: 변경 후 corpus 에 새 노이즈 도입 가능성. `bash ./scripts/ai/check-skill-noise.sh` 의 출력 확인.
- Phase 2 의 FAIL E2E 실패: lefthook hook 등록 실패. `lefthook.yml` 의 `skill-noise-check` 줄 + `lefthook install` 확인.
- Phase 3 BOM PoC 실패: Python 3.x 가용성 + `encoding="utf-8-sig"` 지원 확인.
- Phase Regression FAIL: 다른 hook 와 hook 간섭 (shared shell env / glob 충돌). lefthook order 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-commit validation command to detect skill-projection noise in markdown content.

* **Bug Fixes**
  * Improved markdown noise detection: robust handling of line endings, fenced/inline code regions, emphasis detection, and excessive-empty-line checks; fails early when no markdown files found.

* **Documentation**
  * Clarified user-facing fallback text for result validation and recovery outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/745)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->