### PR TITLE
feat(statusline): worktree 폴더명 == 브랜치명이면 L3 라인 생략

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -803,8 +803,10 @@ fi
 end_line
 
 # L3 (worktree만): branch
-# L2의 "<메인 repo>:<폴더명>" 표기와 GIT_BRANCH가 exact match면 동일 토큰 중복이라 라인째 생략.
-# CWD_CANONICAL 부재 시 L2가 ":<폴더명>" 포맷을 못 쓰므로 가드 비활성.
+# basename(CWD_CANONICAL) == GIT_BRANCH면 L2가 이미 동일 토큰을 담고 있어 L3 라인째 생략.
+#   L2 표시: $IS_WORKTREE && MAIN_REPO_DIR 분기는 "<repo>:<폴더명>", else는 풀 경로 끝에 폴더명.
+#   어느 쪽이든 폴더명 토큰이 L2에 포함되므로 L3은 정보 손실 없이 생략 가능.
+# CWD_CANONICAL 부재 시 basename 결과가 ""라 GIT_BRANCH와 일치 불가 → 가드 자연스럽게 비활성.
 if $IS_WORKTREE; then
   begin_line
   WORKTREE_BASENAME=""

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -803,9 +803,13 @@ fi
 end_line
 
 # L3 (worktree만): branch
+# L2의 "<메인 repo>:<폴더명>" 표기와 GIT_BRANCH가 exact match면 동일 토큰 중복이라 라인째 생략.
+# CWD_CANONICAL 부재 시 L2가 ":<폴더명>" 포맷을 못 쓰므로 가드 비활성.
 if $IS_WORKTREE; then
   begin_line
-  if [ -n "$GIT_BRANCH" ]; then
+  WORKTREE_BASENAME=""
+  [ -n "$CWD_CANONICAL" ] && WORKTREE_BASENAME=$(basename "$CWD_CANONICAL")
+  if [ -n "$GIT_BRANCH" ] && [ "$WORKTREE_BASENAME" != "$GIT_BRANCH" ]; then
     print_icon "32" "" "\xf0\x9f\x8c\xbf" "$GIT_BRANCH"
   fi
   end_line

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -414,3 +414,41 @@ EOF
   echo "$plain" | grep -qF 'feat-foo' \
     || { echo "expected branch label 'feat-foo' in output; got: $plain" >&2; false; }
 }
+
+# CWD_CANONICAL 부재 회귀 가드: canonicalize_cwd_check가 실패해 CWD_CANONICAL=""
+# 이면 WORKTREE_BASENAME=""이라 GIT_BRANCH와 일치할 수 없어 가드가 자연스럽게
+# 비활성된다. L3 가드 블록 주석이 약속한 동작을 박제해 L3가 의도치 않게
+# 숨겨지는 회귀를 막는다. cwd를 상대경로(="tmp")로 보내면
+# canonicalize_cwd_check 의 절대경로 가드(case "$cwd" in /*) ;; *) return ;; esac)에
+# 걸려 CWD_CANONICAL="" 이 자연 유도된다.
+@test "worktree with non-canonical cwd keeps L3 branch line (guard disabled)" {
+  local now five_h seven_d
+  now=$(date +%s)
+  five_h=$((now + 5 * 3600))
+  seven_d=$((now + 5 * 86400))
+  local stdin_json
+  stdin_json=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "tmp",
+  "model": {"display_name": "test"},
+  "workspace": {"current_dir": "tmp", "git_worktree": "tmp"},
+  "worktree": {"branch": "tmp"},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 6, "resets_at": $five_h},
+    "seven_day": {"used_percentage": 82, "resets_at": $seven_d}
+  }
+}
+EOF
+)
+  run run_statusline_with_input "$stdin_json"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  branch_count=$(echo "$plain" | grep -oF '🌿' | wc -l | tr -d ' ')
+  [ "$branch_count" -eq 1 ] \
+    || { echo "expected exactly 1 🌿 (L3 branch) when CWD_CANONICAL=\"\" (guard disabled); got count=$branch_count plain=$plain" >&2; false; }
+  echo "$plain" | grep -qF 'tmp' \
+    || { echo "expected branch label 'tmp' in output; got: $plain" >&2; false; }
+}

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -345,3 +345,72 @@ EOF
   echo "$plain" | grep -q '████████░░ 82%' \
     || { echo "expected filled=8 bar '████████░░ 82%' for 7d in non-SSH; got: $plain" >&2; false; }
 }
