### PR TITLE
docs(codex): hooks rollback 가이드를 codex_hooks → hooks로 정정

### DIFF
--- a/modules/shared/programs/codex/files/config.darwin.toml
+++ b/modules/shared/programs/codex/files/config.darwin.toml
@@ -22,8 +22,10 @@ goals = true
 default_mode_request_user_input = true
 
 # Codex 0.124+ stable hooks (issue #585 / epic #584).
-# `codex_hooks` feature flag는 PR openai/codex#19012로 default-enabled가 되어 명시
-# 활성화 불필요. 발화 미실측 시 rollback path = `[features].codex_hooks = true`.
+# hooks는 PR openai/codex#19012로 default-enabled가 되어 `[features].hooks`로 노출되며
+# 명시 활성화 불필요. 강제 활성화가 필요하면 `[features].hooks = true`.
+# 구 `codex_hooks` flag는 codex 0.130 기준 deprecated alias다 — 입력 시 codex가
+# "[features].codex_hooks is deprecated. Use [features].hooks instead." 경고를 띄우므로 사용 금지.
 # Stop은 _stop-dispatcher.sh 단일 entry로 등록 (Codex가 같은 이벤트의 multiple command를
 # concurrent 실행하므로 ordering 보장을 dispatcher에 위임).
 # subagent agent_id 부재 등은 graceful fallback에 의존.

--- a/modules/shared/programs/codex/files/config.toml
+++ b/modules/shared/programs/codex/files/config.toml
@@ -23,8 +23,10 @@ goals = true
 default_mode_request_user_input = true
 
 # Codex 0.124+ stable hooks (issue #585 / epic #584).
-# `codex_hooks` feature flag는 PR openai/codex#19012로 default-enabled가 되어 명시
-# 활성화 불필요. 발화 미실측 시 rollback path = `[features].codex_hooks = true`.
+# hooks는 PR openai/codex#19012로 default-enabled가 되어 `[features].hooks`로 노출되며
+# 명시 활성화 불필요. 강제 활성화가 필요하면 `[features].hooks = true`.
+# 구 `codex_hooks` flag는 codex 0.130 기준 deprecated alias다 — 입력 시 codex가
+# "[features].codex_hooks is deprecated. Use [features].hooks instead." 경고를 띄우므로 사용 금지.
 # Stop은 _stop-dispatcher.sh 단일 entry로 등록 (Codex가 같은 이벤트의 multiple command를
 # concurrent 실행하므로 ordering 보장을 dispatcher에 위임).
 # subagent agent_id 부재 등은 graceful fallback에 의존.


### PR DESCRIPTION
## Summary

- codex 0.130에서 lifecycle hooks 활성화 feature flag가 `codex_hooks` → `hooks`로 rename되어, `codex_hooks`는 deprecated legacy alias가 되었다.
- Codex config 템플릿(`config.toml` / `config.darwin.toml`) 주석의 rollback 예시가 구 flag명(`[features].codex_hooks = true`)을 가리켜, 가이드대로 입력하면 codex가 deprecation 경고를 띄운다.
- rollback 예시를 `[features].hooks = true`로 정정하고, `codex_hooks`가 deprecated alias임을 주석에 명시한다.

관련 이슈 없음 (Closes 대상 없음).

## 기존 문제/배경

Codex 데스크탑 앱의 "사용자 지정 config.toml 설정" 화면에서 다음 경고가 관측되었다:

> `[features].codex_hooks` is deprecated. Use `[features].hooks` instead.
> Enable it with `--enable hooks` or `[features].hooks` in config.toml.

분석 결과:

- 실제 `~/.codex/config.toml`에는 `codex_hooks`가 **없다**. `plugin_hooks = true`와 정상 `[[hooks.*]]` 배열만 존재한다.
- `codex features list` (codex 0.130.0) 기준 `hooks`는 `stable / true`로 **정상 활성**이며, `codex_hooks`는 목록에 없다(완전히 deprecated alias로 강등).
- 즉 hooks 기능 자체는 default-enabled로 잘 동작하며 기능 장애가 아니다.
- 경고는 Codex 데스크탑 앱이 config 텍스트를 실시간 파싱해 띄우는 인라인 검증이며, 트리거는 `codex_hooks`가 든 텍스트 입력이다.

repo의 config 템플릿 주석에는 다음과 같은 rollback 가이드가 있었다:

> 발화 미실측 시 rollback path = `` `[features].codex_hooks = true` ``

이 가이드대로 강제 활성화를 시도하면 정확히 위 deprecation 경고가 발생한다. `codex_hooks`가 deprecated된 이후 이 주석이 stale 상태였다.

## CIR (Change Intent Record)

단순 주석 정정. 발견 경위와 결정 근거만 기록한다.

- 데스크탑 앱 경고 관측 → 실제 `config.toml` / 앱 상태(`.codex-global-state.json`) / `codex-tui.log`를 점검해 활성 `codex_hooks`가 없음을 확인.
- `codex features list`로 `hooks = stable / true`(정상 활성) 및 `codex_hooks` 미표시를 확인.
- codex 0.130.0 바이너리에서 `codex_hooks`가 deprecated alias로 잔존하고 deprecation 메시지 템플릿(`` `[features].X` is deprecated. Use `[features].Y` instead. ``)이 존재함을 확인.
- 위 사실들을 종합해, 경고의 가장 유력한 트리거가 repo 주석의 stale한 rollback 예시임을 특정.

