### PR TITLE
perf(codex): MiniPC startup latency 완화 (#772)

### DIFF
--- a/modules/shared/programs/codex/files/config.toml
+++ b/modules/shared/programs/codex/files/config.toml
@@ -13,9 +13,11 @@ hide_full_access_warning = true
 [notice.model_migrations]
 "gpt-5.2" = "gpt-5.2-codex"
 
+# Linux default disables `apps` to skip `codex_apps` MCP boot; use `codex-apps`
+# shell alias for opt-in connector / plugin / tool_search surface (#772).
 [features]
 multi_agent = true
-apps = true
+apps = false
 prevent_idle_sleep = true
 goals = true
 default_mode_request_user_input = true

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -101,7 +101,16 @@ in
     c = "claude --dangerously-skip-permissions --mcp-config ~/.claude/mcp.json";
 
     # Codex CLI 위험 모드 단축 (사용자 요청)
-    codex = "command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen";
+    # Linux MiniPC: apps feature 를 template 에서 비활성화해 fast startup 보장 (#772).
+    # 기본 codex 는 connector discovery 가 비활성화되므로 stderr 한 줄 안내를 출력하고,
+    # connector / plugin / tool_search 가 필요하면 codex-apps 로 세 feature 모두 복원한다.
+    # Darwin 은 features default 가 true 라 안내 echo 없이 기존 alias 그대로 유지한다.
+    codex =
+      if pkgs.stdenv.isLinux then
+        "echo '[codex] apps feature disabled for fast startup. Use codex-apps for full connector surface.' >&2; command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen"
+      else
+        "command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen";
+    codex-apps = "command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen --enable apps --enable plugins --enable tool_search";
 
     # lazygit 단축
     lg = "lazygit";


### PR DESCRIPTION
## Summary

- MiniPC (Linux/NixOS) Codex template `[features].apps` 를 `false` 로 변경해 `codex_apps` MCP 부팅으로 인한 startup latency 를 제거 (이슈 #772 PoC: cold 4.5s → ~214ms).
- `codex-apps` opt-in shell alias 추가 (`--enable apps --enable plugins --enable tool_search`) 로 connector / plugin / tool_search 표면을 한 번에 복원.
- Linux 기본 `codex` alias 에 stderr 한 줄 안내 추가 (`[codex] apps feature disabled for fast startup. Use codex-apps for full connector surface.`). Darwin 은 `pkgs.stdenv.isLinux` 분기로 안내 미적용 + 기존 alias 그대로 유지.
- `plugins` / `tool_search` 는 template-owned 로 박지 않고 Codex CLI default (true) 유지 — `--disable apps` 단독으로 baseline 에 도달함을 PoC 가 확인했고, 향후 Codex CLI default 변경이나 Linux plugins 도입 시 default 경로가 자동으로 따라가는 forward-compat 경로를 보존.
- Darwin template (`config.darwin.toml` 의 curated plugins + `chrome-devtools` MCP) 은 미변경 (NG-1).

이슈 본문 자체도 startup latency 단일 트랙으로 사전에 정리 (reasoning effort xhigh 일괄화 트랙은 분리).

## 변경 파일

- `modules/shared/programs/codex/files/config.toml` — `[features].apps = true → false`, 헤더 위 inline 주석 한 줄 추가.
- `modules/shared/programs/shell/default.nix` — `home.shellAliases.codex` 를 `pkgs.stdenv.isLinux` 분기로 정의하고, `codex-apps` alias 추가, 주석 보강.

## Test plan

- [x] Mac `nrs` (darwin-rebuild) 성공 (88s).
- [x] MiniPC `ssh minipc + nrs` (nixos-rebuild) 성공 (153s) — scp 임시 적용 후 측정 완료, MiniPC 는 검증 후 main 으로 복원.
- [x] SC-1: MiniPC `codex features list` → `apps = false` (plugins / tool_search 는 user-owned 설정으로 별개).
- [x] SC-2: MiniPC `codex debug prompt-input` warm 3회 median **158ms ≤ 300ms** (이슈 PoC baseline ~214ms 의 +40% 안전 허용).
- [x] SC-3: MiniPC `codex-apps debug prompt-input` 시 `codex features list` 가 `apps / plugins / tool_search = true` 보고 (세 feature effective true).
- [x] SC-4: Mac `codex features list` 변동 없음 (apps / plugins / tool_search 모두 true 그대로).
- [x] SC-5: 양 호스트 `sync-codex-config.py check` 가 `drift=[], target_state=present` (EXIT_OK).
- [x] SC-6: MiniPC `codex` 호출 시 stderr 안내 한 줄 출력, Mac `codex` 는 안내 미출력 (alias OS 분기 동작 확인).
- [x] zsh alias 정의 grep — Linux 분기는 `echo + command codex ...`, Darwin 분기는 기존 그대로.

## 외부 검토

- plan-mode: preflight gate Review Intensity → RULE-CONFIG-DEPENDENCY first-match → FULL. 4 reviewer 병렬 + first-pass Arbiter. 6 finding 전건 CONFIRMED + HIGH confidence + stability N/A + low_confidence false. 4 finding 자동 반영, 2 finding 사용자 결정으로 처리.
- for_pr: 동일 preflight 결과 → FULL. correctness / regression / maintainability CLEAR, design 1건 (NGMI: pkgs.stdenv.isLinux 가 모든 non-Darwin 호스트에 적용). Arbiter CONFIRMED + HIGH + MEDIUM 심각도. 사용자 명시 supersede (성급한 추상화 금지) — 현재 NixOS 호스트가 1대뿐이라 isLinux 분기로 충분하고, 향후 호스트 추가 시 그 시점에 hostType / hostname 기반 분기 재검토.

## Notes

- 사이드이펙트: MiniPC 기본 `codex` 에서 GitHub / Slack connector discovery 자동 비활성. `codex-apps` opt-in alias 로 복원 가능. 매 호출 시 stderr 한 줄 안내가 in-flow hint 로 작동.
- stderr 캡처 자동화 스크립트는 안내 한 줄 noise 를 받게 된다. 영향 받는 자동화가 있으면 별도 follow-up 으로 다룬다.
- `codex-apps` 는 양 호스트 공통 alias 이므로 Mac 에서도 정의되지만 default features 가 true 라 redundant no-op (의도된 동작).
- 본 작업 범위 밖 (별도 이슈 후보): reasoning effort xhigh 일괄화 (#571 supersede 여부), `verify-ai-compat.sh` 의 lower-effort pin drift 검출 추가, Mac startup latency 단축, NixOS 호스트 추가 시 hostType 분기 도입.

Closes #772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `codex-apps` command to explicitly enable apps, plugins, and tool search functionality.
  * Apps feature is now disabled by default. Linux users will see an advisory message when running `codex`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->