### PR TITLE
fix(pinning): equal-count B→C workflow 우회 차단 + records 정렬 (#779)

### DIFF
--- a/modules/shared/programs/claude/files/CLAUDE.md
+++ b/modules/shared/programs/claude/files/CLAUDE.md
@@ -9,7 +9,9 @@
 - 커밋 메시지, PR/이슈 본문/댓글, markdown, shell, notebook, body temp 파일에는 일회성 리뷰/세션 메타데이터를 박제하지 말라.
 - Claude/Codex PreToolUse `pinning-guard.sh`는 supported edit/apply_patch tools와 targeted git/gh durable commands에서 해당 메타데이터가 새 durable output으로 들어가면 hard-fail한다.
 - PostToolUse `pinning-alert.sh`와 commit-msg `commit-msg-pinning.sh`는 같은 shared pattern library를 사용하는 warn-only 보조 신호다.
-- Canonical non-traversal PRD/plan path(`.claude/prds/*`, `.claude/plans/*`)에서는 PATTERN_A만 예외적으로 허용한다. PATTERN_B/C는 해당 path에서도 계속 차단/경고한다.
+- Canonical non-traversal PRD/plan path(`.claude/prds/*`, `.claude/plans/*`)에서는 PATTERN_A가 예외적으로 허용된다.
+- PRD/plan path + body temp draft path + issue-draft staging path에서는 PATTERN_C의 워크플로 sub-pattern(실행 모드 호출 키워드 두 토큰)이 예외적으로 허용된다.
+- PATTERN_B와 PATTERN_C의 휘발성 sub-pattern(라운드 카운터 결합형 / 번호 reviewer 라벨 / 후속 액션 결합 토큰)은 해당 path에서도 계속 차단/경고한다.
 - 차단되면 리뷰 실행명이나 임시 finding id 대신 안정적인 대상 이름과 자연어 근거로 다시 작성한다.
 - Commit hash 약식 인용은 PR 번호 또는 머지된 long SHA 같은 안정적 식별자로 대체하라 — squash/rebase 후 dangling되어 trace 추적이 깨질 수 있다.
 

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -181,6 +181,13 @@ pinning_should_check_path() {
 # enumeration for the workflow-allow path taxonomy. Path helpers + the
 # raw-shape classifier delegate to this so the supported policy categories
 # (PRD/plan, body temp, issue-draft) stay in lockstep.
+#
+# Args:
+#   $1 path     — already canonicalized (or raw, for the D-1 classifier) path
+#   $2 category — one of "prd_or_plan", "body_temp", "issue_draft"
+#   $3 root     — required only for category="prd_or_plan" (project root for
+#                 the `.claude/{prds,plans}/*` glob). Ignored by the other
+#                 categories; caller may omit the argument or pass "".
 _pinning_path_category_glob_match() {
   local path="$1" category="$2" root="${3:-}"
   case "$category" in
@@ -271,16 +278,15 @@ pinning_is_issue_draft_path() {
   _pinning_path_category_glob_match "$path" "issue_draft"
 }
 
-# Workflow allow predicate for PreToolUse hard-fail. Returns 0 when the
-# canonicalized path is one of the policy categories (PRD / plan / body temp /
-# issue-draft). Traversal raw paths are fail-closed so this never opens a
-# bypass for volatile metadata.
 # Raw-tolerant workflow policy shape classifier. Distinct from the fail-closed
 # allow predicate (pinning_allows_workflow_pattern_c_for_path): this helper
 # runs on the raw input string so the D-1 token-delta branch can route
 # traversal raw paths whose shape would have matched a workflow policy
 # category if they had been canonical. Shares the path-category glob source
-# via _pinning_path_category_glob_match. Used by D-1 only.
+# via _pinning_path_category_glob_match. The helper is intentionally kept
+# separate from the allow predicate (single caller is OK) so the two
+# opposite responsibilities — fail-closed allow vs traversal-tolerant shape —
+# never share an interface. Used by D-1 only.
 _pinning_raw_path_is_workflow_policy_shape() {
   local raw="$1"
   local root
@@ -293,6 +299,13 @@ _pinning_raw_path_is_workflow_policy_shape() {
   return 1
 }
 
+# Workflow allow predicate for PreToolUse hard-fail. Returns 0 when the
+# canonicalized path is one of the policy categories (PRD / plan / body temp /
+# issue-draft). Traversal raw paths are fail-closed so this never opens a
+# bypass for volatile metadata. The body re-checks traversal after
+# canonicalize because `realpath -m` does not always collapse `../` (e.g.
+# when an intermediate symlink escapes the policy directory), so the second
+# pass keeps the fail-closed contract under all canonicalize paths.
 pinning_allows_workflow_pattern_c_for_path() {
   local raw="$1"
   if _pinning_raw_path_has_traversal "$raw"; then
@@ -375,23 +388,19 @@ pinning_apply_patch_section_lines_for_path() {
   ' "$sections_file"
 }
 
-# Generic raw matcher for A/B/C — emits TSV records.
-# Optional 5th argument `sub` carries a stable sub-category tag (e.g.
-# "workflow" / "volatile") so consumers can branch on PATTERN_C sub-patterns
-# without re-parsing the matched token text. When empty, the 4-th column is
-# omitted so legacy 3-column consumers keep working.
+# Generic raw matcher for A/B — emits 3-column TSV records.
+# PATTERN_C sub-pattern handling lives in `_pinning_pattern_c_records_sorted`,
+# which emits the optional 4-th `sub_tag` column (workflow / volatile) so
+# consumers can branch on the sub-pattern without re-parsing the matched
+# token text.
 _pinning_simple_records() {
-  local scan_file="$1" code="$2" pattern="$3" label="$4" sub_tag="${5:-}"
+  local scan_file="$1" code="$2" pattern="$3" label="$4"
   grep -noE "$pattern" "$scan_file" 2>/dev/null \
-    | awk -F: -v code="$code" -v label="$label" -v sub_tag="$sub_tag" '
+    | awk -F: -v code="$code" -v label="$label" '
         {
           lineno = $1
           tok = substr($0, length(lineno) + 2)
-          if (sub_tag != "") {
-            print code "\t" label "\t" lineno ": " tok "\t" sub_tag
-          } else {
-            print code "\t" label "\t" lineno ": " tok
-          }
+          print code "\t" label "\t" lineno ": " tok
         }
       ' || true
 }
@@ -406,27 +415,23 @@ _pinning_simple_records() {
 # sort-key columns before yielding the canonical TSV record format.
 _pinning_pattern_c_records_sorted() {
   local scan_file="$1"
+  # awk script body — single-quoted on purpose so awk vars ($1/$2/$0) are not
+  # expanded by the shell. label / sub_tag are injected via `awk -v` below.
+  # shellcheck disable=SC2016
+  local _awk_emit='
+        {
+          lineno = $1
+          byteoff = $2
+          prefix_len = length(lineno) + length(byteoff) + 2
+          tok = substr($0, prefix_len + 1)
+          printf "%d\t%d\tC\t%s\t%d: %s\t%s\n", lineno, byteoff, label, lineno, tok, sub_tag
+        }
+      '
   {
     grep -bnoE "$PINNING_PATTERN_C_WORKFLOW" "$scan_file" 2>/dev/null \
-      | awk -F: -v label="$PINNING_PATTERN_C_LABEL" '
-          {
-            lineno = $1
-            byteoff = $2
-            prefix_len = length(lineno) + length(byteoff) + 2
-            tok = substr($0, prefix_len + 1)
-            printf "%d\t%d\tC\t%s\t%d: %s\tworkflow\n", lineno, byteoff, label, lineno, tok
-          }
-        ' || true
+      | awk -F: -v label="$PINNING_PATTERN_C_LABEL" -v sub_tag="workflow" "$_awk_emit" || true
     grep -bnoE "$PINNING_PATTERN_C_VOLATILE" "$scan_file" 2>/dev/null \
-      | awk -F: -v label="$PINNING_PATTERN_C_LABEL" '
-          {
-            lineno = $1
-            byteoff = $2
-            prefix_len = length(lineno) + length(byteoff) + 2
-            tok = substr($0, prefix_len + 1)
-            printf "%d\t%d\tC\t%s\t%d: %s\tvolatile\n", lineno, byteoff, label, lineno, tok
-          }
-        ' || true
+      | awk -F: -v label="$PINNING_PATTERN_C_LABEL" -v sub_tag="volatile" "$_awk_emit" || true
   } | sort -t$'\t' -k1,1n -k2,2n \
     | cut -f3-
 }
@@ -624,6 +629,9 @@ pinning_guard_findings_records_for_path() {
 
   if _pinning_raw_path_has_traversal "$path" \
      && _pinning_raw_path_is_workflow_policy_shape "$path"; then
+    # is_prd_or_plan="" + allows_workflow="" — traversal raw paths must keep
+    # the workflow deny contract (no PATTERN_A suppression, no workflow
+    # suppression) so the token-delta surfaces the smuggled workflow token.
     _pinning_new_findings_records_for_state \
       "$old_scan_file" "$new_scan_file" "" ""
     return

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -62,6 +62,18 @@ pinning_canonicalize_path() {
   printf '%s\n' "$canon"
 }
 
+# Raw traversal segment matcher. Consolidates the
+# `*'/../'* | '../'* | *'/..' | '..'` glob check used across path-aware
+# helpers and the D-1 token-delta trigger so a future tweak only updates
+# this single shape. Returns 0 when the input contains a true traversal
+# segment, non-zero otherwise.
+_pinning_raw_path_has_traversal() {
+  case "$1" in
+    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
+  esac
+  return 1
+}
+
 pinning_canonicalize_existing_parent_path() {
   local raw="$1"
   local abs dir suffix parent
@@ -89,9 +101,9 @@ pinning_project_root_path() {
   local root="${PINNING_PROJECT_ROOT:-}"
   local canon
   if [ -n "$root" ]; then
-    case "$root" in
-      *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-    esac
+    if _pinning_raw_path_has_traversal "$root"; then
+      return 1
+    fi
   elif command -v git >/dev/null 2>&1; then
     root="$(git rev-parse --show-toplevel 2>/dev/null)" || root=""
   fi
@@ -103,9 +115,9 @@ pinning_project_root_path() {
     canon="$(pinning_canonicalize_existing_parent_path "$root")"
   fi
   [ -n "$canon" ] || return 1
-  case "$canon" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$canon"; then
+    return 1
+  fi
   printf '%s\n' "$canon"
 }
 
@@ -116,9 +128,9 @@ pinning_should_check_path() {
   # Match only true segment traversal patterns (`/../`, leading `../`,
   # trailing `/..`) instead of any literal `..` so files whose name happens
   # to contain `..` (e.g. `README..md`) keep the existing exempt contract.
-  case "$raw" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$raw"; then
+    return 0
+  fi
   local path
   path="$(pinning_canonicalize_path "$raw")"
   if [ -z "$path" ] && [ ! -L "$raw" ]; then
@@ -130,9 +142,9 @@ pinning_should_check_path() {
     # that we cannot trust.
     return 0
   fi
-  case "$path" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 0 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$path"; then
+    return 0
+  fi
 
   # Eligibility taxonomy goes through helper composition so canonical aliases
   # and issue-draft staging stay in lockstep with the workflow allow predicate.
@@ -165,13 +177,41 @@ pinning_should_check_path() {
   return 0
 }
 
+# Workflow policy path category glob source. Single owner of the glob
+# enumeration for the workflow-allow path taxonomy. Path helpers + the
+# raw-shape classifier delegate to this so the supported policy categories
+# (PRD/plan, body temp, issue-draft) stay in lockstep.
+_pinning_path_category_glob_match() {
+  local path="$1" category="$2" root="${3:-}"
+  case "$category" in
+    prd_or_plan)
+      [ -n "$root" ] || return 1
+      case "$path" in
+        "$root"/.claude/prds/* | "$root"/.claude/plans/*) return 0 ;;
+      esac
+      ;;
+    body_temp)
+      case "$path" in
+        /tmp/*-body* | /var/folders/*/T/*-body*) return 0 ;;
+        /private/tmp/*-body* | /private/var/folders/*/T/*-body*) return 0 ;;
+      esac
+      ;;
+    issue_draft)
+      case "$path" in
+        /tmp/issue-draft/* | /private/tmp/issue-draft/*) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
 pinning_is_prd_or_plan_path() {
   local raw="$1"
   # Keep this helper fail-closed. It grants a narrow category skip, so path
   # traversal must not be normalized into an allowed PRD/plan segment.
-  case "$raw" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$raw"; then
+    return 1
+  fi
 
   local path root
   path="$(pinning_canonicalize_path "$raw")"
@@ -179,17 +219,14 @@ pinning_is_prd_or_plan_path() {
     path="$(pinning_canonicalize_existing_parent_path "$raw")"
   fi
   [ -n "$path" ] || return 1
-  case "$path" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$path"; then
+    return 1
+  fi
 
   root="$(pinning_project_root_path)" || return 1
   [ -n "$root" ] || return 1
 
-  case "$path" in
-    "$root"/.claude/prds/* | "$root"/.claude/plans/*) return 0 ;;
-    *) return 1 ;;
-  esac
+  _pinning_path_category_glob_match "$path" "prd_or_plan" "$root"
 }
 
 # Canonicalize a raw path for policy-category matching with fail-closed
@@ -198,18 +235,18 @@ pinning_is_prd_or_plan_path() {
 # non-zero exit as "this path is outside any policy category" and bail.
 _pinning_canonical_policy_path_fail_closed() {
   local raw="$1"
-  case "$raw" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$raw"; then
+    return 1
+  fi
   local path
   path="$(pinning_canonicalize_path "$raw")"
   if [ -z "$path" ] && [ ! -L "$raw" ]; then
     path="$(pinning_canonicalize_existing_parent_path "$raw")"
   fi
   [ -n "$path" ] || return 1
-  case "$path" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-  esac
+  if _pinning_raw_path_has_traversal "$path"; then
+    return 1
+  fi
   printf '%s\n' "$path"
 }
 
@@ -222,11 +259,7 @@ _pinning_canonical_policy_path_fail_closed() {
 pinning_is_body_temp_path() {
   local path
   path="$(_pinning_canonical_policy_path_fail_closed "$1")" || return 1
-  case "$path" in
-    /tmp/*-body* | /var/folders/*/T/*-body*) return 0 ;;
-    /private/tmp/*-body* | /private/var/folders/*/T/*-body*) return 0 ;;
-  esac
-  return 1
+  _pinning_path_category_glob_match "$path" "body_temp"
 }
 
 # Issue / PR body draft staging directory. Separate from body_temp so the
@@ -235,24 +268,49 @@ pinning_is_body_temp_path() {
 pinning_is_issue_draft_path() {
   local path
   path="$(_pinning_canonical_policy_path_fail_closed "$1")" || return 1
-  case "$path" in
-    /tmp/issue-draft/* | /private/tmp/issue-draft/*) return 0 ;;
-  esac
-  return 1
+  _pinning_path_category_glob_match "$path" "issue_draft"
 }
 
 # Workflow allow predicate for PreToolUse hard-fail. Returns 0 when the
 # canonicalized path is one of the policy categories (PRD / plan / body temp /
 # issue-draft). Traversal raw paths are fail-closed so this never opens a
 # bypass for volatile metadata.
+# Raw-tolerant workflow policy shape classifier. Distinct from the fail-closed
+# allow predicate (pinning_allows_workflow_pattern_c_for_path): this helper
+# runs on the raw input string so the D-1 token-delta branch can route
+# traversal raw paths whose shape would have matched a workflow policy
+# category if they had been canonical. Shares the path-category glob source
+# via _pinning_path_category_glob_match. Used by D-1 only.
+_pinning_raw_path_is_workflow_policy_shape() {
+  local raw="$1"
+  local root
+  root="$(pinning_project_root_path 2>/dev/null)" || root=""
+  if _pinning_path_category_glob_match "$raw" "prd_or_plan" "$root" \
+     || _pinning_path_category_glob_match "$raw" "body_temp" \
+     || _pinning_path_category_glob_match "$raw" "issue_draft"; then
+    return 0
+  fi
+  return 1
+}
+
 pinning_allows_workflow_pattern_c_for_path() {
   local raw="$1"
-  case "$raw" in
-    *'/../'* | '../'* | *'/..' | '..' ) return 1 ;;
-  esac
-  if pinning_is_prd_or_plan_path "$raw" \
-     || pinning_is_body_temp_path "$raw" \
-     || pinning_is_issue_draft_path "$raw"; then
+  if _pinning_raw_path_has_traversal "$raw"; then
+    return 1
+  fi
+  local path root
+  path="$(pinning_canonicalize_path "$raw")"
+  if [ -z "$path" ] && [ ! -L "$raw" ]; then
+    path="$(pinning_canonicalize_existing_parent_path "$raw")"
+  fi
+  [ -n "$path" ] || return 1
+  if _pinning_raw_path_has_traversal "$path"; then
+    return 1
+  fi
+  root="$(pinning_project_root_path 2>/dev/null)" || root=""
+  if _pinning_path_category_glob_match "$path" "prd_or_plan" "$root" \
+     || _pinning_path_category_glob_match "$path" "body_temp" \
+     || _pinning_path_category_glob_match "$path" "issue_draft"; then
     return 0
   fi
   return 1
@@ -338,6 +396,41 @@ _pinning_simple_records() {
       ' || true
 }
 
+# Category C emitter that interleaves the workflow + volatile sub-pattern
+# hits by line and same-line byte offset so the rendered record order
+# matches the file's left-to-right scan order (the order a single combined
+# grep would have produced). Without this, two separate sub-pattern grep
+# calls would emit all workflow records before any volatile record even when
+# the volatile token comes earlier in the file. Uses `grep -bno` to expose
+# the byte offset for tie-breaking inside the same line and strips the
+# sort-key columns before yielding the canonical TSV record format.
+_pinning_pattern_c_records_sorted() {
+  local scan_file="$1"
+  {
+    grep -bnoE "$PINNING_PATTERN_C_WORKFLOW" "$scan_file" 2>/dev/null \
+      | awk -F: -v label="$PINNING_PATTERN_C_LABEL" '
+          {
+            lineno = $1
+            byteoff = $2
+            prefix_len = length(lineno) + length(byteoff) + 2
+            tok = substr($0, prefix_len + 1)
+            printf "%d\t%d\tC\t%s\t%d: %s\tworkflow\n", lineno, byteoff, label, lineno, tok
+          }
+        ' || true
+    grep -bnoE "$PINNING_PATTERN_C_VOLATILE" "$scan_file" 2>/dev/null \
+      | awk -F: -v label="$PINNING_PATTERN_C_LABEL" '
+          {
+            lineno = $1
+            byteoff = $2
+            prefix_len = length(lineno) + length(byteoff) + 2
+            tok = substr($0, prefix_len + 1)
+            printf "%d\t%d\tC\t%s\t%d: %s\tvolatile\n", lineno, byteoff, label, lineno, tok
+          }
+        ' || true
+  } | sort -t$'\t' -k1,1n -k2,2n \
+    | cut -f3-
+}
+
 # Structured findings API. Output: TSV records, one per match.
 # Format: <category_code>\t<label>\t<line>:<token>[\t<sub>]
 # - category_code: stable identifier (A/B/C) — callers branch on this
@@ -353,8 +446,7 @@ pinning_findings_records() {
 
   _pinning_simple_records "$scan_file" "A" "$PATTERN_A" "$PINNING_PATTERN_A_LABEL"
   _pinning_simple_records "$scan_file" "B" "$PATTERN_B" "$PINNING_PATTERN_B_LABEL"
-  _pinning_simple_records "$scan_file" "C" "$PINNING_PATTERN_C_WORKFLOW" "$PINNING_PATTERN_C_LABEL" "workflow"
-  _pinning_simple_records "$scan_file" "C" "$PINNING_PATTERN_C_VOLATILE" "$PINNING_PATTERN_C_LABEL" "volatile"
+  _pinning_pattern_c_records_sorted "$scan_file"
 }
 
 _pinning_findings_records_for_prd_or_plan_state() {
@@ -497,9 +589,23 @@ _pinning_new_findings_records_for_state() {
 # PreToolUse hard-fail records API (delta-aware). Used by Edit/Write/NotebookEdit
 # branches where old + new scan files are both available. Path-aware semantics:
 # - PRD/plan path: token delta (consistent with existing PRD/plan behavior).
-# - non-PRD/plan path: outside count-gate — emit records only when the
+# - traversal raw path whose shape matches a workflow policy category
+#   (body temp / issue-draft / PRD-plan canonical alias): token delta with
+#   allows_workflow="" so workflow tokens are not suppressed. The
+#   workflow allow predicate fail-closes on traversal raw paths, so without
+#   this branch an equal-count `category-B token → category-C workflow token`
+#   replacement at a traversal raw path would slip past the outside
+#   count-gate (new_count == old_count) and pin a workflow token into a
+#   durably-shared body. The split helpers separate the trigger
+#   (_pinning_raw_path_has_traversal + _pinning_raw_path_is_workflow_policy_shape)
+#   from the fail-closed allow predicate so each helper keeps a single
+#   responsibility. Token-delta applies to the full delta surface — equal-count
+#   replacements and `old_count > new_count` edits that introduce a new token
+#   are both denied, matching the security intent.
+# - other non-PRD/plan path: outside count-gate — emit records only when the
 #   workflow-suppressed new-count strictly exceeds the workflow-suppressed
-#   old-count. This preserves the existing outside equal-count clean contract.
+#   old-count. This preserves the existing outside equal-count clean contract
+#   for plain markdown / shell / notebook edits.
 pinning_guard_findings_records_for_path() {
   local old_scan_file="$1"
   local new_scan_file="$2"
@@ -513,6 +619,13 @@ pinning_guard_findings_records_for_path() {
   if [ -n "$is_prd_or_plan" ]; then
     _pinning_new_findings_records_for_state \
       "$old_scan_file" "$new_scan_file" "$is_prd_or_plan" "$allows_workflow"
+    return
+  fi
+
+  if _pinning_raw_path_has_traversal "$path" \
+     && _pinning_raw_path_is_workflow_policy_shape "$path"; then
+    _pinning_new_findings_records_for_state \
+      "$old_scan_file" "$new_scan_file" "" ""
     return
   fi
 

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -287,6 +287,16 @@ pinning_is_issue_draft_path() {
 # separate from the allow predicate (single caller is OK) so the two
 # opposite responsibilities — fail-closed allow vs traversal-tolerant shape —
 # never share an interface. Used by D-1 only.
+#
+# Path lookup order:
+#   1. Raw input — catches absolute traversal like `/tmp/<x>-body/../escape.md`
+#      whose absolute prefix already matches a category glob.
+#   2. Canonicalized input — catches relative traversal like
+#      `./.claude/prds/../plans/foo.md` where the raw string cannot match
+#      an absolute glob anchor but the canonical result does. Mirrors the
+#      canonicalize pattern in pinning_allows_workflow_pattern_c_for_path so
+#      the D-1 branch stays in lockstep with which paths the allow predicate
+#      considers part of a workflow policy category.
 _pinning_raw_path_is_workflow_policy_shape() {
   local raw="$1"
   local root
@@ -294,6 +304,17 @@ _pinning_raw_path_is_workflow_policy_shape() {
   if _pinning_path_category_glob_match "$raw" "prd_or_plan" "$root" \
      || _pinning_path_category_glob_match "$raw" "body_temp" \
      || _pinning_path_category_glob_match "$raw" "issue_draft"; then
+    return 0
+  fi
+  local path
+  path="$(pinning_canonicalize_path "$raw")"
+  if [ -z "$path" ] && [ ! -L "$raw" ]; then
+    path="$(pinning_canonicalize_existing_parent_path "$raw")"
+  fi
+  [ -n "$path" ] || return 1
+  if _pinning_path_category_glob_match "$path" "prd_or_plan" "$root" \
+     || _pinning_path_category_glob_match "$path" "body_temp" \
+     || _pinning_path_category_glob_match "$path" "issue_draft"; then
     return 0
   fi
   return 1

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -1457,8 +1457,9 @@ _check_pinning_policy_text() {
     fail "pinning policy text 확인 불가 ($_label): 파일 없음 ($_policy_file)"
     return
   fi
-  if grep -Fq 'Canonical non-traversal PRD/plan path(`.claude/prds/*`, `.claude/plans/*`)에서는 PATTERN_A만 예외적으로 허용한다.' "$_policy_file" && \
-     grep -Fq 'PATTERN_B/C는 해당 path에서도 계속 차단/경고한다.' "$_policy_file"; then
+  if grep -Fq 'Canonical non-traversal PRD/plan path(`.claude/prds/*`, `.claude/plans/*`)에서는 PATTERN_A가 예외적으로 허용된다.' "$_policy_file" && \
+     grep -Fq 'PRD/plan path + body temp draft path + issue-draft staging path에서는 PATTERN_C의 워크플로 sub-pattern(실행 모드 호출 키워드 두 토큰)이 예외적으로 허용된다.' "$_policy_file" && \
+     grep -Fq 'PATTERN_B와 PATTERN_C의 휘발성 sub-pattern(라운드 카운터 결합형 / 번호 reviewer 라벨 / 후속 액션 결합 토큰)은 해당 path에서도 계속 차단/경고한다.' "$_policy_file"; then
     pass "pinning policy text OK: $_label"
   else
     fail "pinning policy text 누락: $_label ($_policy_file)"

--- a/tests/fixtures/codex-hooks/README.md
+++ b/tests/fixtures/codex-hooks/README.md
@@ -89,7 +89,9 @@ Issue #767 PATTERN_C workflow/volatile split fixtures (workflow sub-pattern allo
 |----------|---------|
 | PATTERN_C **workflow** sub-pattern allowed in `.claude/prds/` and `.claude/plans/` | `pretooluse-pinning-guard-claude-write-{prds,plans}-pattern-c-workflow-clean.*`, `pretooluse-pinning-guard-codex-applypatch-{prds,plans}-pattern-c-workflow-clean.*` |
 | PATTERN_C **workflow** sub-pattern allowed in `/tmp/issue-draft/` (issue/PR body draft staging) | `pretooluse-pinning-guard-claude-write-issue-draft-pattern-c-workflow-clean.*` |
+| PATTERN_C **workflow** sub-pattern allowed in body temp draft path (`/tmp/*-body*`) | `pretooluse-pinning-guard-claude-write-body-temp-pattern-c-workflow-clean.*` |
 | Traversal raw path stays denied even with workflow tokens (workflow allow predicate fail-closes on traversal segment) | `pretooluse-pinning-guard-claude-write-body-temp-traversal-pattern-c-deny.*` |
+| Traversal raw path under body-temp shape denies equal-count `category B → category C workflow` token replacement (D-1 token-delta) | `pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.*` |
 
 PostToolUse `pinning-alert.sh` and commit-msg-pinning.sh keep emitting both sub-patterns under category code "C" (warn-only diagnostic preserved). The PreToolUse hard-fail records API (`pinning_guard_findings_records_for_path`, `pinning_guard_findings_records_for_scan_path`) suppresses only the workflow sub-pattern on the allowed paths above.
 

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.expected
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.expected
@@ -1,0 +1,4 @@
+[pinning-guard] Edit on /tmp/fixture-body/../escape.md contains volatile review/session metadata:
+  - DA 실행 키워드 박제
+         1: DA for_pr
+Use stable identifiers or plain natural-language context before retrying.

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.json
@@ -1,0 +1,8 @@
+{
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/tmp/fixture-body/../escape.md",
+    "old_string": "MAINT-1 reviewer 의견.",
+    "new_string": "DA for_pr 로 리뷰."
+  }
+}

--- a/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-body-temp-pattern-c-workflow-clean.json
+++ b/tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-body-temp-pattern-c-workflow-clean.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/tmp/fixture-body/draft.md",
+    "content": "구현 완료 후 DA for_pr 로 리뷰. 그 다음 DA for_plan 으로 계획 검증."
+  }
+}


### PR DESCRIPTION
## Summary

- traversal raw path + workflow-policy shape 에서 발생하던 equal-count `category B → category C workflow` 토큰 교체 우회를 token-delta 분기로 차단.
- 카테고리 C records 출력 순서를 line + byte offset 기준으로 정렬해 단일 grep 동작과 같은 좌→우 순서 회복.
- 정책 wording 세 bullet 분리, fixture matrix 의 body-temp 워크플로 행 추가, verify-ai-compat 검사 문자열 갱신.

Closes #779.

## 기존 문제 / 배경

이전 PR #778 (review-mode 카테고리를 워크플로 / 휘발성 sub-pattern 으로 분리) 머지 후 후속 감사가 6 결함을 발견했다. 사용자 결정에 따라 보안 1 + UX 1 + 문서 2 의 4 결함을 본 follow-up 에서 처리하고 성능 LOW 2 결함은 측정 없는 최적화로 drop 했다.

처리 대상 결함:

1. **outside count-gate 우회 (보안 MEDIUM)** — `pinning_guard_findings_records_for_path` 의 non-PRD/plan 분기가 `new_count > old_count` 만 deny. traversal raw path 에서 OLD 카테고리 B 1건 ↔ NEW 카테고리 C 워크플로 1건 의 equal-count 토큰 교체 시 카운트 동일 → records 미 emit → 외부 공유 본문에 워크플로 토큰 박제 가능.
2. **records 순서 비일관성 (UX LOW)** — `pinning_findings_records` 가 카테고리 C 워크플로 sub-pattern 매치 emit 후 휘발성 sub-pattern 매치 emit. 같은 카테고리 안의 매치가 파일 line 순서가 아닌 sub-pattern 순서로 노출.
3. **fixture matrix 누락 (문서 LOW)** — body-temp path 의 워크플로 sub-pattern clean 케이스 fixture 부재.
4. **정책 wording drift (문서 LOW)** — `CLAUDE.md` 의 durable-output pinning policy bullet 이 PR #778 후 동작 (PATTERN_A 예외 scope 와 PATTERN_C 워크플로 sub-pattern 예외 scope 가 다름) 과 어긋남.

## CIR (Change Intent Record)

발견 경위는 이전 PR 머지 직후 동일 영역 감사. 설계 의도는 (a) 좁은 fix 로 검증된 token-delta 패턴 재사용 + (b) helper 책임 분리로 fail-closed allow predicate 와 traversal-tolerant shape classifier 가 같은 인터페이스를 공유하지 않게 + (c) path category glob source 를 단일 helper 가 소유하도록 정리.

대안 검토는 외부 plan 단계에서 다회 라운드 진행 후 사용자 stop. 누적 결과 자동 반영 + 핵심 보안 / 설계 / 회귀 결함 안정 후 implementation 진입. implementation 후 코드 수준 자동 검토 1 라운드 추가 + 8 결함 자동 반영 후 4 시각 전수조사 통과.

## ADR (Architecture Decision Record)

traversal raw path 의 equal-count 워크플로 토큰 교체 우회 fix 방향:

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 옵션 A | traversal 시 NEW findings 전체 emit (token-delta 미적용) | 단순 | traversal 입력에서 기존 token 보존 편집도 차단 → 일반 traversal markdown 의 outside equal-count clean 계약 손상 | ❌ |
| 옵션 B | traversal + workflow-policy shape 둘 다 매치 시만 token-delta (workflow suppress 비적용) | 의도 범위 정확, PRD/plan 분기의 검증된 패턴 재사용, 일반 path 의 traversal outside count-gate 보존 | helper 3개 추가 (책임 분리 비용) | ✅ |
| 옵션 C | outside count-gate 자체를 모든 non-PRD/plan path 에서 token-delta 로 교체 | 일반 path 의 우회도 차단 | 본 follow-up 의 좁은 fix 스코프 확장 | ❌ |

옵션 B 채택. helper 책임 분리는 `_pinning_raw_path_has_traversal` (traversal segment 매처) + `_pinning_path_category_glob_match` (path category glob 단일 source) + `_pinning_raw_path_is_workflow_policy_shape` (traversal token-delta 분기 전용 raw-tolerant shape classifier) 세 helper 로 정리.

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/lib/pinning-patterns.sh` | helper 3개 신규 + 기존 5개 traversal pre-check 통합 + 4개 path helper 의 category glob 검사 단일 source 위임 + `pinning_guard_findings_records_for_path` 의 traversal + workflow-policy shape token-delta 분기 + `_pinning_pattern_c_records_sorted` (grep `-bno` + line + byte offset sort) |
| `modules/shared/programs/claude/files/CLAUDE.md` | durable-output pinning policy bullet 을 세 bullet 으로 분리 (PRD/plan 의 PATTERN_A 예외, PRD/plan + body-temp + issue-draft 의 PATTERN_C 워크플로 sub-pattern 예외, PATTERN_B + PATTERN_C 휘발성 sub-pattern 잔류 차단) |
| `scripts/ai/verify-ai-compat.sh` | `_check_pinning_policy_text` 의 두 `grep -Fq` exact-match 문자열을 새 세 bullet wording 세 grep 으로 갱신 |
| `tests/fixtures/codex-hooks/README.md` | sub-pattern split fixture matrix 에 body-temp 워크플로 clean 행 + traversal B→C 워크플로 equal-count deny 행 추가 |
| `tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.*` | 신규 회귀 fixture (Edit 형식) |
| `tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-body-temp-pattern-c-workflow-clean.*` | 신규 clean fixture |

핵심 코드 스니펫 (traversal token-delta 분기):

```bash
if _pinning_raw_path_has_traversal "$path" \
   && _pinning_raw_path_is_workflow_policy_shape "$path"; then
  # is_prd_or_plan="" + allows_workflow="" — traversal raw paths must keep
  # the workflow deny contract (no PATTERN_A suppression, no workflow
  # suppression) so the token-delta surfaces the smuggled workflow token.
  _pinning_new_findings_records_for_state \
    "$old_scan_file" "$new_scan_file" "" ""
  return
fi
```

## 참고 레퍼런스

- 이슈 #779 (본 follow-up 의 결함 정리).
- 이전 PR #778 (review-mode 카테고리 sub-pattern 분리 — 본 follow-up 의 baseline).
- 이전 PR #785 (PATTERN_C_VOLATILE 한글 alternation 단어 경계 fix — 본 follow-up 과 인접 영역).

## Human Test Plan

새 clone / 새 host 에서 본 PR 머지 후 다음 단계를 직접 수행하면 의도된 동작을 확인할 수 있다.

1. host 에 `nrs` 적용 → home-manager activation 으로 host 의 정책 문서 두 경로가 새 세 bullet wording 으로 sync. 적용 실패 시 다른 worktree 의 nrs lock 충돌 가능.
2. `./scripts/ai/verify-ai-compat.sh` 전체 통과. source 정책 문서 + host 정책 문서 두 경로 모두 pinning policy text 검사 OK.
3. `tests/test-codex-hook-fixtures.sh --no-live` 전체 통과 (deterministic). 신규 2 fixture 포함.
4. file_path 가 traversal + body-temp shape (예시 형태: `/tmp/<x>-body/../<outside>.md`) 인 Edit 시도 시 PreToolUse hook 가 deny. old_string 이 카테고리 B 토큰 1건, new_string 이 카테고리 C 워크플로 토큰 1건 인 equal-count 시나리오 가 deny 반환 (stdout JSON 의 `permissionDecision=deny`). 실제 토큰 형식은 `lib/pinning-patterns.sh` 의 PATTERN_B / PATTERN_C_WORKFLOW 정의 참조.
5. body-temp clean 케이스 (Write 의 file_path 가 `/tmp/<x>-body/<filename>.md`, content 가 워크플로 sub-pattern 토큰만 포함) 는 hook 통과 — 빈 stdout.

실패 시 진단:
- (1) 충돌: 다른 worktree 의 `nrs-lock unlock` 후 재실행.
- (2) policy text 누락: source 정책 문서의 세 bullet 이 정확한 문자열인지 확인 후 `nrs` 재실행으로 host symlinks 갱신.
- (3) fixture fail: 어느 fixture 가 fail 했는지 runner 출력 확인. expected sidecar 와 실제 stdout 의 deny reason 비교.

## Pre-Merge E2E 테스트 가이드

LLM 이 머지 전 직접 실행하는 자동 검증 절차. 각 phase 끝까지 통과해야 머지 가능.

### Phase 0 — 정적 검증

```bash
# 변경 파일 존재 확인
ls modules/shared/programs/claude/files/lib/pinning-patterns.sh \
   modules/shared/programs/claude/files/CLAUDE.md \
   scripts/ai/verify-ai-compat.sh \
   tests/fixtures/codex-hooks/README.md
ls tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-edit-body-temp-traversal-pattern-b-to-c-workflow-equal-count-deny.* \
   tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-body-temp-pattern-c-workflow-clean.*

# helper 정의 확인 (4개)
grep -c '^_pinning_raw_path_has_traversal\|^_pinning_path_category_glob_match\|^_pinning_raw_path_is_workflow_policy_shape\|^_pinning_pattern_c_records_sorted' \
   modules/shared/programs/claude/files/lib/pinning-patterns.sh
# expected: 4

# 정책 wording 세 bullet 확인 (세 개의 안정적인 prefix 문구)
grep -c 'PATTERN_A가 예외적으로 허용\|PRD/plan path + body temp\|PATTERN_B와 PATTERN_C의 휘발성' \
   modules/shared/programs/claude/files/CLAUDE.md
# expected: 3

# 정적 lint
bash -n modules/shared/programs/claude/files/lib/pinning-patterns.sh && \
  shellcheck modules/shared/programs/claude/files/lib/pinning-patterns.sh
# expected: 0 issue
```

### Phase 1 — fixture runner 통과

```bash
tests/test-codex-hook-fixtures.sh --no-live
# expected: 마지막 줄 "All codex hook fixture tests passed."
```

실패 시: fail 한 fixture 의 stdout 과 expected sidecar 비교. deny reason 의 카테고리 라벨 / 토큰 wording 차이 확인.

### Phase 2 — verify-ai-compat 통과

```bash
nrs   # host symlinks 갱신
./scripts/ai/verify-ai-compat.sh
# expected: 마지막 줄 "검증 완전 통과"
```

실패 시: `nrs` 가 다른 worktree 의 lock 에 막혔는지 확인 (`nrs-lock unlock` → 재시도). pinning policy text 검사 실패면 source 정책 문서의 세 bullet 문자열을 verify-ai-compat 의 grep 과 char-by-char 비교.

### Phase 3 — traversal token-delta 회귀 spot check

본 phase 의 명령은 실제 박제 토큰을 인용하므로 LLM 호출자가 실측 시에만 셸에서 직접 입력한다 (이 PR 본문 자체에는 토큰을 인용하지 않는다).

수행 절차 (자연어):
1. 임시 디렉토리 생성 후 OLD scan 파일에 카테고리 B 토큰 1건 (`lib/pinning-patterns.sh` 의 PATTERN_B 정의 참조), NEW scan 파일에 카테고리 C 워크플로 토큰 1건 (PATTERN_C_WORKFLOW 정의 참조) 을 작성.
2. shared library source 후 `pinning_guard_findings_records_for_path <OLD> <NEW> "/tmp/fixture-body/../escape.md"` 호출.
3. 출력에 records 1건 (카테고리 C 워크플로 토큰) 가 emit 되는지 확인.

실패 시: traversal 분기 두 helper (`_pinning_raw_path_has_traversal`, `_pinning_raw_path_is_workflow_policy_shape`) 의 정의 위치 확인. 본 path 는 traversal + body-temp glob 매치라 둘 다 true 여야 함.

### Phase 4 — 카테고리 C sort spot check

수행 절차 (자연어):
- case (a): line 2 에 휘발성 sub-pattern 토큰, line 5 에 워크플로 sub-pattern 토큰이 있는 입력 → 출력의 첫 record 가 line 2, 둘째가 line 5 순서.
- case (b): 같은 line 안에 휘발성 토큰 (byte offset 작음) + 워크플로 토큰 (byte offset 큼) → 출력이 휘발성-먼저-워크플로-나중 순서.

실패 시: `_pinning_pattern_c_records_sorted` 의 grep `-bnoE` 출력 + sort `-k1,1n -k2,2n` 동작 확인.

### Phase 5 — regression (인접 fixture)

기존 fixture (body-temp traversal 의 단일-NEW deny, PRD/plan 의 PATTERN_A clean, codex apply_patch 의 카테고리 B deny 등) 가 fixture runner 안에서 그대로 통과. Phase 1 의 runner 통과로 자동 충족.

### 결과 보고

위 5 phase 모두 통과 → merge ready. 어느 phase 라도 fail → 본 PR 머지 보류 후 fail 한 phase 의 진단 가이드 따라 후속 조치.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path traversal detection and enforcement in commit message validation policies, ensuring more consistent behavior across different path categories.

* **Documentation**
  * Updated policy documentation to clarify allowed and blocked patterns under different file path conditions.

* **Tests**
  * Added test fixtures for workflow pattern handling in temporary draft paths and traversal scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->