### PR TITLE
fix(statusline): cwd canonical 실패 시 raw 절대경로 URL fallback

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -124,18 +124,20 @@ validate_session_id() {
   return 0
 }
 
-# cwd validation (D-2 보강: control 문자 거부 우선, 그 다음 절대경로 + canonical 디렉토리)
+# cwd 구문 검증 (보안 경계): control 문자 거부 우선, 그 다음 절대경로.
 # control 문자 검사를 절대경로 검사보다 먼저 — 상대경로 형태 cwd에 control 문자가 있으면
-# 검증 실패 fallback에서 raw display로 escape 주입되는 것을 방지
-# 통과 시 canonical cwd 반환, 미통과 시 빈 문자열
-canonicalize_cwd_check() {
+# 검증 실패 fallback에서 raw display로 escape 주입되는 것을 방지.
+# 통과 시 cwd를 그대로 반환(canonical 변환 없음), 미통과 시 빈 문자열.
+# canonicalize_dir(cd+pwd -P)과 분리된 책임: 이쪽은 escape 주입 방어의 핵심이고,
+# canonical 변환은 symlink resolve/존재 확인이라는 정확도 책임만 가진다.
+validate_cwd_syntax() {
   local cwd=$1
   [ -z "$cwd" ] && return
   if printf '%s' "$cwd" | LC_ALL=C grep -q '[[:cntrl:]]'; then
     return
   fi
   case "$cwd" in /*) ;; *) return ;; esac
-  canonicalize_dir "$cwd"
+  printf '%s' "$cwd"
 }
 
 # Display sanitize: control 문자가 라벨로 직접 흘러가지 않도록 거부
@@ -574,28 +576,49 @@ else
   EFF_COLS=$((COLS - 40))
 fi
 
-# cwd canonical 검증 + display + URL
+# cwd 검증 + display + URL
 # D-4 update: 워크트리일 때 display는 `<메인 repo ~ 단축>:<worktree 폴더명>` 형식
-#   (사용자 요청 — 풀 경로는 너무 길어 잘림). URL은 항상 canonical 풀 path (VSCode 정확 dispatch)
-CWD_CANONICAL=$(canonicalize_cwd_check "$CWD")
-if [ -n "$CWD_CANONICAL" ]; then
+#   (사용자 요청 — 풀 경로는 너무 길어 잘림). URL은 항상 풀 path (VSCode 정확 dispatch)
+#
+# === Change Intent Record ===
+# v1: cwd 검증을 단일 함수(구문 검증 + canonical 변환 결합)로 호출. canonical(cd+pwd -P)
+#    실패 시 URL을 통째로 포기.
+#    [문제] cwd 디렉토리가 그 순간 부재(LLM이 삭제될 임시 디렉토리/워크트리로 작업
+#    디렉토리를 옮긴 찰나)하거나 고부하 fork 실패 시 canonical만 실패해도, escape 방어를
+#    이미 통과한 절대경로가 버려져 OSC 8 vscode:// 링크가 간헐적으로 사라졌다
+#    (클릭 시 에디터 대신 Finder). canonical은 symlink resolve/존재 확인이라는 정확도
+#    책임일 뿐 보안 책임이 아니므로 과한 포기였다.
+# v2 (이번): canonical을 best-effort로 분리. (1) validate_cwd_syntax로 escape 방어
+#    (control 거부 + 절대경로)를 먼저 통과시키고 (2) canonicalize_dir은 best-effort로
+#    시도하되, 실패하면 검증된 raw 절대경로(CWD_VALID)로 fallback한다. URL/display는
+#    CWD_RESOLVED(canonical 우선, 실패 시 raw)를 쓴다. control/절대경로/percent-encode/
+#    sanitize_osc8_url 3중 방어는 그대로 유지되고, 양보하는 것은 symlink resolve
+#    정확도뿐이다 (vscode://file은 symlink·일시 부재 경로도 정상 처리).
+CWD_VALID=$(validate_cwd_syntax "$CWD")
+# CWD_CANONICAL="": (1) CWD_VALID 빈 값(구문 검증 실패)으로 canonicalize_dir 미시도, 또는
+#   (2) 시도했으나 디렉토리 부재/fork 실패. 두 경우 모두 아래 CWD_RESOLVED가 raw fallback으로 흡수.
+CWD_CANONICAL=""
+[ -n "$CWD_VALID" ] && CWD_CANONICAL=$(canonicalize_dir "$CWD_VALID")
+# canonical 우선, 실패 시(디렉토리 일시 부재/고부하 fork 실패) 검증된 raw 절대경로로 fallback
+CWD_RESOLVED="${CWD_CANONICAL:-$CWD_VALID}"
+if [ -n "$CWD_RESOLVED" ]; then
   if $IS_WORKTREE && [ -n "${MAIN_REPO_DIR:-}" ]; then
     MAIN_REPO_SHORT=$(tilde_shorten "$MAIN_REPO_DIR")
-    WORKTREE_NAME=$(basename "$CWD_CANONICAL")
+    WORKTREE_NAME=$(basename "$CWD_RESOLVED")
     CWD_DISPLAY="${MAIN_REPO_SHORT}:${WORKTREE_NAME}"
   else
-    CWD_DISPLAY=$(tilde_shorten "$CWD_CANONICAL")
+    CWD_DISPLAY=$(tilde_shorten "$CWD_RESOLVED")
   fi
   CWD_URL=""
   if ! $IS_SSH; then
-    CWD_URL_PATH=$(percent_encode_segment "$CWD_CANONICAL")
+    CWD_URL_PATH=$(percent_encode_segment "$CWD_RESOLVED")
     # ?windowId=_blank — vscode:// URL handler는 window.openFoldersInNewWindow 설정을
     # 따르지 않고 기본적으로 마지막 활성 창을 덮어쓴다. query param이 공식 해결책으로
     # 항상 새 창을 강제한다 (microsoft/vscode#141548, 머지 commit bcc2da6).
     CWD_URL="vscode://file${CWD_URL_PATH}/?windowId=_blank"
   fi
 else
-  # 검증 실패: 텍스트만 표시. control 문자가 들어와 fallback으로 escape 주입되는 것 방지
+  # 구문 검증 실패(control 문자/상대경로): 텍스트만 표시. escape 주입 방지.
   CWD_DISPLAY=$(sanitize_display_text "$(tilde_shorten "$CWD")")
   CWD_URL=""
 fi
@@ -806,14 +829,17 @@ fi
 end_line
 
 # L3 (worktree만): branch
-# basename(CWD_CANONICAL) == GIT_BRANCH면 L2가 이미 동일 토큰을 담고 있어 L3 라인째 생략.
+# basename(CWD_RESOLVED) == GIT_BRANCH면 L2가 이미 동일 토큰을 담고 있어 L3 라인째 생략.
 #   L2 표시: $IS_WORKTREE && MAIN_REPO_DIR 분기는 "<repo>:<폴더명>", else는 풀 경로 끝에 폴더명.
 #   어느 쪽이든 폴더명 토큰이 L2에 포함되므로 L3은 정보 손실 없이 생략 가능.
-# CWD_CANONICAL 부재 시 basename 결과가 ""라 GIT_BRANCH와 일치 불가 → 가드 자연스럽게 비활성.
+# CWD_RESOLVED 부재 시(구문 검증 실패) basename 결과가 ""라 GIT_BRANCH와 일치 불가 → 가드
+# 자연스럽게 비활성. 아래 basename "$CWD_RESOLVED"는 L2 워크트리 분기의
+# WORKTREE_NAME=$(basename "$CWD_RESOLVED")와 동일 연산이라 L2/L3 폴더명 토큰이 항상 일관된다
+# (canonical 실패 raw fallback 경로에서도 L2가 <repo>:<폴더명>을 담으므로 L3 생략은 중복 제거다).
 if $IS_WORKTREE; then
   begin_line
   WORKTREE_BASENAME=""
-  [ -n "$CWD_CANONICAL" ] && WORKTREE_BASENAME=$(basename "$CWD_CANONICAL")
+  [ -n "$CWD_RESOLVED" ] && WORKTREE_BASENAME=$(basename "$CWD_RESOLVED")
   if [ -n "$GIT_BRANCH" ] && [ "$WORKTREE_BASENAME" != "$GIT_BRANCH" ]; then
     print_icon "32" "" "\xf0\x9f\x8c\xbf" "$GIT_BRANCH"
   fi

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -415,12 +415,12 @@ EOF
     || { echo "expected branch label 'feat-foo' in output; got: $plain" >&2; false; }
 }
 
-# CWD_CANONICAL 부재 회귀 가드: canonicalize_cwd_check가 실패해 CWD_CANONICAL=""
-# 이면 WORKTREE_BASENAME=""이라 GIT_BRANCH와 일치할 수 없어 가드가 자연스럽게
-# 비활성된다. L3 가드 블록 주석이 약속한 동작을 박제해 L3가 의도치 않게
-# 숨겨지는 회귀를 막는다. cwd를 상대경로(="tmp")로 보내면
-# canonicalize_cwd_check 의 절대경로 가드(case "$cwd" in /*) ;; *) return ;; esac)에
-# 걸려 CWD_CANONICAL="" 이 자연 유도된다.
+# CWD_RESOLVED 부재 회귀 가드: 구문 검증 실패로 CWD_RESOLVED=""이면 WORKTREE_BASENAME=""
+# 이라 GIT_BRANCH와 일치할 수 없어 L3 생략 가드가 자연스럽게 비활성된다. L3 가드 블록
+# 주석이 약속한 동작을 박제해 L3가 의도치 않게 숨겨지는 회귀를 막는다. cwd를
+# 상대경로(="tmp")로 보내면 validate_cwd_syntax 의 절대경로 가드(case "$cwd" in /*) ;;
+# *) return ;; esac)에 걸려 CWD_VALID="" → CWD_RESOLVED="" 이 자연 유도된다 (상대경로는
+# raw fallback 대상도 아니다).
 @test "worktree with non-canonical cwd keeps L3 branch line (guard disabled)" {
   local now five_h seven_d
   now=$(date +%s)
@@ -448,9 +448,61 @@ EOF
   plain=$(echo "$output" | strip_ansi)
   branch_count=$(echo "$plain" | grep -oF '🌿' | wc -l | tr -d ' ')
   [ "$branch_count" -eq 1 ] \
-    || { echo "expected exactly 1 🌿 (L3 branch) when CWD_CANONICAL=\"\" (guard disabled); got count=$branch_count plain=$plain" >&2; false; }
+    || { echo "expected exactly 1 🌿 (L3 branch) when CWD_RESOLVED=\"\" (guard disabled); got count=$branch_count plain=$plain" >&2; false; }
   echo "$plain" | grep -qF 'tmp' \
     || { echo "expected branch label 'tmp' in output; got: $plain" >&2; false; }
+}
+
+# ============================================================
+# cwd URL raw fallback (canonical best-effort 회귀 가드)
+# ============================================================
+# canonical(cd+pwd -P) 실패 시 검증된 raw 절대경로로 vscode:// URL 을 유지해야 한다.
+# OSC 8 URL 은 strip_ansi 가 제거하므로 raw $output 에서 직접 매칭한다.
+
+# 부재 절대경로 cwd → raw fallback. 디렉토리가 그 순간 존재하지 않으면
+# (LLM 이 삭제될 임시 디렉토리/워크트리로 작업 디렉토리를 옮긴 찰나, 또는 고부하
+# fork 실패) canonicalize_dir 이 빈 값을 반환한다. canonical 단일 의존 시절엔 이
+# 경우 OSC 8 링크가 통째로 사라져 클릭 시 에디터 대신 Finder 로 열리는 간헐 회귀가
+# 있었다. 절대경로 + control-free 는 통과했으므로 raw 경로로 URL 을 유지해야 한다.
+@test "absent absolute cwd still emits vscode:// URL (raw fallback)" {
+  local gone="/tmp/statusline-bats-gone-$$-${RANDOM}"
+  rm -rf "$gone"
+  local stdin_json
+  stdin_json=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "$gone",
+  "model": {"display_name": "test"}
+}
+EOF
+)
+  run run_statusline_with_input "$stdin_json"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF "vscode://file${gone}/?windowId=_blank" \
+    || { echo "expected raw-fallback vscode URL for absent cwd '$gone'; got: $output" >&2; false; }
+}
+
+# 보안 가드: 상대경로 cwd 는 raw fallback 대상이 아니다. validate_cwd_syntax 의
+# 절대경로 가드가 거부 → CWD_RESOLVED="" → URL 미생성. raw fallback 도입이
+# escape 방어(절대경로/control 검증)를 우회시키지 않음을 박제.
+@test "relative cwd emits no vscode:// URL (fallback respects abs-path guard)" {
+  local stdin_json
+  stdin_json=$(cat <<EOF
+{
+  "session_id": "abc12345-def6-7890-abcd-ef1234567890",
+  "transcript_path": "/tmp/nonexistent.jsonl",
+  "cwd": "relative/path",
+  "model": {"display_name": "test"}
+}
+EOF
+)
+  run run_statusline_with_input "$stdin_json"
+  [ "$status" -eq 0 ]
+  if echo "$output" | grep -qF 'vscode://'; then
+    echo "expected NO vscode URL for relative cwd; got: $output" >&2
+    false
+  fi
 }
 
 # ============================================================


### PR DESCRIPTION
## Summary

- statusline의 cwd 아이콘 `vscode://` OSC 8 하이퍼링크가 간헐적으로 사라져 클릭 시 에디터 대신 Finder로 열리던 문제를 수정한다.
- cwd 검증 책임을 escape 방어(`validate_cwd_syntax`)와 canonical 변환(`canonicalize_dir`)으로 분리하고, canonical 변환이 실패해도 검증된 raw 절대경로로 URL을 유지한다(`CWD_RESOLVED`).
- raw fallback 회귀 가드 + 상대경로 보안 가드 bats 테스트 2건 추가.

## 기존 문제 / 배경

같은 cwd(`~/Workspace/nixos-config`)·같은 세션인데도 cwd 아이콘에 vscode 스킴이 붙었다 안 붙었다 했다. 안 붙은 프레임을 클릭하면 에디터가 아니라 Finder로 열렸다.

원인을 코드 경로로 좁히면 URL이 비는 길은 두 갈래뿐이다 — (1) SSH 판정(`IS_SSH`), (2) `canonicalize_cwd_check`의 cwd canonical 변환 실패. 로컬 console 세션이라 SSH는 배제됐고, 같은 세션 안에서 됐다 안 됐다 하는 간헐성은 환경변수 기반 SSH로 설명되지 않았다. 남은 트리거는 canonical 변환(`(cd "$dir" && pwd -P)`)이 빈 값을 반환하는 경우다.

이 변환은 cwd 디렉토리가 그 순간 존재하지 않으면 빈 값을 낸다. 작업 디렉토리가 곧 삭제될 임시 디렉토리/워크트리를 잠깐 가리키거나, 다수 세션 동시 실행으로 서브셸 fork가 일시적으로 실패하는 찰나에 statusline이 매초 갱신되면 그 프레임만 URL이 사라진다. 텍스트(`tilde_shorten`)는 순수 bash라 그대로 표시되므로, "경로 텍스트는 보이는데 링크만 없는" 정확한 증상이 된다.

재현: 존재하는 디렉토리로 cwd를 주면 100% URL이 붙고, 그 디렉토리를 삭제한 직후 같은 cwd를 주면 URL이 사라지며, 유효한 경로로 복귀하면 다시 붙는다.

## CIR (Change Intent Record)

기존 구현은 cwd 검증 진입점 하나가 "escape 주입 방어"와 "canonical 변환(symlink resolve + 존재 확인)"을 함께 수행하고, 둘 중 하나라도 실패하면 URL을 통째로 포기했다. 그러나 두 책임의 성격이 다르다:

- **escape 방어**(control 문자 거부 + 절대경로 검증)는 보안 경계다. OSC 8 시퀀스로의 escape 주입을 막는 핵심이라 절대 양보할 수 없다.
- **canonical 변환**은 symlink를 풀고 디렉토리 존재를 확인하는 정확도 책임이다. `vscode://file`은 symlink 경로나 일시적으로 없는 경로도 정상 처리하므로, 이 변환의 실패가 URL 자체를 포기할 이유는 되지 못한다.

그래서 두 책임을 분리해, escape 방어를 통과한 절대경로는 canonical 변환이 실패하더라도 raw 형태로 URL에 살린다. 분리 과정에서 두 함수를 묶던 검증 진입점은 사용부가 직접 두 함수를 조합하도록 바뀌면서 호출처가 없어져 제거했다.

`control 거부 → 절대경로 검증 → percent-encode → OSC 8 sanitize`의 3중 방어는 그대로 유지되므로, raw fallback이 추가돼도 escape 주입·상대경로·control 문자는 여전히 차단된다. 양보하는 것은 symlink resolve 정확도뿐이다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| raw 절대경로 fallback | canonical을 best-effort로 시도하고 실패 시 검증된 raw 절대경로로 URL 유지 | 부재·fork 실패 둘 다 근본 해결, 보안 검증 유지, symlink 정확도만 양보 | symlink가 풀리지 않은 경로가 URL에 들어갈 수 있음(vscode가 정상 처리) | ✅ 채택 |
| 진단 로깅 후 판단 | 실패 순간을 로깅해 부재 vs fork 실패를 실데이터로 확정한 뒤 수정 | 트리거 확증 | 수정까지 지연, 사용자 체감 문제 지속 | ❌ 기각 (코드 경로상 트리거가 cwd 검증 실패로 이미 단정됨) |
| sticky URL 캐시 | 마지막 성공 URL을 저장해 실패 시 재사용 | 찰나 실패에 강건 | cwd가 진짜 다른 부재 경로로 옮겨가면 stale·오경로 클릭 위험 | ❌ 기각 |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | cwd 검증을 `validate_cwd_syntax`(escape 방어)와 `canonicalize_dir`(canonical)로 분리, 사용부에서 `CWD_RESOLVED` 합성으로 raw fallback. display/URL/L3 basename 모두 `CWD_RESOLVED` 사용 |
| `modules/shared/programs/claude/files/scripts/tests/statusline.bats` | raw fallback 회귀 가드 + 상대경로 보안 가드 2건 추가, 변수명 정합화 |

핵심:

```sh
CWD_VALID=$(validate_cwd_syntax "$CWD")          # control 거부 + 절대경로 (escape 방어)
CWD_CANONICAL=""
[ -n "$CWD_VALID" ] && CWD_CANONICAL=$(canonicalize_dir "$CWD_VALID")   # best-effort
# canonical 우선, 실패 시(디렉토리 일시 부재/고부하 fork 실패) 검증된 raw 절대경로로 fallback
CWD_RESOLVED="${CWD_CANONICAL:-$CWD_VALID}"
```

`validate_cwd_syntax`는 절대경로가 아니거나 control 문자가 있으면 빈 값을 반환하므로, 상대경로·control 문자 cwd는 raw fallback 대상이 되지 않고 URL이 생성되지 않는다(보안 경계 유지).

## 참고 레퍼런스

- statusline 폭 측정 회귀 분석(#734) — 동일 스크립트의 별개 진단 이력. 본 변경과 직접 관련은 없으나 statusline 입력/환경 의존성 맥락 참고.

## Human Test Plan

1. **정상 cwd 클릭** — repo 루트(`~/Workspace/nixos-config`)에서 statusline의 📁 cwd 아이콘을 클릭한다.
   - 기대: VSCode가 해당 폴더를 새 창으로 연다.
   - 실패 시: Finder로 열리면 URL이 비어 있는 것 — `~/.claude/scripts/statusline.sh`가 최신(nrs 반영)인지 확인.
2. **임시 디렉토리 이동 후** — 터미널에서 `cd $(mktemp -d)` 후 그 디렉토리를 삭제한 상태에서 statusline cwd를 클릭한다.
   - 기대: 부재 경로여도 vscode 링크가 살아 있고, VSCode가 해당 경로(빈 폴더)를 연다.
3. **상대경로/비정상 입력** — 정상 절대경로가 아닌 cwd에서는 링크가 붙지 않고 텍스트만 보이는지 확인(보안 경계).
4. **SSH 세션** — `ssh`로 접속한 세션의 statusline에서는 cwd 링크가 비활성(텍스트만)인지 확인(기존 동작 유지).

## Pre-Merge E2E 테스트 가이드

**Phase 0 — 정적 검증**

```sh
SL=modules/shared/programs/claude/files/scripts/statusline.sh
# (a) 신규 escape-방어 함수 존재
grep -q 'validate_cwd_syntax()' "$SL" && echo "OK: validate_cwd_syntax 존재"
# (b) raw fallback 합성 존재
grep -q 'CWD_RESOLVED="${CWD_CANONICAL:-$CWD_VALID}"' "$SL" && echo "OK: CWD_RESOLVED fallback"
# (c) dead wrapper 제거 확인
grep -q 'canonicalize_cwd_check' "$SL" && echo "FAIL: dead wrapper 잔존" || echo "OK: wrapper 제거됨"
```

기대: (a) OK, (b) OK, (c) "wrapper 제거됨".

**Phase 1 — bats 단위 테스트** (devShell 안에서)

```sh
nix develop -c bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
```

기대: 22개 전부 `ok`. 특히 `absent absolute cwd still emits vscode:// URL (raw fallback)`와 `relative cwd emits no vscode:// URL (fallback respects abs-path guard)` 통과.

**Phase 2 — 실제 동작** (mock stdin)

```sh
SL=modules/shared/programs/claude/files/scripts/statusline.sh
T=/Users/glen/.claude/projects/-Users-glen-Workspace-nixos-config/$(ls ~/.claude/projects/-Users-glen-Workspace-nixos-config/*.jsonl 2>/dev/null | head -1 | xargs basename 2>/dev/null)
G=/tmp/e2e-gone-$$; rm -rf "$G"
# 부재 절대경로 → raw fallback URL 출력되어야
echo "{\"transcript_path\":\"$T\",\"cwd\":\"$G\",\"terminal\":{\"columns\":140}}" | bash "$SL" 2>/dev/null | grep -q "vscode://file$G" && echo "OK: 부재 cwd raw fallback"
# 상대경로 → URL 없어야
echo "{\"transcript_path\":\"$T\",\"cwd\":\"rel/x\",\"terminal\":{\"columns\":140}}" | bash "$SL" 2>/dev/null | grep -q 'vscode://' && echo "FAIL: 상대경로 URL 누출" || echo "OK: 상대경로 URL 차단"
```

기대: "부재 cwd raw fallback", "상대경로 URL 차단".

**Phase 3 — Regression**

```sh
# 정상 cwd는 canonical 경로로 URL 생성(symlink 정리) — 기존 동작 유지
echo "{\"transcript_path\":\"$T\",\"cwd\":\"/Users/glen/Workspace/nixos-config\",\"terminal\":{\"columns\":140}}" | bash "$SL" 2>/dev/null | grep -q 'vscode://file/Users/glen/Workspace/nixos-config/' && echo "OK: 정상 cwd canonical URL"
# SSH 분기는 URL 비활성 유지
echo "{\"transcript_path\":\"$T\",\"cwd\":\"/Users/glen/Workspace/nixos-config\",\"terminal\":{\"columns\":140}}" | SSH_CONNECTION='1 2 3 4' bash "$SL" 2>/dev/null | grep -q 'vscode://' && echo "FAIL: SSH URL 누출" || echo "OK: SSH URL 비활성 유지"
```

기대: "정상 cwd canonical URL", "SSH URL 비활성 유지".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved working directory validation and path resolution with enhanced security handling.
  * Updated branch display logic for worktree sessions.
  * Enhanced editor link generation.

* **Tests**
  * Added test coverage for branch display with various path scenarios.
  * Added test coverage for editor URL generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->