### PR TITLE
fix(cheat): rg cheatsheet -uu/Tip binary 처리 정확화

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/rg/command
+++ b/modules/shared/programs/cheat/cheatsheets/rg/command
@@ -42,7 +42,7 @@ rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
                                 $ rg config --hidden
                                 .config/foo:1:config=...
 
-  -uu                           --no-ignore --hidden 묶음 (ignore 모두 끔)
+  -uu                           --no-ignore --hidden 묶음 (ignore 규칙 비활성 + 숨김 포함; binary 는 여전히 제외)
                                 $ rg foo -uu
                                 node_modules/lib/foo.js:1:...
 
@@ -81,6 +81,6 @@ rg — ripgrep recursive search (gitignore/숨김/바이너리 자동 제외)
                                 src/foo.ts:14:def match
 
 Tip
-- gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도
+- gitignore/숨김/바이너리는 기본 제외 — 숨김 누락은 --hidden 또는 -uu, 바이너리 누락은 -uuu 또는 -a/--text 시도
 - 복잡한 정규식/멀티라인은 LLM에게 위임이 빠를 수 있음
 - --max-columns-preview 는 -M 미지정 시 아예 동작하지 않음 (rg --help: "If the -M/--max-columns flag is not set, then this has no effect.")


### PR DESCRIPTION
## Summary

- `rg` cheatsheet의 `-uu` 설명과 Tip 1번 줄이 binary 파일 처리 측면에서 부정확했던 표현을 수정한다.
- `rg --help` 원문으로 동작 검증 후 정확한 한국어 표현으로 정정.
- 단순 텍스트 정확성 수정 (2줄). 사용자 명시 요청으로 DA / parallel-audit 절차 생략.

Closes #753

## 기존 문제/배경

PR #752 squash merge 직후 CodeRabbit 이 review thread (line 47) 에서 다음을 지적했다:

- **L45 `-uu` 설명**: `--no-ignore --hidden 묶음 (ignore 모두 끔)` — "모두 끔" 표현이 binary 제외까지 끄는 것으로 읽힘. 실제 `-uu` 는 ignore + hidden 만 끄고 binary 필터링은 유지된다.
- **L84 Tip 1**: `gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도` — "바이너리 누락 시 `-uu`" 시도는 잘못. binary 포함하려면 `-uuu` 또는 `-a/--text` 가 필요.

`rg --help` 직접 실행 결과로 동작 검증:

- `-u, --unrestricted`: "Repeated uses (up to 3) reduces the filtering even more. When repeated three times, ripgrep will search every file in a directory tree." → 즉 `-uuu` 만 binary 포함.
- `-a, --text`: "ripgrep's binary file detection is disabled."

cheatsheet 학습 정확성 영향이 있어 follow-up 으로 수정.

## CIR (Change Intent Record)

해당 없음 — 단순 사실 정확성 수정. 대안 검토 없이 `rg --help` 원문에 맞춰 한국어 표현만 정정.

## ADR (Architecture Decision Record)

해당 없음 — 단순 변경. 옵션 풀(14개) 유지하면서 두 줄의 표현만 정확화. cheatsheet 항목 추가/제거나 구조 변경 없음.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/cheat/cheatsheets/rg/command` | 수정 (2줄) | L45 `-uu` 설명 정확화, L84 Tip 1 binary 누락 처리 옵션 보강 |

### BEFORE / AFTER

```diff
-  -uu                           --no-ignore --hidden 묶음 (ignore 모두 끔)
+  -uu                           --no-ignore --hidden 묶음 (ignore 규칙 비활성 + 숨김 포함; binary 는 여전히 제외)
```

```diff
- - gitignore/숨김/바이너리는 기본 제외 — 누락되면 --hidden 또는 -uu 시도
+ - gitignore/숨김/바이너리는 기본 제외 — 숨김 누락은 --hidden 또는 -uu, 바이너리 누락은 -uuu 또는 -a/--text 시도
```

`-uuu` 자체를 새 cheatsheet 항목으로 추가하지는 않는다 (균형형 14개 유지). Tip 본문에서 언급만으로 충분.

## 참고 레퍼런스

- Issue #753 — 본 PR 이 닫는 follow-up 이슈 (Proposed Changes / Acceptance Criteria 본문).
- PR #752 — 원본 cheatsheet 도입 PR (이미 squash merge 됨).
- CodeRabbit 원 지적 thread: https://github.com/greenheadHQ/nixos-config/pull/752#discussion_r3233152263
- SCOPE_DEFERRAL 답글 (→ #753 분리): https://github.com/greenheadHQ/nixos-config/pull/752#discussion_r3233305486
- [ripgrep User Guide](https://github.com/BurntSushi/ripgrep/blob/master/GUIDE.md) — `-u/-uu/-uuu` 동작 근거.

## Human Test Plan

### 정상 동작 검증

1. `cheat rg/command` 실행하여 L45 (`-uu` 줄) 와 Tip 영역 확인.
   - **기대**: `-uu` 설명에 "binary 는 여전히 제외" 명시. Tip 1 에 "바이너리 누락은 -uuu 또는 -a/--text" 명시.
   - **실패 시**: 파일 직접 읽어 두 줄 텍스트 검증.

2. `cheatsheet` fzf 브라우저로 preview 확인.
   - **기대**: 헤더 cyan, 옵션 yellow 강조가 PR #752 머지 직후와 동일하게 유지 (옵션 yellow 영역 = `-uu`).
   - **실패 시**: 옵션 줄 들여쓰기 2칸 + 옵션 + 2칸 이상 공백 + 설명 패턴 확인.

### 의미 검증 (옵션 동작 일치)

3. binary 파일에 대한 검색 동작 직접 확인.
   - 빈 디렉토리에 binary fixture 생성 후 `rg foo`, `rg foo --hidden`, `rg foo -uu`, `rg foo -uuu`, `rg foo -a` 비교.
   - **기대**: `-uuu` 와 `-a` 만 binary 매치 출력. `-uu` 는 매치 없음.
   - **실패 시**: ripgrep 버전이 너무 낮을 가능성 (`rg --version`).

## Pre-Merge E2E 테스트 가이드

본 PR 의 Phase 2 명령은 follow-up 이슈 #754 의 발견을 선반영하여 `grep -Fq` (fixed-string) 패턴으로 작성한다. 이전 PR #752 의 Phase 2 명령은 devShell 의 `grep`(ugrep alias) 환경에서 `mismatched [ ]` 에러를 일으켰다.

### Phase 0: 정적 검증

```bash
F=modules/shared/programs/cheat/cheatsheets/rg/command

