### PR TITLE
fix(pinning): PATTERN_C_VOLATILE 한글 alternation GNU grep 매칭 복원

### DIFF
--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -28,8 +28,15 @@ PATTERN_B='\b(Correctness|CORRECTNESS|Design|DESIGN|Regression|REGRESSION|Mainta
 #   on allowed paths; diagnostic records (warn-only) still emit them.
 # - volatile sub-pattern: round counter / feedback / numbered reviewer label /
 #   parallel-audit follow-up action tokens. These remain hard-fail everywhere.
+#
+# Note on word boundary across multibyte tokens: GNU grep (gnugrep-3.12) does
+# not treat the transition between an ASCII word char and a Hangul (multibyte
+# UTF-8) char as a word boundary, so the trailing `\b` after a Hangul
+# alternative silently fails to match (BSD `grep` does match). To keep the
+# library working under both grep implementations, Hangul alternatives are
+# written without a trailing `\b` while ASCII alternatives retain it.
 PINNING_PATTERN_C_WORKFLOW='\bDA (for_pr|for_plan)\b'
-PINNING_PATTERN_C_VOLATILE='\bDA (피드백|[Rr]ound)\b|\bAuditor [A-Za-z_]+-[0-9][A-Za-z0-9-]*\b|\bparallel-audit (반영|결과|finding)\b'
+PINNING_PATTERN_C_VOLATILE='\bDA 피드백|\bDA [Rr]ound\b|\bAuditor [A-Za-z_]+-[0-9][A-Za-z0-9-]*\b|\bparallel-audit (반영|결과)|\bparallel-audit finding\b'
 
 # Combined PATTERN_C preserves backward-compat for `verify-ai-compat.sh`'s
 # exported-var inventory check. `pinning_findings_records` now grep's the


### PR DESCRIPTION
## Summary

- PATTERN_C_VOLATILE 의 한글 단어 alternation 뒤 단어 경계가 GNU grep 에서 매칭 fail 하던 회귀를 해소.
- 한글 단어는 trailing word boundary 제거, ASCII 단어는 boundary 유지 (의도 보존).
- 단일 라이브러리 수정으로 claude/codex 양쪽 pinning hook + pinning-alert + commit-msg-pinning 모두 복원.

## 배경

직전 PR #767/#778 에서 PATTERN_C 를 workflow/volatile sub-pattern 으로 split 한 이후
PATTERN_C_VOLATILE 의 한글 단어 alternation 뒤 단어 경계가 nix coreutils GNU grep
(gnugrep-3.12) 에서 매칭 fail 했다. macOS BSD grep (/usr/bin/grep) 은 정상 매칭.
nix coreutils GNU grep 이 PATH 우선이라 lefthook 실행 시 한글 fixture 가
deny JSON 을 emit 못 하고 stdout 빈 채 exit 0 → hook event mismatch.

CLAUDE.md \"macOS BSD vs GNU 도구 라우팅\" 정책과 동일 카테고리 (옵션이 아니라
multibyte 단어 경계 처리 차이).

## 수정

`modules/shared/programs/claude/files/lib/pinning-patterns.sh:32`

- PATTERN_C_VOLATILE 의 한글 단어 alternation 을 ASCII 단어와 분리:
  - 한글 단어 뒤 단어 경계 제거 (GNU grep multibyte boundary unreliable)
  - ASCII 단어는 단어 경계 유지 (기존 의도 보존)
- 함수 주석에 GNU grep word boundary multibyte 한계 명시.

영향 범위:
- claude/files/hooks/pinning-guard.sh (PreToolUse hard-fail)
- codex/files/hooks/pinning-guard.sh (동일 라이브러리 source)
- pinning-alert.sh (PostToolUse warn)
- commit-msg-pinning.sh (commit-msg)

## 검증

- 한글 deny fixture: hook 이 정상 deny JSON 출력 + permissionDecision 정확 (재현 완료).
- gnugrep-3.12 직접 매칭 테스트 의도된 매칭 5건 + 의도된 미매칭 2건 모두 정상.
- pre-commit lefthook 전체 통과 (codex-hook-fixtures 46s 포함 7개 hook).
- pre-push hook 통과 (flake-check + shell-script-tests + statusline-bats).

false positive risk: 한글 단어 연결 case 도 매칭됨 (의도된 catch 범위 안).

## Test plan

- [x] 한글 fixture (deny) → hook deny JSON 정상 emit
- [x] ASCII fixture 회귀 없음 (lefthook codex-hook-fixtures 전체 pass)
- [x] pinning shared library behavioral test pass
- [x] commit-msg pinning test pass
- [ ] 머지 후 main 에서 lefthook 정상 (별도 PR 작업 unblock 확인)

## 관련

- 회귀 도입: #767 / #778 (PATTERN_C split)
- Unblock 대상: #782 (process 모니터링 cheatsheet 작업 — 본 fix 머지 대기 중)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern matching compatibility across different grep implementations when handling multi-byte characters.

* **Documentation**
  * Added clarification on grep implementation differences for cross-platform compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->