### PR TITLE
feat(skills): codex-fan-out에 fan-in 표준 절차 명문화 + 호출자 정합 (#757)

### DIFF
--- a/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
@@ -121,6 +121,15 @@ echo "FO_DIR=$FO_DIR"
 
 4. 모든 background 완료 후, 각 결과 파일을 Read 도구로 수집한다.
 
+### fan-in 표준 절차
+
+수집한 worker 산출물(`$FO_DIR/agent-N-result.md`)의 처리 분기는 호출자가 결정한다. 다음 두 분기 중 하나를 선언적으로 선택하고, 머지도 보존 선언도 없는 추적 불가 산출물을 남기지 않는다. 어느 분기든 아래 "주의사항"의 cleanup(`/tmp/fo-*` 임시 디렉토리 정리)은 항상 수행한다 — 보존 분기에서도 SKILL.md cleanup 자체를 생략하지 않는다(prompt/stderr 같은 비-결과 임시 파일까지 lifecycle 약화 방지).
+
+- 머지 분기 (default): worker 산출물을 호출자 컨텍스트에 흡수한다. 호출자가 카테고리 분류 등 자체 통합 전략을 적용한 뒤, cleanup 절차로 `$FO_DIR`을 제거한다.
+- 보존 분기: (1) 호출자가 결과 파일을 호출자 소유의 명시 경로(durable copy)로 복사 또는 이동한다. (2) 원래 `$FO_DIR`은 cleanup 절차로 항상 제거한다. (3) 보존된 durable copy의 lifecycle(보관 위치, 만료 기준 등)은 호출자가 책임진다.
+
+호출자 SoT 적용 예: [`plan-with-questions/references/fanout-fanin.md`](../plan-with-questions/references/fanout-fanin.md#fan-in-통합-전략)의 5 카테고리 통합 전략은 머지 분기 안에서 호출자가 적용하는 카테고리 분류다. 본 SKILL.md는 Claude Code/headless의 `codex exec` mechanics만 담당하므로(SKILL.md `:14-15`), Direct Codex 세션의 native subagent 결과 처리는 본 표준 적용 대상이 아니다 — `plan-with-questions/references/fanout-fanin.md`의 런타임 분기 절을 따른다.
+
 ### reasoning effort
 
 | 기본 | 심층 조사 |

--- a/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
@@ -123,7 +123,7 @@ echo "FO_DIR=$FO_DIR"
 
 ### fan-in 표준 절차
 
-수집한 worker 산출물(`$FO_DIR/agent-N-result.md`)의 처리 분기는 호출자가 결정한다. 다음 두 분기 중 하나를 선언적으로 선택하고, 머지도 보존 선언도 없는 추적 불가 산출물을 남기지 않는다. 어느 분기든 아래 "주의사항"의 cleanup(`/tmp/fo-*` 임시 디렉토리 정리)은 항상 수행한다 — 보존 분기에서도 SKILL.md cleanup 자체를 생략하지 않는다(prompt/stderr 같은 비-결과 임시 파일까지 lifecycle 약화 방지).
+수집한 worker 산출물(`$FO_DIR/agent-N-result.md`)의 처리 분기는 호출자가 결정한다. 다음 두 분기 중 하나를 선언적으로 선택하고, 머지도 보존 선언도 없는 추적 불가 산출물을 남기지 않는다. 어느 분기든 아래 "주의사항"의 cleanup 절차(출력된 `FO_DIR` 리터럴 경로만 `rm -rf` — `/tmp/fo-*` glob 금지, 병렬 fan-out 세션 결과 파일 보호)는 항상 수행한다 — 보존 분기에서도 SKILL.md cleanup 자체를 생략하지 않는다(prompt/stderr 같은 비-결과 임시 파일까지 lifecycle 약화 방지).
 
 - 머지 분기 (default): worker 산출물을 호출자 컨텍스트에 흡수한다. 호출자가 카테고리 분류 등 자체 통합 전략을 적용한 뒤, cleanup 절차로 `$FO_DIR`을 제거한다.
 - 보존 분기: (1) 호출자가 결과 파일을 `$FO_DIR` 밖의 호출자 소유 명시 경로(durable copy)로 복사 또는 이동한다. (2) 원래 `$FO_DIR`은 cleanup 절차로 항상 제거한다. (3) 보존된 durable copy의 lifecycle(보관 위치, 만료 기준 등)은 호출자가 책임진다.

--- a/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
@@ -126,9 +126,9 @@ echo "FO_DIR=$FO_DIR"
 수집한 worker 산출물(`$FO_DIR/agent-N-result.md`)의 처리 분기는 호출자가 결정한다. 다음 두 분기 중 하나를 선언적으로 선택하고, 머지도 보존 선언도 없는 추적 불가 산출물을 남기지 않는다. 어느 분기든 아래 "주의사항"의 cleanup(`/tmp/fo-*` 임시 디렉토리 정리)은 항상 수행한다 — 보존 분기에서도 SKILL.md cleanup 자체를 생략하지 않는다(prompt/stderr 같은 비-결과 임시 파일까지 lifecycle 약화 방지).
 
 - 머지 분기 (default): worker 산출물을 호출자 컨텍스트에 흡수한다. 호출자가 카테고리 분류 등 자체 통합 전략을 적용한 뒤, cleanup 절차로 `$FO_DIR`을 제거한다.
-- 보존 분기: (1) 호출자가 결과 파일을 호출자 소유의 명시 경로(durable copy)로 복사 또는 이동한다. (2) 원래 `$FO_DIR`은 cleanup 절차로 항상 제거한다. (3) 보존된 durable copy의 lifecycle(보관 위치, 만료 기준 등)은 호출자가 책임진다.
+- 보존 분기: (1) 호출자가 결과 파일을 `$FO_DIR` 밖의 호출자 소유 명시 경로(durable copy)로 복사 또는 이동한다. (2) 원래 `$FO_DIR`은 cleanup 절차로 항상 제거한다. (3) 보존된 durable copy의 lifecycle(보관 위치, 만료 기준 등)은 호출자가 책임진다.
 
-호출자 SoT 적용 예: [`plan-with-questions/references/fanout-fanin.md`](../plan-with-questions/references/fanout-fanin.md#fan-in-통합-전략)의 5 카테고리 통합 전략은 머지 분기 안에서 호출자가 적용하는 카테고리 분류다. 본 SKILL.md는 Claude Code/headless의 `codex exec` mechanics만 담당하므로(SKILL.md `:14-15`), Direct Codex 세션의 native subagent 결과 처리는 본 표준 적용 대상이 아니다 — `plan-with-questions/references/fanout-fanin.md`의 런타임 분기 절을 따른다.
+호출자 SoT 적용 범위: [`plan-with-questions/references/fanout-fanin.md`의 5 카테고리 통합 전략](../plan-with-questions/references/fanout-fanin.md#fan-in-통합-전략)은 호출자(`plan-with-questions`)의 런타임 무관 자체 분류 전략이다. 본 SKILL.md의 fan-in 표준 절차는 그 호출자가 codex exec 경로에서 적용하는 worker 산출물 lifecycle 처리(머지 vs 보존 + cleanup)에 한정된다 — 카테고리 분류를 대체하지 않는다. 본 SKILL.md는 도입 설명대로 Claude Code/headless의 `codex exec` mechanics만 담당하므로, Direct Codex 세션의 native subagent 결과 lifecycle은 본 표준 적용 대상이 아니다 — [`plan-with-questions/references/fanout-fanin.md`의 런타임 분기](../plan-with-questions/references/fanout-fanin.md#런타임-분기) 절을 따른다.
 
 ### reasoning effort
 

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/fanout-fanin.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/fanout-fanin.md
@@ -40,7 +40,9 @@ Codex 세션 fan-out delegation 거부 처리: Codex 세션에서 `spawn_agent` 
 
 ## fan-in 통합 전략
 
-Claude Code/headless의 `codex exec` 경로에서 `$FO_DIR/agent-N-result.md` 파일 처리 분기는 [`/codex-fan-out` SKILL.md의 fan-in 표준 절차](../../codex-fan-out/SKILL.md#fan-in-표준-절차)를 따른다(머지 분기 default). Direct Codex native subagent 결과는 위 "런타임 분기"의 hardening contract 경로(`:28`, `:32-35`)를 따른다. 아래 5 카테고리는 머지 분기 안에서 호출자(plan-with-questions)가 적용하는 카테고리 분류다.
+worker 산출물 lifecycle 처리(머지 vs 보존 + cleanup): Claude Code/headless의 `codex exec` 경로에서 `$FO_DIR/agent-N-result.md` 파일 처리는 [`/codex-fan-out` SKILL.md의 fan-in 표준 절차](../../codex-fan-out/SKILL.md#fan-in-표준-절차)를 따른다(머지 분기 default). Direct Codex native subagent 결과는 위 [런타임 분기](#런타임-분기)의 hardening contract 경로를 따른다.
+
+아래 5 카테고리는 `plan-with-questions` 호출자가 런타임과 무관하게 적용하는 자체 통합 전략이다(`codex exec` 머지 분기든 Direct Codex 경로든 동일 적용 — `codex-fan-out`의 fan-in 표준 절차는 lifecycle 처리에만 한정되고 카테고리 분류를 대체하지 않는다).
 
 에이전트 결과를 카테고리별로 분류하여 통합한다:
 

--- a/modules/shared/programs/claude/files/skills/plan-with-questions/references/fanout-fanin.md
+++ b/modules/shared/programs/claude/files/skills/plan-with-questions/references/fanout-fanin.md
@@ -40,6 +40,8 @@ Codex 세션 fan-out delegation 거부 처리: Codex 세션에서 `spawn_agent` 
 
 ## fan-in 통합 전략
 
+Claude Code/headless의 `codex exec` 경로에서 `$FO_DIR/agent-N-result.md` 파일 처리 분기는 [`/codex-fan-out` SKILL.md의 fan-in 표준 절차](../../codex-fan-out/SKILL.md#fan-in-표준-절차)를 따른다(머지 분기 default). Direct Codex native subagent 결과는 위 "런타임 분기"의 hardening contract 경로(`:28`, `:32-35`)를 따른다. 아래 5 카테고리는 머지 분기 안에서 호출자(plan-with-questions)가 적용하는 카테고리 분류다.
+
 에이전트 결과를 카테고리별로 분류하여 통합한다:
 
 1. 코드 패턴: 코드베이스에서 발견한 관련 패턴, 기존 구현.


### PR DESCRIPTION
## Summary

`codex-fan-out` 스킬이 fan-in 통합 전략을 호출자 책임으로 위임하면서 호출자가 따를 표준 fan-in 머지 절차를 SKILL.md에 정의해 두지 않았던 문제를 해결한다 (#757). 호출자가 사실상 `plan-with-questions/references/fanout-fanin.md` 1개 + 사용자 직접 `/codex-fan-out` 호출이라, SKILL.md에 minimum prose 한 단락을 추가하고 호출자 SoT에 경로 한정 한 줄을 추가하여 SoT chain 무결성을 강화했다.

- `codex-fan-out/SKILL.md`: 결과 수집 단계 뒤에 `### fan-in 표준 절차` 섹션 신설
  - 머지 분기(default): worker 산출물 호출자 컨텍스트 흡수 + cleanup
  - 보존 분기: `$FO_DIR` 밖의 호출자 명시 경로로 결과 파일 복사/이동 → 원래 `$FO_DIR`은 항상 cleanup. 보존본 lifecycle만 호출자 책임 (lifecycle 약화 방지)
  - cleanup은 출력된 FO_DIR 리터럴 경로만 `rm -rf` (`/tmp/fo-*` glob 금지 — 병렬 fan-out 세션 결과 파일 보호)
  - 호출자 SoT 적용 범위 단락: codex-fan-out fan-in 표준 절차는 worker 산출물 lifecycle 처리에만 한정, 5 카테고리 분류 대체 아님. Direct Codex native 결과는 본 표준 적용 대상 아님.
- `plan-with-questions/references/fanout-fanin.md`: fan-in 통합 전략 섹션 도입부에 경로 한정 + 5 카테고리 런타임 무관 명시
  - Claude Code/headless의 `codex exec` 경로에서만 SKILL.md 표준 적용
  - Direct Codex native subagent 결과는 기존 hardening contract 경로
  - 5 카테고리는 호출자(plan-with-questions)의 런타임 무관 자체 분류 전략 (lifecycle 처리와 분리)

외부 검증 두 번 (계획 단계 + 코드 단계) + 전수조사 6 bundle 완료. 5건 지적(보존 분기 cleanup 정의 모호, 경로 한정 누락, 5 카테고리 의미 흐림, 비링크 라인 번호 stale 위험, cleanup glob 위험) 모두 반영.

이슈 본문 두 번째 체크박스 (`#756`·`#758`·이 이슈 lifecycle 묶음 재평가)는 본 PR 범위 밖 — 이슈 본문 트래킹 앵커로 유지 (`#756` P1 미머지 의존).

## Test plan

- [x] 이슈 본문 DoD: `grep -qE '^#+ .*fan-in' codex-fan-out/SKILL.md` PASS
- [x] 호출자 정합: `grep -F 'codex-fan-out/SKILL.md' fanout-fanin.md | grep -F 'fan-in 표준 절차'` PASS
- [x] cleanup glob 안전: `grep -qE 'glob 금지|리터럴 경로.*rm -rf' codex-fan-out/SKILL.md` PASS
- [x] bidirectional anchor link: SKILL.md ↔ fanout-fanin.md anchor 양방향 작동
- [x] lefthook pre-commit + pre-push (skill-noise-check, eval-tests, codex-hook-fixtures, flake-check, shell-script-tests, statusline-bats 등) 전체 PASS

Closes #757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fan-in procedures documentation with guidance on handling worker result files, including merge vs. preservation options and cleanup processes.
  * Clarified scope boundaries between result lifecycle management and integration categorization framework.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/799?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->