### PR TITLE
fix(tmux,darwin): NO_COLOR 회귀 차단 + 미사용 cmux 선언 제거

### DIFF
--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -104,7 +104,6 @@ in
         ./programs/vscode
         ./programs/folder-actions
         ./programs/ghostty
-        ./programs/cmux
         ./programs/shottr
         ./programs/keybindings
         ./programs/ssh

--- a/modules/darwin/programs/cmux/default.nix
+++ b/modules/darwin/programs/cmux/default.nix
@@ -1,8 +1,0 @@
-# cmux 설정 (macOS 전용)
-{ ... }:
-
-{
-  xdg.configFile."cmux/cmux.json".text = builtins.toJSON {
-    commands = [ ];
-  };
-}

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -23,11 +23,8 @@
       # [Nix 전환이 불가능한 앱]
       # ghostty: pkgs.ghostty-bin은 CLI 바이너리만 제공하고 macOS .app 번들을 포함하지 않음.
       #          Ghostty.app은 Homebrew Cask로만 설치 가능.
-      # cmux: Homebrew core cask로 제공되므로 별도 tap 불필요.
-      #       사용자 설정은 ./programs/cmux에서 ~/.config/cmux/cmux.json으로 관리.
       casks = [
         "ghostty"
-        "cmux"
       ];
     }
 

--- a/modules/shared/programs/tmux/files/tmux.conf
+++ b/modules/shared/programs/tmux/files/tmux.conf
@@ -26,6 +26,15 @@ set -ga terminal-overrides ",tmux-256color:Tc"
 set -g allow-passthrough on
 set -ga update-environment TERM
 set -ga update-environment TERM_PROGRAM
+set -ga update-environment COLORTERM
+
+# 외부 launcher(예: Codex Desktop, AI 에이전트 GUI 등)가 자식 프로세스에 NO_COLOR=1
+# 또는 COLORTERM='' 을 export한 상태로 tmux server를 첫 spawn하면, tmux는 그 환경을
+# server-global env에 캐시하여 이후 모든 페인이 상속한다(=Claude Code 등 NO_COLOR 표준
+# 준수 앱이 색을 끔). conf source 시점에 강제 정리해 회귀를 차단한다.
+# nixos-config 자체는 NO_COLOR를 관리하지 않으므로 정적 unset이 안전하다.
+set-environment -g -u NO_COLOR
+set-environment -g COLORTERM truecolor
 
 # 창/pane 이름 자동 변경 비활성화
 set -g automatic-rename off


### PR DESCRIPTION
## Summary

<img width="728" height="671" alt="image" src="https://github.com/user-attachments/assets/a367d374-6595-4e56-9755-436ca08cc29c" />

- 외부 launcher(Codex Desktop 등)가 tmux server 첫 spawn 시 자식 환경에 박은 `NO_COLOR=1`/`COLORTERM=''`가 server-global env에 캐시되어 모든 페인의 Claude Code가 색을 잃는 회귀를 conf source 시점 강제 정리로 차단.
- 사용자가 사용하지 않는 cmux(`/Applications/cmux.app`) 관련 선언을 nixos-config에서 들어낸다.

관련: #765 (cmux light fallback) — cmux 선언 제거로 이슈가 자연 해소될 수 있으나, 이슈 본문 정합성은 별도 확인 필요하므로 자동 close는 보류.

## 기존 문제/배경

tmux 셸에서 띄운 Claude Code가 전부 흰색/회색으로 표시되는 사용자 신고로 시작. 호스트 셸 직접 실행 시에는 색이 정상이라 tmux 경유 시에만 회귀.