# 1. 파일 존재 + 줄 수 유지 (86줄, 변경 전과 동일)
test -f "$F"
wc -l "$F"  # 기대: 86

# 2. L45 -uu 설명 정확화 반영
sed -n '45p' "$F" | grep -Fq 'ignore 규칙 비활성 + 숨김 포함; binary 는 여전히 제외'
# 기대: exit 0

# 3. L84 Tip 1 binary 옵션 보강 반영
sed -n '84p' "$F" | grep -Fq '바이너리 누락은 -uuu 또는 -a/--text 시도'
# 기대: exit 0

# 4. 부정확한 옛 표현 부재
! grep -Fq 'ignore 모두 끔' "$F"
! grep -Fq '누락되면 --hidden 또는 -uu 시도' "$F"
# 기대: 둘 다 exit 0 (옛 표현 없음)

# 5. 식별 정보 부재 (대외비 가드 유지)
! rg -iN '자리톡|zaritalk|글렌|glen|Documents/Glen' "$F"
```

### Phase 1: cheat CLI 인식

```bash
# rg/command 항목이 여전히 등록
cheat -l 2>&1 | grep -qE '^rg/command\s'

# 태그 필터 정상
cheat -l -t rg 2>&1 | grep -qE '^rg/command\s'
```

### Phase 2: awk 강조 ANSI escape (ugrep-safe fixed-string)

```bash
PREVIEW=$(bash modules/shared/programs/cheat/files/scripts/cheatsheet.sh --preview rg/command 2>&1)

# fixed-string 매치 (ugrep alias 환경에서도 안전)
printf '%s' "$PREVIEW" | grep -Fq $'\x1b[1;36m'  # cyan 헤더
printf '%s' "$PREVIEW" | grep -Fq $'\x1b[1;33m'  # yellow 옵션

# 개수도 동일 (PR #752 머지 직후 baseline: cyan=10, yellow=20)
cyan=$(printf '%s' "$PREVIEW" | grep -Fc $'\x1b[1;36m')
yellow=$(printf '%s' "$PREVIEW" | grep -Fc $'\x1b[1;33m')
test "$cyan" -eq 10 && test "$yellow" -eq 20
# 기대: exit 0
```

### Phase 3: Regression

```bash
# 기존 cheatsheet 영향 없음
for existing in nrs/command wt/command fzf/keybinding tmux/keybinding yazi/keybinding nvim/buffer; do
  cheat -l 2>&1 | grep -qE "^${existing//\//\\/}\s" || echo "FAIL: $existing"
done

# cheatpaths 워크트리 직접 참조 유지 (nrs 빌드 트리거 없음)
grep -Fq "/Users/glen/Workspace/nixos-config/modules/shared/programs/cheat/cheatsheets" "$HOME/.config/cheat/conf.yml"
```

### Phase 4 (선택, 의미 검증)

```bash
# binary fixture 로 -uu/-uuu/-a 동작 차이 실측
TMP=$(mktemp -d)
printf 'foo\x00bar\n' > "$TMP/binary.dat"

rg foo "$TMP" 2>&1 | grep -q binary.dat || true             # 기대: 매치 없음 (binary 자동 제외)
rg foo -uu "$TMP" 2>&1 | grep -q binary.dat || true         # 기대: 매치 없음 (-uu 도 binary 제외 유지)
rg foo -uuu "$TMP" 2>&1 | grep -q 'binary.*matches'         # 기대: matches (binary 검색됨)
rg foo -a "$TMP" 2>&1 | grep -q binary.dat                  # 기대: 매치 (binary text 취급)

rm -rf "$TMP"
```

운영 환경 spot check 권장: tmux `prefix+C` / Neovim `<leader>C` / Yazi `C` 진입점이 동일하게 동작하는지.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ripgrep (`rg`) command cheat sheet with clarified documentation for the `-uu` flag, explicitly stating its behavior: disables ignore rules and includes hidden files while excluding binaries.
  * Broadened default exclusion behavior guidance to align with hidden file inclusion requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/755)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->