### PR TITLE
fix(statusline): plan 아이콘 false positive 제거 (프로젝트 폴백 + unknown state)

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -274,15 +274,20 @@ if $DO_HEAVY; then
 #    유발했다 (하나의 plan이 장기간 다수의 새 세션에 전염되고, 세션마다
 #    복사본을 양산해 plans 디렉토리를 오염시켰다).
 #    이제 우선순위는 (1) transcript 직접 감지 (2) 세션별 state 뿐이다.
-#    세션별 state는 transcript에서 plan을 감지했을 때만 기록되므로 (아래
-#    첫 분기), 같은 session_id의 resume/compact 복원에만 쓰이고 교차 세션
-#    누출이 없다.
+#    세션별 state는 유효한 SESSION_ID가 있고(SIDECAR_IO_ENABLED) transcript에서
+#    plan을 감지했을 때만 기록되므로 (아래 첫 분기), 같은 session_id의
+#    resume/compact 복원에만 쓰이고 교차 세션 누출이 없다. SESSION_ID 검증
+#    실패(빈 값) 시 다른 sidecar I/O와 동일하게 state를 만들지 않는다 —
+#    `.statusline-plan-${SESSION_ID:-unknown}`의 unknown fallback을 그대로 두면
+#    같은 transcript dir의 모든 invalid identity가 `.statusline-plan-unknown`을
+#    공유해 false positive가 축소 재발하므로, SIDECAR_IO_ENABLED 가드로 막는다.
 #    trade-off: /clear로 session_id가 바뀐 직후 세션은 plan 아이콘이 사라진다.
 #    의도적 컨텍스트 리셋이라 '잘못된 plan 표시'보다 안전한 실패 모드이며,
 #    plan을 다시 보려면 사용자가 직접 열거나 plan mode를 재진입한다.
 PLAN_STATE_FILE=""
-if $TRANSCRIPT_VALID; then
-  PLAN_STATE_FILE="$CANONICAL_TRANSCRIPT_DIR/.statusline-plan-${SESSION_ID:-unknown}"
+if $SIDECAR_IO_ENABLED; then
+  # SIDECAR_IO_ENABLED = 유효 SESSION_ID + TRANSCRIPT_VALID (Section 3). unknown fallback 불필요.
+  PLAN_STATE_FILE="$CANONICAL_TRANSCRIPT_DIR/.statusline-plan-${SESSION_ID}"
 fi
 
 if $TRANSCRIPT_VALID && [ -f "$TRANSCRIPT" ]; then

--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -264,16 +264,25 @@ if $DO_HEAVY; then
 # v2: /clear 시 Claude Code가 새 transcript(= 새 session_id)를 생성하여
 #    이전 session_id의 state file을 찾지 못하는 문제 발견.
 #    프로젝트 단위 fallback (.statusline-plan-current) 추가.
-#    우선순위: transcript 감지 > 세션별 state > 프로젝트 단위 state.
-# v3: 프로젝트 단위 fallback 사용 시 plan 파일 복사본 생성.
-#    원본과의 편집 충돌 방지. 복사본 이름: <원본>-<session_id 8자>.md.
-# v4 (이번): TRANSCRIPT_VALID 조건 추가. canonical transcript dir에 state 파일 조립.
+# v3: 프로젝트 단위 fallback 사용 시 plan 파일 복사본 생성 (편집 충돌 방지).
+#    복사본 이름: <원본>-<session_id 8자>.md.
+# v4: TRANSCRIPT_VALID 조건 추가. canonical transcript dir에 state 파일 조립.
 #    raw `dirname "$TRANSCRIPT"` 대신 canonical 경로 사용으로 path traversal 차단.