조사 결과:
- 현 tmux server의 global env에 **`NO_COLOR=1`** 과 **`COLORTERM=''`** (빈값) 이 박혀 있음 (`tmux show-environment -g`).
- 사용자 dotfile(`~/.z*`), `/etc/zsh*`, `home.sessionVariables`, launchctl, nixos-config 어디에도 `NO_COLOR` 정의 없음. atuin history에도 `NO_COLOR=1` prefix로 명령 실행한 적 없음.
- tmux server는 첫 spawn 시점의 부모 환경을 server-global env에 캐시한다. 그 이후 모든 새 페인이 이 env를 상속받으므로, 한 번 박히면 server가 종료될 때까지 자가 회복 불가.
- 현 tmux server를 띄운 부모는 **Codex Desktop** (OpenAI Electron 앱, `com.openai.codex`). 증거:
  - `__CFBundleIdentifier=com.openai.codex`, `CODEX_INTERNAL_ORIGINATOR_OVERRIDE=Codex Desktop`, `CODEX_CI=1`, `CODEX_SHELL=1`, `CODEX_THREAD_ID=...`
  - `PATH` 앞단에 `/Users/glen/.codex/tmp/arg0/codex-arg05fbxNm`, 뒷단에 `/Applications/Codex.app/Contents/Resources`
  - tmux 세션 cwd가 `/Users/glen/.codex/worktrees/.../zaritalk-front` (Codex worktree)
  - Codex Desktop 설치 직후(약 17분) 첫 tmux server spawn
- Codex Desktop 자체에는 사용자가 끌 수 있는 NO_COLOR 노출 옵션 없음 (`~/.codex/config.toml` 329줄에 색 관련 옵션 부재). asar 내부 검사로도 토글 미발견.
- nixos-config 자체는 `NO_COLOR`를 관리하지 않는 상태이므로, tmux 레이어에서 정적 unset이 안전하다.

별개로, 조사 곁가지에서 cmux(`/Applications/cmux.app`, Homebrew cask)가 이번 사건과 무관함을 확인. 사용자가 cmux를 사용하지 않으므로 선언적 관리 대상에서 제거한다.

## CIR (Change Intent Record)

- **출발**: cmux를 1차 의심. cmux 바이너리 strings에 `SetEnv COLORTERM=truecolor` 와 `export COLORTERM=` 패턴이 보였고, tmux 세션명 `pr<num>-<package>`가 cmux의 워크플로 패턴처럼 보였다.
- **반증**: cmux 프로세스/autorun 부재, shell-integration·바이너리·자체 claude wrapper 어디에도 `NO_COLOR` export 정의 없음. cmux 사용 안 한다는 사용자 확인.
- **진범 식별**: tmux server env에 박힌 다른 변수들(`__CFBundleIdentifier=com.openai.codex`, `CODEX_*`, `PATH`의 `/Applications/Codex.app/...`, `OLDPWD`의 `.codex/worktrees/...`)로 Codex Desktop이 spawn한 것임을 확인.
- **해결 범위 결정**: 사용자 선호 트리(① Codex Desktop 자체 옵션으로 끌 수 있는지 먼저 확인 → 실패 시 ② 즉시 치료 + tmux 안전망). Codex Desktop은 사용자 노출 토글 부재로 ②로 진행.
- **cmux 처리 분리**: 이번 사건과 인과관계 없음을 확인했고, 사용자가 더 이상 사용하지 않으므로 같이 정리 (별 commit으로 분리).

