### PR TITLE
feat(cheat): rg(ripgrep) cheatsheet 추가

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/rg/command
+++ b/modules/shared/programs/cheat/cheatsheets/rg/command
@@ -1,0 +1,86 @@
+---
+tags: [ rg, ripgrep, search, grep ]
+---
+rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
+
+[기본 검색]
+
+  rg PATTERN                    재귀 검색 (현재 디렉토리)
+                                $ rg TODO
+                                src/foo.ts:14:// TODO: refactor
+
+  rg PATTERN path/              특정 경로만 검색
+                                $ rg fn modules/
+                                modules/foo.nix:5:  fn = ...
+
+  -i                            강제 대소문자 무시
+                                $ rg -i todo
+                                src/foo.ts:14:// TODO
+                                src/bar.ts:3:// todo done
+
+  -g 'glob' / -g '!pattern'     glob 한정 / glob 제외
+                                $ rg fn -g '*.nix'
+                                modules/foo.nix:5:  fn = ...
+                                $ rg fn -g '!node_modules/**'
+
+  -M N --max-columns-preview    매치 줄 너비 N자 제한 + 잘림 미리보기
+                                $ rg long -M 80 --max-columns-preview
+                                src/foo.ts:14: very long line truncat[...]
+
+  --files                       검색 대상 파일 목록 (검색 X)
+                                $ rg --files -g '*.nix' | head -3
+                                modules/foo.nix
+                                modules/bar.nix
+
+[파일/디렉토리 범위]
+
+  -t TYPE                       특정 타입만 (rg --type-list 로 목록 확인)
+                                $ rg fn -t nix
+                                modules/foo.nix:5:  fn = ...
+
+  --hidden                      숨김 파일 포함 (.dotfile)
+                                $ rg config --hidden
+                                .config/foo:1:config=...
+
+  -uu                           --no-ignore --hidden 묶음 (ignore 모두 끔)
+                                $ rg foo -uu
+                                node_modules/lib/foo.js:1:...
+
+[컨텍스트]
+
+  -C N                          매치 전후 N줄 (양방향)
+                                $ rg fn -C 1
+                                src/foo.ts:13-// before
+                                src/foo.ts:14:fn match
+                                src/foo.ts:15-// after
+
+[매칭 보조]
+
+  -S                            smart-case (소문자 입력 시 자동 case-insensitive)
+                                $ rg todo -S     → -i 처럼 동작
+                                $ rg Todo -S     → 정확히 'Todo' 만
+
+  -F 'literal'                  정규식 비활성, 리터럴 검색
+                                $ rg -F '$1.foo()'
+                                src/foo.ts:14:result = $1.foo()
+
+[출력 형태]
+
+  -l                            파일명만 출력 (xargs/fzf 파이프용)
+                                $ rg -l TODO
+                                src/foo.ts
+                                src/bar.ts
+
+  -c                            파일별 카운트
+                                $ rg -c TODO
+                                src/foo.ts:3
+                                src/bar.ts:1
+
+  -r '$1'                       치환 미리보기 (파일 수정 X, capture group)
+                                $ rg 'fn (\w+)' -r 'def $1'
+                                src/foo.ts:14:def match
+
+Tip
+- gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도
+- 복잡한 정규식/멀티라인은 LLM에게 위임이 빠를 수 있음
+- --max-columns-preview 는 -M 과 함께 써야 효과 (단독 사용 무의미)

--- a/modules/shared/programs/cheat/cheatsheets/rg/command
+++ b/modules/shared/programs/cheat/cheatsheets/rg/command
@@ -13,7 +13,7 @@ rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
                                 $ rg fn modules/
                                 modules/foo.nix:5:  fn = ...
 
-  -i                            강제 대소문자 무시
+  -i                            대소문자 무시 (=ignore case)
                                 $ rg -i todo
                                 src/foo.ts:14:// TODO
                                 src/bar.ts:3:// todo done
@@ -34,7 +34,7 @@ rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
 
 [파일/디렉토리 범위]
 