+# v5 (이번): 프로젝트 단위 fallback(v2)과 복사본 생성(v3)을 제거.
+#    [근거] 프로젝트 fallback은 영구·무차별적이어서, plan을 세운 적 없는
+#    무관한 세션에도 "프로젝트의 마지막 plan"을 상속시켜 false positive를
+#    유발했다 (하나의 plan이 장기간 다수의 새 세션에 전염되고, 세션마다
+#    복사본을 양산해 plans 디렉토리를 오염시켰다).
+#    이제 우선순위는 (1) transcript 직접 감지 (2) 세션별 state 뿐이다.
+#    세션별 state는 transcript에서 plan을 감지했을 때만 기록되므로 (아래
+#    첫 분기), 같은 session_id의 resume/compact 복원에만 쓰이고 교차 세션
+#    누출이 없다.
+#    trade-off: /clear로 session_id가 바뀐 직후 세션은 plan 아이콘이 사라진다.
+#    의도적 컨텍스트 리셋이라 '잘못된 plan 표시'보다 안전한 실패 모드이며,
+#    plan을 다시 보려면 사용자가 직접 열거나 plan mode를 재진입한다.
 PLAN_STATE_FILE=""
-PROJECT_PLAN_STATE=""
 if $TRANSCRIPT_VALID; then
   PLAN_STATE_FILE="$CANONICAL_TRANSCRIPT_DIR/.statusline-plan-${SESSION_ID:-unknown}"
-  PROJECT_PLAN_STATE="$CANONICAL_TRANSCRIPT_DIR/.statusline-plan-current"
 fi
 
 if $TRANSCRIPT_VALID && [ -f "$TRANSCRIPT" ]; then
@@ -284,22 +293,11 @@ if $TRANSCRIPT_VALID && [ -f "$TRANSCRIPT" ]; then
     | tail -1 | sed 's/^"[^"]*":"//;s/"$//')
 fi
 
+# 우선순위: (1) transcript 직접 감지 → 세션별 state 기록  (2) 미감지 → 세션별 state 복원
 if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ] && [ -n "$PLAN_STATE_FILE" ]; then
   printf '%s' "$PLAN_FILE" > "$PLAN_STATE_FILE" 2>/dev/null
-  [ -n "$PROJECT_PLAN_STATE" ] && printf '%s' "$PLAN_FILE" > "$PROJECT_PLAN_STATE" 2>/dev/null
 elif [ -z "$PLAN_FILE" ] && [ -n "$PLAN_STATE_FILE" ] && [ -f "$PLAN_STATE_FILE" ]; then
   PLAN_FILE=$(cat "$PLAN_STATE_FILE" 2>/dev/null)
-elif [ -z "$PLAN_FILE" ] && [ -n "$PROJECT_PLAN_STATE" ] && [ -f "$PROJECT_PLAN_STATE" ]; then
-  ORIGINAL_PLAN=$(cat "$PROJECT_PLAN_STATE" 2>/dev/null)
-  if [ -n "$ORIGINAL_PLAN" ] && [ -f "$ORIGINAL_PLAN" ]; then
-    PLAN_COPY="$(dirname "$ORIGINAL_PLAN")/$(basename "$ORIGINAL_PLAN" .md)-${SESSION_ID:0:8}.md"
-    if [ ! -f "$PLAN_COPY" ]; then
-      cp "$ORIGINAL_PLAN" "$PLAN_COPY"
-      find "$(dirname "$ORIGINAL_PLAN")" -name "*-????????.md" -mtime +30 -delete 2>/dev/null || true
-    fi
-    PLAN_FILE="$PLAN_COPY"
-    [ -n "$PLAN_STATE_FILE" ] && printf '%s' "$PLAN_FILE" > "$PLAN_STATE_FILE" 2>/dev/null
-  fi
 fi
 
 # -- Memory 감지 (canonical transcript dir 기반)

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -537,3 +537,29 @@ EOF
   echo "$plain" | grep -qF 'Plan' \
     || { echo "expected Plan icon restored from session-level state; got: $plain" >&2; false; }
 }
