### PR TITLE
fix(claude/statusline): v2.1.139 폭 측정 회귀 — fallback chain 도입

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -208,6 +208,7 @@
               lefthook
               gitleaks
               shellcheck
+              bats
               pythonRuntimes.pythonWithTomlkit
               inputs.agenix.packages.${system}.default
             ];

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -55,8 +55,9 @@ pre-push:
       run: nix flake check --no-build --all-systems
     statusline-bats:
       # statusline.sh 폭 측정 fallback chain 회귀 검증. git hook PATH 는 devShell
-      # buildInputs 를 보장하지 않으므로 `nix shell nixpkgs#bats --command` 로 wrap
-      # 하여 hook 실행 환경 PATH 와 무관하게 동작하게 한다 (pre-push 의
-      # `nix shell .#pythonWithTomlkit` 패턴과 일관). pre-commit allowlist guard
-      # 우회를 위해 pre-push 에 배치. bats 4 케이스가 ~1초로 짧아 비용 미미.
-      run: nix shell nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
+      # buildInputs 를 보장하지 않으므로 `nix shell` wrap 으로 hook 실행 환경
+      # PATH 와 무관하게 동작하게 한다. `--inputs-from .` 는 repo flake.lock 의
+      # nixpkgs 입력을 재사용하여 `nix shell .#pythonWithTomlkit` 패턴과 동일하게
+      # 프로젝트 pin 을 우회하지 않게 한다. pre-commit allowlist guard 우회를
+      # 위해 pre-push 에 배치. bats 호출은 ~1초로 짧아 비용 미미.
+      run: nix shell --inputs-from . nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -54,8 +54,9 @@ pre-push:
     flake-check:
       run: nix flake check --no-build --all-systems
     statusline-bats:
-      # statusline.sh 폭 측정 fallback chain 회귀 검증. bats 는 flake.nix devShell
-      # buildInputs 에 포함되어 있어 PATH 직접 호출이 가능하다 (nixfmt/shellcheck 등과
-      # 동일 패턴). pre-push 단계라 push 마다 1회 실행 — bats 4 케이스가 ~1초로 짧아
-      # 비용 미미. pre-commit allowlist guard 우회를 위해 pre-push 에 배치.
-      run: bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
+      # statusline.sh 폭 측정 fallback chain 회귀 검증. git hook PATH 는 devShell
+      # buildInputs 를 보장하지 않으므로 `nix shell nixpkgs#bats --command` 로 wrap
+      # 하여 hook 실행 환경 PATH 와 무관하게 동작하게 한다 (pre-push 의
+      # `nix shell .#pythonWithTomlkit` 패턴과 일관). pre-commit allowlist guard
+      # 우회를 위해 pre-push 에 배치. bats 4 케이스가 ~1초로 짧아 비용 미미.
+      run: nix shell nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -53,3 +53,9 @@ pre-push:
       run: bash ./tests/test-codex-hook-fixtures.sh --no-live
     flake-check:
       run: nix flake check --no-build --all-systems
+    statusline-bats:
+      # statusline.sh 폭 측정 fallback chain 회귀 검증. bats 는 flake.nix devShell
+      # buildInputs 에 포함되어 있어 PATH 직접 호출이 가능하다 (nixfmt/shellcheck 등과
+      # 동일 패턴). pre-push 단계라 push 마다 1회 실행 — bats 4 케이스가 ~1초로 짧아
+      # 비용 미미. pre-commit allowlist guard 우회를 위해 pre-push 에 배치.
+      run: bats modules/shared/programs/claude/files/scripts/tests/statusline.bats

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -244,6 +244,9 @@ in
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/codex-fan-out";
 
     # Statusline script - 양방향 수정 가능
+    # 인접 디렉토리 정책: `scripts/tests/` 는 repo 검증 전용이라
+    # mkOutOfStoreSymlink로 home 에 노출하지 않는다. bats 단위 테스트는 devShell
+    # (`flake.nix` buildInputs `bats`) 안에서만 실행한다.
     ".claude/scripts/statusline.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/scripts/statusline.sh";
 

--- a/modules/shared/programs/claude/files/docs/cache-guide.md
+++ b/modules/shared/programs/claude/files/docs/cache-guide.md
@@ -1,5 +1,9 @@
 # Claude Code Prompt Cache Guide
 
