### PR TITLE
feat(codex): nix/brew 설치를 mise npm backend로 전환

### DIFF
--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -55,12 +55,13 @@ darwinOnly = [ ... pkgs.패키지명 ];
 # cleanup = "none" — 선언되지 않은 앱을 삭제하지 않음 (수동 설치 cask 보호)
 # upgrade = true + greedyCasks = true — 자체 업데이터 앱의 버전 드리프트 방지
 homebrew.casks = [
-  "codex" "ghostty" "raycast" "rectangle"
+  "ghostty" "raycast" "rectangle"
   "hammerspoon" "homerow" "docker-desktop"
   "fork" "monitorcontrol"
 ];
 homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, 오디오 처리
 # shottr → Nix 패키지로 관리 (libraries/packages.nix darwinOnly)
+# codex → Nix 관리로 전환 (mise npm backend, modules/shared/programs/codex)
 # figma → Homebrew에서 제거 (자체 업데이터가 버전을 변경하여 adopt 시 버전 충돌)
 # slack → Homebrew에서 제거 (수동 설치 선호, 자체 업데이터에 위임)
 ```

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -429,7 +429,7 @@ brew install --cask --adopt docker-desktop:
 brew install --cask --adopt docker-desktop
 
 # 여러 앱 일괄 adopt (Nix 패키지로 관리하는 shottr, vscode 제외)
-for cask in codex ghostty raycast rectangle hammerspoon homerow docker-desktop fork monitorcontrol; do
+for cask in ghostty raycast rectangle hammerspoon homerow docker-desktop fork monitorcontrol; do
   brew install --cask --adopt "$cask" || echo "FAILED: $cask"
 done
 

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -339,7 +339,6 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 
 | 앱             | 용도                       |
 | -------------- | -------------------------- |
-| Codex          | AI 코딩 에이전트           |
 | Raycast        | 런처 (Spotlight 대체)      |
 | Rectangle      | 창 관리                    |
 | Hammerspoon    | 키보드 리매핑/자동화       |

--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -12,7 +12,7 @@ mise를 사용한 Node.js, pnpm 등 런타임 버전 관리 가이드.
 ## 목적과 범위
 
 런타임 버전 선택, shims 경로, SSH 비대화형 셸 이슈를 안정적으로 운영하는 절차를 다룬다.
-macOS에서는 Homebrew로 mise를 설치하고, NixOS에서는 `pkgs.mise`를 사용한다.
+macOS·NixOS 모두 `pkgs.mise`(nix, `libraries/packages.nix`의 shared)로 설치한다. 과거 macOS에서 Homebrew로 mise를 수동 설치했다면 PATH 경합을 피하기 위해 `brew uninstall mise`를 권장한다.
 
 ## 빠른 참조
 
@@ -20,7 +20,7 @@ macOS에서는 Homebrew로 mise를 설치하고, NixOS에서는 `pkgs.mise`를 �
 
 | 항목 | macOS | NixOS |
 |------|-------|-------|
-| mise 설치 | Homebrew | `libraries/packages.nix` (nixosOnly) |
+| mise 설치 | `libraries/packages.nix` (shared, nix) | `libraries/packages.nix` (shared, nix) |
 | 소스 빌드 | 기본값 사용 | `MISE_ALL_COMPILE=0` 환경변수로 비활성화 |
 | Node 빌드 | 기본값 사용 | `MISE_NODE_COMPILE=0` 환경변수로 비활성화 |
 | 환경변수 위치 | - | `modules/shared/programs/shell/nixos.nix` |
@@ -56,7 +56,7 @@ mise trust
 |------|------|
 | `modules/shared/programs/shell/default.nix` | zsh mise 활성화 (shims + activate) |
 | `modules/shared/programs/shell/nixos.nix` | NixOS 환경변수 (`MISE_ALL_COMPILE=0`, `MISE_NODE_COMPILE=0`) |
-| `libraries/packages.nix` | `pkgs.mise` 패키지 설치 (nixosOnly) |
+| `libraries/packages.nix` | `pkgs.mise` 패키지 설치 (shared — macOS+NixOS 공통) |
 
 ## 셸 활성화 구조
 

--- a/libraries/packages.nix
+++ b/libraries/packages.nix
@@ -12,6 +12,7 @@
     pkgs.ripgrep # grep 대체 (빠른 텍스트 검색)
 
     # 개발 도구
+    pkgs.mise # 런타임 버전 관리 (node/pnpm; codex npm backend도 의존). macOS는 nix mise 사용 — 과거 수동 brew mise와 PATH 경합 시 brew uninstall 권장
     pkgs.shellcheck # 쉘 스크립트 린터
 
     # TUI 도구
@@ -52,6 +53,5 @@
     # Termius 등 다른 SSH 클라이언트는 자체 TERM(보통 xterm-256color)을 사용하므로 무관.
     pkgs.ghostty.terminfo
     pkgs.lm_sensors # 하드웨어 온도 모니터링 (sensors 명령어)
-    pkgs.mise # 런타임 버전 관리
   ];
 }

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -87,9 +87,11 @@
       # figma: 자체 업데이터가 적극적으로 버전을 변경하여 Homebrew가 관리하는 버전과 불일치 발생.
       #        adopt 시 버전 불일치로 설치 거부됨. 자체 업데이터에 위임.
       # slack: 수동 설치 선호. 자체 업데이터에 위임.
+      # codex: mise npm backend(@openai/codex)로 전환 — modules/shared/programs/codex/default.nix.
+      #        cleanup="none"이라 cask 목록 제거만으론 미삭제되므로 codex activation의
+      #        cleanupLegacyCodexCli가 `brew uninstall --cask codex`로 정리한다.
       #
       casks = [
-        "codex"
         "raycast"
         "rectangle"
         "hammerspoon"

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -1,5 +1,7 @@
 # Codex CLI 설정 (공통)
-# 바이너리: macOS=brew cask, NixOS=GitHub releases 직접 다운로드
+# 바이너리: macOS/NixOS 공통 — mise npm backend(npm:@openai/codex)로 설치 관리.
+#   버전 pinning 없음(@latest) + 자동 업데이트 없음(멱등 가드로 재호출 차단).
+#   설치/정리: home.activation.{cleanupLegacyCodexCli, installCodexCli, cleanupManualNodeCodex}.
 # Claude Code 스킬을 Codex에서도 사용할 수 있도록 심볼릭 링크 관리
 # trust는 런타임 mutation(사용자 승인, 디렉토리당 1회)이 SoT. template은 trust를
 # 하드코딩하지 않으며, ~/.codex/config.toml은 activation의 syncCodexConfig가
@@ -11,7 +13,6 @@
   pkgs,
   lib,
   nixosConfigPath,
-  hostType ? null,
   ...
 }:
 
@@ -84,17 +85,6 @@ in
     ".codex/scripts/fleiss-kappa.py".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/scripts/fleiss-kappa.py";
 
-    # macOS personal hosts install Codex via the Homebrew cask, but login/non-interactive
-    # shells only get the Home Manager session PATH. Expose a narrow wrapper in
-    # ~/.local/bin instead of prepending the whole Homebrew prefix and changing
-    # unrelated command resolution such as notification hook `timeout` behavior.
-    ".local/bin/codex" = lib.mkIf (pkgs.stdenv.isDarwin && hostType == "personal") {
-      source = pkgs.writeShellScript "codex-homebrew-wrapper" ''
-        exec /opt/homebrew/bin/codex "$@"
-      '';
-      executable = true;
-    };
-
     # Codex 0.124+ stable hooks (issue #585 / epic #584).
     # Claude `~/.claude/hooks/*` 무변경 보장이 필요하므로 Codex 전용 사본을 분리한다.
     # 사본은 modules/shared/programs/codex/files/hooks/ 에서 mkOutOfStoreSymlink로 노출.
@@ -141,31 +131,100 @@ in
       "$config_dir/config.toml"
   '';
 
-  # ─── NixOS: Codex CLI 바이너리 설치 (GitHub releases) ───
-  # macOS는 brew cask로 관리 (modules/darwin/programs/homebrew.nix)
-  home.activation.installCodexCli = lib.mkIf pkgs.stdenv.isLinux (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      if ! command -v codex >/dev/null 2>&1; then
-        echo "Installing Codex CLI from GitHub releases..."
-        TAG="$(${pkgs.curl}/bin/curl -sI --connect-timeout 5 --max-time 10 \
-          "https://github.com/openai/codex/releases/latest" \
-          | ${pkgs.gnugrep}/bin/grep -i '^location:' | ${pkgs.gnused}/bin/sed 's|.*/tag/||; s/\r//')"
-        if [ -n "$TAG" ]; then
-          BINARY="codex-x86_64-unknown-linux-musl"
-          URL="https://github.com/openai/codex/releases/download/''${TAG}/''${BINARY}.tar.gz"
-          mkdir -p "$HOME/.local/bin"
-          ${pkgs.curl}/bin/curl -fsSL "$URL" | ${pkgs.gnutar}/bin/tar --use-compress-program=${pkgs.gzip}/bin/gzip -x -C /tmp
-          mv "/tmp/''${BINARY}" "$HOME/.local/bin/codex"
-          chmod +x "$HOME/.local/bin/codex"
-          echo "Codex CLI ''${TAG#rust-v} installed to ~/.local/bin/codex"
-        else
-          echo "Warning: Could not fetch Codex CLI release tag (skipping install)"
+  # ─── Codex CLI 설치 (mise npm backend — macOS + NixOS 공통) ───
+  # nix(GitHub 바이너리)/brew cask 대신 mise npm backend(npm:@openai/codex)로 통일한다.
+  # 3단계 DAG: 레거시 정리 → 설치 → 수동 npm 잔재 정리. 전부 non-fatal로,
+  # mise/node 부재나 네트워크 실패가 nrs(home-manager activation) 전체를 깨지 않게 한다.
+
+  # (1) 레거시 Codex CLI 정리
+  #   - NixOS: ~/.local/bin/codex (과거 GitHub releases ELF; HM 미추적 regular file)
+  #   - macOS: brew cask codex (homebrew cleanup="none"이라 cask 목록 제거만으론 미삭제)
+  #     darwin wrapper ~/.local/bin/codex(symlink)는 home.file 항목 제거로 HM이 자동 정리.
+  home.activation.cleanupLegacyCodexCli = lib.hm.dag.entryAfter [ "writeBoundary" ] (
+    lib.optionalString pkgs.stdenv.isLinux ''
+      legacy_bin="$HOME/.local/bin/codex"
+      if [ -f "$legacy_bin" ] && [ ! -L "$legacy_bin" ]; then
+        if ${pkgs.file}/bin/file -b "$legacy_bin" | ${pkgs.gnugrep}/bin/grep -q ELF; then
+          echo "Removing legacy GitHub-release Codex CLI at $legacy_bin"
+          $DRY_RUN_CMD rm -f "$legacy_bin"
         fi
-      else
-        echo "Codex CLI already installed at $(command -v codex)"
+      fi
+    ''
+    + lib.optionalString pkgs.stdenv.isDarwin ''
+      # Apple Silicon 전용 경로 — Intel Mac(/usr/local/bin/brew)은 이 프로젝트 범위 밖.
+      # brew 부재 시 아래 -x 가드로 no-op.
+      brew_bin="/opt/homebrew/bin/brew"
+      if [ -x "$brew_bin" ] && "$brew_bin" list --cask codex >/dev/null 2>&1; then
+        echo "Uninstalling Homebrew cask codex (migrated to mise npm backend)"
+        $DRY_RUN_CMD "$brew_bin" uninstall --cask codex \
+          || echo "Warning: 'brew uninstall --cask codex' failed (non-fatal)"
       fi
     ''
   );