+
+@test "plan: invalid session_id does NOT restore shared unknown state" {
+  # stdin session_id가 validate_session_id 실패('..' 포함)면 SESSION_ID="" →
+  # SIDECAR_IO_ENABLED=false → PLAN_STATE_FILE 미생성. 따라서 같은 transcript dir의
+  # 다른 invalid identity가 남긴 .statusline-plan-unknown 공유 state를 복원하지 않아야 한다.
+  # (가드 부재 시: .statusline-plan-${SESSION_ID:-unknown} = .statusline-plan-unknown 복원 → false positive)
+  local sid="bad..sid"
+  local validname="abcd1234-0000-1111-2222-333344445555"
+  PLAN_HOME="$BATS_TEST_TMPDIR/h-invalidsid"
+  PLAN_TDIR="$PLAN_HOME/.claude/projects/test-proj"
+  local leak_md="$PLAN_HOME/.claude/plans/leaked.md"
+  mkdir -p "$PLAN_TDIR" "$(dirname "$leak_md")"
+  printf '# leaked\n' > "$leak_md"
+  printf '%s\n' '{"type":"user","message":{"role":"user"}}' > "$PLAN_TDIR/$validname.jsonl"
+  # unknown 공유 state가 실재 plan을 가리켜도 복원되면 안 된다
+  printf '%s' "$leak_md" > "$PLAN_TDIR/.statusline-plan-unknown"
+
+  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TDIR/$validname.jsonl")" HOME="$PLAN_HOME"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  if echo "$plain" | grep -qF 'Plan'; then
+    echo "expected NO Plan icon with invalid session_id (unknown state must not be restored); got: $plain" >&2
+    false
+  fi
+}

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -488,6 +488,22 @@ _plan_json() {
 EOF
 }
 
+# plan fixture 실행 helper: HOME + XDG_* 를 모두 PLAN_HOME 하위로 pin 한다.
+# statusline.sh 는 HEAVY_CACHE_DIR/CACHE_TTL_DIR 에서 XDG_* 를 직접 참조하므로
+# (sidecar test 와 동일 사유), HOME 만 override 하면 부모 shell 의 XDG_* 가 set 일 때
+# heavy/cache 파일이 실제 시스템 경로로 leak 되어 호스트를 오염시키고 다음 run 의
+# cached vars 가 stale 해져 비결정적이 된다. PLAN_HOME 은 BATS_TEST_TMPDIR 하위라
+# 케이스마다 새로 생성된다.
+_run_plan() {
+  run run_statusline_with_input "$1" \
+    HOME="$PLAN_HOME" \
+    XDG_CONFIG_HOME="$PLAN_HOME/.config" \
+    XDG_CACHE_HOME="$PLAN_HOME/.cache" \
+    XDG_STATE_HOME="$PLAN_HOME/.local/state" \
+    XDG_DATA_HOME="$PLAN_HOME/.local/share" \
+    XDG_RUNTIME_DIR="$PLAN_HOME/.run"
+}
+
 @test "plan: project-level state alone does NOT show Plan (v5 false-positive guard)" {
   local sid="planfp01-1111-2222-3333-444455556666"
   _setup_plan_home "$sid"
@@ -496,7 +512,7 @@ EOF
   # 다른 세션이 남긴 프로젝트 단위 state만 존재 (v5 이전엔 이게 상속됐다)
   printf '%s' "$PLAN_MD" > "$PLAN_TDIR/.statusline-plan-current"
 
-  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")" HOME="$PLAN_HOME"
+  _run_plan "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")"
   [ "$status" -eq 0 ]
   local plain
   plain=$(echo "$output" | strip_ansi)
@@ -515,7 +531,7 @@ EOF
   _setup_plan_home "$sid"
   printf '%s\n' "{\"type\":\"assistant\",\"planFilePath\":\"$PLAN_MD\"}" > "$PLAN_TRANSCRIPT"
 
-  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")" HOME="$PLAN_HOME"
+  _run_plan "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")"
   [ "$status" -eq 0 ]
   local plain
   plain=$(echo "$output" | strip_ansi)
