### PR TITLE
refactor(codex): claude↔codex hook 공통 코어 추출 + cross-tree fallback 제거 + USED-BY oracle (#759)

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -172,6 +172,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/lib/pinning-patterns.sh";
     ".claude/lib/session-state.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/lib/session-state.sh";
+    ".claude/lib/hook-runtime.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/lib/hook-runtime.sh";
     # Cache TTL tracking hooks
     ".claude/hooks/record-last-stop.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/record-last-stop.sh";

--- a/modules/shared/programs/claude/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-alert.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # pinning-alert.sh — PostToolUse Edit/Write/NotebookEdit warn-only alert (Claude Code).
-# 정책 출처: https://github.com/greenheadHQ/nixos-config/issues/603
 # 패턴 SSOT: modules/shared/programs/claude/files/lib/pinning-patterns.sh.
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
 # commit-msg, Claude/Codex PostToolUse alert, Claude/Codex PreToolUse guard가 같은
 # shared library를 source한다. runtime별 hook에는 stdin 파싱과 출력 정책만 남긴다.
 # 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
 #
-# pipefail 안전 모델 (commit-msg-pinning.sh:26-29와 동일 SSOT):
+# pipefail 안전 모델 (commit-msg-pinning.sh와 동일 SSOT):
 #   `printf '%s' "$TEXT" | grep -qE ...` 조합은 큰 입력에서 grep -q 조기 종료 + SIGPIPE로
 #   producer가 nonzero를 반환해 pipefail 환경에서 silent miss를 만든다. 검사 텍스트를 mktemp
 #   파일에 저장하고 `grep -qE "$PATTERN" "$tmpfile"`로 검사하여 회피한다.
@@ -18,17 +18,26 @@ set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PINNING_LIB="${PINNING_PATTERNS_LIB:-$HOME/.claude/lib/pinning-patterns.sh}"
-if [ ! -f "$PINNING_LIB" ]; then
-  PINNING_LIB="$SCRIPT_DIR/../lib/pinning-patterns.sh"
+# Bootstrap: hook-runtime.sh source. 미발견 시 warn-only 계약대로 exit 0.
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+if [ ! -f "$HOOK_RUNTIME_LIB" ]; then
+  printf '[pinning-alert] hook-runtime.sh 미발견 (%s) — 검사 skip\n' "$HOOK_RUNTIME_LIB" >&2
+  exit 0
 fi
-[ -f "$PINNING_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
+# pinning-patterns.sh 로드. 미발견 시 warn-only 계약대로 exit 0.
+PINNING_LIB=$(hook_load_lib PINNING_PATTERNS_LIB "$HOME/.claude/lib" pinning-patterns.sh) || PINNING_LIB=""
+if [ -z "$PINNING_LIB" ]; then
+  printf '[pinning-alert] pinning-patterns.sh 미발견 — 검사 skip. PINNING_PATTERNS_LIB env var 또는 ~/.claude/lib/ 설치 필요.\n' >&2
+  exit 0
+fi
 # shellcheck source=../lib/pinning-patterns.sh
 . "$PINNING_LIB"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+TOOL_NAME=$(printf '%s' "$INPUT" | hook_parse_tool_name)
 case "$TOOL_NAME" in
   Edit | Write | NotebookEdit) ;;
   *) exit 0 ;;
@@ -52,9 +61,10 @@ case "$TOOL_NAME" in
 esac
 [ -n "$TEXT" ] || exit 0
 
-# 검사 텍스트를 mktemp 파일에 저장 후 파일 기반 grep으로 SIGPIPE 회피.
-SCAN_FILE=$(mktemp "${TMPDIR:-/tmp}/pinning-scan-XXXXXX") || exit 0
-trap 'rm -f "$SCAN_FILE"' EXIT
+# 검사 디렉토리 생성 (pipefail 안전 모델 — 파일 기반 grep). trap은 호출자가 설치.
+SCAN_DIR=$(hook_init_scan_dir pinning-scan) || exit 0
+trap 'rm -rf "$SCAN_DIR"' EXIT
+SCAN_FILE="$SCAN_DIR/scan.txt"
 printf '%s' "$TEXT" > "$SCAN_FILE"
 
 findings="$(pinning_findings_text_for_path "$SCAN_FILE" "$FILE_PATH")"

--- a/modules/shared/programs/claude/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-guard.sh
@@ -1,33 +1,44 @@
 #!/usr/bin/env bash
 # pinning-guard.sh — Claude Code PreToolUse hard-fail guard.
