### PR TITLE
feat(claude/statusline): SSH에서 Jira/Slack/Figma를 OSC8 대신 평문 URL로 출력

### DIFF
--- a/modules/shared/programs/claude/files/scripts/statusline.sh
+++ b/modules/shared/programs/claude/files/scripts/statusline.sh
@@ -235,10 +235,22 @@ fi
 
 # ============================================================
 # Section 4: SSH 감지
-#   SSH 세션에서는 OSC 8 hyperlink 클릭 불가 → URL 비활성, 텍스트만
+#   SSH 세션(Termius 등)에서는 OSC 8 클릭 불가 (클라이언트 미지원 + Claude Code Ink 유실).
+#   → Jira/Slack/Figma는 평문 URL로 출력(print_icon SSH 분기)해 클라이언트 URL regex 감지에 맡긴다.
+#   감지: SSH_CONNECTION 직접 + tmux 세션 환경 폴백(tmux attach 대응).
 # ============================================================
 IS_SSH=false
 [ -n "$SSH_CONNECTION" ] && IS_SSH=true
+# tmux attach 폴백: SSH 밖에서 시작한 tmux에 SSH로 attach하면, 이미 떠 있던 pane의
+# 프로세스는 갱신된 SSH_CONNECTION을 물려받지 못한다 (fork 모델 — update-environment는
+# 새 pane에만 주입). tmux 세션 환경을 조회해 보강한다. 값이 있을 때(SSH_CONNECTION=?*)만
+# SSH로 판정 — 로컬 클라이언트 재attach 시 tmux가 남기는 제거표시(-SSH_CONNECTION)는
+# 배제해, 데스크톱 재attach 시 OSC 8 동작으로 자동 복귀한다.
+if ! $IS_SSH && command -v tmux >/dev/null 2>&1; then
+  case "$(tmux show-environment SSH_CONNECTION 2>/dev/null)" in
+    SSH_CONNECTION=?*) IS_SSH=true ;;
+  esac
+fi
 
 CACHE_GUIDE_URL="https://github.com/greenheadHQ/nixos-config/blob/main/modules/shared/programs/claude/files/docs/cache-guide.md"
 $IS_SSH && CACHE_GUIDE_URL=""
