### PR TITLE
docs(cheat): pgrep "활성 상태 보기 ≠ pgrep" 매칭 함정 박제

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/process/pgrep
+++ b/modules/shared/programs/cheat/cheatsheets/process/pgrep
@@ -42,6 +42,23 @@ pgrep — 이름/속성으로 PID 검색. 출력은 PID(들). top/htop의 시각
 [조합]
   pgrep -fU green "Chrome"   green 소유 + Chrome 풀 커맨드라인 매칭
 
+[매칭 함정 — "활성 상태 보기에는 보이는데 pgrep은 안 잡을 때"]
+  $ pgrep -l chrome
+  972 chrome_crashpad        ← 15자에서 잘린 결과 (원본: chrome_crashpad_handler)
+  2786 chrome-native-h       ← 동일하게 15자에서 잘림
+  3301 node ...              ← chrome-devtools-mcp 스크립트는 실제 실행 파일이
+                               `node`라서 `chrome`으로는 매칭 안 됨
+  # Google Chrome 계열은 아예 안 보임 — 대문자 `Chrome` 이라 소문자 `chrome` 매칭 실패
+
+  원리:
+    - pgrep 디폴트는 프로세스의 "짧은 실행 파일 이름"(`comm` 필드)만 본다.
+      macOS는 이 필드를 15자에서 자르고, 대소문자도 구분한다.
+    - 활성 상태 보기 "프로세스 이름" 컬럼은 앱 번들의 표시 이름(Info.plist)과
+      실행 명령어(argv) 를 합쳐 보여줘서, pgrep `comm` 과 근본적으로 다르다.
+
+  해법: $ pgrep -fil chrome
+          # -f 실행 명령어 전체 매칭 / -i 대소문자 무시 / -l 이름 같이 출력
+
 Tip
 - 결과를 죽이려면 pgrep 대신 pkill을 직접 쓴다 (cheat process/pkill).
 - top 화면의 COMMAND 컬럼은 잘려 있으니 `pgrep -f` 또는 `ps -Ao command` 로 풀 이름 확인.


### PR DESCRIPTION
## Summary
- macOS 활성 상태 보기의 chrome 검색 결과와 `pgrep chrome` 결과가 1:1로 매칭되지 않는 이유 4가지를 `process/pgrep` cheatsheet에 시나리오 형태로 박제한다.
- 다음 혼선 시 즉시 참조 가능하도록 해법 명령(`pgrep -fil PATTERN`)도 함께 기록한다.

## 기존 문제/배경

활성 상태 보기에서 "chrome"으로 검색하면 `Google Chrome`, `Google Chrome Helper (Renderer)`, `chrome-devtools-mcp`, `chrome_crashpad_handler`, `chrome-native-host` 등이 보이지만, 터미널에서 `pgrep -l chrome`을 치면:

- `chrome_crashpad`, `chrome-native-h` (이름이 잘려서 활성 상태 보기와 표기가 다름)
- 다수의 `node` 프로세스 (chrome 키워드로는 매칭이 안 잡힐 것 같은데도 잡힘)
- `Google Chrome*` 류는 아예 안 나옴

같은 화면을 보고 있는데 결과가 다르게 보여 사용자가 혼선을 겪는다. 네 가지 원인(comm vs argv, BSD 15자 트렁케이트, 대소문자 구분, 활성 상태 보기의 합성 표시명)이 동시에 작용하지만 cheatsheet 어디에도 적혀 있지 않아 같은 혼선이 반복될 수 있다.

## CIR (Change Intent Record)

- **형식 결정**: Tip 1줄 vs 새 섹션 → 새 섹션 채택. 4가지 원인이 동시에 작용하는 사례라서 한 줄로는 재발 방지가 어렵다고 판단.
- **범위 결정**: 핵심 2가지(comm vs argv + 15자 트렁케이트) vs 4가지 전부 → 4가지 전부. 각 원인이 단독으로도 혼선을 유발할 수 있어 하나라도 빠지면 같은 함정이 다시 발생.
- **구조 결정**: 원인 나열형 vs 시나리오 재현형 → 시나리오 재현형. 인접 파일 `process/scenarios`의 스타일과 일관되고, 재발 시 검색 매칭이 용이.
- **톤 결정**: 작성자가 시스템 엔지니어링 무경험임을 명시. 기술 용어(`comm`, `argv`, `Info.plist`)는 동일 시리즈(`process/ps`의 `comm vs command`) 어휘와 통일하되, 첫 등장 시 짧은 풀이를 옆에 붙여 진입 장벽을 낮춤.