+# 패턴 SSOT: modules/shared/programs/claude/files/lib/pinning-patterns.sh.
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
+# 정책: PreToolUse fail-closed — lib 누락 시 deny JSON 반환 (보안 경계 유지).
 set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || exit 0
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PINNING_LIB="${PINNING_PATTERNS_LIB:-$HOME/.claude/lib/pinning-patterns.sh}"
-if [ ! -f "$PINNING_LIB" ]; then
-  PINNING_LIB="$SCRIPT_DIR/../lib/pinning-patterns.sh"
-fi
-if [ ! -f "$PINNING_LIB" ]; then
-  jq -n --arg reason "[pinning-guard] shared pinning policy library is missing: $PINNING_LIB" \
+_deny_with_reason() {
+  local reason="$1"
+  jq -n --arg reason "$reason" \
     '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
   exit 0
+}
+
+# Bootstrap: hook-runtime.sh source. 미발견 시 fail-closed (deny).
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+if [ ! -f "$HOOK_RUNTIME_LIB" ]; then
+  _deny_with_reason "[pinning-guard] shared pinning policy library is missing: hook-runtime.sh ($HOOK_RUNTIME_LIB)"
+fi
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
+# pinning-patterns.sh 로드. 미발견 시 fail-closed (deny).
+PINNING_LIB=$(hook_load_lib PINNING_PATTERNS_LIB "$HOME/.claude/lib" pinning-patterns.sh) || PINNING_LIB=""
+if [ -z "$PINNING_LIB" ]; then
+  _deny_with_reason "[pinning-guard] shared pinning policy library is missing: pinning-patterns.sh. PINNING_PATTERNS_LIB env var 또는 ~/.claude/lib/pinning-patterns.sh 설치 필요."
 fi
 # shellcheck source=../lib/pinning-patterns.sh
 . "$PINNING_LIB"
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
+TOOL_NAME=$(printf '%s' "$INPUT" | hook_parse_tool_name)
 
 _deny() {
   local surface="$1" target="$2" findings="$3"
   local reason
   reason=$(printf '[pinning-guard] %s on %s contains volatile review/session metadata:%b\nUse stable identifiers or plain natural-language context before retrying.' \
     "$surface" "$target" "$findings")
-  jq -n --arg reason "$reason" \
-    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
-  exit 0
+  _deny_with_reason "$reason"
 }
 
 _scan_text_file() {
@@ -51,7 +62,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-SCAN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pinning-guard-XXXXXX") || exit 0
+SCAN_DIR=$(hook_init_scan_dir pinning-guard) || exit 0
 trap 'rm -rf "$SCAN_DIR"' EXIT
 
 case "$TOOL_NAME" in

--- a/modules/shared/programs/claude/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/pinning-guard.sh
@@ -62,7 +62,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-SCAN_DIR=$(hook_init_scan_dir pinning-guard) || exit 0
+SCAN_DIR=$(hook_init_scan_dir pinning-guard) || _deny_with_reason "[pinning-guard] failed to initialize scan workspace; denying by fail-closed policy."
 trap 'rm -rf "$SCAN_DIR"' EXIT
 
 case "$TOOL_NAME" in

--- a/modules/shared/programs/claude/files/hooks/record-last-stop.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-stop.sh
@@ -5,17 +5,30 @@ set -euo pipefail
 # 주의: settings.json의 Stop 훅 배열에서 첫 번째로 실행되어야 한다.
 # 다른 Stop 훅보다 먼저 타임스탬프를 기록하여
 # statusline 카운트다운의 레이스 컨디션을 최소화한다.
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
+# 정책: hook-runtime.sh 미발견 시 inline fallback 자체 로직 실행 (자체 동작 보존).
 
 # stdin에서 세션 정보 읽기 (agent_id 가드 + session_id 파싱 공용)
 INPUT=""
 [ ! -t 0 ] && INPUT=$(cat)
 
 if [ -n "$INPUT" ]; then
-  # 서브에이전트 내부 Stop은 무시 (메인 턴 완료만 추적)
+  # 서브에이전트 내부 Stop은 무시 (메인 턴 완료만 추적) — claude 전용 런타임 가드, inline 유지.
   AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
   [ -n "$AGENT_ID" ] && exit 0
-  # stdin JSON에서 session_id 파싱 (env var보다 신뢰성 높음)
-  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+
+# hook-runtime.sh source 시도. 실패 시 inline fallback 으로 session_id 파싱.
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+if [ -f "$HOOK_RUNTIME_LIB" ] && command -v jq >/dev/null 2>&1; then
+  # shellcheck source=../lib/hook-runtime.sh
+  . "$HOOK_RUNTIME_LIB"
+  [ -n "$INPUT" ] && SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
+else
+  # inline fallback — hook-runtime.sh 또는 jq 미발견 시 자체 파싱.
+  if [ -n "$INPUT" ] && command -v jq >/dev/null 2>&1; then
+    SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+  fi
 fi
 
 # fallback: env var → 빈 문자열

--- a/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
+++ b/modules/shared/programs/claude/files/hooks/record-prompt-submit.sh
@@ -2,17 +2,30 @@
 set -euo pipefail
 # record-prompt-submit.sh — 프롬프트 전송 시 캐시 TTL을 "in-flight" 상태로 전환
 # "0"을 기록하면 statusline.sh가 mtime 기준 카운트다운 표시 (Stop 미기록 상태)
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
+# 정책: hook-runtime.sh 미발견 시 inline fallback 자체 로직 실행 (자체 동작 보존).
 
 # stdin에서 세션 정보 읽기 (agent_id 가드 + session_id 파싱 공용)
 INPUT=""
 [ ! -t 0 ] && INPUT=$(cat)
 
 if [ -n "$INPUT" ]; then
-  # 서브에이전트 내부 UserPromptSubmit은 무시 (메인 턴만 추적)
+  # 서브에이전트 내부 UserPromptSubmit은 무시 (메인 턴만 추적) — claude 전용 런타임 가드, inline 유지.
   AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
   [ -n "$AGENT_ID" ] && exit 0
-  # stdin JSON에서 session_id 파싱 (env var보다 신뢰성 높음)
-  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+
+# hook-runtime.sh source 시도. 실패 시 inline fallback 으로 session_id 파싱.
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+if [ -f "$HOOK_RUNTIME_LIB" ] && command -v jq >/dev/null 2>&1; then
+  # shellcheck source=../lib/hook-runtime.sh
+  . "$HOOK_RUNTIME_LIB"
+  [ -n "$INPUT" ] && SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
+else
+  # inline fallback — hook-runtime.sh 또는 jq 미발견 시 자체 파싱.
+  if [ -n "$INPUT" ] && command -v jq >/dev/null 2>&1; then
+    SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+  fi
 fi
 
 # fallback: env var → 빈 문자열

--- a/modules/shared/programs/claude/files/lib/hook-runtime.sh
+++ b/modules/shared/programs/claude/files/lib/hook-runtime.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# hook-runtime.sh — claude/codex hook 공통 helper 라이브러리.
+# 정책 출처: https://github.com/greenheadHQ/nixos-config/issues/759
+#
+# 본 라이브러리는 claude/codex 양 트리의 논리 hook 4종 (pinning-alert, pinning-guard,
+# record-last-stop, record-prompt-submit) 의 8개 구현 use-site 에서 사용한다. 런타임별
+# 전용 로직 (CLAUDECODE/CODEX_PROGRAMMATIC 가드, agent_id 가드, apply_patch envelope
+# dispatch) 은 각 hook 본문에 inline 유지한다.
+#
+# 비대상: nrs-session-cleanup (claude/codex 양쪽) — 자체 NRS_LOCK_FILE cleanup 로직만
+# 사용하며 lib 의존성 없음.
+#
+# 호출자는 본 lib 의 실패 정책 (fail-closed / warn-only / inline fallback) 을 결정한다.
+# `hook_load_lib` 는 정책 결정권 없이 stdout 으로 path 또는 빈 문자열을 반환한다.
+#
+# USED-BY:
+#   claude/files/hooks/pinning-alert.sh         # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/pinning-guard.sh         # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/record-last-stop.sh      # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/record-prompt-submit.sh  # via $HOOK_RUNTIME_LIB
+#   codex/files/hooks/pinning-alert.sh          # via $HOOK_RUNTIME_LIB
+#   codex/files/hooks/pinning-guard.sh          # via $HOOK_RUNTIME_LIB
+#   codex/files/hooks/record-last-stop.sh       # via $HOOK_RUNTIME_LIB
+#   codex/files/hooks/record-prompt-submit.sh   # via $HOOK_RUNTIME_LIB
+#
+# scripts/ai/verify-ai-compat.sh 가 본 USED-BY 선언과 실제 source 호출 일치를 oracle로 검증.
+
+# shellcheck disable=SC2034
+# 본 lib 의 함수는 source 후 호출되며, 정적 분석은 사용처를 보지 못해 unused 로 false positive.
+
+# hook_load_lib <env_var_name> <home_lib_dir> <lib_basename>
+#
+# 공유 라이브러리 경로 해결. env var primary + home lib dir secondary 시도.
+# cross-tree fallback 없음. 호출자가 환경별 경로를 명시적으로 전달한다.
+#
+# 인자:
+#   env_var_name: env var 이름 (예: PINNING_PATTERNS_LIB)
+#   home_lib_dir: nix-installed lib 디렉토리 (예: $HOME/.codex/lib)
+#   lib_basename: lib 파일명 (예: pinning-patterns.sh)
+#
+# stdout: 성공 시 lib path 출력. 실패 시 빈 문자열.
+# exit code: 0 (성공) / 1 (실패).
+#
+# 호출자는 stdout 결과로 fail-closed / warn-only / inline fallback 정책을 결정한다.
+# 본 helper 는 stderr 메시지 출력 안 함 — 호출자가 정책에 맞는 메시지 작성.
+hook_load_lib() {
+  local env_var_name="$1" home_lib_dir="$2" lib_basename="$3"
+  local env_val lib_path
+  # bash indirect expansion. hook은 #!/usr/bin/env bash 로 실행되어 source되므로 안전.
+  env_val="${!env_var_name:-}"
+  if [ -n "$env_val" ] && [ -f "$env_val" ]; then
+    printf '%s' "$env_val"
+    return 0
+  fi
+  lib_path="$home_lib_dir/$lib_basename"
+  if [ -f "$lib_path" ]; then
+    printf '%s' "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+# hook_init_scan_dir [prefix]
+#
+# 임시 디렉토리 생성. mktemp -d 사용. trap 은 호출자가 설치한다.
+#
+# 인자:
+#   prefix: mktemp prefix (기본값: hook-scan)
+#
+# stdout: 생성된 디렉토리 path.
+# exit code: 0 (성공) / 1 (실패).
+hook_init_scan_dir() {
+  local prefix="${1:-hook-scan}"
+  mktemp -d "${TMPDIR:-/tmp}/${prefix}-XXXXXX"
+}
+
+# hook_parse_tool_name
+#
+# stdin 으로 받은 JSON 에서 .tool_name 추출. jq 사용.
+#
+# stdin: hook stdin JSON (예: '{"tool_name": "Edit", ...}')
+# stdout: tool_name 값 또는 빈 문자열.
+# exit code: 항상 0 (jq 파싱 실패 시에도 빈 문자열 + 0).
+hook_parse_tool_name() {
+  jq -r '.tool_name // empty' 2>/dev/null || true
+}
+
+# hook_parse_session_id
+#
+# stdin 으로 받은 JSON 에서 .session_id 추출. jq 사용.
+#
+# stdin: hook stdin JSON
+# stdout: session_id 값 또는 빈 문자열.
+# exit code: 항상 0.
+hook_parse_session_id() {
+  jq -r '.session_id // empty' 2>/dev/null || true
+}

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Shared pinning pattern helpers for commit-msg and hook scanners.
 # Consumers decide whether a match is warn-only or hard-fail.
+#
+# USED-BY:
+#   claude/files/hooks/pinning-alert.sh   # via $PINNING_LIB
+#   claude/files/hooks/pinning-guard.sh   # via $PINNING_LIB
+#   codex/files/hooks/pinning-alert.sh    # via $PINNING_LIB
+#   codex/files/hooks/pinning-guard.sh    # via $PINNING_LIB
+#   scripts/ai/commit-msg-pinning.sh      # via $PINNING_LIB
+#
+# scripts/ai/verify-ai-compat.sh 가 본 USED-BY 선언과 실제 source 호출 일치를 oracle로 검증.
 
 # Named indent constant for line:token report rendering. Single SSOT for all
 # rendered output (findings_text wrapper).

--- a/modules/shared/programs/claude/files/lib/session-state.sh
+++ b/modules/shared/programs/claude/files/lib/session-state.sh
@@ -9,6 +9,13 @@
 # 공유하는 상수·함수의 SSOT. 한쪽에서 변경하면 lineage 복원/sidecar I/O가
 # silently 어긋나는 위험을 코드 레벨에서 차단한다.
 #
+# USED-BY:
+#   claude/files/hooks/session-init-icons.sh    # via $SESSION_STATE_LIB
+#   claude/files/hooks/record-last-session.sh   # via $SESSION_STATE_LIB
+#   claude/files/scripts/statusline.sh          # via $SESSION_STATE_LIB (validate_session_id 정책)
+#
+# scripts/ai/verify-ai-compat.sh 가 본 USED-BY 선언과 실제 source 호출 일치를 oracle로 검증.
+#
 # 공개 API
 # ─────────
 #   상수:

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -116,6 +116,8 @@ in
       config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/codex/files/hooks/pinning-guard.sh";
     ".codex/lib/pinning-patterns.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/claude/files/lib/pinning-patterns.sh";
+    ".codex/lib/hook-runtime.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${nixosConfigPath}/modules/shared/programs/claude/files/lib/hook-runtime.sh";
   }
   # 글로벌 스킬 (Claude와 동일 소스 공유) — exposedCodexSkills에서 자동 생성
   // codexSkillEntries;

--- a/modules/shared/programs/codex/files/hooks/pinning-alert.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-alert.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # pinning-alert.sh — Codex 0.124+ PostToolUse warn-only alert.
-# 정책 출처: https://github.com/greenheadHQ/nixos-config/issues/603
 # 패턴 SSOT: modules/shared/programs/claude/files/lib/pinning-patterns.sh.
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
 # commit-msg, Claude/Codex PostToolUse alert, Claude/Codex PreToolUse guard가 같은
 # shared library를 source한다. runtime별 hook에는 stdin 파싱과 출력 정책만 남긴다.
 # 정책: warn-only — stderr alert + exit 0. permissionDecision 사용 금지.
 #
-# pipefail 안전 모델 (commit-msg-pinning.sh:26-29와 동일 SSOT):
+# pipefail 안전 모델 (commit-msg-pinning.sh와 동일 SSOT):
 #   `printf '%s' "$TEXT" | grep -qE ...` 조합은 큰 입력에서 grep -q 조기 종료 + SIGPIPE로
 #   producer가 nonzero를 반환해 pipefail 환경에서 silent miss를 만든다. 검사 텍스트를 mktemp
 #   파일에 저장하고 `grep -qE "$PATTERN" "$tmpfile"`로 검사하여 회피한다.
@@ -23,7 +23,7 @@
 # apply_patch attribution 모델:
 #   patch envelope을 파일 섹션별로 분리하여, eligible path마다 그 파일의 added line(`^+`,
 #   `*** Begin/End Patch` 헤더 제외)만 검사한다. 삭제 라인(`^-`)·context 라인(` `)·헤더는 제외.
-#   매치된 파일 path를 alert에 보고. multi-file patch에서 첫 파일만 보고하던 구조 회귀 (#603 DA for_pr Design-1/Regression-2).
+#   매치된 파일 path를 alert에 보고. multi-file patch에서 첫 파일만 보고하던 구조 회귀 방지.
 set -euo pipefail
 
 # 환경 가드(CLAUDECODE/CODEX_PROGRAMMATIC) 없음 — PostToolUse pinning-alert는 자식 LLM 세션의
@@ -35,27 +35,37 @@ set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+# tool_name 사전 분기 — Codex의 PostToolUse는 모든 tool 호출(Bash 포함)에 발화하므로,
+# 검사 대상이 아닌 tool은 lib bootstrap 또는 SCAN_DIR 생성 비용 없이 즉시 종료한다.
+# 이 순서는 lib 미발견 stderr skip 메시지의 영향 범위를 pinning 검사 대상 tool 로 한정한다.
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
 
-# tool_name 사전 분기 — Codex의 PostToolUse는 모든 tool 호출(Bash 포함)에 발화하므로,
-# 검사 대상이 아닌 tool은 SCAN_DIR 생성/cleanup 비용 없이 즉시 종료한다.
 case "$TOOL_NAME" in
   Edit | Write | NotebookEdit | apply_patch) ;;
   *) exit 0 ;;
 esac
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PINNING_LIB="${PINNING_PATTERNS_LIB:-$HOME/.codex/lib/pinning-patterns.sh}"
-if [ ! -f "$PINNING_LIB" ]; then
-  PINNING_LIB="$SCRIPT_DIR/../../../claude/files/lib/pinning-patterns.sh"
+# Bootstrap: hook-runtime.sh source. 미발견 시 warn-only 계약대로 exit 0.
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.codex/lib/hook-runtime.sh}"
+if [ ! -f "$HOOK_RUNTIME_LIB" ]; then
+  printf '[pinning-alert] hook-runtime.sh 미발견 (%s) — 검사 skip. HOOK_RUNTIME_LIB env var 또는 ~/.codex/lib/ 설치 필요.\n' "$HOOK_RUNTIME_LIB" >&2
+  exit 0
 fi