+
+# L3 worktree branch line: 폴더명 basename 과 branch 가 exact match 면 L2 의
+# "<메인 repo>:<폴더명>" 표기가 이미 같은 토큰을 담고 있어 동일 토큰 중복이라
+# L3 라인째 생략한다. cwd=/tmp (basename=tmp) + worktree.branch=tmp fixture.
+# macOS 에서 /tmp 는 /private/tmp symlink 지만 basename 은 동일하게 tmp.
+@test "worktree dir==branch hides L3 branch line" {
+  local now five_h seven_d
+  now=$(date +%s)
+  five_h=$((now + 5 * 3600))
+  seven_d=$((now + 5 * 86400))
+  local stdin_json
+  stdin_json=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "/tmp",
+  "model": {"display_name": "test"},
+  "workspace": {"current_dir": "/tmp", "git_worktree": "/tmp"},
+  "worktree": {"branch": "tmp"},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 6, "resets_at": $five_h},
+    "seven_day": {"used_percentage": 82, "resets_at": $seven_d}
+  }
+}
+EOF
+)
+  run run_statusline_with_input "$stdin_json"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  if echo "$plain" | grep -qF '🌿'; then
+    echo "expected no 🌿 branch icon when worktree dir==branch (tmp); leaked: $plain" >&2
+    false
+  fi
+}
+
+# Negative: dir!=branch 면 L3 가 살아 있어 🌿 가 정확히 1번 + branch 라벨 출력.
+# 새 가드가 mismatch 케이스까지 잘못 차단하면 fail.
+@test "worktree dir!=branch keeps L3 branch line" {
+  local now five_h seven_d
+  now=$(date +%s)
+  five_h=$((now + 5 * 3600))
+  seven_d=$((now + 5 * 86400))
+  local stdin_json
+  stdin_json=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "/tmp",
+  "model": {"display_name": "test"},
+  "workspace": {"current_dir": "/tmp", "git_worktree": "/tmp"},
+  "worktree": {"branch": "feat-foo"},
+  "rate_limits": {
+    "five_hour": {"used_percentage": 6, "resets_at": $five_h},
+    "seven_day": {"used_percentage": 82, "resets_at": $seven_d}
+  }
+}
+EOF
+)
+  run run_statusline_with_input "$stdin_json"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  branch_count=$(echo "$plain" | grep -oF '🌿' | wc -l | tr -d ' ')
+  [ "$branch_count" -eq 1 ] \
+    || { echo "expected exactly 1 🌿 (L3 branch) when dir!=branch; got count=$branch_count plain=$plain" >&2; false; }
+  echo "$plain" | grep -qF 'feat-foo' \
+    || { echo "expected branch label 'feat-foo' in output; got: $plain" >&2; false; }
+}


### PR DESCRIPTION
## 1. Summary

- worktree 폴더명과 브랜치명이 exact match일 때 statusline L3의 `🌿 <branch>` 라인을 라인째 생략한다.
- L2의 `<메인 repo>:<폴더명>` 표기가 이미 같은 토큰을 담고 있어 동일 정보 중복이라는 판단.
- worktree 분기에만 적용 — main repo의 L2 표시(`📁 cwd 🌿 branch`)는 변경 없음.

## 2. 기존 문제 / 배경

워크트리 작업 표준 워크플로는 폴더명과 브랜치명을 같게 두는 경우가 많다 (예: `.claude/worktrees/audit-pr-802` / branch `audit-pr-802`). 이때 statusline은:

```
📁 ~/Workspace/nixos-config:audit-pr-802
🌿 audit-pr-802
```

두 줄을 차지하는데 `audit-pr-802` 토큰이 두 번 반복된다. statusline 세로 공간은 1초마다 refresh되는 제한된 시각 자원이라, 정보가 같은 두 줄이 한 줄로 줄어들면 다른 정보(Plan/Memory/Cache TTL/Rate Limits)를 표시할 시각 여유가 늘어난다.

## 3. CIR (Change Intent Record)

사용자 보고(스크린샷)로 시작한 grill-me 인터뷰에서 결정 트리 네 분기를 해소했다:

- **"동일"의 정의**: `basename(CWD_CANONICAL)` 와 `GIT_BRANCH` 의 **exact string match** 만 적용. 슬래시 포함 브랜치(`feat/foo`)는 worktree 폴더가 `foo`로 떨어져 leaf만 같아 보이지만, `feat/` prefix가 사용자에게 의미 있는 정보라 표시 유지가 맞다.
- **적용 범위**: worktree 분기만. main repo는 폴더명==브랜치명 케이스가 실제로 거의 발생하지 않고, L2가 한 줄에 cwd+branch 동거하는 시각 패턴을 깨고 싶지 않다.
- **추가 visual cue**: 없음. L2의 `<repo>:<폴더명>` 콜론 표기 자체가 worktree 식별자 역할을 이미 한다.
- **env escape hatch**: 두지 않음. 동작이 예측 가능하고 되돌릴 이유가 떠오르지 않아 YAGNI.

코드 변경은 기존 L3 블록에 한 줄 가드(`WORKTREE_BASENAME != GIT_BRANCH`)를 추가하는 트리비얼한 표면이라 변경 위험이 낮다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| Exact match만 (basename(CWD) == GIT_BRANCH) | 정확 문자열 일치 시에만 L3 생략 | 단순/예측 가능, slash 브랜치 prefix 정보 보존 | `feat/foo` worktree(폴더=foo)는 매치 안 됨 — leaf 중복은 남음 | ✅ |
| Leaf segment match | branch의 마지막 슬래시 후 토큰과 폴더명 비교 | `feat/foo` 케이스도 정리됨 | 비예측, prefix `feat/` 정보 손실 | ❌ |
| Case-insensitive exact | 대소문자 무시 비교 | macOS APFS와 명목 정합 | git branch는 case-sensitive라 의도적으로 다른 브랜치를 같다고 오판 | ❌ |
| main repo도 적용 | L2 한 줄 분기에서도 폴더명==branch면 branch 생략 | 일관성 | hypothetical 이득, L2 시각 패턴 깨짐, 실제 발생 거의 없음 | ❌ |
| env escape hatch | `CLAUDE_STATUSLINE_KEEP_REDUNDANT_BRANCH=1` 등으로 끄기 | 일부 세션에서 되돌릴 수 있음 | YAGNI, 조건 분기 + 테스트 표면 증가 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | L3 worktree 블록에 `WORKTREE_BASENAME != GIT_BRANCH` 가드 추가 |
| `modules/shared/programs/claude/files/scripts/tests/statusline.bats` | dir==branch 숨김 케이스 + dir!=branch 회귀 가드 케이스 |

핵심 변경 (statusline.sh):

```bash
# L3 (worktree만): branch
# L2의 "<메인 repo>:<폴더명>" 표기와 GIT_BRANCH가 exact match면 동일 토큰 중복이라 라인째 생략.
# CWD_CANONICAL 부재 시 L2가 ":<폴더명>" 포맷을 못 쓰므로 가드 비활성.
if $IS_WORKTREE; then
  begin_line
  WORKTREE_BASENAME=""
  [ -n "$CWD_CANONICAL" ] && WORKTREE_BASENAME=$(basename "$CWD_CANONICAL")
  if [ -n "$GIT_BRANCH" ] && [ "$WORKTREE_BASENAME" != "$GIT_BRANCH" ]; then
    print_icon "32" "" "\xf0\x9f\x8c\xbf" "$GIT_BRANCH"
  fi
  end_line
fi
```

`begin_line` / `end_line` 패턴의 `LINE_HAS_OUTPUT=false` 분기 덕에 `print_icon` 호출만 skip하면 라인 자체가 자동 생략된다. 별도 라인 제어 로직 불필요.

bats 케이스 (positive + negative):

- `worktree dir==branch hides L3 branch line`: cwd=`/tmp` + worktree.branch=`tmp` fixture에서 출력에 `🌿` 가 한 번도 나오지 않는지 검증.
- `worktree dir!=branch keeps L3 branch line`: cwd=`/tmp` + worktree.branch=`feat-foo` fixture에서 `🌿` 가 정확히 1번 + 브랜치 라벨이 출력되는지 검증 (새 가드의 오발 회귀 가드).

## 6. 참고 레퍼런스

- 직전 인접 변경: PR #802 (settings.json `worktree.baseRef` 를 fresh → head)
- statusline 폭 fallback chain 진화 이력: PR 본문 내 `statusline.sh` Section 8 의 v1~v5 Change Intent Record
- 보안 가드(D-prefix audit findings) 컨텍스트는 동일 파일의 `validate_transcript_path`, `is_safe_session_id`, `sanitize_osc8_url` 참조

## 7. Human Test Plan

전제: main에 머지 후 `nrs` 한 번 돌려 statusline.sh out-of-store symlink가 새 코드로 정렬됐다고 가정.