-  -t TYPE                       특정 타입만 (rg --type-list 로 목록 확인)
+  -t TYPE                       특정 확장자만 (rg --type-list 로 목록 확인)
                                 $ rg fn -t nix
                                 modules/foo.nix:5:  fn = ...
 
@@ -83,4 +83,4 @@ rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
 Tip
 - gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도
 - 복잡한 정규식/멀티라인은 LLM에게 위임이 빠를 수 있음
-- --max-columns-preview 는 -M 과 함께 써야 효과 (단독 사용 무의미)
+- --max-columns-preview 는 -M 과 함께 써야 효과 (rg --help: "If the -M/--max-columns flag is not set, then this has no effect.")

--- a/modules/shared/programs/cheat/cheatsheets/rg/command
+++ b/modules/shared/programs/cheat/cheatsheets/rg/command
@@ -83,4 +83,4 @@ rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
 Tip
 - gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도
 - 복잡한 정규식/멀티라인은 LLM에게 위임이 빠를 수 있음
-- --max-columns-preview 는 -M 과 함께 써야 효과 (rg --help: "If the -M/--max-columns flag is not set, then this has no effect.")
+- --max-columns-preview 는 -M 미지정 시 아예 동작하지 않음 (rg --help: "If the -M/--max-columns flag is not set, then this has no effect.")


### PR DESCRIPTION
## Summary

- 자주 쓰는 `rg`(ripgrep) 옵션 14개를 균형형 큐레이션으로 cheat + fzf 시스템에 추가한다.
- 각 옵션에 `$ rg ...` 예시 호출 + 1-2줄 출력을 첨부해 줄글만으로 직관되지 않는 동작을 보완한다.
- `cheatpaths`가 워크트리 절대 경로를 직접 가리키므로 `nrs` 빌드 없이 즉시 cheat가 인식한다.

Closes #751

## 기존 문제/배경

기존 cheat 인프라(`modules/shared/programs/cheat/`)에는 `nrs` / `wt` / `tmux` / `fzf` / `yazi` / `nvim` cheatsheet가 있지만 `rg`만 빠져 있다. 일상 검색에서 단순 작업을 LLM에 위임하는 라운드트립이 직접 입력보다 느린 경우가 있어, 자주 쓰는 옵션을 즉시 참조할 수 있는 cheatsheet가 필요했다.

본인 실측 (zsh_history 기반) 패턴은 옵션 없는 단순 검색 60% / `-g` 제외 + `-M N` 조합 37% / `-i` 26% 위주이며, 표준 권장 옵션 일부(`-S`, `-t TYPE`, `-C N`, `--hidden`, `-uu`)는 history에 잡히지 않았다. 즉 cheatsheet에 표준 권장 옵션을 함께 두면 학습 채널로도 활용 가능하다.

## CIR (Change Intent Record)

- **v1** (이번 변경): for_issue 인터뷰로 큐레이션 두께를 결정하고 단일 파일 + 예시 입출력 첨부 형태로 채택.
  - 라운드 1: 큐레이션 두께 → 균형형 선택 (미니멀/포괄형 트레이드오프 후).
  - 라운드 2: 개인 환경 의존 패턴 → cheatsheet에는 표준 형태만, 본인 alias는 별도 이슈 범위.
  - 라운드 3: 학습 채널 그룹 → 4그룹 모두 선택 + 예시 입출력 첨부 요구.
  - 라운드 4: 4그룹 + 베이스 = 22개로 균형형(10-14) 초과 → 솎아내서 14개로 재맞춤.
  - 라운드 5: 최종 14개 큐레이션 확정 + 본인 식별 정보(개인 디렉토리 경로, 회사명, 본명) 검열 가드 추가.

**trade-off**: 포괄형(16+)이 아니라 균형형(14)이라 모든 rg 옵션을 reference하지 못한다. 다만 cheatsheet 본질은 "자주 쓰는 것 즉시 참조"이므로 노이즈를 줄이는 쪽으로 의도적으로 절단. 추가 옵션 필요 시 같은 파일에 섹션 추가로 확장 가능 (`cheatpaths.readonly: false` 설정).