+
+  # (2) mise npm backend로 Codex CLI 설치
+  #   - node 보장: 글로벌 node가 없을 때만 mise use -g node@lts. node는 npm backend 전반의
+  #     공통 선행조건이지만, 현재 npm backend 도구가 codex 하나뿐이라 별도 ensureMiseNode 모듈로
+  #     분리하지 않고 여기서 보장한다(YAGNI). npm backend 도구가 늘면 그때 공통 activation으로 분리.
+  #     node@lts: 버전을 pin하지 않고 최초 설치 시점의 최신 LTS를 받는다. 이후에는 그 버전이 유지되며
+  #     사용자가 명시적으로 mise upgrade 하기 전까지 자동 갱신되지 않는다(자동 추적이 아니라 1회 고정).
+  #     NixOS는 소스 빌드 회피를 위해 prebuilt 강제(MISE_*_COMPILE=0; shell/nixos.nix와 동일 의도).
+  #   - 멱등 가드: command -v codex / mise which codex 는 수동 npm·legacy 바이너리에 속으므로 쓰지 않고,
+  #     mise config 등록 + 실제 installed된 backend(mise ls --json의 installed:true)로 판정한다.
+  #     기존 사용자의 수동 npm 글로벌 codex는 config 미등록이라 가드에 안 잡히므로, 마이그레이션
+  #     최초 1회는 @latest로 설치되어 버전 점프가 생길 수 있다(의도된 전환; 이후 nrs는 가드로 skip).
+  home.activation.installCodexCli = lib.hm.dag.entryAfter [ "cleanupLegacyCodexCli" ] ''
+    mise_bin="${pkgs.mise}/bin/mise"
+    if [ ! -x "$mise_bin" ]; then
+      echo "Warning: mise not found; skipping Codex CLI install (non-fatal)"
+    else
+      # NixOS는 mise의 node 소스 빌드를 막고 prebuilt를 강제한다(shell/nixos.nix와 동일 의도). macOS는 불필요.
+      ${lib.optionalString pkgs.stdenv.isLinux "export MISE_NODE_COMPILE=0 MISE_ALL_COMPILE=0"}
+      # 글로벌 node 보장. mise which는 로컬 .mise.toml에도 반응하므로 -g --current로 글로벌만 확인한다.
+      node_ok=1
+      if ! "$mise_bin" ls -g --current node 2>/dev/null | grep -q .; then
+        echo "Installing node@lts via mise (Codex CLI dependency)..."
+        $DRY_RUN_CMD "$mise_bin" use -g node@lts \
+          || { node_ok=0; echo "Warning: 'mise use -g node@lts' failed; skipping Codex CLI install (non-fatal)"; }
+      fi
+      if [ "$node_ok" = 1 ]; then
+        # config 등록 + installed:true인 backend만 "이미 관리됨"으로 판정한다.
+        # length>0만 보면 config 등록 후 install 실패한 [{installed:false}] 상태에 속아 영구 미설치로 고착된다.
+        if "$mise_bin" ls -g --current --json npm:@openai/codex 2>/dev/null \
+            | ${pkgs.jq}/bin/jq -e '[.[] | select(.installed == true)] | length > 0' >/dev/null 2>&1; then
+          echo "Codex CLI already managed by mise npm backend"
+        else
+          echo "Installing Codex CLI via mise npm backend (npm:@openai/codex)..."
+          $DRY_RUN_CMD "$mise_bin" use -g npm:@openai/codex \
+            || echo "Warning: Codex CLI install via mise skipped (non-fatal)"
+        fi
+      fi
+    fi
+  '';
+
+  # (3) mise node 글로벌의 수동 npm @openai/codex 잔재 제거 (일회성 마이그레이션)
+  #   전환 전 수동 `npm install -g @openai/codex`로 깔린 잔재를 정리한다. mise npm backend 정착
+  #   이후에는 재발생하지 않으므로 한동안 멱등 no-op으로 남는다(향후 제거 가능).
+  #   PATH상 node/<ver>/bin이 mise shims보다 우선이라, 남기면 backend shim을 가린다.
+  #   node 버전이 동적이라 mise 기본 data dir의 installs 트리를 스캔한다(MISE_DATA_DIR 커스텀
+  #   환경은 경로가 달라질 수 있으나 이 프로젝트 범위 밖).
+  home.activation.cleanupManualNodeCodex = lib.hm.dag.entryAfter [ "installCodexCli" ] ''
+    installs_dir="$HOME/.local/share/mise/installs/node"
+    if [ -d "$installs_dir" ]; then
+      for node_prefix in "$installs_dir"/*; do
+        # 실제 버전 디렉토리만 — lts/24/latest 등 symlink 별칭은 같은 실체를 가리키므로 skip(중복 uninstall 방지).
+        { [ -d "$node_prefix" ] && [ ! -L "$node_prefix" ]; } || continue
+        [ -d "$node_prefix/lib/node_modules/@openai/codex" ] || continue
+        npm_bin="$node_prefix/bin/npm"
+        [ -x "$npm_bin" ] || continue
+        # mise node의 npm은 `exec node "$npm_cli"` 형태 bash 래퍼다(node로 직접 실행하면 파싱 실패).
+        # 래퍼가 PATH에서 node와 mise(reshim)를 찾으므로 둘을 PATH 앞에 두고 npm을 직접 실행한다.
+        echo "Removing manually-installed npm global @openai/codex under $node_prefix"
+        $DRY_RUN_CMD env PATH="$node_prefix/bin:${pkgs.mise}/bin:$PATH" "$npm_bin" uninstall -g @openai/codex \
+          || echo "Warning: manual codex cleanup failed under $node_prefix (non-fatal)"
+      done
+    fi
+  '';
 
   # ─── 프로젝트 심볼릭 링크 (activation script) ───
   # 이전 시도(5ef4e67)의 sync-codex-from-claude.sh 로직을 Nix activation으로 이식


### PR DESCRIPTION
## Summary

- Codex CLI 설치를 NixOS(GitHub releases 바이너리)·macOS(brew cask)에서 **mise npm backend(`npm:@openai/codex`)로 통일**한다.
- 버전을 pin하지 않고 멱등 가드로 자동 업데이트를 차단하며, 레거시 설치를 정리하는 3단계 activation으로 분리한다.
- macOS에도 mise를 nix로 선언해 양쪽 설치 경로를 단일화한다.

## 기존 문제 / 배경

MiniPC(NixOS)에서 codex가 두 벌 공존하고 있었다. nix는 GitHub releases 바이너리를 `~/.local/bin/codex`에 설치하도록 선언했지만, PATH에서는 mise node 위에 **수동 npm으로 설치된 `@openai/codex`**가 우선이라 실제 실행되는 건 npm 쪽이었다. nix가 의도한 바이너리는 `command -v codex` 가드에 막혀 갱신되지 않은 채 가려져 고착됐다.

macOS는 brew cask로 설치하고 있어, npm 배포가 1차이고 호환성이 가장 좋은 codex를 두 OS에서 서로 다른 방식으로 관리하던 상태였다. 즉 "선언적 관리"라는 목표와 실제 실행 바이너리가 어긋나 있었다.

## CIR (Change Intent Record)

- codex는 npm 호환성이 가장 좋으므로 설치를 npm으로 통일하되, nixos-config가 "설치까지만" 선언적으로 관리하고 버전은 pin하지 않는 방향으로 정했다.
- 이미 mise가 node/pnpm을 관리하고 있어, npm 글로벌을 직접 다루는 대신 mise의 npm backend로 codex를 선언하는 것이 런타임 생태계와 일관된다고 판단했다.
- macOS에 mise가 nix·brew 어느 쪽으로도 선언돼 있지 않다는 점(수동 설치 의존)이 확인되어, 양쪽을 진짜로 통일하려면 mise 자체를 nix 공통 패키지로 올려야 한다는 결론에 도달했다.
- 설치 보장은 멱등이어야 하고(매 빌드마다 재설치/업데이트 금지), 네트워크·런타임 부재가 빌드 전체를 깨지 않도록 모든 단계를 non-fatal로 설계했다.

## ADR (Architecture Decision Record)

### 설치 메커니즘
| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| nix 패키지 | nodePackages 등 nix 빌드 | 완전 선언 | 버전 핀 고정, npm 호환 약함, "nix 설치 제거" 의도와 배치 | ❌ |
| mise npm backend | activation에서 `mise use -g npm:@openai/codex` | npm 호환, mise 생태계 일관, 버전 미pin | mise/node 의존 | ✅ |
| 순수 npm activation | `npm install -g @openai/codex` | 단순 | node 버전 전환 시 글로벌 소실, mise와 이원화 | ❌ |
| mise config.toml을 nix 생성 | 도구 전체를 nix가 선언 | 단일 SoT | 수동 config 워크플로 상실, scope 확대 | ❌ |

### macOS mise 보장
| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| preflight skip | mise 없으면 경고 후 건너뜀 | 변경 최소 | mise 부재 시 codex 미설치(조건부 선언) | ❌ |
| mise를 nix shared로 | `pkgs.mise`를 공통 패키지로 | 완전 양쪽 선언 통일 | mise 런타임 관리가 nix scope로 확대 | ✅ |
| brew로 mise 선언 | homebrew.nix에 mise 추가 | 문서 관례 유지 | brew/nix 혼재, node 별도 보장 | ❌ |

### node 보장
| 대안 | 설명 | 결정 |
|------|------|------|
| codex activation이 글로벌 node 없을 때만 보장 | `mise use -g node@lts`(없을 때만) | ✅ (codex 하나뿐이라 별도 모듈 분리는 YAGNI) |
| 별도 ensureMiseNode 모듈 | node 부트스트랩 분리 | ❌ (지금은 과설계 — npm backend 도구가 늘면 분리) |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `libraries/packages.nix` | `pkgs.mise`를 nixosOnly → shared (macOS도 nix 설치) |
| `modules/shared/programs/codex/default.nix` | `installCodexCli`(GitHub 다운로드) 제거 → 3-activation 분할 + darwin wrapper·`hostType` 파라미터 제거 |
| `modules/darwin/programs/homebrew.nix` | personal casks에서 `codex` 제거 |
| `.claude/skills/managing-mise/SKILL.md` | mise 설치 방식 설명을 nix shared로 갱신 |
| `.claude/skills/managing-macos/SKILL.md`, `references/features.md` | casks 예시·adopt 목록에서 codex 제거 |

3-activation 구조 (DAG: `writeBoundary → cleanupLegacyCodexCli → installCodexCli → cleanupManualNodeCodex`):

- **cleanupLegacyCodexCli**: NixOS는 `~/.local/bin/codex` GitHub ELF 바이너리 제거, macOS는 `brew uninstall --cask codex`(`cleanup="none"`이라 cask 목록 제거만으론 미삭제되므로 보완).
- **installCodexCli**: 글로벌 node 보장(없을 때만; NixOS는 소스 빌드 회피 위해 prebuilt 강제) → mise config 등록 + 실제 installed 여부로 멱등 판정 → 미설치 시에만 `mise use -g npm:@openai/codex`.
- **cleanupManualNodeCodex**: mise node 트리에서 수동 npm 글로벌 codex 잔재 제거(실 버전 디렉토리만 순회, npm 래퍼를 직접 실행).

핵심 멱등 가드 — config 등록만 보면 설치 실패 상태에 속을 수 있어 `installed:true`까지 확인한다:

```sh
if "$mise_bin" ls -g --current --json npm:@openai/codex 2>/dev/null \
    | jq -e '[.[] | select(.installed == true)] | length > 0' >/dev/null 2>&1; then
  echo "Codex CLI already managed by mise npm backend"
else
  ... mise use -g npm:@openai/codex ...
fi
```

## 참고 레퍼런스

- 관련 스킬: `configuring-codex`, `managing-mise`, `using-codex-exec`
- mise npm backend (`npm:` 프리픽스로 npm 글로벌 패키지를 mise 도구로 관리)

## Human Test Plan

1. **MiniPC(NixOS)에서 nrs 실행**
   - 기대: 기존 `~/.local/bin/codex`(GitHub 바이너리)가 제거되고, mise npm backend로 codex가 설치(또는 이미 관리 중이면 skip)되며, 수동 npm 글로벌 잔재가 정리된다.
   - 확인: `mise ls -g --current npm:@openai/codex`에 codex 표시 / `command -v codex`가 mise shim 경로(`~/.local/share/mise/shims/codex`) / `~/.local/bin/codex` 부재.
   - 실패 시: activation 로그의 Warning(mise/node 부재, 네트워크 실패) 확인.
2. **재nrs 멱등성**
   - 기대: "Codex CLI already managed by mise npm backend" 출력, 재설치·버전 변경 없음.
3. **codex 실행**
   - 기대: `codex --version` 정상, `codex`/`codex-apps` alias 동작.
4. **macOS에서 nrs** (별도 머신)
   - 기대: brew cask codex 제거, mise npm backend로 codex 설치.
   - ⚠️ 과거 macOS에서 brew로 mise를 수동 설치했다면 nix mise와 PATH 경합 가능 → `brew uninstall mise` 후 nrs 권장.

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증
- `nix flake check` 통과.
- `git grep -n "GitHub releases" modules/shared/programs/codex/` → 옛 설치 설명 부재.
- `git grep -n '"codex"' modules/darwin/programs/homebrew.nix` → cask 목록에 codex 부재.
- `git grep -n "Homebrew로 mise" .claude/skills/managing-mise/` → 옛 문구 부재.

### Phase 1: activation eval
- NixOS: `nix eval --raw .#nixosConfigurations.greenhead-minipc.config.home-manager.users.greenhead.home.activation.installCodexCli.data` → `node_ok` 가드 + `select(.installed == true)` 필터 포함.
- darwin: `nix eval --raw '.#darwinConfigurations."greenhead-MacBookPro".config.home-manager.users.green.home.activation.installCodexCli.data'` → `MISE_NODE_COMPILE` 미포함(NixOS 전용 분기) 확인.
- cleanupManualNodeCodex: symlink 별칭 skip(`[ ! -L ]`) + `npm` 직접 실행(`node npm` 아님) 확인.

### Phase 2: Regression
- mise가 여전히 node/pnpm을 관리하는지(`mise ls -g`), 다른 codex activation(config 동기화, 스킬 프로젝션)이 영향받지 않는지.

---

**Follow-up 후보**: 3개 신규 activation에 대한 테스트 커버리지 추가 (현재 activation 로직 전반에 테스트가 없음).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex CLI now installs via mise npm backend for unified management across macOS and Linux.

* **Bug Fixes**
  * Automatic cleanup of legacy Codex Homebrew cask and manually installed binaries.
  * Added PATH conflict resolution for mise installations on macOS.

* **Documentation**
  * Updated installation guidance for mise and related package management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->