### PR TITLE
chore(flake): update inputs + caddy FOD hash (multi-host)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777713215,
-        "narHash": "sha256-8GzXDOXckDWwST8TY5DbwYFjdvQLlP7K9CLSVx6iTTo=",
+        "lastModified": 1778958912,
+        "narHash": "sha256-6pvS9rIF9mZRj1ENwu9fDLHeG1JFDTCpRyy6vJhXkTA=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "63b4e7e6cf75307c1d26ac3762b886b5b0247267",
+        "rev": "6e8dc7aa0e65fce67c76e18227a13a7d529f2cdf",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778444552,
-        "narHash": "sha256-f18pIiR9q/p1vHY93gmAum7aHhQOG49oGvAB9+lptRo=",
+        "lastModified": 1779113444,
+        "narHash": "sha256-/L61sT1PIKmGWIQpIh0uJGH/ANvcsf6y4alxtb9kelg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dcebe66f958673729896eec2de4abfd86ef22d21",
+        "rev": "74f170c62d57f90e656841f1f699e6bdf40f0a24",
         "type": "github"
       },
       "original": {
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777780666,
-        "narHash": "sha256-8wURyQMdDkGUarSTKOGdCuFfYiwa3HbzwscUfn3STDE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "8c62fba0854ba15c8917aed18894dbccb48a3777",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778384975,
-        "narHash": "sha256-+27MJizhdJGXTl3jzNKnGU3C+fJJBcTsBQb6PtS5vBE=",
+        "lastModified": 1779077424,
+        "narHash": "sha256-2nuxPFMR1R3IlV/OlF65qjs2gGjHhASa7U0+8QX0bJg=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "5d9f84ecc813690afdd4b35c896904fc02ab6cac",
+        "rev": "b7bde1772cdb20e77381516fbbb5306a621d0965",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -152,11 +152,11 @@
     "yazi-flavors": {
       "flake": false,
       "locked": {
-        "lastModified": 1775725639,
-        "narHash": "sha256-Gm6ThktOLUR+KDs6f3s1WCgrw2TOKQ4tolVvVdCxnCM=",
+        "lastModified": 1778937272,
+        "narHash": "sha256-46x4K4dx4rlU108SXhctJOeGlO/W57Pnofb914Sa4vA=",
         "owner": "yazi-rs",
         "repo": "flavors",
-        "rev": "06708015bfb53b169d99bb3907829f9175105d57",
+        "rev": "54ab389e4deb3d1bc1d8de18d99e825962a55da1",
         "type": "github"
       },
       "original": {

--- a/modules/nixos/programs/caddy.nix
+++ b/modules/nixos/programs/caddy.nix
@@ -17,7 +17,7 @@ let
 
   caddyWithPlugins = pkgs.caddy.withPlugins {
     plugins = [ "github.com/caddy-dns/cloudflare@v0.2.2" ];
-    hash = "sha256-VBmICI1wklu02jmgDRmmlfNc9ftK7a74uF280xzx8uc=";
+    hash = "sha256-dNmccsad8nFm2X9w/6mdgAdhPSquNm6oVhf3sNc46SQ=";
   };
 
   envFilePath = "/run/caddy/env";


### PR DESCRIPTION
## Summary

- Flake input 6개 갱신: `disko`, `home-manager`, `nix-darwin`, `nix-vscode-extensions`, `nixpkgs`, `yazi-flavors`.
- NixOS 전용 `caddy.withPlugins` FOD hash를 새 nixpkgs/caddy 조합에 맞게 갱신.
- Mac (`nrs`) → MiniPC (`nrs`) 양쪽 호스트 적용 검증 완료.

## 기존 문제/배경

`nfu`는 현재 실행 호스트의 빌드만으로 FOD hash mismatch를 잡는다 (mac에서는 darwinConfiguration만, MiniPC에서는 nixosConfiguration만 검증). 이번 nixpkgs 갱신은 `caddy.withPlugins` FOD를 무효화시켰지만 mac 단독 `nfu` 실행으로는 감지 불가했고, MiniPC `nrs`에서 mismatch가 처음 드러났다.

## CIR (Change Intent Record)

해당 없음 — 단순 input 갱신 + 후속 FOD hash 동기화.

검증 흐름만 기록:
1. Mac에서 `nfu` 실행 → flake.lock 6개 input 갱신, darwin nrs 성공.
2. MiniPC에서 `nrs --force` → `caddy-src-with-plugins` FOD hash mismatch.
3. MiniPC에서 `./scripts/fix-fod-hashes.sh --no-cache-check` → 자동으로 caddy.nix hash 교체 + nix build 검증.
4. Mac에서 동일 hash로 commit·push (MiniPC는 lefthook nixfmt가 PATH에 없어 commit 불가, 동일 내용을 mac에서 commit하는 우회).
5. MiniPC가 origin/chore/flake-update를 reset --hard 후 `nrs --force` → 31s 성공, caddy.service 재시작 정상.

## ADR

해당 없음 — 단순 input 갱신.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `flake.lock` | 수정 | 6개 input 갱신 (disko, home-manager, nix-darwin, nix-vscode-extensions, nixpkgs, yazi-flavors) |
| `modules/nixos/programs/caddy.nix` | 수정 | caddy-with-plugins FOD hash 교체 |

### 핵심 코드

```nix
# modules/nixos/programs/caddy.nix
caddyWithPlugins = pkgs.caddy.withPlugins {
  plugins = [ "github.com/caddy-dns/cloudflare@v0.2.2" ];
-  hash = "sha256-VBmICI1wklu02jmgDRmmlfNc9ftK7a74uF280xzx8uc=";
+  hash = "sha256-dNmccsad8nFm2X9w/6mdgAdhPSquNm6oVhf3sNc46SQ=";
};
```

## 참고 레퍼런스

해당 없음 — 정기 input 갱신.

## Human Test Plan

### Mac (darwin)
1. 브랜치를 checkout한 뒤 `nrs --force` 실행.
   - **기대**: home-manager / nix-darwin 새 rev로 활성화 성공.
   - **실패 시**: `nix flake metadata`로 lock된 input rev 확인, `nrs --show-trace`로 활성화 단계 식별.

### MiniPC (NixOS)
2. `ssh minipc 'cd ~/Workspace/nixos-config && ~/.local/bin/nrs --force'`.
   - **기대**: caddy 2.11.3 + cloudflare DNS 플러그인 빌드 성공, `caddy.service` 재시작 후 active.
   - **실패 시**: `systemctl --no-pager status caddy` 및 `journalctl -u caddy -n 50`로 ACME / Tailscale 바인딩 점검.

### 서비스 정합성
3. MiniPC에서 `curl -sI https://archive.greenhead.dev` 등 Tailscale 내부 도메인으로 Caddy 응답 확인.
   - **기대**: HTTPS 응답 200/301/302 (Cloudflare DNS-01 발급 인증서 정상).
   - **실패 시**: `caddy.service` 환경 변수(`/run/agenix/cloudflare-dns-api-token`) 마운트와 ACME 디렉터리 권한을 확인한다.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. flake.lock에 새 nixpkgs rev 반영 확인
grep -q '"rev": "d233902339c02a9c334e7e593de68855ad26c4cb"' flake.lock
# 기대: exit 0

# 2. caddy.nix에 새 FOD hash 반영 확인
grep -q 'sha256-dNmccsad8nFm2X9w/6mdgAdhPSquNm6oVhf3sNc46SQ=' modules/nixos/programs/caddy.nix
# 기대: exit 0

# 3. 옛 FOD hash 잔존 부재 확인
! grep -q 'sha256-VBmICI1wklu02jmgDRmmlfNc9ftK7a74uF280xzx8uc=' modules/nixos/programs/caddy.nix
# 기대: exit 0
```

### Phase 1: Mac 빌드 검증

```bash
nix build ".#darwinConfigurations.\"$(scutil --get LocalHostName)\".config.system.build.toplevel" --no-link
```
- **기대**: 빌드 성공 (exit 0).
- **실패 시**: `nix flake check`로 darwin module 평가 오류 위치 식별.

### Phase 2: MiniPC 빌드 검증

```bash
ssh minipc 'cd ~/Workspace/nixos-config && nix build ".#nixosConfigurations.\"greenhead-minipc\".config.system.build.toplevel" --no-link'
```
- **기대**: caddy-2.11.3 + plugins 포함 toplevel 빌드 성공.
- **실패 시**: `caddy-src-with-plugins` FOD hash mismatch가 재현되면 `scripts/fix-fod-hashes.sh`를 MiniPC에서 재실행.

### Phase 3: Regression (서비스 활성)

```bash
ssh minipc 'systemctl --no-pager is-active caddy anki-sync-server anki-connect'
```
- **기대**: 세 서비스 모두 `active`.
- **실패 시**: `journalctl -u <서비스> -n 100`로 nixpkgs/home-manager 갱신에 의한 systemd 유닛 변화 점검.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Caddy Cloudflare DNS plugin dependency to a newer version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->