**trade-off**: 17줄 추가로 다른 섹션 대비 약간 길어지지만, 4가지 원인 + 시나리오 + 해법까지 한 곳에서 자기완결적으로 해소된다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Tip 한 줄 추가 | 기존 `Tip` 섹션에 1줄 보충 | 최소 변경 | 4원인 전달 불가, 시나리오 재현 불가 | ❌ |
| `[매칭 함정]` 새 섹션 | 실제 혼선 상황을 재현하며 4원인 + 해법 명령 박제 | 검색 매칭 용이, 자기완결적, 인접 cheatsheet 스타일과 일관 | 17줄로 다른 섹션보다 약간 김 | ✅ |
| `process/scenarios`에만 추가 | scenarios 파일에 새 시나리오로 분리 | scenarios 본래 용도와 일치 | `pgrep` cheatsheet만 보는 흐름에서는 발견 불가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/cheat/cheatsheets/process/pgrep` | 수정 | `[조합]` 뒤, `Tip` 앞에 `[매칭 함정]` 섹션 17줄 추가 |

### 핵심 스니펫

```
[매칭 함정 — "활성 상태 보기에는 보이는데 pgrep은 안 잡을 때"]
  $ pgrep -l chrome
  972 chrome_crashpad        ← 15자에서 잘린 결과 (원본: chrome_crashpad_handler)
  2786 chrome-native-h       ← 동일하게 15자에서 잘림
  3301 node ...              ← chrome-devtools-mcp 스크립트는 실제 실행 파일이
                               `node`라서 `chrome`으로는 매칭 안 됨
  # Google Chrome 계열은 아예 안 보임 — 대문자 `Chrome` 이라 소문자 `chrome` 매칭 실패

  원리:
    - pgrep 디폴트는 프로세스의 "짧은 실행 파일 이름"(`comm` 필드)만 본다.
      macOS는 이 필드를 15자에서 자르고, 대소문자도 구분한다.
    - 활성 상태 보기 "프로세스 이름" 컬럼은 앱 번들의 표시 이름(Info.plist)과
      실행 명령어(argv) 를 합쳐 보여줘서, pgrep `comm` 과 근본적으로 다르다.

  해법: $ pgrep -fil chrome
          # -f 실행 명령어 전체 매칭 / -i 대소문자 무시 / -l 이름 같이 출력
```

## 참고 레퍼런스

- `modules/shared/programs/cheat/cheatsheets/process/ps` — `comm vs command` 어휘가 먼저 정의된 인접 cheatsheet (용어 일관성 유지)
- `modules/shared/programs/cheat/cheatsheets/process/scenarios` — 시나리오형 cheatsheet의 기존 스타일 참고

## Human Test Plan

### 정상 동작 검증

1. 변경을 반영한 뒤(`nrs`) 터미널에서 `cheat process/pgrep`을 실행한다.
   - **기대**: `[매칭 함정 — "활성 상태 보기에는 보이는데 pgrep은 안 잡을 때"]` 섹션이 `[조합]`과 `Tip` 사이에 표시된다.
   - **실패 시**: home-manager activation으로 cheatsheet 파일이 `$HOME` 경로에 정상 배포되었는지 확인.

2. 같은 페이지에서 4가지 원인이 모두 식별되는지 읽는다.
   - **기대**: 15자 트렁케이트, node 스크립트, 대소문자, 표시명 합성 — 4가지가 모두 본문에 등장.
   - **실패 시**: 부분 누락이면 cheatsheet 파일을 다시 확인.

3. 실제로 활성 상태 보기에서 chrome 검색 후 터미널에서 `pgrep -fil chrome`을 실행해 결과를 비교한다.
   - **기대**: 활성 상태 보기 표시 항목 거의 전부가 pgrep 결과에도 포함된다.

### 엣지 케이스

4. 시스템 엔지니어링 무경험자가 읽고 4가지 원인을 즉시 이해할 수 있는지 검토.
   - **기대**: 괄호 안 풀이만 보고도 `comm`/`argv`/`Info.plist`가 무엇을 가리키는지 짐작 가능.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 섹션 헤더 존재
grep -Fq '[매칭 함정' modules/shared/programs/cheat/cheatsheets/process/pgrep
# 기대: exit 0

# 2. 해법 명령 존재
grep -Fq 'pgrep -fil chrome' modules/shared/programs/cheat/cheatsheets/process/pgrep
# 기대: exit 0

# 3. 기존 Tip 섹션 보존
grep -q '^Tip$' modules/shared/programs/cheat/cheatsheets/process/pgrep
# 기대: exit 0
```

### Phase 1: 섹션 배치 검증

> "새 섹션이 [조합]과 Tip 사이에 위치하는지 확인"

```bash
awk '/^\[조합\]/{f=1; next} /^Tip$/{f=0} f' \
  modules/shared/programs/cheat/cheatsheets/process/pgrep \
  | grep -Fq '매칭 함정'
```
- **기대**: exit 0.
- **실패 시**: 섹션이 다른 위치에 들어갔거나 헤더 문자열이 다른지 확인.

### Phase 2: 4가지 원인 모두 박제 여부 검증

> "comm vs argv, 15자 트렁케이트, 대소문자, 표시명 합성 4가지가 모두 본문에 등장"

```bash
file=modules/shared/programs/cheat/cheatsheets/process/pgrep
grep -Fq '15자에서 잘린' "$file"
grep -Fq 'node' "$file"
grep -Fq '대문자' "$file"
grep -Fq 'Info.plist' "$file"
```
- **기대**: 4개 모두 exit 0.
- **실패 시**: 누락된 원인을 본문에 보강.

### Phase 3: Regression

> "기존 섹션이 모두 보존되어 있는지 확인"

```bash
file=modules/shared/programs/cheat/cheatsheets/process/pgrep
for h in '[기본 매칭]' '[풀 커맨드라인 매칭]' '[속성 필터]' '[조합]' 'Tip'; do
  grep -Fq "$h" "$file" || echo "MISSING: $h"
done
```
- **기대**: 출력 없음.
- **실패 시**: 누락된 헤더를 복원.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the pgrep cheatsheet with a new section explaining when processes may not match as expected, including limitations around character length and case sensitivity, with practical examples and workaround solutions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->