### PR TITLE
fix(codex): installCodexCli PATH 보강에 mise bin 추가

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -188,11 +188,13 @@ in
           || { node_ok=0; echo "Warning: 'mise use -g node@lts' failed; skipping Codex CLI install (non-fatal)"; }
       fi
       if [ "$node_ok" = 1 ]; then
-        # mise npm backend 설치는 내부적으로 npm 래퍼(exec node)를 호출하는데, 이 래퍼는 PATH의
-        # node를 찾는다. home-manager activation의 제한된 PATH에는 node가 없어 'exec: node: not found'로
-        # 실패하므로, mise-managed node bin을 PATH 앞에 보강한다(cleanupManualNodeCodex와 동일 의도).
+        # mise npm backend 설치는 내부적으로 npm 래퍼를 호출하는데, 이 래퍼는 두 외부 명령을 PATH에서
+        # 찾는다: (1) node 실행(exec node), (2) 설치 후 reshim 단계의 'mise reshim'. home-manager
+        # activation의 제한된 PATH에는 둘 다 없어 node는 'exec: node: not found', mise는
+        # 'mise: command not found'(reshim 단계 exit 127 → install 전체 실패)로 깨진다.
+        # mise-managed node bin과 mise bin을 함께 PATH 앞에 보강한다(cleanupManualNodeCodex와 동일 의도).
         node_bin="$("$mise_bin" where node 2>/dev/null)/bin"
-        [ -d "$node_bin" ] && export PATH="$node_bin:$PATH"
+        [ -d "$node_bin" ] && export PATH="$node_bin:${pkgs.mise}/bin:$PATH"
         # config 등록 + installed:true인 backend만 "이미 관리됨"으로 판정한다.
         # length>0만 보면 config 등록 후 install 실패한 [{installed:false}] 상태에 속아 영구 미설치로 고착된다.
         if "$mise_bin" ls -g --current --json npm:@openai/codex 2>/dev/null \


### PR DESCRIPTION
## Summary
- mise npm backend 설치 단계(`installCodexCli`)에서 npm 래퍼의 reshim 호출이 PATH의 `mise`를 찾도록 `${pkgs.mise}/bin`을 PATH 보강에 추가한다.
- macOS(nix-darwin)에서 codex 설치가 매 `nrs`마다 실패하던 문제를 고친다. 같은 파일의 `cleanupManualNodeCodex`가 이미 쓰던 검증된 패턴(node + mise bin 보강)을 설치 단계에도 적용한다.

## 기존 문제/배경

PR #814가 codex CLI 설치를 mise npm backend(`npm:@openai/codex`)로 전환했고, PR #815가 npm 래퍼의 `exec: node: not found`를 고치려 node bin을 PATH 앞에 보강했다. 그러나 mise npm 래퍼는 글로벌 패키지 설치 **후 reshim 단계에서 `mise reshim`을 PATH에서 호출**한다. home-manager activation의 제한된 PATH(특히 nix-darwin)에는 `mise`가 없어 다음과 같이 깨진다:

```
Installing Codex CLI via mise npm backend (npm:@openai/codex)...
Reshimming mise latest...
.../mise/installs/node/latest/bin/npm: line 75: mise: command not found
mise ERROR npm failed
added 2 packages in 2s
mise ERROR Failed to install npm:@openai/codex@latest: npm exited with non-zero status: exit code 127
Warning: Codex CLI install via mise skipped (non-fatal)
```

npm install 자체는 성공(`added 2 packages`)하지만 reshim이 exit 127로 실패 → mise가 install 전체를 실패로 처리 → backend 미등록(`mise ls -g --current --json npm:@openai/codex` → `[]`), `codex` 미작동. 멱등 가드가 `installed: true`를 보지 못하므로 매 `nrs`마다 동일 실패가 반복된다.

이 증상은 **macOS에서만 발현**한다. NixOS는 activation PATH에 user profile(`/etc/profiles/per-user/...`)이 포함되어 `mise`가 우연히 잡혀 영향받지 않았다.

## CIR (Change Intent Record)

- **PR #814 (이전)**: nix(GitHub 바이너리)/brew cask 설치를 mise npm backend로 전환.
- **PR #815 (이전)**: npm 래퍼의 `exec: node: not found`를 발견하고 node bin을 PATH 앞에 보강. 단 npm 래퍼가 설치 후 reshim 단계에서 `mise`도 PATH로 호출한다는 점은 놓쳤다.
- **(이번 변경)**: reshim 단계의 `mise: command not found`(exit 127)가 install 실패의 실제 원인임을 확인. node bin만이 아니라 mise bin도 PATH에 필요하다. 같은 파일의 `cleanupManualNodeCodex`가 이미 동일 패턴(node + mise bin PATH 보강)을 사용하고 있어, 설치 단계에 누락됐던 mise bin만 보강한다.

