### PR TITLE
fix(codex): installCodexCli node_bin 빈 출력 시 /bin PATH 삽입 방지

### DIFF
--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -193,8 +193,11 @@ in
         # activation의 제한된 PATH에는 둘 다 없어 node는 'exec: node: not found', mise는
         # 'mise: command not found'(reshim 단계 exit 127 → install 전체 실패)로 깨진다.
         # mise-managed node bin과 mise bin을 함께 PATH 앞에 보강한다(cleanupManualNodeCodex와 동일 의도).
-        node_bin="$("$mise_bin" where node 2>/dev/null)/bin"
-        [ -d "$node_bin" ] && export PATH="$node_bin:${pkgs.mise}/bin:$PATH"
+        # `mise where node`가 빈 문자열을 반환하면(비정상 mise 상태) 빈 값에 "/bin"이 붙어
+        # node_dir이 비어도 "/bin"이 PATH 앞에 삽입될 수 있다. node_dir을 먼저 받아
+        # 비어있지 않을 때만 보강해 시스템 /bin이 PATH를 오염시키는 것을 방지한다.
+        node_dir="$("$mise_bin" where node 2>/dev/null)"
+        [ -n "$node_dir" ] && [ -d "$node_dir/bin" ] && export PATH="$node_dir/bin:${pkgs.mise}/bin:$PATH"
         # config 등록 + installed:true인 backend만 "이미 관리됨"으로 판정한다.
         # length>0만 보면 config 등록 후 install 실패한 [{installed:false}] 상태에 속아 영구 미설치로 고착된다.
         if "$mise_bin" ls -g --current --json npm:@openai/codex 2>/dev/null \


### PR DESCRIPTION
## Summary
- `installCodexCli`의 node bin PATH 보강에서 `mise where node`가 빈 문자열을 반환하면 시스템 `/bin`이 PATH 맨 앞에 삽입되던 latent defect를 방지한다.
- `node_dir`을 먼저 받아 비어있지 않을 때만 PATH를 보강한다.

Closes #822

## 기존 문제/배경

PR #815에서 도입된 node bin PATH 보강 라인은 다음과 같았다:

```sh
node_bin="$("$mise_bin" where node 2>/dev/null)/bin"
[ -d "$node_bin" ] && export PATH="$node_bin:${pkgs.mise}/bin:$PATH"
```

`mise where node`가 빈 문자열을 반환하면(비정상 mise 상태) `node_bin`은 `"/bin"`이 되고, `/bin`은 실제 디렉토리이므로 `[ -d "$node_bin" ]` 가드를 통과해 `export PATH="/bin:${pkgs.mise}/bin:$PATH"`가 실행된다. 즉 시스템 `/bin`이 PATH 맨 앞에 삽입되어, 이후 mise npm 래퍼가 bare `node` 등을 탐색할 때 영향받을 수 있다.

도달 조건은 매우 드물다 — 상위 가드 `node_ok=1`(mise가 `ls -g --current node`로 node 설치를 인식)인데 직후 `mise where node`만 빈 문자열을 반환하는 mise 내부 상태 불일치에서만 발생한다. non-fatal이고 `/bin`은 신뢰 경로라 실제 영향은 미미하나 latent defect로 남아 있었다.

## CIR (Change Intent Record)

- **(이번 변경)**: PR #821(reshim PATH 수정) 작업 중 자동 전수조사에서 이 EDGECASE를 pre-existing으로 발견했고, 해당 PR 범위와 분리하여 이슈 #822로 등록한 뒤 별도 수정한다. `node_bin`(bin까지 포함한 경로) 변수를 `node_dir`(mise가 반환하는 디렉토리)로 바꿔 빈 출력 검사를 명시한다.

**설계 의도**: 빈 출력 시 PATH 보강을 건너뛰어 `/bin` 오염을 방지한다. node 경로가 불명이면 보강을 skip하는 것이 안전하다(이후 `mise use`가 non-fatal하게 실패하더라도 PATH 오염은 발생하지 않음).

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 현행 (가드 없음) | `node_bin="$(...)/bin"` 후 `[ -d ]` | 단순 | 빈 출력 시 `/bin` 삽입 | ❌ |
| node_dir 분리 + `[ -n ]` 가드 | where 결과를 먼저 받아 빈 검사 후 `$node_dir/bin` 보강 | 빈 출력 방어, 정상 경로 동등 | 변수 의미 변경 1곳 | ✅ |
| 빈 출력 시 `node_ok=0` 강등 | where 실패를 node 미보장으로 처리 | 명시적 실패 전파 | 과한 변경, mise use가 어차피 non-fatal 처리 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/codex/default.nix` | 수정 | `node_bin` → `node_dir`, `[ -n "$node_dir" ]` 빈 출력 가드 추가 + why 주석 |

### 핵심 코드

```sh
# BEFORE: 빈 출력 시 node_bin="/bin" → [ -d /bin ] 통과 → /bin이 PATH 앞에 삽입
node_bin="$("$mise_bin" where node 2>/dev/null)/bin"
[ -d "$node_bin" ] && export PATH="$node_bin:${pkgs.mise}/bin:$PATH"

# AFTER: node_dir을 먼저 받아 비어있지 않을 때만 보강 (정상 경로에서는 동일 결과)
node_dir="$("$mise_bin" where node 2>/dev/null)"
[ -n "$node_dir" ] && [ -d "$node_dir/bin" ] && export PATH="$node_dir/bin:${pkgs.mise}/bin:$PATH"
```

## 참고 레퍼런스

- 이슈 #822 — 본 PR이 해결하는 EDGECASE
- PR #815 — node bin PATH 보강(이 라인) 최초 도입
- PR #821 — reshim PATH 수정 작업 중 본 EDGECASE 발견·분리

## Human Test Plan

### 정상 동작 검증

1. node가 정상 설치된 상태에서 `nrs`를 실행한다.
   - **기대**: PATH 보강이 변경 전과 동일하게 동작한다(`$node_dir/bin` == 기존 `$node_bin`). codex 설치/멱등 가드 정상.
   - **실패 시**: `mise where node` 출력과 `$node_dir/bin` 경로를 비교한다.

### Negative / 엣지 검증

2. `mise where node`가 빈 문자열을 반환하는 상황(비정상 mise 상태)을 모사한다:
   ```sh
   node_dir=""; [ -n "$node_dir" ] && [ -d "$node_dir/bin" ] && echo "prepend" || echo "skip (no /bin pollution)"
   ```
   - **기대**: `skip` 출력 — `/bin`이 PATH에 삽입되지 않는다.
   - **실패 시**: `[ -n "$node_dir" ]` 가드 누락을 확인한다.

3. 정상 경로 동등성: 변경 전(`node_bin="$(...)/bin"; [ -d "$node_bin" ]`)과 변경 후(`node_dir="$(...)"; [ -n ] && [ -d "$node_dir/bin" ]`)가 정상 케이스에서 동일한 PATH를 만드는지 확인한다.

### Regression 검증

4. 변수명 변경(`node_bin` → `node_dir`)이 다른 곳을 깨지 않는지: `grep -n node_bin modules/shared/programs/codex/default.nix`로 잔존 참조 0건을 확인하고, `nrs` 전체가 정상 완료되는지 확인한다.