trade-off: tmux.conf에 박힌 정적 unset은 사용자가 의도적으로 `NO_COLOR=1`을 export하고 싶을 때도 적용된다. 본 저장소는 `NO_COLOR`를 관리하지 않으므로 이 trade-off가 무해하다고 판단.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Codex Desktop 자체 옵션 조정 | `~/.codex/config.toml` 등 사용자 노출 토글로 NO_COLOR export 비활성화 | 원인 측에서 차단, tmux 변경 불필요 | 사용자 노출 토글 부재 (config.toml에 없음, asar 내부에도 미발견) | ❌ |
| 현 tmux server만 즉시 치료 | `tmux set-environment -g -u NO_COLOR` + `set-environment -g COLORTERM truecolor` | 코드 변경 0, 즉시 효과 | server 재기동 시 재발 가능. Codex Desktop 미사용해도 동종 launcher가 다시 박을 수 있음 | ❌ (즉시 치료는 별도 수행, 영구 해법으로는 불충분) |
| tmux.conf에 영구 안전망 | conf source 시점에 NO_COLOR unset + COLORTERM=truecolor 정적 set + update-environment 등록 | 어떤 launcher가 spawn해도 새 server부터 안전. nixos-config는 NO_COLOR 미관리이므로 정적 unset 무해 | 사용자가 의도적으로 NO_COLOR를 쓰고 싶을 때 충돌 (trade-off 수용) | ✅ |
| cmux 선언 보존 | 곁가지 발견은 별개 PR로 | 본 PR scope 명확 | 사용 의도 없는 cmux 관련 회귀 위험(예: #765) 잔존 | ❌ |
| cmux 선언 같이 제거 | homebrew cask + home-manager import + 빈 모듈 일괄 제거 | 미사용 표면 축소, 인접 회귀 가능성 감소 | scope 두 갈래로 약간 확장 (commit 분리로 추적성 유지) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/tmux/files/tmux.conf` | 수정 | `update-environment`에 `COLORTERM` 추가, `set-environment -g -u NO_COLOR`, `set-environment -g COLORTERM truecolor` 추가 |
| `modules/darwin/programs/homebrew.nix` | 수정 | `casks`에서 `"cmux"` 제거, 인접 주석 정리 |
| `modules/darwin/home.nix` | 수정 | home-manager `imports`에서 `./programs/cmux` 제거 |
| `modules/darwin/programs/cmux/default.nix` | 삭제 | 빈 `commands={}`만 들어있던 cmux.json 모듈 |

### 핵심 코드 (tmux.conf)

```tmux
set -ga update-environment TERM
set -ga update-environment TERM_PROGRAM
set -ga update-environment COLORTERM

# 외부 launcher(예: Codex Desktop, AI 에이전트 GUI 등)가 자식 프로세스에 NO_COLOR=1
# 또는 COLORTERM='' 을 export한 상태로 tmux server를 첫 spawn하면, tmux는 그 환경을
# server-global env에 캐시하여 이후 모든 페인이 상속한다(=Claude Code 등 NO_COLOR 표준
# 준수 앱이 색을 끔). conf source 시점에 강제 정리해 회귀를 차단한다.
# nixos-config 자체는 NO_COLOR를 관리하지 않으므로 정적 unset이 안전하다.
set-environment -g -u NO_COLOR
set-environment -g COLORTERM truecolor
```

`set-environment -g COLORTERM truecolor`는 attach 없이 daemon-only로 시작하는 시나리오의 정적 default를 보장하고, `set -ga update-environment COLORTERM`은 client attach 시 호스트 셸의 실제 `COLORTERM` 값을 server-global env로 동기화한다 — 두 layer가 함께 안전망을 형성.

## 참고 레퍼런스

- [NO_COLOR 표준](https://no-color.org/) — 환경변수가 set돼 있기만 하면(값 무관) 색 출력을 끄도록 권고. Claude Code(Ink/React), Node `process.env.NO_COLOR` 등이 준수.
- [tmux `update-environment` 옵션](https://man.openbsd.org/tmux#update-environment) — client attach 시 server-global env로 동기화할 변수 목록.
- Issue #765 — cmux 관련 색상 fallback (cmux 선언 제거로 자연 해소 가능, close 여부는 이슈 본문 확인 후 별도 판단).
- PR #783 — 최근 lefthook/direnv 회귀 차단 작업 (안전망 패턴 참고).

## Human Test Plan

### 정상 동작 검증

1. 이 PR 머지 후 `nrs` 실행 → home-manager 활성화로 새 `tmux.conf` 반영.
   - **기대**: nix flake check 통과 (현 워크트리에서 미리 검증 완료, "all checks passed!").
   - **실패 시**: `git diff main -- modules/shared/programs/tmux/files/tmux.conf` 차이 확인 + `home.file.".tmux/tmux.conf"` symlink가 최신 워크트리 source를 가리키는지 점검.

2. 기존 tmux server를 한 번 종료(`tmux kill-server`) 후 새 tmux를 띄우고 페인에서 다음 확인:
   ```sh
   echo "NO_COLOR='${NO_COLOR-<unset>}' COLORTERM='$COLORTERM'"
   ```
   - **기대**: `NO_COLOR='<unset>' COLORTERM='truecolor'`.
   - **실패 시**: `tmux show-environment -g | grep -iE '^NO_COLOR|^COLORTERM'` 으로 server env 확인. `~/.config/tmux/tmux.conf`가 home-manager가 만든 wrapper에서 `source-file ~/.tmux/tmux.conf`를 거치는지 확인.

3. tmux 내 페인에서 `claude` 실행.
   - **기대**: 호스트 직접 실행과 동일하게 색상 정상.
   - **실패 시**: claude를 띄운 페인의 env에 `NO_COLOR`가 들어와 있는지, tmux server를 띄운 부모가 다시 외부 launcher인지 확인.

### 회귀 시나리오 검증

4. 외부 launcher가 다시 박는 시나리오를 모사: `NO_COLOR=1 COLORTERM= tmux new-session -d -s test-regression 'sleep 30'`.
   - **기대**: 그래도 새 페인에서 `NO_COLOR=<unset>`, `COLORTERM=truecolor`. (conf source가 부모 env를 덮어쓰므로).
   - **실패 시**: tmux 버전이 `set-environment -g -u`를 지원하는지 확인 (`tmux -V` ≥ 2.0 이상).

### cmux 제거 검증

5. `nrs` 후 `brew list --cask | grep cmux`.
   - **기대**: cmux가 자동 제거되지는 않음 (`cleanup="none"` 정책). `brew uninstall --cask cmux`로 수동 정리하거나 그대로 두어도 무관.
   - **실패 시**: homebrew.nix의 `casks` 배열에 cmux가 잔존하는지 grep.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. tmux.conf에 NO_COLOR 안전망 존재 확인
grep -q "set-environment -g -u NO_COLOR" modules/shared/programs/tmux/files/tmux.conf
# 기대: exit 0

grep -q "set-environment -g COLORTERM truecolor" modules/shared/programs/tmux/files/tmux.conf
# 기대: exit 0

grep -q "set -ga update-environment COLORTERM" modules/shared/programs/tmux/files/tmux.conf
# 기대: exit 0

# 2. cmux 관련 잔존물 부재 확인 (Negative)
! grep -q '"cmux"' modules/darwin/programs/homebrew.nix
# 기대: exit 0

! grep -q './programs/cmux' modules/darwin/home.nix
# 기대: exit 0

! test -e modules/darwin/programs/cmux/default.nix
# 기대: exit 0 (파일 없음)
```

### Phase 1: nix flake 평가

> "darwin/nixos configuration이 cmux 제거 후에도 평가 가능한지 확인"

```bash
nix flake check --no-build
```
- **기대**: `all checks passed!`
- **실패 시**: `nix flake check --show-trace`로 평가 실패 위치 추적. `home.nix`의 `imports`에서 cmux가 빠졌는지, 다른 모듈이 `./programs/cmux`를 참조하지 않는지 확인.

### Phase 2: tmux.conf syntax sanity

> "tmux가 conf 파일을 syntax error 없이 source할 수 있는지 확인"

```bash
# 임시 tmux server에서 conf 평가 (실제 server 생성/종료)
tmux -f modules/shared/programs/tmux/files/tmux.conf -L pr-validate start-server \; show-environment -g \; kill-server 2>&1 | grep -iE '^NO_COLOR|^COLORTERM'
```
- **기대**: `COLORTERM=truecolor` 한 줄, `NO_COLOR` 부재.
- **실패 시**: tmux 버전(`tmux -V`)이 `set-environment -g -u` 문법 지원 버전인지 확인. 출력에 syntax error가 보이면 해당 라인 수정.

### Phase 3: Regression (인접 기능)

> "tmux의 기존 update-environment 동작과 terminal-overrides가 깨지지 않았는지 확인"

```bash
# 기존 update-environment 항목(TERM, TERM_PROGRAM) 잔존 확인
grep -c "set -ga update-environment" modules/shared/programs/tmux/files/tmux.conf
# 기대: 3 (TERM, TERM_PROGRAM, COLORTERM)

grep -c "terminal-overrides" modules/shared/programs/tmux/files/tmux.conf
# 기대: 3 (xterm-256color, xterm-ghostty, tmux-256color)
```
- **실패 시**: edit 작업이 의도치 않게 기존 라인을 지웠는지 git diff로 확인.

```bash
# cmux 제거 후에도 homebrew cask 공통 항목(ghostty) 잔존 확인
grep -q '"ghostty"' modules/darwin/programs/homebrew.nix
# 기대: exit 0
```