### PR TITLE
docs(claude-code): .claude/plans/ 디렉토리 정책 README (#756 P0)

### DIFF
--- a/.claude/plans/README.md
+++ b/.claude/plans/README.md
@@ -1,0 +1,42 @@
+# `.claude/plans/` 디렉토리 정책
+
+본 디렉토리는 `plan-with-questions` 스킬의 `for_action` 모드가 만드는 **SSOT plan 파일** (`.claude/plans/<slug>.md`) 의 위치다. 동시에 Claude Code harness의 plan-mode runtime이 떨어뜨리는 **transient plan buffer** (`<slug>-<8hex>.md`) 도 같은 디렉토리에 누적된다. 두 종류를 구분해 다루는 것이 본 정책의 목표다.
+
+연관 이슈: #756 (P0 — 본 README), #756 P1 (transient buffer GC 정책/훅, 별도 사이클).
+
+## Plan 파일 bind 원칙
+
+새 plan을 만들기 전에 `plan-with-questions/modes/for_action.md:120-122` 규약에 따라 같은 source(이슈 ref) + non-terminal Status를 가진 기존 SSOT plan이 있는지 먼저 검색한다. 있으면 새 파일을 만들지 않고 그 파일에 bind 한 뒤 `Resume From` / `Last Completed Step` / `DA State` 로 재개한다. 새 파일이 필요한 collision (terminal Status 또는 unrelated source) 일 때만 `-2`, `-3` 같은 숫자 suffix로 collision을 해소한다. 무작위 hex suffix (`<slug>-<8hex>.md`) 는 SSOT plan을 위한 합법 파일명이 아니다.
+
+## Transient buffer 식별 기준
+
+파일명이 `<prefix>-<8hex>.md` 형식 (8자리 hex suffix) 이면 plan-mode runtime이 자동 생성한 transient plan buffer다. plan-with-questions 스킬 문서는 이 buffer를 새 SSOT plan으로 **승격하지 말라**고만 규정하고 (`modes/for_action.md:136`, `references/runtime-boundaries.md:76-78`), 정리(GC) 주체는 명시하지 않는다. 따라서 buffer는 무한 누적되는 경향이 있다 (#756 P1이 정리 정책/훅을 다룰 예정).
+
+본 README 작성 시점 실측: hex 변종 누적이 가장 많은 prefix는 동일 topic의 SSOT plan canonical과 공존한다. canonical 식별은 아래 snippet 출력의 prefix 중 `<prefix>.md` (suffix 없음) 가 디렉토리에 존재하면 그것이 canonical SSOT plan이다.
+
+`-agent-<NHex>` 같은 다른 패턴 (예: `cosmic-booping-peach-agent-a1cbb08.md`) 도 일부 존재하나 2026-02-28 이후 추가 생성되지 않는 historical artifacts다 (과거 Claude Code sub-agent 산출물). 본 README의 식별 기준에 포함하지 않는다. P1에서 별도 일회성 정리 대상으로 분리한다.
+
+## Prefix별 hex 변종 집계 snippet
+
+다음 one-liner를 main checkout의 repo root에서 실행하면 prefix별 hex 변종 누적 수를 내림차순으로 본다.
+
+```bash
+find "${1:-.claude/plans}" -maxdepth 1 -type f \
+  -name '*-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].md' \
+  | sed -E 's|^.*/||; s/-[0-9a-f]{8}\.md$//' \
+  | sort | uniq -c | sort -rn
+```
+
+이 snippet은 실측 plan 누적 디렉토리 점검용이다. 다른 머신 또는 다른 디렉토리에서 실행하려면 첫 인자로 경로를 넘긴다 (`bash <(...) /other/path` 또는 stdin 파이프). hex suffix 파일만 입력으로 삼으므로 canonical `<prefix>.md` 는 집계에 포함되지 않는다 (의도). GNU/BSD find 공통 형태로 macOS 와 NixOS 양쪽에서 동작한다.
+
+## DoD 실행 컨텍스트
+
+이슈 #756 P0의 DoD 두 번째 검증 명령 (코드블록 marker는 일부러 ```text — README의 첫 ```bash 블록은 위 snippet 단 하나여야 DoD awk 추출 + bash 실행이 self-reference 없이 통과한다):
+
+```text
+test -f .claude/plans/README.md && \
+  awk '/^```bash/{f=1;next} /^```/{f=0;next} f' .claude/plans/README.md \
+  | bash | grep -qE 'anki-study-mvp|noble-tumbling-dolphin'
+```
+
+이 검증은 hex 변종이 누적된 host의 main checkout (`<repo>/.claude/plans/`) 에서 수동 실행 가정이다. worktree 또는 fresh clone의 `.claude/plans/` 는 plan 누적이 없으므로 매칭 실패한다. PR/CI 자동 검증 대상이 아니다 — PR reviewer는 main checkout에서 한 번 수동 실행해 통과를 확인한다.

--- a/.claude/plans/README.md
+++ b/.claude/plans/README.md
@@ -31,7 +31,7 @@ find "${1:-.claude/plans}" -maxdepth 1 -type f \
 
 ## DoD 실행 컨텍스트
 
-이슈 #756 P0의 DoD 두 번째 검증 명령 (코드블록 marker는 일부러 ```text — README의 첫 ```bash 블록은 위 snippet 단 하나여야 DoD awk 추출 + bash 실행이 self-reference 없이 통과한다):
+이슈 `#756` P0의 DoD 두 번째 검증 명령 (코드블록 marker는 일부러 `` ```text `` — README의 첫 `` ```bash `` 블록은 위 snippet 단 하나여야 DoD awk 추출 + bash 실행이 self-reference 없이 통과한다):
 
 ```text
 test -f .claude/plans/README.md && \

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,13 @@
 .claude/skills/*/agents/
 .claude/skills/*/references/references
 
+# .claude/plans/ — 글로벌 gitignore(~/.config/git/ignore)가 **/.claude/plans 디렉토리를 차단.
+# 디렉토리 정책 문서 README.md만 tracked로 유지하고 (이슈 #756 P0) 다른 plan 파일
+# (transient buffer + SSOT plan)은 그대로 untracked 유지.
+!.claude/plans
+.claude/plans/*
+!.claude/plans/README.md
+
 # 브라우저 자동화 인증 상태 파일 (평문 세션 토큰 포함)
 auth-state.json
 oauth-state.json


### PR DESCRIPTION
## Summary

- `.claude/plans/` 디렉토리 정책 문서 README 신규 작성 — plan 파일 bind 원칙, 8-hex transient buffer 식별 기준, prefix별 hex 변종 집계 one-liner snippet 세 가지를 박제.
- 글로벌 git ignore (`~/.config/git/ignore`) 가 `**/.claude/plans` 를 차단하므로 본 repo `.gitignore`에 negate 패턴 3줄 추가 (README만 tracked, 다른 plan 파일은 untracked 유지).
- Refs #756 (P0 portion). P1 (transient buffer GC 정책/훅) 은 별도 사이클로 분리.

## 기존 문제/배경

`.claude/plans/`에 plan 파일 175개가 누적되어 있고 그 중 8-hex suffix 변종이 103개 (59%). 이슈 #756 본문 기재 시점 (154/82) 대비 +21개씩 추가 누적 중. 동일 topic의 변종이 다수 공존하다 보니 LLM이 디렉토리를 조회할 때 어느 파일이 canonical SSOT plan인지 판별 불가하다.

근본 원인: Claude Code harness의 plan-mode runtime이 별도 transient plan buffer를 disk에 hex suffix 파일명으로 떨어뜨리는데, plan-with-questions 스킬 문서 (`modes/for_action.md:136`, `references/runtime-boundaries.md:76-78`) 는 이 buffer를 새 SSOT plan으로 **승격하지 말라**고만 규정하고 **생성·정리 주체는 명시하지 않는다**. `references/consulting-step-shell.md:154` 는 pinning hard-fail enforcement가 임시 경로 hex를 잡지 않는다고 명시하므로 pinning-guard도 책임 범위 밖이다. GC 정책이 없으면 누적이 무한 반복된다.

본 PR (P0) 은 정책 문서를 박제해서 LLM이 디렉토리 상태를 정확히 해석할 수 있게 만든다. 실제 정리 (GC 정책/훅) 는 P1에서 다룬다.

## CIR (Change Intent Record)

본 PR은 plan-with-questions for_action 모드의 정형 절차를 거쳐 작성되었다. 주요 의사 결정 이력:

- **Scope 분리**: 이슈 본문은 P0 (README, ~1h) + P1 (GC 정책/훅, ~4h) 을 한 묶음으로 트래킹한다. 본 PR은 epic 코멘트의 Wave 1/Wave 2 분배 권장에 따라 P0만 떼어내고 P1을 별도 사이클로 분리. P0 트레이드오프가 사라져 외부 자문 트리거 회피.
- **Hex 식별 범위**: 실측에서 8-hex (현재 lifecycle) 외에 `-agent-<NHex>` 변종 16개도 발견됨. mtime이 모두 2026-02-06 ~ 02-28 사이로 멈춰 있고 내용 형식이 DA review 산출물이라 과거 Claude Code sub-agent의 historical artifacts로 판정. P0는 8-hex만 다루고 historical artifacts는 P1에서 별도 일회성 정리 대상으로 분리.
- **Snippet 재설계**: 이슈 본문의 원본 snippet (`find ... -printf '%f\n' | sed ...`) 을 LITE 외부 검토 (Correctness reviewer + Arbiter) 가 세 가지 결함으로 판정 — (a) canonical까지 합산해 의미와 불일치, (b) DoD 검증이 실행 디렉토리 (worktree vs main checkout) 에 의존, (c) GNU `-printf` 의존으로 macOS BSD find에서 깨짐. 세 결함을 모두 해결하도록 snippet 재설계 (자세한 비교는 ADR 참조).
- **README의 git tracking**: `.claude/plans/` 자체는 untracked 유지하되 정책 문서 README만 tracked로 박는 결정. CLAUDE.md와 같은 instructional artifact 성격.
- **부산물 발견**: 본 P0 작업 중 N=1 사이드이펙트 광역 조사로 두 P1 follow-up 발견 — `wt bootstrap.sh:28-29` 가 worktree 생성 시 `.claude/plans` 를 무조건 rm 하므로 미래에 worktree에서 README가 삭제될 위험 (현 P0 commit 영향 없음), `statusline.sh:284-286` 의 plan-file grep 화이트리스트에 8-hex/README가 누락. 둘 다 P1 작업으로 이관.

## ADR (Architecture Decision Record)

핵심 결정: README의 prefix별 hex 변종 집계 snippet 형태.

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 이슈 본문 원본 snippet (`find ... -printf '%f\n'`) | 모든 `.md` 파일을 입력으로 받고 hex/`.md` 모두 제거 후 집계 | 가장 단순한 한 줄 | canonical까지 합산해 의미 모순, GNU find 전용, 디렉토리 고정 | ❌ |
| hex-only + 디렉토리 인자화 + BSD/GNU 호환 (`find "${1:-.claude/plans}" -name '*-[0-9a-f]{8}.md' \| sed basename`) | hex suffix 파일만 입력, 첫 인자 default로 디렉토리 변경 가능, `sed`로 basename 추출 | 의미 정확, macOS/NixOS 양쪽 동작, 다른 머신에서 인자로 경로 변경 | snippet이 약간 길어짐 | ✅ |
| DoD 자체를 weakening (이슈 본문 수정) | snippet은 그대로, DoD 명령을 `test -f && bash code` 정도로 약화 | 변경 최소 | DoD가 의미를 잃음, 이슈 본문 수정 동의 필요 | ❌ |

## 구현 상세

| 파일 | 변경 | 핵심 |
|------|------|------|
| `.claude/plans/README.md` | 신규 42줄 | 4섹션 — plan 파일 bind 원칙, transient buffer 식별 기준, snippet, DoD 실행 컨텍스트 |
| `.gitignore` | +7줄 | 글로벌 git ignore `**/.claude/plans` 차단을 negate (Codex CLI 섹션의 line 13-15 패턴과 동일 형태) |

핵심 snippet (README의 첫 bash 코드블록, DoD `awk \| bash` 추출 패턴에 정확히 일치):

```bash
find "${1:-.claude/plans}" -maxdepth 1 -type f \
  -name '*-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].md' \
  | sed -E 's|^.*/||; s/-[0-9a-f]{8}\.md$//' \
  | sort | uniq -c | sort -rn
```

`.gitignore` 추가 패턴 (README만 tracked로 유지):

```gitignore
!.claude/plans
.claude/plans/*
!.claude/plans/README.md
```

## 참고 레퍼런스

- 이슈: #756 (epic:llm-harness #756~#764 그룹 중 1번. 본 PR은 P0 portion만, P1은 별도 사이클)
- 관련 epic 이슈: #757 (codex-fan-out fan-in 표준 절차), #758 (`wt cleanup --auto` 강화) — 본 PR과 lifecycle GC 통합 재평가 후보지만 본 PR은 그 통합을 다루지 않음 (epic 코멘트의 `harness-gc` 체크박스, blocked-by #756 + #758)
- 스킬 SSOT: `modules/shared/programs/claude/files/skills/plan-with-questions/modes/for_action.md:120-122` (bind 원칙), `:136` (transient buffer 비승격 규정), `references/runtime-boundaries.md:76-78` (동일 규정), `references/consulting-step-shell.md:154` (pinning-guard 책임 범위 명시)

## Human Test Plan

- [ ] **README 가독성**: `.claude/plans/README.md` 를 열어 4섹션 (bind 원칙, transient buffer 식별 기준, snippet, DoD 실행 컨텍스트) 이 LLM context로 처음 읽혔을 때 디렉토리 정책을 명확히 전달하는지 확인. 특히 `-agent-<NHex>` historical artifacts 주석이 명확한지.
- [ ] **`.gitignore` 의도 확인**: `git check-ignore -v .claude/plans/README.md` 가 `.gitignore:27:!.claude/plans/README.md` 를 출력해야 한다 (README는 tracked). `git check-ignore -v .claude/plans/anki-study-mvp.md` (또는 임의 plan 파일) 는 `.gitignore:26:.claude/plans/*` 를 출력해야 한다 (다른 plan 파일은 untracked 유지).
- [ ] **snippet 사용성**: main checkout의 repo root에서 README 첫 bash 코드블록을 실행하면 prefix별 hex 변종 누적 수가 내림차순으로 출력되어야 한다. 첫 인자로 다른 디렉토리 (예: 클론한 다른 머신) 를 넘기면 그 디렉토리 기준으로 동작하는지 확인.
- [ ] **DoD 실행**: 본 PR을 main에 머지한 뒤 main checkout에서 DoD 두 검증 명령을 1회 수동 실행. 통과해야 한다 (실측 기준 anki-study-mvp 42건, noble-tumbling-dolphin 7건 매칭).

실패 시 진단:
- snippet 출력이 빈 줄: 실행 디렉토리에 hex 변종이 없음 (fresh clone 또는 worktree에서 실행한 경우. main checkout으로 cd 후 재시도).
- snippet이 syntax error: shell이 bash가 아닌 다른 환경 (sh 등) 일 가능성. `bash` 명시 실행 또는 `bash --version` 확인.
- README가 untracked로 표시: 글로벌 git ignore의 다른 룰이 더 specific하게 매칭할 가능성. `git check-ignore -v` 로 어떤 패턴이 잡는지 진단.

## Pre-Merge E2E 테스트 가이드

### Phase 0 — 정적 검증

```bash
# README 존재
test -f .claude/plans/README.md && echo PASS || echo FAIL

# .gitignore에 negate 패턴 존재 확인
grep -F '!.claude/plans/README.md' .gitignore && echo PASS || echo FAIL
grep -F '.claude/plans/*' .gitignore && echo PASS || echo FAIL

# README에 4섹션 모두 존재
for h in "Plan 파일 bind 원칙" "Transient buffer 식별 기준" "Prefix별 hex 변종 집계" "DoD 실행 컨텍스트"; do
  grep -qF "$h" .claude/plans/README.md && echo "PASS: $h" || echo "FAIL: $h"
done
```

### Phase 1 — 이슈 #756 P0 DoD

실행 디렉토리: hex 변종이 누적된 host의 main checkout 으로 cd 후:

```bash
test -f .claude/plans/README.md && \
  awk '/^```bash/{f=1;next} /^```/{f=0;next} f' .claude/plans/README.md \
  | bash | grep -qE 'anki-study-mvp|noble-tumbling-dolphin' && echo PASS || echo FAIL
```

기대: PASS. 실패 시 진단:
- `bash: ... syntax error`: README 안에 ```bash 코드블록이 2개 이상이면 awk가 합쳐서 self-recursion 발생. README의 다른 코드블록 marker는 ```text 등 ```bash 외 형식이어야 함 — 본 PR은 이를 보장.
- `FAIL` (exit=1): 실행 디렉토리에 hex 변종이 누적되지 않음. main checkout으로 cd 후 재시도.

### Phase 2 — git ignore 정책 검증

```bash
# README 자체는 tracked로 add 가능
git check-ignore -v .claude/plans/README.md | grep -q '!.claude/plans/README.md' && echo PASS || echo FAIL

# 임의 plan 파일은 ignored 유지
touch .claude/plans/tmp-test-12345678.md 2>/dev/null
git check-ignore -v .claude/plans/tmp-test-12345678.md | grep -q '.claude/plans/\*' && echo PASS || echo FAIL
rm -f .claude/plans/tmp-test-12345678.md
```

### Phase 3 — snippet portability sanity check

```bash
# BSD/GNU find 공통 옵션만 사용했는지 (-printf 미사용)
awk '/^```bash/{f=1;next} /^```/{f=0;next} f' .claude/plans/README.md \
  | grep -q -- '-printf' && echo "FAIL: GNU -printf 발견" || echo "PASS: -printf 미사용"
```

### Phase 4 — Regression

```bash
# Codex CLI negate 패턴 (line 13-15 영역) 그대로 보존되는지
grep -qE '!AGENTS\.md' .gitignore && echo PASS || echo FAIL
grep -qE '!AGENTS\.override\.md' .gitignore && echo PASS || echo FAIL
grep -qE '!\.agents/' .gitignore && echo PASS || echo FAIL

# Codex sync 부산물 ignore 패턴도 보존
grep -qE '\.claude/skills/\*/agents/' .gitignore && echo PASS || echo FAIL
```

모든 Phase가 PASS면 머지 가능. 어느 한 Phase라도 FAIL이면 진단 후 수정 또는 머지 보류.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for managing Claude Code plan files, distinguishing between canonical and transient file naming conventions with collision resolution procedures.

* **Chores**
  * Updated version control configuration to exclude plan file variants while preserving core documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->