@@ -530,7 +546,7 @@ EOF
   # 같은 session_id가 과거에 감지해 남긴 세션별 state (resume/compact 복원 경로)
   printf '%s' "$PLAN_MD" > "$PLAN_TDIR/.statusline-plan-$sid"
 
-  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")" HOME="$PLAN_HOME"
+  _run_plan "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")"
   [ "$status" -eq 0 ]
   local plain
   plain=$(echo "$output" | strip_ansi)
@@ -554,7 +570,7 @@ EOF
   # unknown 공유 state가 실재 plan을 가리켜도 복원되면 안 된다
   printf '%s' "$leak_md" > "$PLAN_TDIR/.statusline-plan-unknown"
 
-  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TDIR/$validname.jsonl")" HOME="$PLAN_HOME"
+  _run_plan "$(_plan_json "$sid" "$PLAN_TDIR/$validname.jsonl")"
   [ "$status" -eq 0 ]
   local plain
   plain=$(echo "$output" | strip_ansi)

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -452,3 +452,88 @@ EOF
   echo "$plain" | grep -qF 'tmp' \
     || { echo "expected branch label 'tmp' in output; got: $plain" >&2; false; }
 }
+
+# ============================================================
+# Plan 아이콘 감지 (v5: 프로젝트 단위 fallback 제거 회귀 가드)
+# ============================================================
+# Plan 아이콘은 (1) transcript 직접 감지 또는 (2) 세션별 state 복원으로만
+# 표시된다. v5 이전의 프로젝트 단위 fallback(.statusline-plan-current)은
+# plan을 세운 적 없는 무관한 세션에 다른 세션의 plan을 상속시켜 false
+# positive를 유발했으므로 제거됐다. 아래 케이스는 가짜 HOME 아래
+# $HOME/.claude/projects/<dir>/ 구조를 만들어 TRANSCRIPT_VALID 신뢰 경계를
+# 통과시킨 뒤 plan 분기를 직접 검사한다. plan 토큰은 아이콘 label "Plan"으로
+# 식별한다 (strip_ansi가 OSC 8 hyperlink를 제거해도 label은 남는다).
+
+# 가짜 HOME + canonical transcript dir + plan .md 생성.
+# 인자: $1=session_id (고유). 전역 PLAN_HOME/PLAN_TDIR/PLAN_TRANSCRIPT/PLAN_MD 설정.
+_setup_plan_home() {
+  PLAN_HOME="$BATS_TEST_TMPDIR/h-$1"
+  PLAN_TDIR="$PLAN_HOME/.claude/projects/test-proj"
+  PLAN_TRANSCRIPT="$PLAN_TDIR/$1.jsonl"
+  PLAN_MD="$PLAN_HOME/.claude/plans/the-plan.md"
+  mkdir -p "$PLAN_TDIR" "$(dirname "$PLAN_MD")"
+  printf '# plan body\n' > "$PLAN_MD"
+}
+
+# plan fixture용 stdin JSON. $1=session_id $2=transcript_path
+_plan_json() {
+  cat <<EOF
+{
+  "session_id": "$1",
+  "transcript_path": "$2",
+  "cwd": "/tmp",
+  "model": {"display_name": "test"},
+  "workspace": {"current_dir": "/tmp"}
+}
+EOF
+}
+
+@test "plan: project-level state alone does NOT show Plan (v5 false-positive guard)" {
+  local sid="planfp01-1111-2222-3333-444455556666"
+  _setup_plan_home "$sid"
+  # transcript에 plan 경로 없음 (무관한 user 라인만)
+  printf '%s\n' '{"type":"user","message":{"role":"user"}}' > "$PLAN_TRANSCRIPT"
+  # 다른 세션이 남긴 프로젝트 단위 state만 존재 (v5 이전엔 이게 상속됐다)
+  printf '%s' "$PLAN_MD" > "$PLAN_TDIR/.statusline-plan-current"
+
+  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")" HOME="$PLAN_HOME"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  if echo "$plain" | grep -qF 'Plan'; then
+    echo "expected NO Plan icon from project-level state alone (v5 removed project fallback); got: $plain" >&2
+    false
+  fi
+  # 복사본도 생성되지 않아야 한다 (v3 복사본 로직 제거 확인)
+  copy_count=$(find "$(dirname "$PLAN_MD")" -name 'the-plan-*.md' 2>/dev/null | wc -l | tr -d ' ')
+  [ "$copy_count" -eq 0 ] \
+    || { echo "expected no plan copy created (v5 removed v3 copy logic); got count=$copy_count" >&2; false; }
+}
+
+@test "plan: transcript with plan path shows Plan" {
+  local sid="planok01-1111-2222-3333-444455556666"
+  _setup_plan_home "$sid"
+  printf '%s\n' "{\"type\":\"assistant\",\"planFilePath\":\"$PLAN_MD\"}" > "$PLAN_TRANSCRIPT"
+
+  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")" HOME="$PLAN_HOME"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  echo "$plain" | grep -qF 'Plan' \
+    || { echo "expected Plan icon from transcript planFilePath; got: $plain" >&2; false; }
+}
+
+@test "plan: session-level state restores Plan when transcript lacks it" {
+  local sid="planss01-1111-2222-3333-444455556666"
+  _setup_plan_home "$sid"
+  printf '%s\n' '{"type":"user","message":{"role":"user"}}' > "$PLAN_TRANSCRIPT"
+  # 같은 session_id가 과거에 감지해 남긴 세션별 state (resume/compact 복원 경로)
+  printf '%s' "$PLAN_MD" > "$PLAN_TDIR/.statusline-plan-$sid"
+
+  run run_statusline_with_input "$(_plan_json "$sid" "$PLAN_TRANSCRIPT")" HOME="$PLAN_HOME"
+  [ "$status" -eq 0 ]
+  local plain
+  plain=$(echo "$output" | strip_ansi)
+  echo "$plain" | grep -qF 'Plan' \
+    || { echo "expected Plan icon restored from session-level state; got: $plain" >&2; false; }
+}