+> 관련 docs: 터미널 폭 측정과 `CLAUDE_STATUSLINE_COLUMNS` env override 등 statusline 자체의
+> 환경 변수는 [`statusline-env.md`](./statusline-env.md) 가 다룬다. 본 문서는 prompt cache
+> 동작과 `CLAUDE_CACHE_TTL` override 만 다룬다.
+
 ## Statusline 표시
 
 ```

--- a/modules/shared/programs/claude/files/docs/statusline-env.md
+++ b/modules/shared/programs/claude/files/docs/statusline-env.md
@@ -1,0 +1,66 @@
+# Statusline 환경 변수 가이드
+
+statusline.sh 의 동작을 외부에서 조정할 수 있는 환경 변수 모음.
+
+## `CLAUDE_STATUSLINE_COLUMNS` — 터미널 폭 명시 override
+
+Claude Code v2.1.139 부터 hook/statusline 자식 프로세스에서 controlling tty 가
+제거되어 statusline.sh 가 터미널 폭을 자동 감지하지 못한다 (`stty size </dev/tty`
+실패). 그 결과 rate_limits 의 progressive disclosure 가 가장 좁은 단계로 고정되고
+session-id 도 단축 표시로 떨어진다.
+
+```bash
+# 사용자 shell rc 또는 home-manager sessionVariables 에 추가
+export CLAUDE_STATUSLINE_COLUMNS=200
+```
+
+위 변수가 설정되면 다른 어떤 감지 경로보다도 우선 적용된다. 값은 **raw 터미널 cols**
+이며, statusline.sh 가 내부적으로 `EFF_COLS = COLS - 40` 보정을 자동 처리한다.
+
+### 폭 감지 우선순위 (5단계 chain)
+
+statusline.sh 는 아래 순서로 폭을 결정한다. 한 단계가 양수 값을 반환하면 즉시 그
+값을 사용한다.
+
+| 단계 | 출처 | 비고 |
+|------|------|------|
+| 1 | `CLAUDE_STATUSLINE_COLUMNS` env | 사용자 명시 override, 항상 우선 |
+| 2 | stdin `terminal.columns` | upstream 폭 전달 요청 이슈가 채택되면 자동 활용 |
+| 3 | `COLUMNS` env | interactive parent shell 이 export 한 경우 hit |
+| 4 | `stty size </dev/tty` | pre-2.1.139 compatibility branch. v2.1.139+ 에서는 항상 실패 |
+| 5 | 정적 기본값 `140` | 모든 동적 감지 실패 시 fallback. EFF_COLS=100 → detail=4 + full UUID |
+
+### 임계값 매트릭스
+
+| EFF_COLS 범위 | rate_limits 표시 | session-id 표시 |
+|---------------|------------------|-----------------|
+| ≥100 | bar + pct + window + → remaining + reset_date (detail=4 또는 3) | full UUID |
+| 88-99 | bar + pct + window + → remaining + reset_date (detail=4) | short prefix (8자) |
+| 58-87 | bar + pct + window + → remaining (detail=3) | short prefix |
+| 40-57 | bar + pct + window (detail=2) | short prefix |
+| <40 | pct + window (detail=1) | short prefix |
+
+raw COLS 입력값 기준으로는 위 EFF_COLS 에 40 을 더한 값이다 (`COLS≥80` 일 때).
+
+### 권장 설정
+
+| 환경 | 권장값 |
+|------|--------|
+| Ghostty / iTerm2 fullscreen (~200 cols) | 200 |
+| 일반 desktop terminal (~120-150 cols) | 그 값 그대로 |
+| split pane / 좁은 ssh 세션 (~80 cols) | 80 (또는 unset → default 140 — wrap 위험 감수) |
+
+### 잘못된 값 처리
+
+비숫자, 음수, 0 같은 잘못된 값을 설정하면 단계 1 이 fallthrough 되어 다음 단계로
+넘어간다. `CLAUDE_CACHE_TTL` 동일 패턴.
+
+## 관련 환경 변수
+
+- `CLAUDE_CACHE_TTL` — cache TTL 강제 (`cache-guide.md` 참조).
+
+## 레퍼런스
+
+- nixos-config issue #734 — v2.1.139 폭 측정 회귀 분석 및 fix.
+- [anthropics/claude-code#22115](https://github.com/anthropics/claude-code/issues/22115) — statusLine columns 요청 OPEN.
+- [Claude Code statusLine docs](https://code.claude.com/docs/en/statusline) — Available data 표 (현재 columns 부재).

--- a/modules/shared/programs/claude/files/docs/statusline-env.md
+++ b/modules/shared/programs/claude/files/docs/statusline-env.md
@@ -90,7 +90,7 @@ leading-zero 차단 사유: bash 산술 (`$((COLS - 40))`) 이 `0NNN` 형식을 
 
 ## 관련 환경 변수
 
-- `CLAUDE_CACHE_TTL` — cache TTL 강제 (`cache-guide.md` 참조).
+- `CLAUDE_CACHE_TTL` — cache TTL 강제. 자세한 내용은 [`cache-guide.md`](./cache-guide.md) 참조.
 
 ## 레퍼런스
 

--- a/modules/shared/programs/claude/files/docs/statusline-env.md
+++ b/modules/shared/programs/claude/files/docs/statusline-env.md
@@ -79,12 +79,14 @@ raw COLS 입력값과 EFF_COLS 사이는 piecewise 보정이다:
 ### 잘못된 값 처리
 
 비숫자, 음수, 0, **leading-zero 값 (`070`, `0140` 등)**, 5자리 이상 (10000+) 입력은
-모두 invalid 로 간주하고 다음 fallback 단계로 fallthrough 한다. `CLAUDE_CACHE_TTL`
-동일 패턴.
+모두 invalid 로 간주하고 다음 fallback 단계로 fallthrough 한다.
 
 leading-zero 차단 사유: bash 산술 (`$((COLS - 40))`) 이 `0NNN` 형식을 octal 로
 해석한다 (`0140` → 96). canonical decimal 만 허용해 호출부 정수 연산 오염을
 방지한다. 폭으로 `70` 을 명시하려면 leading-zero 없이 `70` 으로 입력하라.
+
+(`CLAUDE_CACHE_TTL` 의 가드는 `[ -gt 0 ]` 만 적용되어 본 폭 가드보다 느슨하다.
+폭과 TTL 의 입력 신뢰 모델이 다르기 때문이다.)
 
 ## 관련 환경 변수
 

--- a/modules/shared/programs/claude/files/docs/statusline-env.md
+++ b/modules/shared/programs/claude/files/docs/statusline-env.md
@@ -50,7 +50,23 @@ session-id 표시 (별도 임계값):
 | ≥100 | full UUID |
 | <100 | short prefix (8자) |
 
-raw COLS 입력값 기준으로는 위 EFF_COLS 에 40 을 더한 값이다 (`COLS≥80` 일 때).
+raw COLS 입력값과 EFF_COLS 사이는 piecewise 보정이다:
+
+| raw COLS | EFF_COLS |
+|----------|----------|
+| < 80 | EFF_COLS = COLS (보정 없음) |
+| ≥ 80 | EFF_COLS = COLS - 40 |
+
+자주 쓰는 raw 값과 변환 결과:
+
+| raw COLS | EFF_COLS | rate_limits detail | session-id |
+|----------|----------|-------------------|------------|
+| 50 | 50 | detail=2 | short |
+| 80 | 40 | detail=2 | short |
+| 100 | 60 | detail=3 | short |
+| 128 | 88 | detail=4 | short |
+| 140 (default) | 100 | detail=4 | full UUID |
+| 200 | 160 | detail=4 | full UUID |
 
 ### 권장 설정
 

--- a/modules/shared/programs/claude/files/docs/statusline-env.md
+++ b/modules/shared/programs/claude/files/docs/statusline-env.md
@@ -78,8 +78,13 @@ raw COLS 입력값과 EFF_COLS 사이는 piecewise 보정이다:
 
 ### 잘못된 값 처리
 
-비숫자, 음수, 0 같은 잘못된 값을 설정하면 단계 1 이 fallthrough 되어 다음 단계로
-넘어간다. `CLAUDE_CACHE_TTL` 동일 패턴.
+비숫자, 음수, 0, **leading-zero 값 (`070`, `0140` 등)**, 5자리 이상 (10000+) 입력은
+모두 invalid 로 간주하고 다음 fallback 단계로 fallthrough 한다. `CLAUDE_CACHE_TTL`
+동일 패턴.
+
+leading-zero 차단 사유: bash 산술 (`$((COLS - 40))`) 이 `0NNN` 형식을 octal 로
+해석한다 (`0140` → 96). canonical decimal 만 허용해 호출부 정수 연산 오염을
+방지한다. 폭으로 `70` 을 명시하려면 leading-zero 없이 `70` 으로 입력하라.
 
 ## 관련 환경 변수
 

--- a/modules/shared/programs/claude/files/docs/statusline-env.md
+++ b/modules/shared/programs/claude/files/docs/statusline-env.md
@@ -32,13 +32,23 @@ statusline.sh 는 아래 순서로 폭을 결정한다. 한 단계가 양수 값
 
 ### 임계값 매트릭스
 
-| EFF_COLS 범위 | rate_limits 표시 | session-id 표시 |
-|---------------|------------------|-----------------|
-| ≥100 | bar + pct + window + → remaining + reset_date (detail=4 또는 3) | full UUID |
-| 88-99 | bar + pct + window + → remaining + reset_date (detail=4) | short prefix (8자) |
-| 58-87 | bar + pct + window + → remaining (detail=3) | short prefix |
-| 40-57 | bar + pct + window (detail=2) | short prefix |
-| <40 | pct + window (detail=1) | short prefix |
+rate_limits detail 단계와 session-id 표시는 서로 다른 임계값에 의존한다.
+
+rate_limits progressive disclosure (`statusline.sh` 의 `RATE_DETAIL` 임계값):
+
+| EFF_COLS 범위 | rate_limits 표시 |
+|---------------|------------------|
+| ≥88 | bar + pct + window + → remaining + reset_date (detail=4) |
+| 58-87 | bar + pct + window + → remaining (detail=3) |
+| 40-57 | bar + pct + window (detail=2) |
+| <40 | pct + window (detail=1) |
+
+session-id 표시 (별도 임계값):
+
+| EFF_COLS 범위 | session-id 표시 |
+|---------------|-----------------|
+| ≥100 | full UUID |
+| <100 | short prefix (8자) |
 
 raw COLS 입력값 기준으로는 위 EFF_COLS 에 40 을 더한 값이다 (`COLS≥80` 일 때).
 

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -524,24 +524,30 @@ resolve_raw_terminal_cols() {
   #   docs/임계값 매트릭스와 bats assertion 메시지도 함께 갱신한다.
   local DEFAULT_RAW_COLS=140
   local v
+  # decimal-only 가드: `0140` 같은 leading-zero 입력은 호출부의 `$((COLS - 40))`
+  # 에서 bash 가 octal로 해석한다. canonical decimal (1-9 leading) 만 통과시키고
+  # 그 외는 다음 fallback 단계로 fallthrough. 다중 자리 0140 / single 0 모두 차단.
+  _is_decimal() {
+    [[ "$1" =~ ^[1-9][0-9]*$ ]]
+  }
 
   # (1) CLAUDE_STATUSLINE_COLUMNS env — 명시 override, 항상 우선
   v=${CLAUDE_STATUSLINE_COLUMNS:-}
-  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+  if _is_decimal "$v"; then
     printf '%s' "$v"
     return
   fi
 
   # (2) stdin .terminal.columns (Section 1-2의 jq 추출 결과)
   v=${STDIN_COLS:-}
-  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+  if _is_decimal "$v"; then
     printf '%s' "$v"
     return
   fi
 
   # (3) $COLUMNS env (interactive parent shell이 export 한 경우)
   v=${COLUMNS:-}
-  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+  if _is_decimal "$v"; then
     printf '%s' "$v"
     return
   fi
@@ -551,7 +557,7 @@ resolve_raw_terminal_cols() {
   # ENXIO로 실패하면서 shell 이 직접 stderr를 낸다. command group 의 stderr 까지
   # 리다이렉트해서 noise 를 막는다.
   v=$({ stty size </dev/tty | awk '{print $2}'; } 2>/dev/null)
-  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+  if _is_decimal "$v"; then
     printf '%s' "$v"
     return
   fi

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -519,6 +519,10 @@ fi
 #    아래 산식 그대로 유지한다.
 #    상세 결정 근거는 .claude/plans/statusline-width-fallback.md 참조.
 resolve_raw_terminal_cols() {
+  # raw cols default → EFF_COLS=COLS-40=100 → detail=4 임계값(EFF_COLS>=88) 통과
+  #   + session-id full UUID 임계값(EFF_COLS>=100) 도달. 기본값을 조정할 때
+  #   docs/임계값 매트릭스와 bats assertion 메시지도 함께 갱신한다.
+  local DEFAULT_RAW_COLS=140
   local v
 
   # (1) CLAUDE_STATUSLINE_COLUMNS env — 명시 override, 항상 우선
@@ -553,7 +557,7 @@ resolve_raw_terminal_cols() {
   fi
 
   # (5) 정적 기본값
-  printf '140'
+  printf '%s' "$DEFAULT_RAW_COLS"
 }
 
 COLS=$(resolve_raw_terminal_cols)

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -526,8 +526,8 @@ resolve_raw_terminal_cols() {
   local v
   # decimal-only 가드: `0140` 같은 leading-zero 입력은 호출부의 `$((COLS - 40))`
   # 에서 bash 가 octal로 해석한다. canonical decimal (1-9 leading) 1-4자리 (1..9999)
-  # 만 통과시킨다. 1자리: 단일 terminal cols 후보 거의 없으나 fallthrough 가능.
-  # 4자리 상한: 99999+ overflow 입력으로 bash 정수 연산이 오염되는 것을 차단한다.
+  # 만 통과시킨다. 4자리 상한: 10000 이상 5자리+ 입력으로 bash 정수 연산이
+  # 오염되는 것을 차단한다 (정상 터미널 폭 80-300 범위 충분히 포함).
   _is_decimal() {
     [[ "$1" =~ ^[1-9][0-9]{0,3}$ ]]
   }

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -525,10 +525,11 @@ resolve_raw_terminal_cols() {
   local DEFAULT_RAW_COLS=140
   local v
   # decimal-only 가드: `0140` 같은 leading-zero 입력은 호출부의 `$((COLS - 40))`
-  # 에서 bash 가 octal로 해석한다. canonical decimal (1-9 leading) 만 통과시키고
-  # 그 외는 다음 fallback 단계로 fallthrough. 다중 자리 0140 / single 0 모두 차단.
+  # 에서 bash 가 octal로 해석한다. canonical decimal (1-9 leading) 1-4자리 (1..9999)
+  # 만 통과시킨다. 1자리: 단일 terminal cols 후보 거의 없으나 fallthrough 가능.
+  # 4자리 상한: 99999+ overflow 입력으로 bash 정수 연산이 오염되는 것을 차단한다.
   _is_decimal() {
-    [[ "$1" =~ ^[1-9][0-9]*$ ]]
+    [[ "$1" =~ ^[1-9][0-9]{0,3}$ ]]
   }
 
   # (1) CLAUDE_STATUSLINE_COLUMNS env — 명시 override, 항상 우선

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -171,7 +171,8 @@ if command -v jq >/dev/null 2>&1; then
     @sh "STDIN_SESSION_ID=\(.session_id // "")",
     @sh "CWD=\(.cwd // "")",
     @sh "WS_WORKTREE=\(.workspace.git_worktree // "")",
-    @sh "WORKTREE_BRANCH=\(.worktree.branch // "")"
+    @sh "WORKTREE_BRANCH=\(.worktree.branch // "")",
+    @sh "STDIN_COLS=\(.terminal.columns // "")"
   ' 2>/dev/null)" 2>/dev/null || true
 fi
 
@@ -500,9 +501,62 @@ fi
 # ============================================================
 # Section 8: 폭/임계값 + display values (D-5: 정적 threshold)
 # ============================================================
+#
+# === Change Intent Record ===
+# v1 (초기): `stty size </dev/tty` → terminfo 80 fallback. controlling tty가
+#    있는 환경에서는 정상 동작.
+# v5 (이번): Claude Code v2.1.139부터 hook/statusline 자식에서 controlling tty가
+#    제거되어 stty가 항상 실패. RATE_DETAIL과 session-id display가 항상 가장
+#    좁은 fallback으로 떨어지는 회귀 발생. 폭 측정을 raw cols resolver
+#    `resolve_raw_terminal_cols`로 위임하여 5단계 chain으로 회복한다:
+#      (1) CLAUDE_STATUSLINE_COLUMNS env (사용자 명시 override, 항상 우선)
+#      (2) stdin .terminal.columns (forward-compat for upstream columns 요청 이슈)
+#      (3) $COLUMNS env (interactive parent shell이 export 한 경우)
+#      (4) stty size </dev/tty (pre-2.1.139 compatibility branch — v2.1.139+에서
+#          항상 실패하지만 1회 fork 비용 미미. 사용자 명시 결정으로 유지.)
+#      (5) 정적 기본값 140 cols (EFF_COLS=100 → detail=4 + full UUID 보장)
+#    함수는 raw cols만 반환한다. EFF_COLS 보정 (`COLS - 40`)은 호출자 책임이며
+#    아래 산식 그대로 유지한다.
+#    상세 결정 근거는 .claude/plans/statusline-width-fallback.md 참조.
+resolve_raw_terminal_cols() {
+  local v
 
-COLS=$(stty size </dev/tty 2>/dev/null | awk '{print $2}')
-[ "${COLS:-0}" -gt 0 ] 2>/dev/null || COLS=80
+  # (1) CLAUDE_STATUSLINE_COLUMNS env — 명시 override, 항상 우선
+  v=${CLAUDE_STATUSLINE_COLUMNS:-}
+  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+    printf '%s' "$v"
+    return
+  fi
+
+  # (2) stdin .terminal.columns (Section 1-2의 jq 추출 결과)
+  v=${STDIN_COLS:-}
+  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+    printf '%s' "$v"
+    return
+  fi
+
+  # (3) $COLUMNS env (interactive parent shell이 export 한 경우)
+  v=${COLUMNS:-}
+  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+    printf '%s' "$v"
+    return
+  fi
+
+  # (4) stty size </dev/tty (pre-2.1.139 compatibility branch, dead in v2.1.139+)
+  # /dev/tty 가 stat-level 에서는 readable 이지만 controlling tty 부재 시 open이
+  # ENXIO로 실패하면서 shell 이 직접 stderr를 낸다. command group 의 stderr 까지
+  # 리다이렉트해서 noise 를 막는다.
+  v=$({ stty size </dev/tty | awk '{print $2}'; } 2>/dev/null)
+  if [ -n "$v" ] && [ "$v" -gt 0 ] 2>/dev/null; then
+    printf '%s' "$v"
+    return
+  fi
+
+  # (5) 정적 기본값
+  printf '140'
+}
+
+COLS=$(resolve_raw_terminal_cols)
 if [ "$COLS" -lt 80 ]; then
   EFF_COLS=$COLS
 else

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -12,23 +12,33 @@
 
 setup() {
   STATUSLINE="${BATS_TEST_DIRNAME}/../statusline.sh"
-  MOCK_JSON='{
-    "session_id": "abc12345-def6-7890-abcd-ef1234567890",
-    "transcript_path": "/tmp/nonexistent.jsonl",
-    "cwd": "/tmp",
-    "model": {"display_name": "test"},
-    "workspace": {"current_dir": "/tmp"},
-    "rate_limits": {
-      "five_hour": {"used_percentage": 6, "resets_at": 1747400000},
-      "seven_day": {"used_percentage": 82, "resets_at": 1747900000}
-    },
-    "context_window": {
-      "current_usage": {
-        "cache_read_input_tokens": 8000,
-        "cache_creation_input_tokens": 2000
-      }
+  # resets_at 을 실행 시점 기준 미래로 동적 생성. 절대값 timestamp 를 박으면 시간이
+  # 지나며 stale 되어 statusline.sh 의 `remaining > 0` 가드가 `→ remaining` 출력을
+  # 건너뛰고 SC-1 의 detail=4 검증이 무력화된다.
+  local now five_h seven_d
+  now=$(date +%s)
+  five_h=$((now + 5 * 3600))
+  seven_d=$((now + 5 * 86400))
+  MOCK_JSON=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "/tmp",
+  "model": {"display_name": "test"},
+  "workspace": {"current_dir": "/tmp"},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 6, "resets_at": $five_h},
+    "seven_day": {"used_percentage": 82, "resets_at": $seven_d}
+  },
+  "context_window": {
+    "current_usage": {
+      "cache_read_input_tokens": 8000,
+      "cache_creation_input_tokens": 2000
     }
-  }'
+  }
+}
+EOF
+)
 }
 
 run_statusline() {
@@ -47,22 +57,33 @@ run_statusline() {
   reset_count=$(echo "$output" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
   [ "$reset_count" -eq 2 ] \
     || { echo "expected detail=4 (2 reset_date) from env=200; got count=$reset_count" >&2; false; }
+  # detail=3 부터 `→ remaining` 도 양 window 모두 표시. detail=4 의 핵심 마커.
+  remaining_count=$(echo "$output" | grep -oE '→ [0-9]+[dhm]' | wc -l)
+  [ "$remaining_count" -ge 2 ] \
+    || { echo "expected → remaining (≥2) from env=200; got count=$remaining_count" >&2; false; }
 }
 
-@test "env override 50 collapses to compact output (short UUID, no reset_date)" {
+@test "env override 50 collapses to compact output (short UUID, detail=2)" {
+  # raw 50 → COLS<80 piecewise: EFF_COLS=50. EFF_COLS<100 → short prefix.
+  # EFF_COLS=50 은 RATE_DETAIL 임계값 (88/58/40) 중 ≥40 만 통과 → detail=2
+  # (bar + pct + window, → remaining/reset_date 없음).
   run run_statusline CLAUDE_STATUSLINE_COLUMNS=50
   [ "$status" -eq 0 ]
-  # short prefix = 처음 8 자 + space. EFF_COLS=50 < 100 → short.
+  # short prefix = 처음 8 자.
   echo "$output" | grep -qE 'abc12345[^-]' \
     || { echo "expected short UUID prefix from env=50; got: $output" >&2; false; }
-  # full UUID 가 나오면 실패. 추가 확인.
   if echo "$output" | grep -q "abc12345-def6"; then
     echo "expected short UUID, but full UUID leaked from env=50; got: $output" >&2
     false
   fi
-  # detail<3 시 reset_date 형식이 없어야 함.
+  # detail=2 → reset_date 없음.
   if echo "$output" | grep -qE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)'; then
-    echo "expected no reset_date from env=50 (detail<3); got: $output" >&2
+    echo "expected no reset_date from env=50 (detail=2); got: $output" >&2
+    false
+  fi
+  # detail=2 → → remaining 도 없음 (detail≥3 부터 출력).
+  if echo "$output" | grep -qE '→ [0-9]+[dhm]'; then
+    echo "expected no → remaining from env=50 (detail=2); got: $output" >&2
     false
   fi
 }

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -86,3 +86,16 @@ run_statusline() {
   [ "$reset_count" -eq 2 ] \
     || { echo "expected detail=4 from static default 140; got count=$reset_count" >&2; false; }
 }
+
+@test "leading-zero env value falls through to default (octal regression guard)" {
+  # 가드 부재 시 0140 은 bash 산술에서 octal 96으로 해석되어 EFF_COLS=56 → short
+  # prefix 가 됐다. decimal-only 가드가 0140 을 거부하고 default 140 으로
+  # fallthrough 하면 EFF_COLS=100 → full UUID + detail=4.
+  run run_statusline CLAUDE_STATUSLINE_COLUMNS=0140
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+    || { echo "expected default-140 fallthrough on octal-looking input; got: $output" >&2; false; }
+  reset_count=$(echo "$output" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
+  [ "$reset_count" -eq 2 ] \
+    || { echo "expected detail=4 from default-140 fallthrough; got count=$reset_count" >&2; false; }
+}

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -131,3 +131,73 @@ strip_ansi() {
   [ "$reset_count" -eq 2 ] \
     || { echo "expected detail=4 from default-140 fallthrough; got count=$reset_count" >&2; false; }
 }
+
+# 비숫자, 음수, 0, 5자리 이상, 빈 string, 공백 같은 invalid 입력이 모두 default 140
+# fallthrough 로 떨어지는지 검증. _is_decimal 가드의 입력 다양성을 한 케이스로 묶는다.
+@test "invalid env values all fall through to default 140" {
+  local case
+  for case in "-1" "0" "10000" "abc" "" " 140" "140 "; do
+    run run_statusline CLAUDE_STATUSLINE_COLUMNS="$case"
+    [ "$status" -eq 0 ]
+    local plain
+    plain=$(echo "$output" | strip_ansi)
+    echo "$plain" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+      || { echo "case=\"$case\": expected default-140 fallthrough; got: $plain" >&2; false; }
+  done
+}
+
+# stdin .terminal.columns 가 env 부재 시 활용되는 forward-compat 경로 검증.
+@test "stdin terminal.columns is used when env unset" {
+  local now five_h seven_d
+  now=$(date +%s)
+  five_h=$((now + 5 * 3600))
+  seven_d=$((now + 5 * 86400))
+  local stdin_json
+  stdin_json=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "/tmp",
+  "model": {"display_name": "test"},
+  "workspace": {"current_dir": "/tmp"},
+  "terminal": {"columns": 150},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 6, "resets_at": $five_h},
+    "seven_day": {"used_percentage": 82, "resets_at": $seven_d}
+  },
+  "context_window": {
+    "current_usage": {
+      "cache_read_input_tokens": 8000,
+      "cache_creation_input_tokens": 2000
+    }
+  }
+}
+EOF
+)
+  run bash -c "printf '%s' \"\$1\" | env -u CLAUDE_STATUSLINE_COLUMNS -u COLUMNS bash \"\$2\" 2>/dev/null" _ "$stdin_json" "$STATUSLINE"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  # stdin terminal.columns=150 → EFF_COLS=110 → detail=4 + full UUID
+  echo "$plain" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+    || { echo "expected full UUID from stdin terminal.columns=150; got: $plain" >&2; false; }
+  reset_count=$(echo "$plain" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
+  [ "$reset_count" -eq 2 ] \
+    || { echo "expected detail=4 from stdin terminal.columns=150; got count=$reset_count" >&2; false; }
+}
+
+# CLAUDE_STATUSLINE_COLUMNS 가 COLUMNS 와 동시에 설정되면 env override 가 우선해야 한다
+# (G-3 명시 override 의도). 우선순위 역전 회귀를 잡는다.
+@test "CLAUDE_STATUSLINE_COLUMNS wins over COLUMNS when both set" {
+  run run_statusline CLAUDE_STATUSLINE_COLUMNS=50 COLUMNS=200
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  # env=50 우선 → short UUID. COLUMNS=200 가 우선이면 full UUID 노출.
+  if echo "$plain" | grep -q "abc12345-"; then
+    echo "expected CLAUDE_STATUSLINE_COLUMNS=50 to win (short UUID); COLUMNS=200 leaked full UUID: $plain" >&2
+    false
+  fi
+  echo "$plain" | grep -q "abc12345" \
+    || { echo "expected short UUID prefix; got: $plain" >&2; false; }
+}

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -47,18 +47,26 @@ run_statusline() {
   printf '%s' "$MOCK_JSON" | env -u CLAUDE_STATUSLINE_COLUMNS -u COLUMNS "$@" bash "$STATUSLINE" 2>/dev/null
 }
 
+# ANSI escape sequence 제거 (색 코드, OSC 8 hyperlink 분리). statusline.sh 출력은
+# 토큰 사이에 escape 가 끼어 있어 grep 패턴이 직접 매치하지 못한다.
+strip_ansi() {
+  sed -E $'s/\x1b\\[[0-9;]*m//g; s/\x1b\\][0-9]*;[^\x07]*\x07//g'
+}
+
 @test "env override 200 enables full detail + full UUID" {
   run run_statusline CLAUDE_STATUSLINE_COLUMNS=200
   [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
   # full UUID = 36 자 UUID 형식. session_id 의 long form 이 통째로 나와야 한다.
-  echo "$output" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
-    || { echo "expected full UUID from env=200 path; got: $output" >&2; false; }
+  echo "$plain" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+    || { echo "expected full UUID from env=200 path; got: $plain" >&2; false; }
   # detail=4 시 reset_date 가 `(MM/DD HH:MM)` 형식으로 두 window 모두 표시.
-  reset_count=$(echo "$output" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
+  reset_count=$(echo "$plain" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
   [ "$reset_count" -eq 2 ] \
     || { echo "expected detail=4 (2 reset_date) from env=200; got count=$reset_count" >&2; false; }
   # detail=3 부터 `→ remaining` 도 양 window 모두 표시. detail=4 의 핵심 마커.
-  remaining_count=$(echo "$output" | grep -oE '→ [0-9]+[dhm]' | wc -l)
+  remaining_count=$(echo "$plain" | grep -oE '→ [0-9]+[dhm]' | wc -l)
   [ "$remaining_count" -ge 2 ] \
     || { echo "expected → remaining (≥2) from env=200; got count=$remaining_count" >&2; false; }
 }
@@ -69,21 +77,24 @@ run_statusline() {
   # (bar + pct + window, → remaining/reset_date 없음).
   run run_statusline CLAUDE_STATUSLINE_COLUMNS=50
   [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
   # short prefix = 처음 8 자.
-  echo "$output" | grep -qE 'abc12345[^-]' \
-    || { echo "expected short UUID prefix from env=50; got: $output" >&2; false; }
-  if echo "$output" | grep -q "abc12345-def6"; then
-    echo "expected short UUID, but full UUID leaked from env=50; got: $output" >&2
+  echo "$plain" | grep -q "abc12345" \
+    || { echo "expected short UUID prefix from env=50; got: $plain" >&2; false; }
+  # full UUID dash 확장이 없어야 short prefix 확정.
+  if echo "$plain" | grep -q "abc12345-"; then
+    echo "expected short UUID, but full UUID leaked from env=50; got: $plain" >&2
     false
   fi
   # detail=2 → reset_date 없음.
-  if echo "$output" | grep -qE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)'; then
-    echo "expected no reset_date from env=50 (detail=2); got: $output" >&2
+  if echo "$plain" | grep -qE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)'; then
+    echo "expected no reset_date from env=50 (detail=2); got: $plain" >&2
     false
   fi
   # detail=2 → → remaining 도 없음 (detail≥3 부터 출력).
-  if echo "$output" | grep -qE '→ [0-9]+[dhm]'; then
-    echo "expected no → remaining from env=50 (detail=2); got: $output" >&2
+  if echo "$plain" | grep -qE '→ [0-9]+[dhm]'; then
+    echo "expected no → remaining from env=50 (detail=2); got: $plain" >&2
     false
   fi
 }

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# statusline.sh polh 측정 fallback chain unit tests.
+#
+# 각 케이스는 mock stdin JSON 과 env 매트릭스를 조합해 statusline.sh 출력을
+# 검사한다. 폭은 raw cols 로 입력되며 statusline.sh 내부에서 `EFF_COLS = COLS - 40`
+# 보정이 적용된 뒤 RATE_DETAIL 임계값(88/58/40)과 session-id 표시 조건(EFF_COLS>=100)
+# 이 평가된다.
+#
+# 회귀 시 assertion 메시지에는 어떤 fallback 단계가 hit 됐다고 기대했는지
+# 명시한다. 출력의 ANSI 이스케이프와 OSC 8 hyperlink 가 grep 패턴을 깨지 않도록
+# 패턴은 색 코드 무관한 키 토큰만 매칭한다.
+
+setup() {
+  STATUSLINE="${BATS_TEST_DIRNAME}/../statusline.sh"
+  MOCK_JSON='{
+    "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+    "transcript_path": "/tmp/nonexistent.jsonl",
+    "cwd": "/tmp",
+    "model": {"display_name": "test"},
+    "workspace": {"current_dir": "/tmp"},
+    "rate_limits": {
+      "five_hour": {"used_percentage": 6, "resets_at": 1747400000},
+      "seven_day": {"used_percentage": 82, "resets_at": 1747900000}
+    },
+    "context_window": {
+      "current_usage": {
+        "cache_read_input_tokens": 8000,
+        "cache_creation_input_tokens": 2000
+      }
+    }
+  }'
+}
+
+run_statusline() {
+  # env 인자: NAME=VALUE 형태로 0개 이상 전달.
+  # stdout 만 capture (stderr 누설 노이즈 차단).
+  printf '%s' "$MOCK_JSON" | env -u CLAUDE_STATUSLINE_COLUMNS -u COLUMNS "$@" bash "$STATUSLINE" 2>/dev/null
+}
+
+@test "env override 200 enables full detail + full UUID" {
+  run run_statusline CLAUDE_STATUSLINE_COLUMNS=200
+  [ "$status" -eq 0 ]
+  # full UUID = 36 자 UUID 형식. session_id 의 long form 이 통째로 나와야 한다.
+  echo "$output" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+    || { echo "expected full UUID from env=200 path; got: $output" >&2; false; }
+  # detail=4 시 reset_date 가 `(MM/DD HH:MM)` 형식으로 두 window 모두 표시.
+  reset_count=$(echo "$output" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
+  [ "$reset_count" -eq 2 ] \
+    || { echo "expected detail=4 (2 reset_date) from env=200; got count=$reset_count" >&2; false; }
+}
+
+@test "env override 50 collapses to compact output (short UUID, no reset_date)" {
+  run run_statusline CLAUDE_STATUSLINE_COLUMNS=50
+  [ "$status" -eq 0 ]
+  # short prefix = 처음 8 자 + space. EFF_COLS=50 < 100 → short.
+  echo "$output" | grep -qE 'abc12345[^-]' \
+    || { echo "expected short UUID prefix from env=50; got: $output" >&2; false; }
+  # full UUID 가 나오면 실패. 추가 확인.
+  if echo "$output" | grep -q "abc12345-def6"; then
+    echo "expected short UUID, but full UUID leaked from env=50; got: $output" >&2
+    false
+  fi
+  # detail<3 시 reset_date 형식이 없어야 함.
+  if echo "$output" | grep -qE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)'; then
+    echo "expected no reset_date from env=50 (detail<3); got: $output" >&2
+    false
+  fi
+}
+
+@test "COLUMNS fallback when CLAUDE_STATUSLINE_COLUMNS unset" {
+  run run_statusline COLUMNS=150
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+    || { echo "expected full UUID from COLUMNS=150 fallback; got: $output" >&2; false; }
+  reset_count=$(echo "$output" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
+  [ "$reset_count" -eq 2 ] \
+    || { echo "expected detail=4 from COLUMNS=150 fallback; got count=$reset_count" >&2; false; }
+}
+
+@test "static default 140 enables full detail when all sources unset" {
+  run run_statusline
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "abc12345-def6-7890-abcd-ef1234567890" \
+    || { echo "expected full UUID from static default 140; got: $output" >&2; false; }
+  reset_count=$(echo "$output" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
+  [ "$reset_count" -eq 2 ] \
+    || { echo "expected detail=4 from static default 140; got count=$reset_count" >&2; false; }
+}


### PR DESCRIPTION
## Summary

- Claude Code v2.1.139 부터 hook/statusline 자식 프로세스의 controlling tty 가 제거되어 `stty size </dev/tty` 가 항상 실패. `rate_limits` progressive disclosure 가 detail=2 고정, session-id 가 8자 prefix 고정되는 회귀를 해결.
- 폭 측정을 `resolve_raw_terminal_cols()` 5단계 fallback chain 으로 위임: `CLAUDE_STATUSLINE_COLUMNS env` → `stdin.terminal.columns` (forward-compat) → `$COLUMNS env` → `stty size </dev/tty` (pre-2.1.139 compatibility) → 정적 기본값 140.
- Closes #734.

## 주요 변경

- `modules/shared/programs/claude/files/scripts/statusline.sh`: `resolve_raw_terminal_cols()` 함수 신설 (decimal-only guard 1..9999, octal/overflow 차단), stdin jq 추출에 `terminal.columns` 필드 추가, Section 8 폭 측정 블록을 함수 호출로 교체. v5 Change Intent Record 주석.
- `modules/shared/programs/claude/files/scripts/tests/statusline.bats`: 신규 8 케이스 (env=200, env=50, COLUMNS=150, default 140, octal regression, invalid matrix, stdin terminal.columns, env+COLUMNS 우선순위). dynamic timestamp + ANSI strip helper.
- `flake.nix`: devShell `buildInputs` 에 `bats` 추가.
- `lefthook.yml`: pre-push 에 `statusline-bats` job (`nix shell --inputs-from . nixpkgs#bats --command bats ...`).
- `modules/shared/programs/claude/default.nix`: `.claude/scripts/` 노출 구역에 "scripts/tests 미노출" 정책 주석.
- `modules/shared/programs/claude/files/docs/statusline-env.md`: 신규 (env override 가이드 + 임계값 매트릭스 + raw COLS ↔ EFF_COLS 변환 표 + 잘못된 값 처리).
- `modules/shared/programs/claude/files/docs/cache-guide.md`: 상단에 `statusline-env.md` cross-link.