## ADR (Architecture Decision Record)

### 큐레이션 두께

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 미니멀 (7-8개) | 실측 빈도 Top만 | 노이즈 최소, "정말 자주 쓰는 것"에 충실 | 학습 채널 효과 없음, 표준 옵션 누락 | ❌ |
| 균형형 (10-14개) | 실측 베이스 + 표준 학습 채널 그룹 일부 | 자주 쓰는 것 + 학습 가치 옵션 함께 커버 | 22개 그룹 전체 선택 시 길이 초과 → 솎아내기 필요 | ✅ |
| 표준 포괄형 (16+개) | ripgrep Tier 1 전체 | reference value 최대 | 길이 부담, 본인 실 사용과 갭 | ❌ |

### 파일 분할

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 단일 파일 (`rg/command`) | 한 파일에 모든 옵션 | 한 화면에서 grep 가능, 기존 단일 도메인 컨벤션 일치 | 항목 수가 nvim 수준으로 커지면 분할 필요 | ✅ |
| 분할 (`rg/basics`, `rg/types`, ...) | nvim처럼 카테고리별 파일 | 각 파일 집중도 ↑ | 전체 관점 보려면 여러 파일 열어야 함, 14개 항목엔 과도 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/cheat/cheatsheets/rg/command` | 추가 (86줄) | frontmatter + 5섹션 + 14개 옵션 + 예시 입출력 + Tip |

### 구조 예시

```
---
tags: [ rg, ripgrep, search, grep ]
---
rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)

[기본 검색]

  rg PATTERN                    재귀 검색 (현재 디렉토리)
                                $ rg TODO
                                src/foo.ts:14:// TODO: refactor
  ...

[파일/디렉토리 범위]
[컨텍스트]
[매칭 보조]
[출력 형태]

Tip
- gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도
- ...
```

awk 강조 호환: 2칸 들여쓰기 + 옵션 + 스페이스 2칸 이상 + 한국어 설명. `cheatsheet.sh`의 awk가 옵션을 bold yellow, 섹션 헤더를 bold cyan으로 처리.

## 참고 레퍼런스

- Issue #751 — 본 PR이 닫는 이슈 (큐레이션 결정 사항 + Acceptance Criteria 본문).
- `modules/shared/programs/cheat/default.nix` — cheat 모듈 정의, `cheatpaths`와 래퍼 스크립트 생성.
- `modules/shared/programs/cheat/files/scripts/cheatsheet.sh` — fzf 브라우저, awk 강조 규칙 (헤더 cyan / 옵션 yellow).
- `modules/shared/programs/cheat/cheatsheets/nrs/command`, `modules/shared/programs/cheat/cheatsheets/wt/command` — 단일 도메인 cheatsheet 컨벤션 참고.
- [ripgrep User Guide](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md) — 옵션 동작 근거.

## Human Test Plan

### 정상 동작 검증

1. 셸에서 `cheat rg/command`를 실행한다.
   - **기대**: 14개 옵션이 5섹션으로 정렬되어 출력. 옵션 컬럼이 들여쓰기 2칸 + 옵션 + 30자 컬럼 정렬되어 보임.
   - **실패 시**: `~/.config/cheat/conf.yml`의 `cheatpaths.path`가 `modules/shared/programs/cheat/cheatsheets`를 가리키는지 확인.

2. `cheat -l | grep rg/command`로 목록 등록을 확인한다.
   - **기대**: `rg/command` 항목 + 태그 `grep,personal,rg,ripgrep,search` 표시.
   - **실패 시**: frontmatter `tags:` 배열 문법 점검.

3. `cheatsheet`로 fzf 브라우저를 열고 `rg/command` 항목을 선택한다.
   - **기대**: preview에서 섹션 헤더(`[기본 검색]` 등)가 bold cyan, 옵션(`rg PATTERN`, `-i` 등)이 bold yellow로 강조.
   - **실패 시**: 옵션 줄의 들여쓰기가 정확히 2칸인지, 옵션과 설명 사이 스페이스가 2칸 이상인지 확인.

4. tmux 안에서 `prefix + C`, Neovim 안에서 `<leader>C`, Yazi 안에서 `C`를 눌러 동일 진입점이 동작하는지 spot check.
   - **기대**: 동일한 fzf 브라우저 표시. `rg/command` 검색/선택 후 preview 강조 동일.
   - **실패 시**: 각 도구의 키바인딩 설정(`tmux.conf`, `keymaps.lua`, `yazi/default.nix`)이 `$HOME/.local/bin/cheatsheet`를 호출하는지 확인.

### 엣지 케이스

5. `cheat -l -t rg`로 태그 필터를 호출한다.
   - **기대**: `rg/command`만 출력.
   - **실패 시**: frontmatter `tags:` 배열에 `rg`가 포함되어 있는지 확인.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 파일 존재 + 줄 수 확인
test -f modules/shared/programs/cheat/cheatsheets/rg/command
wc -l modules/shared/programs/cheat/cheatsheets/rg/command  # 기대: 86

# 2. frontmatter 태그 확인
head -3 modules/shared/programs/cheat/cheatsheets/rg/command | grep -q 'tags: \[ rg, ripgrep, search, grep \]'

# 3. 14개 옵션 모두 포함 확인 (5섹션 헤더)
for section in '\[기본 검색\]' '\[파일/디렉토리 범위\]' '\[컨텍스트\]' '\[매칭 보조\]' '\[출력 형태\]'; do
  grep -qE "^${section}$" modules/shared/programs/cheat/cheatsheets/rg/command || echo "FAIL: $section"
done

# 4. 본인 식별 정보 부재 확인 (대외비 가드)
! grep -iE '자리톡|zaritalk|글렌|glen|Documents/Glen' modules/shared/programs/cheat/cheatsheets/rg/command
# 기대: exit 0 (매치 없음 → grep -v failure로 exit 1, ! 로 반전 → exit 0)
```