### PR DESCRIPTION
## 1. Summary

- Claude Code custom statusline의 📝 Plan 아이콘이 **plan을 세운 적 없는 무관한 세션에도 false positive로 표시되던 문제**를 제거한다.
- 원인인 plan 감지의 "프로젝트 단위 폴백"(`.statusline-plan-current`)과 그에 딸린 복사본 생성 로직을 제거하고, 감지를 `(1) transcript 직접 감지 → (2) 세션별 state 복원` 2단계로 단순화한다.
- 세션별 state 가드를 다른 sidecar I/O와 동일한 `SIDECAR_IO_ENABLED`로 통일해, 무효 `SESSION_ID`에서 공유 `unknown` state로 false positive가 축소 재발하지 않도록 막는다.

(연관 이슈 없음 — 사용자 직접 관찰로 발견)

## 2. 기존 문제 / 배경

`statusline.sh`는 매초 세션 JSON을 받아 statusbar를 렌더하며, 📝 Plan 아이콘은 세션의 plan 파일(`.claude/plans/*.md`)을 감지해 표시한다. plan 감지는 3단계 우선순위였다:

1. transcript(`.jsonl`) 직접 감지
2. 세션별 state (`.statusline-plan-<session_id>`) 복원 — resume/compact 대응
3. **프로젝트 단위 state (`.statusline-plan-current`) 폴백** ← 문제 지점

3순위 폴백은 영구적이고 무차별적이었다. 한 세션이 plan을 세우면 그 경로가 `.statusline-plan-current`에 박제되고, 이후 **plan을 전혀 세우지 않은 무관한 새 세션들이 그 plan을 상속**해 📝 Plan을 표시했다. 게다가 상속 시 세션마다 복사본(`<원본>-<sid앞8자>.md`)을 생성해 plans 디렉토리를 오염시켰다.