## Test plan

- [x] 로컬 mock JSON 4 케이스 sanity (env=200/50, COLUMNS=150, all unset → default 140)
- [x] bats 8 케이스 통과 (`bats modules/shared/programs/claude/files/scripts/tests/statusline.bats`)
- [x] pre-push hook 전체 통과 (codex-hook-fixtures + flake-check + shell-script-tests + statusline-bats)
- [x] shellcheck 통과 (lefthook pre-commit)
- [ ] 머지 후 사용자 환경에서 `nrs` + 실제 Claude Code 세션 statusline 시각 확인 (`→ Xh` + `(MM/DD HH:MM)` + full UUID 표시)

## 주요 결정 사항

| 결정 | 값 | 근거 |
|------|-----|------|
| Chain shape | 5단계 풀 체인 (env → stdin → \$COLUMNS → stty → 140) | 사용자 명시: "가능한 모든 단서 사용". env 우선으로 G-3 명시 override 의도 보존 |
| 정적 기본값 | 140 (raw cols) | EFF_COLS=100 → detail=4 + full UUID 둘 다 보장 |
| stdin 키 | `.terminal.columns` 한 키만 | anthropics/claude-code#22115 제안 형태 |
| stty 단계 | "pre-2.1.139 compatibility branch" 라벨로 보존 | 사용자 명시 결정 (1회 fork 비용 미미) |
| 검증 인프라 | bats devShell + pre-push hook | statusline.sh 변경 빈도 (PR #444, #327, #733) 와 회귀 방지 가치 |
| 입력 가드 | `_is_decimal` regex `^[1-9][0-9]{0,3}$` | leading-zero octal 해석 + 5자리+ overflow 차단 |

이미 거친 검증: 5 round for_pr DA + Arbiter (총 14 finding 자동 반영 또는 사용자 명시 결정 supersede), parallel-audit 6 bundle (7 finding 중 본 fix 범위 직접 4건 반영).

## Upstream 상태 (2026-05-16 재확인)

- [anthropics/claude-code#22115](https://github.com/anthropics/claude-code/issues/22115) — OPEN, community confirmation 누적 (Ghostty, kitty, NixOS, Go ccstatus 등)
- [anthropics/claude-code#5430](https://github.com/anthropics/claude-code/issues/5430) — CLOSED `not_planned` (60일 inactivity bot close)
- Claude Code 2.1.143 이 최신. 2.1.140-143 changelog 에 statusline 폭 측정 fix 없음
- upstream 이 `terminal.columns` 를 stdin 에 추가하면 본 fix 의 chain 2단계가 자동 활용. 그 시점에 stty/정적 기본값 단계 제거 PR 로 follow-up 가능

## Follow-up

- `lefthook.yml` 의 `nix shell --inputs-from . nixpkgs#bats` 는 attacker-controlled `flake.lock` 시나리오에서 hook 이 신뢰되지 않은 bats 실행 파일을 해석할 수 있다. 같은 패턴이 기존 `pre-push` 의 `nix shell .#pythonWithTomlkit` 에도 적용되는 systemic trust model 이슈로, 별도 issue 로 등록 예정 (본 PR 범위 외).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal width for statusline display can now be configured via environment variable with intelligent fallback detection chain

* **Documentation**
  * New Korean documentation guide explaining how to configure statusline display through environment variables
  * Cache guide updated with reference to statusline configuration resources

* **Tests**
  * Expanded test coverage for statusline configuration and behavior validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->