### PR TITLE
fix(shell): guard Ghostty zsh integration source

### DIFF
--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -63,7 +63,10 @@ in
 
       # Ghostty 쉘 통합 설정
       if [ -n "''${GHOSTTY_RESOURCES_DIR}" ]; then
-        builtin source "''${GHOSTTY_RESOURCES_DIR}/shell-integration/zsh/ghostty-integration"
+        # cmux can set GHOSTTY_RESOURCES_DIR without Ghostty.app's zsh integration path.
+        if [ -r "''${GHOSTTY_RESOURCES_DIR}/shell-integration/zsh/ghostty-integration" ]; then
+          builtin source "''${GHOSTTY_RESOURCES_DIR}/shell-integration/zsh/ghostty-integration"
+        fi
       fi
 
       # Homebrew 설정


### PR DESCRIPTION
## Summary

- Guard Ghostty zsh integration source with a readable-file check.
- Preserve the existing Ghostty.app integration path when available.
- Avoid cmux startup missing-file errors when cmux sets `GHOSTTY_RESOURCES_DIR` without Ghostty.app's zsh integration layout.

## Validation

- `nrs`
- `GHOSTTY_RESOURCES_DIR=/Applications/cmux.app/Contents/Resources/ghostty zsh -ic 'echo ok'` with no missing `ghostty-integration` path error
- `GHOSTTY_RESOURCES_DIR=/Applications/Ghostty.app/Contents/Resources/ghostty zsh -ic 'echo ok'` with no missing `ghostty-integration` path error
- `direnv exec . git commit ...` hooks: nixfmt, gitleaks, eval tests, codex hook fixtures, commit-msg pinning
- `git push` pre-push hooks: codex hook fixtures, flake check, shell script tests

Closes #766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Ghostty shell integration reliability on macOS by adding a validation check to ensure configuration files are readable before loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/768)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->