실측: 하나의 plan이 장기간 다수의 새 세션에 전염되어, plans 디렉토리에 sid-suffix 복사본이 86개 누적된 상태였다(원본 35개 대비 2.5배).

## 3. Change Intent Record

- **발견 경위**: plan을 세우지 않은 세션의 statusline에 📝 Plan이 표시되고, 클릭 시 다른 세션이 만든 plan 파일이 열리는 것을 관찰. 파일명의 sid suffix가 현재 세션 ID와 일치해, 3순위 폴백의 복사본 메커니즘이 원인임을 확인했다.
- **설계 의도**: 폴백의 원래 목적은 `/clear`로 session_id가 바뀐 직후의 연속 작업을 돕는 것이었다. 그러나 그 trade-off가 "장기간 무관 세션 전염"으로 번졌다. "잘못된 plan을 띄우는 것"보다 "표시하지 않는 것"이 안전한 실패 모드라고 판단해 폴백 자체를 제거했다.
- **대안 검토**: 폴백에 staleness TTL을 두는 안도 고려했으나, 복사본 양산 메커니즘이 유지되고 임계값이 자의적이며 짧은 시간 창의 false positive가 남아 기각했다.
- **2차 보강**: 코드 리뷰 과정에서, 폴백 제거 후에도 세션별 state 파일명이 `${SESSION_ID:-unknown}`이라 무효 `SESSION_ID`일 때 `.statusline-plan-unknown` 공유 state로 동일 문제가 축소 재발할 수 있음이 드러났다. 다른 sidecar I/O는 모두 유효 `SESSION_ID`를 요구하는데 plan state만 예외였던 일관성 결함을 제거하기 위해, 가드를 `SIDECAR_IO_ENABLED`로 통일하고 `unknown` fallback을 없앴다.

## 4. ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 프로젝트 폴백 제거 | 3순위 폴백 + 복사본 로직 삭제, 2단계 감지로 단순화 | false positive·복사본 오염 근본 차단, 코드 단순화 | `/clear` 직후 새 세션은 plan 아이콘이 사라짐 | ✅ 채택 |
| staleness TTL 가드 | `.statusline-plan-current` mtime이 N시간 이내일 때만 상속 | `/clear` 연속성 유지 | 복사본 메커니즘 유지, 임계값 자의적, 짧은 false positive 잔존 | ❌ 기각 |
| 현행 유지 | 변경 없음 | — | false positive 지속, 디렉토리 오염 | ❌ 기각 |

trade-off(`/clear` 직후 plan 미표시)는 의도적 컨텍스트 리셋이므로 수용한다. plan을 다시 보려면 직접 열거나 plan mode를 재진입한다.

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | plan 감지에서 프로젝트 단위 폴백 + 복사본 생성(`cp`/`find -delete`) 제거. 세션별 state 가드를 `TRANSCRIPT_VALID` → `SIDECAR_IO_ENABLED`로 통일, `unknown` fallback 제거. Change Intent Record 주석 갱신. |
| `modules/shared/programs/claude/files/scripts/tests/statusline.bats` | plan 감지 회귀 테스트 4개 추가 (프로젝트 state 단독 → 미표시·복사본 미생성, transcript 감지 → 표시, 세션별 복원 → 표시, 무효 `SESSION_ID` → unknown 공유 state 미복원). |

감지 우선순위 단순화 (3-way → 2-way):

```bash
# 우선순위: (1) transcript 직접 감지 → 세션별 state 기록  (2) 미감지 → 세션별 state 복원
if [ -n "$PLAN_FILE" ] && [ -f "$PLAN_FILE" ] && [ -n "$PLAN_STATE_FILE" ]; then
  printf '%s' "$PLAN_FILE" > "$PLAN_STATE_FILE" 2>/dev/null
elif [ -z "$PLAN_FILE" ] && [ -n "$PLAN_STATE_FILE" ] && [ -f "$PLAN_STATE_FILE" ]; then
  PLAN_FILE=$(cat "$PLAN_STATE_FILE" 2>/dev/null)
fi
```

