### PR TITLE
docs(create-pr): fixed-string grep guidance

### DIFF
--- a/modules/shared/programs/claude/files/skills/create-pr/references/pr-template.md
+++ b/modules/shared/programs/claude/files/skills/create-pr/references/pr-template.md
@@ -191,6 +191,8 @@ local heavy_packages=("anki" "mise")
 ### 작성 규칙
 - LLM이 직접 실행하여 PR 머지 전에 검증할 수 있는 자동화된 절차를 기술한다.
 - Phase 기반 구조를 따른다: Phase 0(정적) → Phase 1-N(기능) → Phase N+1(Regression).
+- ANSI escape sequence 또는 regex metacharacter를 literal로 검증할 때는 `grep -Fq`를 사용한다.
+  예: `printf '%s' "$preview_out" | grep -Fq $'\x1b[1;36m'`
 - 상세 작성 규칙은 `references/pre-merge-guide.md` 참조.
 
 ### 예시

--- a/modules/shared/programs/claude/files/skills/create-pr/references/pre-merge-guide.md
+++ b/modules/shared/programs/claude/files/skills/create-pr/references/pre-merge-guide.md
@@ -32,6 +32,16 @@ ls <expected_file>
 - `grep -q "/new/path"` (새 값 존재) + `! grep -q "/old/path"` (old 값 부재)
 두 가지를 모두 검증한다.
 
+핵심 원칙 — Literal 검증은 fixed-string:
+ANSI escape sequence, `[` / `]`, `.` / `*` 처럼 regex metacharacter를 포함한 출력은 literal로 검증한다.
+이 경우 `grep -q` 대신 `grep -Fq`를 사용한다. Regex가 필요한 검증은 `grep -qE` 또는 `grep -q`를 명시적으로 사용한다.
+
+```bash
+# ANSI cyan escape가 출력에 포함되는지 literal로 확인
+printf '%s' "$preview_out" | grep -Fq $'\x1b[1;36m'
+# 기대: exit 0
+```
+
 ### Phase 1-N: 기능별 검증
 
 변경의 핵심 기능을 각각 독립적으로 검증한다.


### PR DESCRIPTION
## Summary

- `create-pr` Pre-Merge E2E 작성 규칙에 ANSI escape / regex metacharacter literal 검증은 `grep -Fq`를 쓰도록 명시한다.
- PR body template에도 같은 fixed-string 예시를 추가해 복사 가능한 패턴을 제공한다.
- Regex 검증이 필요한 기존 예시는 유지해 literal 검증과 regex 검증의 경계를 분리한다.

Closes #754

## 기존 문제/배경

PR #752 post-merge E2E 확인 중 ANSI escape 존재 여부를 regex grep으로 검사하는 명령이 실패했다.

문제 형태:

```bash
grep -q $'\x1b[1;36m'
```

`[`가 regex bracket expression으로 해석되어 BSD grep과 GNU grep 모두에서 오류가 발생한다. 실제 목적은 ANSI escape 문자열의 literal 존재 여부 확인이므로 fixed-string 검사인 `grep -Fq`가 더 적합하다.

## CIR (Change Intent Record)

Issue #754는 `create-pr` 스킬의 Pre-Merge E2E Phase 작성 규칙이 향후 같은 ANSI 검증 실패를 만들지 않도록 보강하는 작업이다.

초기 후보는 세 가지였다.

| 대안 | 설명 | 판단 |
|------|------|------|
| 규칙 문서만 수정 | `pre-merge-guide.md`에 fixed-string 규칙 추가 | 최소 변경이지만 템플릿 예시를 따라 쓰는 흐름은 덜 보강됨 |
| 규칙 + 예시 수정 | 규칙 문서와 PR template 예시를 함께 보강 | 채택 |
| 스킬 본문까지 반복 | `SKILL.md`에도 같은 내용을 중복 기재 | reference SSOT drift 위험으로 제외 |