-[ -f "$PINNING_LIB" ] || exit 0
+# shellcheck source=../../../claude/files/lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
+# pinning-patterns.sh 로드. 미발견 시 warn-only 계약대로 exit 0.
+PINNING_LIB=$(hook_load_lib PINNING_PATTERNS_LIB "$HOME/.codex/lib" pinning-patterns.sh) || PINNING_LIB=""
+if [ -z "$PINNING_LIB" ]; then
+  printf '[pinning-alert] pinning-patterns.sh 미발견 — 검사 skip. PINNING_PATTERNS_LIB env var 또는 ~/.codex/lib/ 설치 필요.\n' >&2
+  exit 0
+fi
 # shellcheck source=../../../claude/files/lib/pinning-patterns.sh
 . "$PINNING_LIB"
 
 # 임시 디렉토리 (모든 mktemp 파일을 한 곳에 두고 EXIT trap으로 일괄 정리).
-SCAN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pinning-scan-XXXXXX") || exit 0
+SCAN_DIR=$(hook_init_scan_dir pinning-scan) || exit 0
 trap 'rm -rf "$SCAN_DIR"' EXIT
 
 case "$TOOL_NAME" in
@@ -106,8 +116,8 @@ case "$TOOL_NAME" in
     # 각 eligible path마다 added line만 모아 검사.
     # scan 파일명에 path 원문을 사용하지 않는다 — 긴 nested path가 NAME_MAX(보통 255 bytes)를
     # 초과하면 redirection이 'File name too long'으로 실패하고 set -e로 hook이 exit 1이 되어