세션별 state 가드 통일 (다른 sidecar I/O와 동일 가드):

```bash
PLAN_STATE_FILE=""
if $SIDECAR_IO_ENABLED; then
  # SIDECAR_IO_ENABLED = 유효 SESSION_ID + TRANSCRIPT_VALID. unknown fallback 불필요.
  PLAN_STATE_FILE="$CANONICAL_TRANSCRIPT_DIR/.statusline-plan-${SESSION_ID}"
fi
```

## 6. 참고 레퍼런스

- PR #806 — worktree 폴더명==브랜치명이면 L3 라인 생략 (동일 스크립트 `statusline.sh`의 최근 변경).
- 외부 이슈 없이 사용자 관찰로 발견된 회귀 수정이다.

## 7. Human Test Plan

전제: `nrs`로 변경을 반영한 뒤.

1. **plan 없는 새 세션** — plan을 세우지 않은 채 아무 작업이나 시작한다.
   - 기대: statusline에 📝 Plan 아이콘이 **표시되지 않는다**.
   - 실패 시 진단: `ls ~/.claude/projects/<encoded>/.statusline-plan-*`로 stale state 잔존 확인. 기존 오염 state는 이 변경이 자동 정리하지 않으므로(코드 수정 범위), 해당 세션 state 파일이 남아있으면 수동 삭제.
2. **plan mode 진입** — plan mode로 plan을 세운다.
   - 기대: 📝 Plan 아이콘 표시, 클릭 시 해당 plan 파일이 열린다.
3. **resume** — plan을 세운 세션을 resume한다.
   - 기대: 세션별 state 복원으로 📝 Plan 유지.
4. **/clear 후** — plan을 세운 뒤 `/clear`한다.
   - 기대: 새 session_id라 📝 Plan이 사라진다 (의도된 trade-off).

## 8. Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
SL=modules/shared/programs/claude/files/scripts/statusline.sh
# 프로젝트 폴백 제거 (0 기대)
grep -c 'statusline-plan-current' "$SL"
# 복사본 로직 제거 (0 기대)
grep -cE 'PLAN_COPY|ORIGINAL_PLAN' "$SL"
# 세션별 state 가드가 SIDECAR_IO_ENABLED로 통일됐는지 (매치 기대)
grep -A2 '^PLAN_STATE_FILE=""' "$SL" | grep -c 'if \$SIDECAR_IO_ENABLED'
# unknown fallback 제거 (0 기대)
grep -c 'statusline-plan-\${SESSION_ID:-unknown}' "$SL"
```

### Phase 1: 단위 테스트

```bash
nix shell --inputs-from . nixpkgs#bats --command \
  bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
```

→ **20 tests, 0 failures** 기대. plan 4개 케이스(`project-level state alone does NOT show Plan`, `transcript with plan path shows Plan`, `session-level state restores Plan`, `invalid session_id does NOT restore shared unknown state`)가 모두 통과해야 한다.

### Phase 2: Regression

- Phase 1에 포함된 기존 16개 케이스(폭 측정 fallback, rate limit progressive disclosure, SSH gauge, worktree L3 등)가 그대로 통과하는지 확인한다.
- smoke: 임의 세션 JSON을 stdin으로 전달해 에러 없이 렌더되는지 확인한다 (전제: `transcript_path`는 `$HOME/.claude/projects/` 하위 canonical 경로여야 plan/메모리 분기가 활성화됨).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan state persistence to be session-specific, eliminating unreliable project-level fallbacks.
  * Fixed plan icon detection to prevent false positives from invalid sessions.

* **Tests**
  * Added test coverage for plan icon rendering and session state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->