**trade-off**: 주석 라인이 2줄 늘지만, rollback 가이드의 유용성을 유지하면서 정확성과 재발 방지(왜 codex_hooks를 쓰면 안 되는지)를 확보한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| rollback 라인 삭제 | rollback 가이드 자체를 제거 | 주석 간결 | 강제 활성화 방법 안내가 사라짐 | ❌ |
| flag명 정정 + deprecated 명시 | `codex_hooks` → `hooks`로 고치고 구 flag가 deprecated임을 경고로 추가 | 가이드 유지 + 정확성 + 재발 방지 | 주석 2줄 증가 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/codex/files/config.toml` | 수정 | hooks rollback 주석 정정 (codex_hooks → hooks) |
| `modules/shared/programs/codex/files/config.darwin.toml` | 수정 | 동일 주석 정정 (두 파일 동기 유지) |

### 핵심 변경 (BEFORE / AFTER)

```diff
 # Codex 0.124+ stable hooks (issue #585 / epic #584).
-# `codex_hooks` feature flag는 PR openai/codex#19012로 default-enabled가 되어 명시
-# 활성화 불필요. 발화 미실측 시 rollback path = `[features].codex_hooks = true`.
+# hooks는 PR openai/codex#19012로 default-enabled가 되어 `[features].hooks`로 노출되며
+# 명시 활성화 불필요. 강제 활성화가 필요하면 `[features].hooks = true`.
+# 구 `codex_hooks` flag는 codex 0.130 기준 deprecated alias다 — 입력 시 codex가
+# "[features].codex_hooks is deprecated. Use [features].hooks instead." 경고를 띄우므로 사용 금지.
```

`[features]` 본문(hooks 배열, `plugin_hooks` 등 실제 동작 키)은 변경하지 않았다. 주석만 바뀌어 동작 변화는 없다.

## 참고 레퍼런스

- PR openai/codex#19012 — hooks를 default-enabled로 전환한 upstream PR (주석 내 기존 참조).
- issue #585 / epic #584 — 본 repo의 Codex stable hooks 도입 작업 (주석 내 기존 참조).
- [Codex config — feature flags](https://developers.openai.com/codex/config-basic#feature-flags) — `hooks`(Stable, default true) 문서. `codex_hooks` 항목은 문서에서 제거됨.

## Human Test Plan

### 정상 동작 검증

1. main 또는 본 브랜치에서 `nrs`를 실행한다.
   - **기대**: `~/.codex/config.toml`의 `[features]` 본문은 변화 없이, hooks 관련 주석만 새 문구로 반영된다.
   - **실패 시**: `syncCodexConfig`가 leaf 단위 merge만 수행하므로, 주석은 seed(template) 기준으로 반영된다. 실제 파일과 seed의 주석을 비교한다.

2. Codex 데스크탑 앱 "사용자 지정 config.toml 설정" 화면에서 `[features]`에 `hooks = true`를 입력한다.
   - **기대**: deprecation 경고가 뜨지 않는다.
   - **실패 시**: codex 버전을 확인한다(`codex --version`). 0.130 미만이면 flag 동작이 다를 수 있다.

3. 같은 화면에서 `codex_hooks = true`를 입력한다.
   - **기대**: `codex_hooks is deprecated. Use [features].hooks instead.` 경고가 재현된다 (의도된 동작 — 주석이 이를 경고함).

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# 1. 새 rollback 문구(hooks)가 두 파일에 모두 반영되었는지
grep -Fq '`[features].hooks = true`' modules/shared/programs/codex/files/config.toml
grep -Fq '`[features].hooks = true`' modules/shared/programs/codex/files/config.darwin.toml
# 기대: 둘 다 exit 0

# 2. 구 rollback 예시(codex_hooks = true)가 사라졌는지
! grep -Fq 'rollback path = `[features].codex_hooks = true`' modules/shared/programs/codex/files/config.toml
! grep -Fq 'rollback path = `[features].codex_hooks = true`' modules/shared/programs/codex/files/config.darwin.toml
# 기대: 둘 다 exit 0 (구 문구가 없어야 성공)

# 3. deprecated 경고 명시 라인이 추가되었는지
grep -Fq 'deprecated alias' modules/shared/programs/codex/files/config.toml
# 기대: exit 0
```

### Phase 1: 기능 검증 (codex 0.130 환경)

> "현재 config 기준 hooks가 정상 활성 상태인지 확인"

```bash
codex features list 2>/dev/null | grep -E '^hooks\s' 
# 기대: hooks ... stable ... true
codex features list 2>/dev/null | grep -E '^codex_hooks\s' || echo "codex_hooks 미표시 (정상 — deprecated alias)"
# 기대: codex_hooks 라인 없음
```

- **실패 시**: codex 버전이 0.130 미만이거나 alias 동작이 환경마다 다를 수 있다. `codex --version` 확인.

### Phase 2: Regression

> "주석만 바뀌고 실제 동작 키는 무변경인지 확인"

```bash
# [features] 본문 키들이 그대로인지 (multi_agent / hooks 배열 / plugin 등록 등)
git diff main...HEAD -- modules/shared/programs/codex/files/config.toml \
  | grep -E '^[+-]' | grep -vE '^[+-]#' | grep -vE '^[+-]{3}'
# 기대: 출력 없음 (주석 외 라인 변경이 없어야 함)
```

- **실패 시**: 주석 외 라인이 변경되었다면 본 PR 범위를 벗어난 것이므로 재검토한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified configuration documentation for the hooks feature, confirming default-enabled status and the recommended configuration method
  * Added guidance to avoid deprecated configuration options that trigger warnings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->