**Step 1 — 폴더명==브랜치명 worktree**

1. 새 worktree 생성 (또는 기존 워크트리 진입). 예: `.claude/worktrees/foo-bar` 폴더, branch `foo-bar`.
2. statusline 관찰. 기대:
   ```
   📁 ~/Workspace/nixos-config:foo-bar
   📝 Plan ...
   ```
   L3 `🌿 foo-bar` 라인이 **사라진다**.
3. 실패 시 진단: `bash modules/shared/programs/claude/files/scripts/statusline.sh < /dev/null` 직접 실행 → 입력 stdin 누락만 보이면 정상. 실제 입력으로 stdin replay 가능.

**Step 2 — 폴더명≠브랜치명 worktree (회귀 가드)**

1. 같은 worktree에서 `git checkout -b different-branch`.
2. statusline 관찰. 기대:
   ```
   📁 ~/Workspace/nixos-config:foo-bar
   🌿 different-branch
   📝 Plan ...
   ```
   L3 `🌿 different-branch` 라인이 **유지된다**.
3. 실패 시 진단: 가드의 부정 조건이 잘못 적용된 회귀. statusline.sh L3 블록의 `WORKTREE_BASENAME != GIT_BRANCH` 비교를 확인.

**Step 3 — main repo (영향 없음 회귀 가드)**

1. main repo (`~/Workspace/nixos-config`)에서 `main` 브랜치로 작업.
2. statusline 관찰. 기대:
   ```
   📁 ~/Workspace/nixos-config   🌿 main
   ```
   한 줄에 cwd + branch가 함께 표시되는 기존 동작 유지.
3. 실패 시 진단: L2 분기에 영향을 줬다는 신호. statusline.sh의 `# L2:` 블록은 본 PR이 건드리지 않았어야 한다.

## 8. Pre-Merge E2E 테스트 가이드

PR 머지 직전 LLM이 직접 실행 가능한 검증 절차.

### Phase 0 — 정적 검증

```bash
# (1) 변경 반영 확인: WORKTREE_BASENAME 가드 토큰이 L3 블록에 존재
grep -n 'WORKTREE_BASENAME' modules/shared/programs/claude/files/scripts/statusline.sh

# (2) bats 케이스가 두 개 추가됐는지
grep -cE '^@test ".*worktree dir' modules/shared/programs/claude/files/scripts/tests/statusline.bats

# (3) 기존 L3 블록의 print_icon 호출이 가드 안으로 들어갔는지
grep -B1 -A2 '"\\xf0\\x9f\\x8c\\xbf" "\$GIT_BRANCH"' modules/shared/programs/claude/files/scripts/statusline.sh
```

기대: (1) 한 줄 이상 매칭, (2) `2`, (3) `WORKTREE_BASENAME != GIT_BRANCH` 조건 분기 안에 등장.

### Phase 1 — bats 자동 테스트

```bash
bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
```

기대: `15 tests, 0 failures` (기존 13 + 새 2).

실패 케이스 진단:
- `worktree dir==branch hides L3 branch line` fail → 가드가 동작 안 함. `WORKTREE_BASENAME` 추출이 빈 문자열로 끝나는지 점검 (`CWD_CANONICAL` 추출 chain 확인).
- `worktree dir!=branch keeps L3 branch line` fail → 가드가 mismatch까지 잘못 차단. 비교 연산자가 `=`로 뒤집혔는지 점검.

### Phase 2 — Regression (인접 기능)

```bash
# main repo 분기 (L2 한 줄 패턴)는 본 PR이 건드리지 않았음을 코드 레벨에서 확인
grep -n '# L2:' modules/shared/programs/claude/files/scripts/statusline.sh
```

기대: L2 블록(`if ! $IS_WORKTREE; then ... print_icon ... GIT_BRANCH`)에 본 PR 가드가 누설되지 않았는지 시각 확인.

### Phase 3 — 시각 검증 (사람 위임)

LLM이 직접 다중 라인 ANSI/OSC 8 출력의 픽셀 단위 정합성을 검증하기 어려우므로, 위 Human Test Plan의 Step 1-3을 사람에게 위임한다. bats 케이스가 토큰 단위 회귀를 잡으므로 시각 검증은 보강 가드에 해당.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed statusline display to prevent duplicate branch indicators when using git worktrees. Branch tokens now render correctly without redundancy.

* **Tests**
  * Added unit tests validating worktree branch rendering behavior across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->