### PR TITLE
fix(codex): installCodexCli mise 호출에 node bin PATH 보강

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -188,6 +188,11 @@ in
           || { node_ok=0; echo "Warning: 'mise use -g node@lts' failed; skipping Codex CLI install (non-fatal)"; }
       fi
       if [ "$node_ok" = 1 ]; then
+        # mise npm backend 설치는 내부적으로 npm 래퍼(exec node)를 호출하는데, 이 래퍼는 PATH의
+        # node를 찾는다. home-manager activation의 제한된 PATH에는 node가 없어 'exec: node: not found'로
+        # 실패하므로, mise-managed node bin을 PATH 앞에 보강한다(cleanupManualNodeCodex와 동일 의도).
+        node_bin="$("$mise_bin" where node 2>/dev/null)/bin"
+        [ -d "$node_bin" ] && export PATH="$node_bin:$PATH"
         # config 등록 + installed:true인 backend만 "이미 관리됨"으로 판정한다.
         # length>0만 보면 config 등록 후 install 실패한 [{installed:false}] 상태에 속아 영구 미설치로 고착된다.
         if "$mise_bin" ls -g --current --json npm:@openai/codex 2>/dev/null \


### PR DESCRIPTION
## Summary

- `installCodexCli`의 mise 호출 전에 mise-managed node bin을 PATH에 보강한다.
- PR #814가 도입한 codex 설치 activation이 clean install에서 실패하던 회귀를 수정한다.

## 배경 (회귀)

PR #814 머지 후 로컬 E2E(nrs 실제 적용)에서 발견했다. mise npm backend 설치(`mise use -g npm:@openai/codex`)는 내부적으로 npm 래퍼를 호출하는데, 이 래퍼가 `exec node`로 **PATH의 node**를 찾는다. home-manager activation의 제한된 PATH에는 node가 없어 `exec: node: not found`로 설치가 실패한다.

결과: 정리 단계(레거시 GitHub 바이너리 · 수동 npm 글로벌 제거)는 동작하지만 설치가 실패해 codex shim이 stale 상태가 되고 `mise ERROR: codex is not a valid shim`으로 실행 불가가 된다.

정리 단계(`cleanupManualNodeCodex`)에는 node bin PATH 보강이 있었으나 **설치 단계(`installCodexCli`)에는 누락**된 비대칭이 원인이다.

## 수정

`installCodexCli`의 node 보장 직후, mise npm backend 호출 전에 node bin을 PATH에 추가한다:

```nix
node_bin="$("$mise_bin" where node 2>/dev/null)/bin"
[ -d "$node_bin" ] && export PATH="$node_bin:$PATH"
```

## 검증 (E2E)

- `nix flake check` 통과, 양쪽 플랫폼(NixOS/darwin) activation eval 확인.
- **clean install 재현**: `mise rm -g npm:@openai/codex`로 codex를 제거(설치 실패 상태 재현) → 수정된 코드로 nrs → codex 0.133.0 정상 설치 + config 등록 확인. 수정 전에는 동일 상태에서 설치가 실패했다.
- **제한 PATH 재현**: node bin이 없는 PATH에서 npm 래퍼가 `exec: node: not found`로 실패, node bin을 PATH에 추가하면 정상 동작 확인.

## Human Test

- macOS nrs 적용 시 codex 설치 성공 + `codex --version` 확인.
- 기존 머신(이미 codex 설치됨)은 멱등 가드(`installed:true`)로 skip되는지 확인.

## 참고

- PR #814 (Codex 설치를 nix/brew → mise npm backend로 전환) 후속 회귀 수정.