-    # warn-only 계약을 위반한다 (#603 DA for_pr R2 Correctness-1/Regression-1). path는 보고용
-    # 변수로만 유지하고 scan 파일은 mktemp으로 익명 basename을 받는다.
+    # warn-only 계약을 위반한다. path는 보고용 변수로만 유지하고 scan 파일은 mktemp으로
+    # 익명 basename을 받는다.
     pinning_apply_patch_section_paths "$SECTIONS_FILE" | while IFS= read -r p; do
       [ -n "$p" ] || continue
       if ! pinning_should_check_path "$p"; then

--- a/modules/shared/programs/codex/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-guard.sh
@@ -40,7 +40,7 @@ fi
 # shellcheck source=../../../claude/files/lib/pinning-patterns.sh
 . "$PINNING_LIB"
 
-SCAN_DIR=$(hook_init_scan_dir pinning-guard) || exit 0
+SCAN_DIR=$(hook_init_scan_dir pinning-guard) || _deny_with_reason "[pinning-guard] failed to initialize scan workspace; denying by fail-closed policy."
 trap 'rm -rf "$SCAN_DIR"' EXIT
 
 _deny() {

--- a/modules/shared/programs/codex/files/hooks/pinning-guard.sh
+++ b/modules/shared/programs/codex/files/hooks/pinning-guard.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 # pinning-guard.sh — Codex PreToolUse hard-fail guard.
+# 패턴 SSOT: modules/shared/programs/claude/files/lib/pinning-patterns.sh.
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
+# 정책: PreToolUse fail-closed — lib 누락 시 deny JSON 반환 (보안 경계 유지).
 set -euo pipefail
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+_deny_with_reason() {
+  local reason="$1"
+  jq -n --arg reason "$reason" \
+    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
+  exit 0
+}
+
+# tool_name 사전 분기 — 비대상 tool 은 lib bootstrap 비용 없이 즉시 종료한다.
+# 이 순서는 fail-closed 경계의 영향 범위를 pinning 검사 대상 tool 로 한정한다.
 INPUT=$(cat)
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || exit 0
 
@@ -12,20 +24,23 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PINNING_LIB="${PINNING_PATTERNS_LIB:-$HOME/.codex/lib/pinning-patterns.sh}"
-if [ ! -f "$PINNING_LIB" ]; then
-  PINNING_LIB="$SCRIPT_DIR/../../../claude/files/lib/pinning-patterns.sh"
+# Bootstrap: hook-runtime.sh source. 미발견 시 fail-closed (deny).
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.codex/lib/hook-runtime.sh}"
+if [ ! -f "$HOOK_RUNTIME_LIB" ]; then
+  _deny_with_reason "[pinning-guard] shared pinning policy library is missing: hook-runtime.sh ($HOOK_RUNTIME_LIB). HOOK_RUNTIME_LIB env var 또는 ~/.codex/lib/ 설치 필요."
 fi