### Phase 1: cheat CLI 인식 검증

```bash
# rg/command 항목이 cheat -l에 등록되는지
cheat -l 2>&1 | grep -qE '^rg/command\s'
# 기대: exit 0

# 태그 필터 동작
cheat -l -t rg 2>&1 | grep -qE '^rg/command\s'
# 기대: exit 0
```

### Phase 2: awk 강조 ANSI escape 검증

```bash
# 헤더 cyan (\033[1;36m) + 옵션 yellow (\033[1;33m) ANSI sequence가 출력되는지
preview_out=$(bash modules/shared/programs/cheat/files/scripts/cheatsheet.sh --preview rg/command 2>&1)
echo "$preview_out" | grep -q $'\033\[1;36m' || echo "FAIL: cyan missing"
echo "$preview_out" | grep -q $'\033\[1;33m' || echo "FAIL: yellow missing"
```

### Phase 3: Regression

```bash
# 기존 cheatsheet 영향 없음 확인
for existing in nrs/command wt/command fzf/keybinding tmux/keybinding yazi/keybinding nvim/buffer; do
  cheat -l 2>&1 | grep -qE "^${existing//\//\\/}\s" || echo "FAIL: $existing missing"
done

# nrs 빌드가 트리거되지 않음 (cheatpaths 워크트리 직접 참조 — 검증: 래퍼 경로 변동 없음)
test -L "$HOME/.local/bin/cheatsheet"
```

### Phase 4 (선택): 운영 환경 spot check

> "tmux prefix+C, Neovim <leader>C, Yazi C로 진입점 동등성 확인"

- 운영 환경에서 위 진입점 3개로 cheatsheet 브라우저가 같은 형태로 표시되는지 수동 확인 (Phase 0-3 통과 시 자동 동작 보장되나 운영 환경 spot check 권장).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a bilingual ripgrep (rg) cheatsheet as a quick reference covering recursive and case-insensitive search, smart-case and literal modes, glob inclusion/exclusion, limiting preview width, context lines, file-type/hidden-file controls, filename-only and per-file count outputs, substitution preview, and notes on ignore/hidden/binary behavior and common flags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/752)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->