### PR TITLE
fix(ghostty): pin dark theme for cmux

### DIFF
--- a/modules/darwin/programs/ghostty/default.nix
+++ b/modules/darwin/programs/ghostty/default.nix
@@ -14,6 +14,9 @@
     font-family = JetBrainsMono Nerd Font
     font-family = D2Coding
 
+    # cmux가 system light appearance에서 밝은 fallback 색상을 선택하지 않도록 dark theme를 명시한다.
+    theme = Ghostty Default Style Dark
+
     # macOS Option 키를 Alt로 사용 (왼쪽만)
     macos-option-as-alt = left
 


### PR DESCRIPTION
## Summary
- Pin `Ghostty Default Style Dark` in the repo-managed Ghostty config so cmux terminals no longer fall back to light terminal colors under system light appearance.
- Keep cmux app-owned theme override state unmanaged; standalone Ghostty shares the same dark default.

Closes #765

## 기존 문제/배경

cmux follows the macOS system appearance, and the system can be in light mode. The existing repo-managed Ghostty config did not set `theme`, `background`, `foreground`, or `palette`, so cmux could render terminal panels with light fallback colors instead of the expected dark terminal appearance.

## CIR (Change Intent Record)

- **이번 변경**: confirmed that cmux JSON only carries cmux app settings, while terminal rendering settings belong in Ghostty config. The change therefore pins a named dark Ghostty theme in the shared Ghostty config.
- **trade-off**: standalone Ghostty also gets the dark default. This is accepted to avoid taking ownership of cmux app-owned mutable theme override state.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Shared Ghostty config | Set the theme in `~/.config/ghostty/config` through Home Manager | Smallest repo-managed change; works for cmux and Ghostty; avoids app-owned override state | Also affects standalone Ghostty | ✅ |
| cmux app support Ghostty config | Manage cmux-specific `config.ghostty` under app support | Narrows the change to cmux | Conflicts with cmux theme picker/CLI ownership | ❌ |
| Raw color palette | Hand-author background, foreground, and ANSI palette | Independent of named theme availability | More maintenance and higher drift risk | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/programs/ghostty/default.nix` | 수정 | Add an explicit dark Ghostty theme after the font fallback chain. |

### 핵심 코드

```ghostty
# cmux가 system light appearance에서 밝은 fallback 색상을 선택하지 않도록 dark theme를 명시한다.
theme = Ghostty Default Style Dark
```

## 참고 레퍼런스

- Issue #765 — cmux terminal panels can use light fallback colors.
- `cmux docs settings` — terminal rendering settings such as `theme` are configured through Ghostty config.

## Human Test Plan

1. Run `nrs`.
   - **기대**: Home Manager activates successfully and links the generated Ghostty config.
   - **실패 시**: inspect the Home Manager activation error and rerun after resolving the reported target.

2. Check the active Ghostty config.
   - **명령**: `rg '^theme = Ghostty Default Style Dark$' ~/.config/ghostty/config`
   - **기대**: the theme line is present once.
   - **실패 시**: verify `~/.config/ghostty/config` points to the latest Home Manager generation.

3. Check cmux theme resolution.
   - **명령**: `cmux themes list | sed -n '1,4p'`
   - **기대**: both current light and current dark report `Ghostty Default Style Dark`.
   - **실패 시**: confirm cmux is reading `~/.config/ghostty/config`; if `cmux reload-config` reports a socket error, restart cmux and recheck.

4. Open a cmux terminal panel under system light appearance.
   - **기대**: the terminal content area renders with a dark background.
   - **실패 시**: inspect `cmux themes list` and the active Ghostty effective config.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. Theme line exists exactly once
test "$(rg -c '^\s*theme = Ghostty Default Style Dark$' modules/darwin/programs/ghostty/default.nix)" -eq 1

# 2. cmux module was not changed for app-owned theme state
! git diff main...HEAD --name-only | rg '^modules/darwin/programs/cmux/'

# 3. No raw color palette was introduced
! rg -n '^\s*(background|foreground|palette) =' modules/darwin/programs/ghostty/default.nix
```

### Phase 1: Theme Availability

> "The bundled cmux Ghostty runtime knows the pinned dark theme."

```bash
/Applications/cmux.app/Contents/Resources/bin/ghostty +list-themes --plain --color=dark \
  | rg '^Ghostty Default Style Dark \(resources\)$|^Ghostty Default Style Dark$'
```

- **기대**: the command returns the theme name.
- **실패 시**: choose another bundled dark Ghostty theme or revisit raw color settings.

### Phase 2: Activated Config

> "Home Manager activates the theme and Ghostty accepts it."

```bash
nrs
/Applications/cmux.app/Contents/Resources/bin/ghostty +validate-config
/Applications/cmux.app/Contents/Resources/bin/ghostty +show-config --no-pager \
  | rg '^theme = Ghostty Default Style Dark$'
```

- **기대**: `nrs` succeeds, config validation exits 0, and effective config reports the pinned theme.
- **실패 시**: inspect the generated `~/.config/ghostty/config` symlink and Ghostty validation output.

### Phase 3: cmux Runtime Resolution

> "cmux resolves both appearance modes to the dark Ghostty theme."

```bash
cmux themes list | sed -n '1,4p'
```

- **기대**: current light and current dark both report `Ghostty Default Style Dark`.
- **실패 시**: restart cmux and confirm it is sourcing `~/.config/ghostty/config`.

### Phase 4: Regression

> "Existing Ghostty behavior settings remain present."

```bash
rg -n 'font-family =|macos-option-as-alt|notify-on-command-finish|shell-integration-features' \
  modules/darwin/programs/ghostty/default.nix
```

- **기대**: existing font fallback, Option-as-Alt, command notification, and shell integration settings are still present.
- **실패 시**: compare the Ghostty config block with `main` and restore the missing existing setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ghostty configuration on macOS to properly handle color rendering when system light appearance is enabled. The terminal now applies an explicit default dark theme, preventing incorrect bright color fallbacks and ensuring consistent, accurate color display in all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/769)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->