-if [ ! -f "$PINNING_LIB" ]; then
-  jq -n --arg reason "[pinning-guard] shared pinning policy library is missing: $PINNING_LIB" \
-    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
-  exit 0
+# shellcheck source=../../../claude/files/lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
+# pinning-patterns.sh 로드. 미발견 시 fail-closed (deny).
+PINNING_LIB=$(hook_load_lib PINNING_PATTERNS_LIB "$HOME/.codex/lib" pinning-patterns.sh) || PINNING_LIB=""
+if [ -z "$PINNING_LIB" ]; then
+  _deny_with_reason "[pinning-guard] shared pinning policy library is missing: pinning-patterns.sh. PINNING_PATTERNS_LIB env var 또는 ~/.codex/lib/pinning-patterns.sh 설치 필요."
 fi
 # shellcheck source=../../../claude/files/lib/pinning-patterns.sh
 . "$PINNING_LIB"
 
-SCAN_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pinning-guard-XXXXXX") || exit 0
+SCAN_DIR=$(hook_init_scan_dir pinning-guard) || exit 0
 trap 'rm -rf "$SCAN_DIR"' EXIT
 
 _deny() {
@@ -33,9 +48,7 @@ _deny() {
   local reason
   reason=$(printf '[pinning-guard] %s on %s contains volatile review/session metadata:%b\nUse stable identifiers or plain natural-language context before retrying.' \
     "$surface" "$target" "$findings")
-  jq -n --arg reason "$reason" \
-    '{hookSpecificOutput: {hookEventName: "PreToolUse", permissionDecision: "deny", permissionDecisionReason: $reason}}'
-  exit 0
+  _deny_with_reason "$reason"
 }
 
 _targeted_bash_command() {

--- a/modules/shared/programs/codex/files/hooks/record-last-stop.sh
+++ b/modules/shared/programs/codex/files/hooks/record-last-stop.sh
@@ -12,6 +12,8 @@ fi
 # 다른 Stop 훅보다 먼저 타임스탬프를 기록하여
 # statusline 카운트다운의 레이스 컨디션을 최소화한다.
 # Codex에서는 _stop-dispatcher.sh가 이 순서를 직렬로 보장한다 (issue #585).
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
+# 정책: hook-runtime.sh 미발견 시 inline fallback 자체 로직 실행 (자체 동작 보존).
 
 # stdin에서 세션 정보 읽기 (Codex 0.124+ schema는 agent_id 키 없음 — issue #585 DA C-2).
 # Claude 원본의 agent_id subagent guard는 Codex에서는 항상 비활성이므로 제거했다.
@@ -19,9 +21,17 @@ fi
 INPUT=""
 [ ! -t 0 ] && INPUT=$(cat)
 
-if [ -n "$INPUT" ]; then
-  # stdin JSON에서 session_id 파싱 (env var보다 신뢰성 높음)
-  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+# hook-runtime.sh source 시도. 실패 시 inline fallback 으로 session_id 파싱.
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.codex/lib/hook-runtime.sh}"
+if [ -f "$HOOK_RUNTIME_LIB" ] && command -v jq >/dev/null 2>&1; then
+  # shellcheck source=../../../claude/files/lib/hook-runtime.sh
+  . "$HOOK_RUNTIME_LIB"
+  [ -n "$INPUT" ] && SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
+else
+  # inline fallback — hook-runtime.sh 또는 jq 미발견 시 자체 파싱.
+  if [ -n "$INPUT" ] && command -v jq >/dev/null 2>&1; then
+    SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+  fi
 fi
 
 # fallback: env var → 빈 문자열

--- a/modules/shared/programs/codex/files/hooks/record-prompt-submit.sh
+++ b/modules/shared/programs/codex/files/hooks/record-prompt-submit.sh
@@ -8,6 +8,8 @@ if [ "${CLAUDECODE:-}" = "1" ] || [ "${CODEX_PROGRAMMATIC:-}" = "1" ]; then
 fi
 # record-prompt-submit.sh — 프롬프트 전송 시 캐시 TTL을 "in-flight" 상태로 전환
 # "0"을 기록하면 statusline.sh가 mtime 기준 카운트다운 표시 (Stop 미기록 상태)
+# 공통 helper SSOT: modules/shared/programs/claude/files/lib/hook-runtime.sh.
+# 정책: hook-runtime.sh 미발견 시 inline fallback 자체 로직 실행 (자체 동작 보존).
 
 # stdin에서 세션 정보 읽기 (Codex 0.124+ schema는 agent_id 키 없음 — issue #585 DA C-2).
 # Claude 원본의 agent_id subagent guard는 Codex에서는 항상 비활성이므로 제거했다.
@@ -15,9 +17,17 @@ fi
 INPUT=""
 [ ! -t 0 ] && INPUT=$(cat)
 
-if [ -n "$INPUT" ]; then
-  # stdin JSON에서 session_id 파싱 (env var보다 신뢰성 높음)
-  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+# hook-runtime.sh source 시도. 실패 시 inline fallback 으로 session_id 파싱.
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.codex/lib/hook-runtime.sh}"
+if [ -f "$HOOK_RUNTIME_LIB" ] && command -v jq >/dev/null 2>&1; then
+  # shellcheck source=../../../claude/files/lib/hook-runtime.sh
+  . "$HOOK_RUNTIME_LIB"
+  [ -n "$INPUT" ] && SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
+else
+  # inline fallback — hook-runtime.sh 또는 jq 미발견 시 자체 파싱.
+  if [ -n "$INPUT" ] && command -v jq >/dev/null 2>&1; then
+    SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+  fi
 fi
 
 # fallback: env var → 빈 문자열

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -1614,7 +1614,7 @@ verify_used_by_oracle() {
     # 변수 할당 + source 호출 패턴 둘 다 있어야 진짜 후보.
     if grep -qE "^[[:space:]]*[A-Z_]+_LIB=.*${_lib_basename_re}" "$_candidate" \
       && grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$[A-Z_]+_LIB\"" "$_candidate"; then
-      _candidate_abs_rel="${_candidate#$REPO_ROOT/}"
+      _candidate_abs_rel="${_candidate#"$REPO_ROOT"/}"
       _candidate_rel="${_candidate_abs_rel#modules/shared/programs/}"
       if ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_rel" \
         && ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_abs_rel"; then

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -1412,6 +1412,9 @@ _check_readable_symlink_suffix() {
 _pinning_lib_suffix="modules/shared/programs/claude/files/lib/pinning-patterns.sh"
 _check_readable_symlink_suffix ".claude/lib/pinning-patterns.sh" "$_pinning_lib_suffix"
 _check_readable_symlink_suffix ".codex/lib/pinning-patterns.sh" "$_pinning_lib_suffix"
+_hook_runtime_lib_suffix="modules/shared/programs/claude/files/lib/hook-runtime.sh"
+_check_readable_symlink_suffix ".claude/lib/hook-runtime.sh" "$_hook_runtime_lib_suffix"
+_check_readable_symlink_suffix ".codex/lib/hook-runtime.sh" "$_hook_runtime_lib_suffix"
 
 # Pinning patterns shared library 검사:
 #   scripts/ai/commit-msg-pinning.sh 및 Pre/PostToolUse pinning hook들이 공통 lib를 source한다.
@@ -1468,6 +1471,169 @@ _check_pinning_policy_text() {
 _check_pinning_policy_text "$REPO_ROOT/modules/shared/programs/claude/files/CLAUDE.md" "source CLAUDE.md"
 _check_pinning_policy_text "$HOME/.claude/CLAUDE.md" "\$HOME/.claude/CLAUDE.md"
 _check_pinning_policy_text "$HOME/.codex/AGENTS.md" "\$HOME/.codex/AGENTS.md"
+
+# ─── USED-BY oracle ───
+# claude/files/lib/ 의 공유 라이브러리 (pinning-patterns.sh, session-state.sh, hook-runtime.sh)
+# 헤더의 `# USED-BY:` 블록에 선언된 use-site 와 실제 source 호출 패턴 일치를 strict 검증한다.
+#
+# 각 USED-BY 라인은 `<path>   # via $VAR_NAME` 형식이어야 한다. 형식 위반 라인은 silent skip
+# 하지 않고 awk 가 `BAD\t<line>` sentinel 을 emit, shell 이 fail 로 보고한다.
+#
+# `via $VAR_NAME` 의 의미: use-site 의 source local 변수 (예: `PINNING_LIB`, `SESSION_STATE_LIB`,
+# `HOOK_RUNTIME_LIB`). hook_load_lib helper 의 env override 변수 (예: `PINNING_PATTERNS_LIB`)
+# 와는 다르다. helper 호출은 `<expected_var>=$(hook_load_lib <env_var> "..." <basename>)` 형태로
+# expected_var 변수에 할당하고 그 변수를 source 한다.
+#
+# 매칭 조건: 같은 파일에 `<expected_var>=...<lib_basename>...` 변수 할당 + `. "$<expected_var>"`
+# 또는 `source "$<expected_var>"` 호출. helper 호출도 변수 할당 RHS 의 일부이므로 같은 매칭이 적용된다.
+# `# shellcheck source=` 주석 라인은 oracle 대상에서 제외 (실제 source 호출이 아니므로).
+verify_used_by_oracle() {
+  local _lib_path="$1"
+  local _lib_label="$2"
+  local _lib_basename _lib_basename_re
+  _lib_basename=$(basename "$_lib_path")
+  _lib_basename_re=${_lib_basename//./\\.}
+  if [ ! -f "$_lib_path" ]; then
+    fail "USED-BY oracle: lib 파일 없음 ($_lib_label) — $_lib_path"
+    return
+  fi
+
+  # 헤더에서 USED-BY 블록 파싱. `^#[[:space:]]+` 로 시작하는 모든 indented 주석 라인을 후보로
+  # 처리하고, 라인 형식이 정확히 `<path>.sh   # via $VAR_NAME` 인지 strict 검증한다.
+  # 위반은 `BAD\t<line>` sentinel 로 emit 하여 shell loop 가 명시 fail. 정상은 `OK\t<path>\t<var>`.
+  # 빈 주석 (`^#$`) 또는 비-주석 라인 (`!/^#/`) 에서만 블록 종료.
+  #
+  # strict 형식 (고정 위치):
+  #   - arr[1] = path (`.sh` 로 끝나는 형태)
+  #   - arr[2] = `#` (구분자)
+  #   - arr[3] = `via` (literal)
+  #   - arr[4] = `$VAR_NAME` ($ prefix + `[A-Z_][A-Z0-9_]*` 형태)
+  #   - arr[5+] = 선택적 trailing 주석/설명 (검증 안 함)
+  local _used_by_entries
+  _used_by_entries=$(awk '
+    /^# USED-BY:/ { in_block=1; next }
+    in_block {
+      if (/^#$/ || !/^#/) {
+        in_block=0
+        next
+      }
+      if (/^#[[:space:]]+/) {
+        line = $0
+        sub(/^#[[:space:]]+/, "", line)
+        if (line == "") next
+        n = split(line, arr, /[[:space:]]+/)
+        if (n < 4) {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        path = arr[1]
+        if (path !~ "^[a-zA-Z][a-zA-Z0-9_./-]+\\.sh$") {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        if (arr[2] != "#" || arr[3] != "via") {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        var_raw = arr[4]
+        if (var_raw !~ "^\\$[A-Z_][A-Z0-9_]*$") {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        var = var_raw
+        sub(/^\$/, "", var)
+        printf "OK\t%s\t%s\n", path, var
+      }
+    }
+  ' "$_lib_path")
+
+  if [ -z "$_used_by_entries" ]; then
+    fail "USED-BY oracle: lib 헤더에 USED-BY 블록 없음 ($_lib_label)"
+    return
+  fi
+
+  local _ok=1
+  local _count=0
+  # Forward check: 선언된 각 use-site 가 실제 source 패턴을 가지는지 확인.
+  # Declared list: backward check 시 비교용. newline-delimited 정규화된 path 를 모아 두고
+  # grep -Fxq 로 set membership 검사. `declare -A` (Bash 4+) 회피하여 macOS /bin/bash 3.2 호환.
+  local _declared_list=""
+  while IFS=$'\t' read -r _tag _arg1 _arg2; do
+    [ -n "$_tag" ] || continue
+    if [ "$_tag" = "BAD" ]; then
+      fail "USED-BY oracle: $_lib_label 헤더의 USED-BY 라인 형식 위반 ($_arg1) — \`<path>.sh   # via \$VAR_NAME\` 형식 필요"
+      _ok=0
+      continue
+    fi
+    local _use_site="$_arg1" _expected_var="$_arg2"
+    [ -n "$_use_site" ] || continue
+    _count=$((_count + 1))
+    _declared_list="${_declared_list}${_use_site}"$'\n'
+    local _use_full_path
+    case "$_use_site" in
+      claude/*|codex/*)
+        _use_full_path="$REPO_ROOT/modules/shared/programs/$_use_site"
+        ;;
+      *)
+        _use_full_path="$REPO_ROOT/$_use_site"
+        ;;
+    esac
+    if [ ! -f "$_use_full_path" ]; then
+      fail "USED-BY oracle: 선언된 use-site 미존재 ($_lib_label → $_use_site)"
+      _ok=0
+      continue
+    fi
+    # 주석 라인 제외 (특히 `# shellcheck source=`).
+    local _non_comment
+    _non_comment=$(grep -vE '^[[:space:]]*#' "$_use_full_path")
+
+    # 단일 매칭 규칙: expected_var (use-site source local 변수) 의 할당 RHS 가 lib_basename 포함
+    # + 동일 var 의 source 호출. hook_load_lib helper 호출은 변수 할당 RHS 의 일부이므로 같은 매칭 적용.
+    if printf '%s\n' "$_non_comment" | grep -qE "^[[:space:]]*${_expected_var}=.*${_lib_basename_re}" \
+      && printf '%s\n' "$_non_comment" | grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$${_expected_var}\""; then
+      continue
+    fi
+    fail "USED-BY oracle: $_lib_label → $_use_site 에서 실제 source 패턴 미발견 (\$${_expected_var} 변수 할당 RHS 에 ${_lib_basename} 포함 + 동일 var source 필요)"
+    _ok=0
+  done <<< "$_used_by_entries"
+
+  # Backward check: repo 내에서 lib_basename 을 변수 할당 RHS 로 사용 + 동일 var source 호출이
+  # 있는 .sh 파일을 후보로 수집한 뒤, _declared_list 에 없는 후보는 fail.
+  # 이는 `실제 source 하지만 USED-BY 헤더에 미선언` 인 drift 를 잡는다 (양방향 검증).
+  # 검색 범위: modules/shared/programs/ + scripts/. 자기 자신 lib path 는 제외.
+  local _candidate _candidate_rel _candidate_abs_rel
+  while IFS= read -r _candidate; do
+    [ -n "$_candidate" ] || continue
+    # 자기 자신 (lib 정의 파일) 제외.
+    [ "$_candidate" = "$_lib_path" ] && continue
+    # lib 자체 디렉토리 내 다른 lib 파일은 제외 (예: hook-runtime 검증 시 pinning-patterns 본문 매치).
+    case "$_candidate" in
+      */modules/shared/programs/claude/files/lib/*) continue ;;
+      */modules/shared/programs/codex/files/lib/*) continue ;;
+    esac
+    # 변수 할당 + source 호출 패턴 둘 다 있어야 진짜 후보.
+    if grep -qE "^[[:space:]]*[A-Z_]+_LIB=.*${_lib_basename_re}" "$_candidate" \
+      && grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$[A-Z_]+_LIB\"" "$_candidate"; then
+      _candidate_abs_rel="${_candidate#$REPO_ROOT/}"
+      _candidate_rel="${_candidate_abs_rel#modules/shared/programs/}"
+      if ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_rel" \
+        && ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_abs_rel"; then
+        fail "USED-BY oracle: $_lib_label backward check 실패 — $_candidate_rel 가 lib 을 source 하지만 USED-BY 헤더에 미선언"
+        _ok=0
+      fi
+    fi
+  done < <(grep -rlE "${_lib_basename_re}" \
+    --include='*.sh' \
+    "$REPO_ROOT/modules/shared/programs/" "$REPO_ROOT/scripts/" 2>/dev/null)
+
+  if [ "$_ok" = "1" ]; then
+    pass "USED-BY oracle 통과: $_lib_label ($_count use-site, backward check OK)"
+  fi
+}
+
+verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/pinning-patterns.sh" "pinning-patterns.sh"
+verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/session-state.sh" "session-state.sh"
+verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" "hook-runtime.sh"
 
 # fixture self-test (deterministic, live 미실행).
 if [ ! -x "$_active_hooks_runner" ]; then

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -67,6 +67,7 @@ TEST_TMP_FILE="$(mktemp "${TMPDIR:-/tmp}/codex-hook-fixtures-list.XXXXXX")"
 
 HOOK_REPO_DIR="$REPO_ROOT/modules/shared/programs/codex/files/hooks"
 PINNING_LIB_REPO_FILE="$REPO_ROOT/modules/shared/programs/claude/files/lib/pinning-patterns.sh"
+HOOK_RUNTIME_LIB_REPO_FILE="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh"
 # verify-ai-compat의 _TEMPLATE 분기와 동일하게 host platform에 맞는 template을 sync-preservation
 # 검증에 사용한다. Darwin은 mcp_servers.chrome-devtools 같은 platform-specific managed leaves를
 # 추가로 가지므로 platform-agnostic 검증은 부족하다.
@@ -169,6 +170,8 @@ new_hook_sandbox() {
   chmod +x "$sandbox/home/.codex/hooks/"*.sh
   cp -L "$PINNING_LIB_REPO_FILE" "$sandbox/home/.codex/lib/"
   cp -L "$PINNING_LIB_REPO_FILE" "$sandbox/home/.claude/lib/"
+  cp -L "$HOOK_RUNTIME_LIB_REPO_FILE" "$sandbox/home/.codex/lib/"
+  cp -L "$HOOK_RUNTIME_LIB_REPO_FILE" "$sandbox/home/.claude/lib/"
 
   printf '%s\n' "$sandbox"
 }
@@ -216,7 +219,7 @@ _exec_with_sandbox_env() {
   if [[ -n "$env_pairs_string" ]]; then
     read -ra env_array <<<"$env_pairs_string"
   fi
-  env -u CLAUDECODE -u CODEX_PROGRAMMATIC -u PINNING_PATTERNS_LIB "${env_array[@]}" \
+  env -u CLAUDECODE -u CODEX_PROGRAMMATIC -u PINNING_PATTERNS_LIB -u HOOK_RUNTIME_LIB "${env_array[@]}" \
       PATH="$sandbox/bin-stubs:${PATH:-/usr/bin:/bin}" \
       HOME="$sandbox/home" \
       XDG_DATA_HOME="$sandbox/xdg-data" \
@@ -979,6 +982,29 @@ $unexpected"
   if [ -s "$stdout_log" ]; then
     unexpected="$(head -40 "$stdout_log")"
     fail "[7b/meta] host PINNING_PATTERNS_LIB leak check: expected clean pass with empty stdout, got:
+$unexpected"
+  fi
+
+  # Issue #759 — host HOOK_RUNTIME_LIB leak check.
+  sandbox=$(new_hook_sandbox)
+  stdout_log="$sandbox/pretooluse-hookruntime-leak-stdout.log"
+  stderr_log="$sandbox/pretooluse-hookruntime-leak-stderr.log"
+  if HOOK_RUNTIME_LIB="$sandbox/host-leaked-hook-runtime.sh" \
+      _exec_with_sandbox_env "$sandbox" "" "$sandbox/home/.codex/hooks/pinning-guard.sh" \
+        < "$clean_fixture" >"$stdout_log" 2>"$stderr_log"; then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+  assert_eq "$exit_code" "0" "[7b/meta] host HOOK_RUNTIME_LIB leak check: hook must exit 0"
+  if [ -s "$stderr_log" ]; then
+    unexpected="$(head -40 "$stderr_log")"
+    fail "[7b/meta] host HOOK_RUNTIME_LIB leak check: expected empty stderr, got:
+$unexpected"
+  fi
+  if [ -s "$stdout_log" ]; then
+    unexpected="$(head -40 "$stdout_log")"
+    fail "[7b/meta] host HOOK_RUNTIME_LIB leak check: expected clean pass with empty stdout, got:
 $unexpected"
   fi
 


### PR DESCRIPTION
## Summary

claude/codex 양 트리의 동명 hook 5개 (`nrs-session-cleanup`, `pinning-alert`, `pinning-guard`, `record-last-stop`, `record-prompt-submit`) 의 공통 helper 를 신규 lib `hook-runtime.sh` 로 추출. codex pinning hook 의 `../../../claude/files/lib/` cross-tree 상대경로 fallback 제거. lib 헤더에 USED-BY 주석 + `verify-ai-compat.sh` oracle 추가.

Closes #759

## 핵심 결정

- **공통 코어 4 helper**: `hook_load_lib` (3-arg signature), `hook_init_scan_dir`, `hook_parse_tool_name`, `hook_parse_session_id`. 런타임별 전용 함수 (apply_patch envelope dispatch, CLAUDECODE/CODEX_PROGRAMMATIC 가드, agent_id 가드) 는 hook 본문 inline 유지.
- **hook 별 lib 누락 실패 정책 분리**:
  - `pinning-guard` (PreToolUse hard-fail) — deny JSON 반환 (fail-closed 보존)
  - `pinning-alert` (PostToolUse warn-only) — stderr 경고 + exit 0
  - `record-last-stop` / `record-prompt-submit` — inline fallback 자체 로직 실행 (lib 없이도 동작 보존)
  - `nrs-session-cleanup` — lib 의존성 없음
- **codex pinning hook tool_name 사전 분기**: lib bootstrap 이전으로 두어 비대상 tool 에 대한 fail-closed/warn-only 영향 차단
- **nix 외부 직접 실행**: silent no-op 대신 명확한 stderr 에러 메시지 + 필요한 env var 안내 출력
- **USED-BY oracle**: lib 헤더의 USED-BY 블록 strict 형식 (`<path>.sh # via \$VAR_NAME`) 검증 + 양방향 (forward + backward) source 일치 검증. Bash 3.2 호환 newline-list 사용 (declare -A 회피)
- **공통 lib subtree 위치**: claude 유지 (기존 `pinning-patterns.sh`/`session-state.sh` 패턴 일관성). 별도 `modules/shared/programs/hooks/` shared subtree 신설은 follow-up 이슈로 분리

## 변경 대상 파일 (15개)

신규: `modules/shared/programs/claude/files/lib/hook-runtime.sh`

수정:
- `modules/shared/programs/{claude,codex}/files/hooks/{pinning-alert,pinning-guard,record-last-stop,record-prompt-submit}.sh` (8개)
- `modules/shared/programs/{claude,codex}/default.nix` (2개) — `hook-runtime.sh` mkOutOfStoreSymlink entry
- `modules/shared/programs/claude/files/lib/{pinning-patterns,session-state}.sh` (2개) — USED-BY 주석 추가
- `scripts/ai/verify-ai-compat.sh` — USED-BY oracle 추가 + `hook-runtime.sh` 배포 symlink check
- `tests/test-codex-hook-fixtures.sh` — `hook-runtime.sh` sandbox copy + `HOOK_RUNTIME_LIB` env unset + leak check 신규 케이스

`nrs-session-cleanup.sh` 는 claude/codex 본문이 이미 동일이라 변경 없음.

## 검증

- shellcheck `-S warning` 15 파일 통과
- cross-tree 상대경로 잔존 검사 0건 (`! grep -rn '\.\./\.\./\.\./claude/files/lib' modules/shared/programs/codex/files/hooks/`)
- `verify-ai-compat.sh` USED-BY oracle 통과 (pinning-patterns 5 use-site + session-state 3 + hook-runtime 8 = 합 16 use-site, 양방향 검증 OK)
- `tests/test-codex-hook-fixtures.sh --no-live` 모든 시나리오 통과 (missing-lib + HOOK_RUNTIME_LIB sandbox leak check 신규 추가)
- `scripts/ai/verify-ai-compat.sh` 통과
- `nix build .#darwinConfigurations.greenhead-MacBookPro.system` 통과
- 구현 후 외부 검토 6회 사이클 진행 — 누적 26건 반영, 7건은 의도된 결정과 일치 (NOT_AN_ISSUE)

## 머지 순서 안내

- **#764 (verify-ai-compat.sh 분할 가부 측정 RFC, OPEN)**: 본 PR 이 `verify-ai-compat.sh` 에 USED-BY oracle (`verify_used_by_oracle` 함수, ~166 라인) 을 추가하므로 #764 측정 chunk 와 동일 파일을 수정합니다. #764 측정 착수 시 본 PR 머지 여부를 baseline 으로 고정 부탁드립니다.
- **#761 (commit-msg evidence trail lint, OPEN)**: 본 PR 은 `pinning-patterns.sh` 헤더에 USED-BY 주석 9 라인 추가만 합니다. blocked-by 는 아니지만 동일 파일 soft 머지 충돌 가능 — 머지 순서 주의.

## Follow-up 이슈 후보

- shared lib subtree 신설 (NG-3 광범위 refactor 회피로 본 PR scope 밖):
  `modules/shared/programs/hooks/files/lib/` 같은 별도 shared subtree 로 `pinning-patterns.sh` + `session-state.sh` + `hook-runtime.sh` 이동. 외부 검토 Design reviewer 가 plan-mode 단계에서 권장 (HIGH→MEDIUM 으로 조정 후 follow-up 으로 분리). 본 변경은 기존 cross-tree symlink 패턴 일관성 유지.

## Test plan

- [ ] `nrs` 실행 후 \`~/.{claude,codex}/lib/hook-runtime.sh\` symlink 생성 확인
- [ ] PreToolUse Edit positive (박제 패턴 포함) → deny (claude+codex 양쪽)
- [ ] PreToolUse Edit negative (정상) → allow
- [ ] PreToolUse apply_patch positive (codex) → deny
- [ ] PreToolUse apply_patch negative (codex) → allow
- [ ] PostToolUse Edit positive → stderr alert
- [ ] PostToolUse Edit negative → no alert
- [ ] Stop trigger → record-last-stop 타임스탬프 기록 + nrs-session-cleanup lock 해제
- [ ] UserPromptSubmit trigger → record-prompt-submit "0" 기록

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated hook runtime utilities into a shared library for improved consistency and reliability across Claude and Codex integrations.
  * Updated hooks to implement fail-closed behavior with improved error handling when shared libraries are unavailable.

* **Tests**
  * Added verification checks to ensure consistent library usage patterns and sandbox isolation in hook fixtures.

* **Documentation**
  * Added usage tracking documentation to shared libraries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->