**설계 의도**: PATH 환경 의존을 제거해 macOS/NixOS 양쪽에서 결정론적으로 동작하게 한다. `${pkgs.mise}/bin`은 Nix evaluation 시점에 고정되는 immutable store path이므로 `mise_bin`(절대경로) 호출과 동일 바이너리를 가리킨다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| node bin만 PATH 보강 (현행 #815) | npm 래퍼의 node 탐색만 해결 | 최소 변경 | reshim 단계의 mise 탐색 실패 → install 전체 실패 | ❌ |
| node bin + mise bin PATH 보강 | npm 래퍼가 node와 reshim용 mise를 둘 다 PATH에서 찾도록 | `cleanupManualNodeCodex`와 동일한 검증된 패턴, PATH 환경 의존 제거 | `${pkgs.mise}/bin` 보간이 2곳에 중복 | ✅ |
| 공통 헬퍼로 PATH 보강 로직 추출 | installCodexCli/cleanupManualNodeCodex가 공유 | 중복 제거 | npm backend 도구가 codex 하나뿐 — 과한 추상화 (YAGNI) | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/codex/default.nix` | 수정 | `installCodexCli` PATH 보강에 `${pkgs.mise}/bin` 추가 + reshim 단계 의존을 명시하도록 주석 보강 |

### 핵심 코드

```sh
# BEFORE: node bin만 보강 → npm 래퍼가 reshim 단계에서 mise를 못 찾음
[ -d "$node_bin" ] && export PATH="$node_bin:$PATH"

# AFTER: node bin + mise bin 보강 (npm 래퍼가 node 실행과 reshim용 mise를 둘 다 PATH에서 탐색)
[ -d "$node_bin" ] && export PATH="$node_bin:${pkgs.mise}/bin:$PATH"
```

## 참고 레퍼런스

- PR #814 — codex nix/brew 설치를 mise npm backend로 전환
- PR #815 — npm 래퍼 node bin PATH 보강 (이번 PR이 그 후속 보완)
- 해당 없음 — 별도 추적 이슈 없이 `nrs` 실행 중 발견된 회귀

## Human Test Plan

### 정상 동작 검증 (macOS)

1. codex backend가 비어 있는 상태(`mise ls -g --current --json npm:@openai/codex` → `[]`)에서 `nrs`를 실행한다.
   - **기대**: `Installing Codex CLI via mise npm backend...` 이후 `mise: command not found` 없이 `Reshimming mise ...` → 설치 성공. activation 경고 없음.
   - **실패 시**: nrs 로그에서 `mise ERROR` / `command not found` / `exit code 127` 출현 여부를 확인한다.

2. 설치 확인: `mise ls -g --current --json npm:@openai/codex`가 `installed: true, active: true`를 반환하고, `~/.local/share/mise/shims/codex --version`이 `codex-cli` 버전을 출력한다.
   - **실패 시**: backend가 `[]`이면 reshim 단계에서 PATH의 mise가 잡혔는지 확인한다.

3. 멱등 재실행: codex가 설치된 상태에서 `nrs`를 재실행한다.
   - **기대**: `Codex CLI already managed by mise npm backend`로 skip되고 재설치하지 않는다.

### Regression 검증 (NixOS)

4. NixOS(MiniPC)에서 동일 변경으로 NixOS toplevel을 빌드한다.
   - **기대**: eval/build 정상, codex 정상 유지. NixOS는 원래 이 버그의 영향을 받지 않았으므로 회귀가 없어야 한다.
   - **실패 시**: `activation-script` derivation 빌드 에러 메시지를 확인한다.

5. `installCodexCli` 외 activation step(`syncCodexConfig`, `cleanupManualNodeCodex`, `createCodexProjectSymlinks` 등)이 PATH 보강으로 깨지지 않는지 확인한다.
   - **기대**: `nrs` 전체가 정상 완료된다. PATH 보강은 같은 shell의 후속 step에 전파되나, 후속 step은 모두 nix store 절대경로 또는 `env` override를 사용하므로 동작이 바뀌지 않는다.
   - **실패 시**: activation 로그에서 해당 step의 에러를 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex CLI installation process to properly configure system environment paths, ensuring both the Node runtime and package management tools are accessible during setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->