선택한 방향은 규칙과 예시를 함께 보강하되, `SKILL.md` 본문에는 중복 기재하지 않는 것이다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `grep -Fq` | literal fixed-string 검사 | BSD/GNU grep에서 같은 의미, ANSI escape 목적과 일치 | regex 검증에는 부적합 | ✅ |
| `/usr/bin/grep` 절대경로 | macOS 시스템 grep 강제 | 특정 macOS 환경의 PATH 영향을 줄임 | NixOS와 devShell portability가 낮고, regex bracket 문제 자체를 해결하지 않음 | ❌ |
| 모든 `grep -q`를 `grep -Fq`로 변경 | 일괄 literal화 | 규칙이 단순함 | `heavy.*anki`처럼 regex 의도가 있는 예시를 깨뜨림 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/skills/create-pr/references/pre-merge-guide.md` | Literal 검증은 fixed-string으로 처리하라는 핵심 원칙과 ANSI cyan 예시 추가 |
| `modules/shared/programs/claude/files/skills/create-pr/references/pr-template.md` | Pre-Merge E2E 작성 규칙에 `grep -Fq` copy-paste 예시 추가 |

핵심 예시:

```bash
printf '%s' "$preview_out" | grep -Fq $'\x1b[1;36m'
```

## 참고 레퍼런스

- Issue #754 - create-pr Pre-Merge E2E Phase 2 grep 명령 호환 보강.
- PR #752 post-merge E2E comment - ANSI escape 검증 명령 실패가 발견된 원래 맥락.
- `modules/shared/programs/claude/files/skills/create-pr/references/pre-merge-guide.md` - Pre-Merge E2E 작성 규칙 SSOT.
- `modules/shared/programs/claude/files/skills/create-pr/references/pr-template.md` - PR body template 예시.

## Human Test Plan

### 정상 동작 검증

1. ANSI preview 출력을 만들고 regex grep 실패를 확인한다.
   - **기대**: `grep -q $'\x1b[1;36m'`는 bracket 오류로 실패한다.
   - **실패 시**: 테스트 shell과 grep 구현이 실제 bracket regex를 해석하는지 확인한다.

2. 같은 출력에서 fixed-string grep 성공을 확인한다.
   - **기대**: `grep -Fq $'\x1b[1;36m'`는 exit 0이다.
   - **실패 시**: preview 출력에 ANSI escape가 실제 포함되는지 확인한다.

3. `create-pr` reference 문서에 guidance가 들어갔는지 확인한다.
   - **기대**: `pre-merge-guide.md`와 `pr-template.md` 모두 `grep -Fq` 예시를 포함한다.
   - **실패 시**: source file 경로가 repo 원본인지 확인한다.

### 엣지 케이스

4. Regex가 필요한 기존 예시가 유지되는지 확인한다.
   - **기대**: `grep -q "heavy.*anki"` 예시는 그대로 남아 있다.
   - **실패 시**: literal 검증과 regex 검증의 경계가 과도하게 바뀌지 않았는지 확인한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
rg -n "grep -Fq|x1b\\[1;36m|ANSI|fixed-string" modules/shared/programs/claude/files/skills/create-pr
rg -n 'grep -q "heavy\\.\\*anki"' modules/shared/programs/claude/files/skills/create-pr/references/pr-template.md
```

- **기대**: fixed-string guidance가 두 reference 문서에 있고, regex 의도 예시는 유지된다.
- **실패 시**: `pre-merge-guide.md`와 `pr-template.md`의 Pre-Merge E2E 섹션을 확인한다.

### Phase 1: grep 호환 재현

```bash
bash modules/shared/programs/cheat/files/scripts/cheatsheet.sh --preview rg/command >/tmp/issue754-preview.out 2>&1
LC_ALL=C grep -q $'\x1b[1;36m' /tmp/issue754-preview.out; test $? -eq 2
LC_ALL=C grep -Fq $'\x1b[1;36m' /tmp/issue754-preview.out
```

- **기대**: regex grep은 bracket 오류로 실패하고, fixed-string grep은 exit 0이다.
- **실패 시**: preview 출력과 grep 구현을 확인한다.

### Phase 2: 스킬 surface 검증

```bash
nrs
./scripts/ai/verify-ai-compat.sh
```

- **기대**: `nrs`가 worktree symlink를 relink하고, AI compatibility 검증이 통과한다.
- **실패 시**: shared skill symlink target이 현재 worktree를 가리키는지 확인한다.

### Phase 3: Regression

```bash
git diff --check main...HEAD -- modules/shared/programs/claude/files/skills/create-pr/references/pre-merge-guide.md modules/shared/programs/claude/files/skills/create-pr/references/pr-template.md
```

- **기대**: whitespace 또는 markdown fence 관련 diff 오류가 없다.
- **실패 시**: 추가된 fenced block 주변 indentation과 trailing whitespace를 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-merge testing guides and PR templates with enhanced validation rules for test outputs containing special characters and escape sequences, including practical examples for verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/771)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->