@@ -647,8 +659,18 @@ print_icon() {
   local label=$4
   url=$(sanitize_osc8_url "$url")
   $LINE_HAS_OUTPUT && printf '  '
-  if [ -n "$url" ]; then
-    # OSC 8 hyperlink: escape sequence는 %b, URL은 %s, label은 %s
+  if [ -n "$url" ] && $IS_SSH; then
+    # SSH(Termius 등): OSC 8 미지원 + Claude Code Ink 유실로 하이퍼링크 클릭 불가.
+    # 평문 URL을 라벨 뒤에 출력해 SSH 클라이언트의 URL regex 감지에 맡긴다.
+    # url은 위에서 sanitize_osc8_url을 거친 값 — control 문자가 있으면 통째로 비워지고,
+    # 빈 값이면 위 `[ -n "$url" ]` 가드에서 이 분기에 진입하지 못한다. 즉 여기 도달한 url은
+    # control 문자가 없음이 보장되어 escape 주입 방어가 유지된다.
+    printf '%b' "\e[${color}m${emoji} "
+    printf '%s' "$label"
+    printf '%b' "\e[0m "
+    printf '%s' "$url"
+  elif [ -n "$url" ]; then
+    # OSC 8 hyperlink (로컬 터미널): escape sequence는 %b, URL은 %s, label은 %s
     printf '%b' "\e[4;${color}m\e]8;;"
     printf '%s' "$url"
     printf '%b' "\a${emoji} "
@@ -799,13 +821,15 @@ render_rate_window() {
 
 # L1: /set-icons (Jira → Slack → Figma → Memo) — 조건부 라인
 begin_line
-if [ -n "$JIRA_URL" ] && [ -n "$JIRA_LABEL" ] && ! $IS_SSH; then
+# SSH(Termius 등)에서도 출력한다: print_icon이 SSH 분기에서 평문 URL로 렌더한다.
+# cwd/Plan/Memory/Memo/Cache는 SSH일 때 호출부에서 url=""로 넘겨 평문화 대상에서 빠진다.
+if [ -n "$JIRA_URL" ] && [ -n "$JIRA_LABEL" ]; then
   print_icon "33" "$JIRA_URL" "\xe2\x9a\xa1" "$JIRA_LABEL"
 fi
-if [ -n "$SLACK_URL" ] && [ -n "$SLACK_LABEL" ] && ! $IS_SSH; then
+if [ -n "$SLACK_URL" ] && [ -n "$SLACK_LABEL" ]; then
   print_icon "35" "$SLACK_URL" "\xf0\x9f\x92\xac" "$SLACK_LABEL"
 fi
-if [ -n "$FIGMA_URL" ] && [ -n "$FIGMA_LABEL" ] && ! $IS_SSH; then
+if [ -n "$FIGMA_URL" ] && [ -n "$FIGMA_LABEL" ]; then
   print_icon "31" "$FIGMA_URL" "\xf0\x9f\x8e\xa8" "$FIGMA_LABEL"
 fi
 if [ -n "$MEMO_PATH" ] && [ -f "$MEMO_PATH" ]; then

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -13,6 +13,14 @@
 
 setup() {
   STATUSLINE="${BATS_TEST_DIRNAME}/../statusline.sh"
+  # tmux SSH 폴백 격리: bats 를 실제 tmux 세션 안에서 실행해도 비-SSH 케이스가
+  # `tmux show-environment SSH_CONNECTION` 폴백으로 SSH branch 에 오염되지 않도록
+  # fake tmux(빈 출력)를 PATH 앞에 둔다. SSH 케이스는 SSH_CONNECTION 을 직접 주입해
+  # 폴백을 타지 않으므로 영향이 없다.
+  FAKE_BIN="$BATS_TEST_TMPDIR/fakebin"
+  mkdir -p "$FAKE_BIN"
+  printf '#!/bin/sh\nexit 0\n' > "$FAKE_BIN/tmux"
+  chmod +x "$FAKE_BIN/tmux"
   # resets_at 을 실행 시점 기준 미래로 동적 생성. 절대값 timestamp 를 박으면 시간이
   # 지나며 stale 되어 statusline.sh 의 `remaining > 0` 가드가 `→ remaining` 출력을
   # 건너뛰고 detail=4 검증이 무력화된다.
@@ -53,7 +61,7 @@ EOF
 run_statusline_with_input() {
   local stdin="$1"
   shift
-  printf '%s' "$stdin" | env -u CLAUDE_STATUSLINE_COLUMNS -u COLUMNS -u SSH_CONNECTION "$@" bash "$STATUSLINE" 2>/dev/null
+  printf '%s' "$stdin" | env -u CLAUDE_STATUSLINE_COLUMNS -u COLUMNS -u SSH_CONNECTION PATH="$FAKE_BIN:$PATH" "$@" bash "$STATUSLINE" 2>/dev/null
 }
 
 # setup 의 MOCK_JSON 을 stdin 으로 쓰는 thin wrapper. 대부분의 케이스가 이 경로.
@@ -214,6 +222,28 @@ EOF
   reset_count=$(echo "$plain" | grep -oE '\([0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}\)' | wc -l)
   [ "$reset_count" -eq 2 ] \
     || { echo "expected detail=4 in SSH branch too; got reset_count=$reset_count plain=$plain" >&2; false; }
+}
+
+# SSH 평문 URL: Jira 아이콘 URL 이 OSC 8 hyperlink 가 아니라 평문 URL 로 출력돼야
+# SSH 클라이언트(Termius 등)의 URL regex 감지에 걸린다. sidecar 아이콘 + transcript
+# 가 valid 해야 SIDECAR_IO_ENABLED 가 켜지므로 fake HOME 으로 projects 경계를 만든다.
+@test "SSH renders Jira icon as plain URL (no OSC 8)" {
+  local fake_home="$BATS_TEST_TMPDIR/home"
+  local sid="abc12345-def6-7890-abcd-ef1234567890"
+  mkdir -p "$fake_home/.claude/projects/proj" "$fake_home/.claude/status-icons"
+  local tr="$fake_home/.claude/projects/proj/$sid.jsonl"
+  printf '{}\n' > "$tr"
+  printf '{"jira":{"url":"https://ex.atlassian.net/browse/PROJ-1","label":"PROJ-1"}}\n' \
+    > "$fake_home/.claude/status-icons/$sid.json"
+  local stdin
+  stdin=$(printf '{"session_id":"%s","transcript_path":"%s","cwd":"/tmp","rate_limits":{"five_hour":{"used_percentage":5}}}' "$sid" "$tr")
+  run run_statusline_with_input "$stdin" SSH_CONNECTION=192.168.1.1 HOME="$fake_home" SESSION_STATE_DIR="$fake_home/.claude/status-icons"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qF 'https://ex.atlassian.net/browse/PROJ-1' \
+    || { echo "expected plain Jira URL in SSH branch; got: $output" >&2; false; }
+  if printf '%s' "$output" | grep -q $'\x1b]8;;'; then
+    echo "expected NO OSC 8 sequence in SSH plain mode; got: $output" >&2; false
+  fi
 }
 
 # SSH 0% gauge edge: pct=0 일 때 core 가 literal " " (공백) 으로 치환되어 `▏ ▕` 가


### PR DESCRIPTION
## 1. Summary

- SSH 환경(Termius 등)에서 Jira/Slack/Figma 웹링크를 OSC 8 하이퍼링크 대신 **평문 URL**로 출력 → SSH 클라이언트의 URL regex 감지로 외부 브라우저 클릭 가능
- SSH 감지를 `SSH_CONNECTION` 직접 + `tmux show-environment` 폴백으로 보강 (tmux attach 시나리오 대응)
- bats: tmux 폴백 격리(fake tmux) + SSH 평문 URL 케이스 추가

Closes #819

## 2. 기존 문제 / 배경

iPad의 Termius(SSH)로 statusline을 볼 때, 아이콘에 걸린 OSC 8 하이퍼링크를 탭해도 외부 브라우저가 열리지 않았다. 원인은 이 repo에서 우회 불가능한 두 제약이다:

1. **Termius가 OSC 8 escape sequence를 클릭 가능 링크로 처리하지 않는다** — 화면에 보이는 평문 URL만 regex로 감지한다.
2. **Claude Code Ink 렌더러가 statusline의 OSC 8 메타데이터를 재그리기에서 유실한다** (tmux 경유 시 특히).

여기에 더해 기존 SSH 감지는 `SSH_CONNECTION`만 봐서, tmux를 SSH 밖에서 시작한 뒤 attach하면 SSH를 오판했고, 동시에 SSH일 때 Jira/Slack/Figma 아이콘을 아이콘째 숨겨 정작 클릭할 URL이 화면에 없었다.

## 3. Change Intent Record

- **발견 경위**: Termius에서 평문 URL은 "Open in browser" 툴팁이 뜨지만 OSC 8 아이콘은 무반응이었다. 조사 결과 OSC 8 경로는 네 겹의 장벽(SSH 감지 오판 / tmux `hyperlinks` terminal-feature 부재 / Claude Code Ink 유실 / Termius 미지원)으로 막혀 있고, 뒤 두 개는 사용자가 우회할 수 없음을 실측·레퍼런스로 확인했다.
- **설계 의도**: OSC 8을 포기하고 SSH에서 평문 URL을 출력한다. 평문 텍스트는 Ink 유실·tmux feature 문제를 타지 않아 SSH 전반(순수 SSH + tmux attach)에서 안정적으로 클릭된다.
- **범위 한정**: 외부 브라우저에서 의미 있는 https 링크(Jira/Slack/Figma)만 평문화한다. cwd(`vscode://`)·Plan/Memory/Memo(`file://`)·Cache guide는 iPad 외부 브라우저에서 무의미하므로 현행 유지한다 — 이들은 SSH일 때 호출부에서 이미 `url=""`로 넘어가므로 `print_icon`만 고쳐도 자동으로 평문화 대상에서 빠진다.
- **단축 URL은 후속으로 분리**: URL 길이 대응(자체 호스팅 단축기)은 새 서비스 규모라 이 변경 범위에서 제외했다. 평문 전환을 먼저 적용해 실사용 후 필요할 때 추가한다.

## 4. Architecture Decision Record

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| OSC 8 유지 | 현행 하이퍼링크 그대로 | 로컬 터미널에서 클릭 가능 | Termius 미지원 + Ink 유실로 SSH 클릭 불가 | ❌ |
| 평문 URL (SSH 분기) | SSH일 때 OSC 8 대신 평문 URL 출력 | Termius regex 감지, Ink/tmux 문제 회피, 평문이라 안정적 | 긴 URL은 줄이 길어질 수 있음 | ✅ |
| tmux `hyperlinks` feature 활성화 | `terminal-features`에 `hyperlinks` 추가 | tmux가 OSC 8을 바깥으로 emit | Ink 유실 + Termius 미지원이 상위에서 차단하므로 무효 | ❌ |
| 단축 URL 자체 호스팅 | 길이 단축용 서비스 도입 | URL이 짧아짐 | 새 서비스 + Caddy + agenix 규모 | ❌ (후속) |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/scripts/statusline.sh` | SSH 감지 tmux 폴백, `print_icon` SSH 평문 분기, Jira/Slack/Figma 출력 조건 해제 |
| `modules/shared/programs/claude/files/scripts/tests/statusline.bats` | fake tmux 격리 + SSH 평문 URL 검증 케이스 |

**`print_icon` SSH 평문 분기** (`print_icon`은 모든 아이콘이 공유하므로, SSH일 때 `url=""`로 넘어오는 cwd/Plan/Memory/Memo/Cache는 이 분기를 안 타고 자동 제외):

```bash
if [ -n "$url" ] && $IS_SSH; then
  # SSH: 평문 URL을 라벨 뒤에 출력 (SSH 클라이언트 URL regex 감지)
  printf '%b' "\e[${color}m${emoji} "; printf '%s' "$label"
  printf '%b' "\e[0m "; printf '%s' "$url"
elif [ -n "$url" ]; then
  # OSC 8 hyperlink (로컬 터미널) — 기존 동작 유지
  ...
fi
```

**SSH 감지 tmux 폴백** (값이 있을 때만 SSH 판정 → 로컬 재attach 시 제거표시 `-SSH_CONNECTION`은 배제되어 OSC 8 자동 복귀):

```bash
if ! $IS_SSH && command -v tmux >/dev/null 2>&1; then
  case "$(tmux show-environment SSH_CONNECTION 2>/dev/null)" in
    SSH_CONNECTION=?*) IS_SSH=true ;;
  esac
fi
```

## 6. 참고 레퍼런스

- Closes #819 (설계 + 이행 가이드)
- Claude Code statusline OSC 8 유실: `anthropics/claude-code#37216`, `#13008`, `#23438`
- Termius OSC 8 미지원: OSC8-Adoption 목록 누락 + Termius changelog(OSC 52만 추가, OSC 8 없음)
- tmux OSC 8 네이티브 지원: tmux 3.4 CHANGES "Add support for OSC 8 hyperlinks"

## 7. Human Test Plan

1. iPad Termius로 MiniPC tmux 세션에 attach → Claude Code 실행
2. `/set-icons`로 Jira(또는 Slack/Figma) 링크를 등록
3. **기대**: statusline의 해당 아이콘 줄에 평문 URL(`https://...`)이 표시된다
4. 그 URL을 탭 → "Open in browser" 툴팁(Safari/Embedded browser)이 뜨고, 선택하면 브라우저로 열린다
5. 로컬 데스크톱 터미널(비SSH)에서 확인 → 기존 OSC 8 하이퍼링크가 유지되고 평문 URL은 노출되지 않는다

**실패 시 진단**
- SSH인데 평문 URL이 안 보임 → IS_SSH 감지 실패. `tmux show-environment SSH_CONNECTION`이 `SSH_CONNECTION=값`을 반환하는지 확인 (제거표시 `-SSH_CONNECTION`이면 비SSH로 판정됨)
- cwd/Plan/Memory 등도 평문 URL로 노출됨 → 해당 호출부의 `$IS_SSH && ..._URL=""` 처리 회귀 확인
- bats 회귀 → `nix shell nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Enhanced SSH session detection to check tmux environment when SSH_CONNECTION is unavailable
* URLs in SSH sessions now render as plain text for improved compatibility
* Status line icons (Jira, Slack, Figma) display correctly in SSH sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/820?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->