### PR TITLE
fix(mcp): chrome-devtools-mcp NODE_OPTIONS 힙 상한으로 autoConnect OOM 방어

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -143,6 +143,8 @@ in
 
     # MCP 설정 - 양방향 수정 가능
     # chrome-devtools MCP(CDP)만 사용 — claude-in-chrome(--chrome)은 제거됨 (CIR 참조: shell/default.nix)
+    # mcp.darwin.json의 chrome-devtools env.NODE_OPTIONS(--max-old-space-size, autoConnect OOM 방어)는
+    # JSON이라 주석을 못 단다 — 값 근거·동기화 규칙은 codex files/config.darwin.toml의 동일 키 주석을 정전(canonical)으로 본다.
     ".claude/mcp.json".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/${claudeMcpFile}";
 

--- a/modules/shared/programs/claude/files/mcp.darwin.json
+++ b/modules/shared/programs/claude/files/mcp.darwin.json
@@ -10,7 +10,8 @@
         "--no-usage-statistics"
       ],
       "env": {
-        "npm_config_registry": "https://registry.npmjs.org/"
+        "npm_config_registry": "https://registry.npmjs.org/",
+        "NODE_OPTIONS": "--max-old-space-size=8192"
       }
     }
   }

--- a/modules/shared/programs/codex/files/config.darwin.toml
+++ b/modules/shared/programs/codex/files/config.darwin.toml
@@ -84,3 +84,7 @@ args = ["-y", "chrome-devtools-mcp@latest", "--autoConnect", "--channel=stable",
 
 [mcp_servers.chrome-devtools.env]
 npm_config_registry = "https://registry.npmjs.org/"
+# chrome-devtools-mcp --autoConnect의 heavy 작업(큰 스냅샷·무거운 페이지) 시 V8 old-space OOM 방어.
+# 값은 상한일 뿐 평소 점유와 무관하다. upstream 메모리 누수(ChromeDevTools/chrome-devtools-mcp#1192)는
+# 이미 수정됐으나, 단발성 OOM에 대한 안전벨트로 명시 유지한다.
+NODE_OPTIONS = "--max-old-space-size=8192"

--- a/modules/shared/programs/codex/files/config.darwin.toml
+++ b/modules/shared/programs/codex/files/config.darwin.toml
@@ -85,6 +85,9 @@ args = ["-y", "chrome-devtools-mcp@latest", "--autoConnect", "--channel=stable",
 [mcp_servers.chrome-devtools.env]
 npm_config_registry = "https://registry.npmjs.org/"
 # chrome-devtools-mcp --autoConnect의 heavy 작업(큰 스냅샷·무거운 페이지) 시 V8 old-space OOM 방어.
-# 값은 상한일 뿐 평소 점유와 무관하다. upstream 메모리 누수(ChromeDevTools/chrome-devtools-mcp#1192)는
-# 이미 수정됐으나, 단발성 OOM에 대한 안전벨트로 명시 유지한다.
+# 8192MB(=8GB)는 점유가 아닌 상한이며, host RAM(32GB)의 25% 내에서 무거운 힙 스냅샷까지 여유를 두고 선정한다
+# (4096MB로도 단발 OOM 방어엔 충분하나 여유분으로 8192MB 채택). NODE_OPTIONS는 npx install 단계를 포함한
+# npx 프로세스 트리 전체에 상속되지만, 상한일 뿐이라 동작상 부작용은 없다. upstream 메모리 누수
+# (ChromeDevTools/chrome-devtools-mcp#1192)는 이미 수정됐으나, 단발성 OOM 안전벨트로 명시 유지한다.
+# 동일 값이 Claude용 mcp.darwin.json env에도 중복 존재한다 — 한쪽 변경 시 반드시 양쪽을 함께 수정한다.
 NODE_OPTIONS = "--max-old-space-size=8192"


### PR DESCRIPTION
## 1. Summary

- Claude(`mcp.darwin.json`)·Codex(`config.darwin.toml`) 양쪽 `chrome-devtools` MCP 서버의 `env`에 `NODE_OPTIONS=--max-old-space-size=8192`를 추가한다.
- `--autoConnect`의 heavy 작업(큰 힙 스냅샷·무거운 페이지)에서 V8 old-space 고갈로 MCP 서버 프로세스가 OOM 사망 → `Transport closed`로 이어지는 경로를 막는 **안전벨트**다.
- 값은 상한일 뿐 평소 점유와 무관하며, JSON은 주석을 달 수 없어 의도/근거는 TOML 주석과 `default.nix` cross-reference로 문서화한다.

(연관 이슈 없음 — 자체 발견 개선이라 `Closes` 없음)

## 2. 기존 문제 / 배경

`chrome-devtools-mcp`를 `--autoConnect`로 사용하던 중, 세션 도중 MCP 연결이 높은 확률로 끊기며 `Transport closed` 경고가 발생하는 문제를 조사했다. 끊김의 원인은 복합적이다:

- **클라이언트단**: stdio 트랜스포트 서버는 끊긴 뒤 자동 재연결되지 않아 사용자가 매번 수동 재연결해야 한다(MCP 호스트의 알려진 제약).
- **서버단(이 PR의 범위)**: `--autoConnect` 모드에서 heavy 작업 시 메모리가 급증해 Node 프로세스가 V8 old-space 한도에 도달하면 OOM으로 죽는다. 프로세스가 죽으면 그 자체가 `Transport closed`로 표면화된다.

upstream의 핵심 메모리 누수는 이미 수정되었으나(아래 레퍼런스), 단발성 heavy 작업에서의 OOM 가능성은 누수와 별개로 남아 있다. 힙 **상한**을 넉넉히 올려두면 이 단발 OOM에 의한 프로세스 사망을 예방할 수 있다.

## 3. CIR (Change Intent Record)

- chrome-devtools-mcp의 잦은 연결 끊김을 분석한 결과, "왜 끊기나(서버 OOM 등)"와 "왜 자동 복구가 안 되나(클라이언트 stdio 재연결 부재)"라는 두 층위가 겹쳐 있음을 확인했다. 이 PR은 그중 **서버 OOM에 의한 프로세스 사망**이라는 한 축만 직접 방어한다(클라이언트단 재연결은 본 repo 범위 밖, 별도 추적).
- `--max-old-space-size`는 메모리 사용량을 늘리는 옵션이 아니라 V8 old-space가 도달 가능한 **상한(ceiling)**이다. 평소 점유에는 영향이 없고, 누수가 없는 한 추가 메모리를 소비하지 않으므로 부작용이 거의 없는 방어선으로 판단해 채택했다.
- Claude와 Codex 모두 동일한 `npx chrome-devtools-mcp@latest --autoConnect`로 같은 서버를 띄우므로, 한쪽만 적용하면 비대칭이 생긴다. 두 클라이언트에 동일하게 적용해 효과를 일치시켰다.
- 적용 시점에 실측으로 NODE_OPTIONS가 `npx`→서버 node 프로세스에 상속되어 V8 `heap_size_limit`을 실제로 상승시킴을 확인했다(Node 25.x 기준 ~4.3GB → ~8.4GB).

## 4. ADR (Architecture Decision Record)

| 결정 | 대안 | 장점 | 단점 | 채택 |
|------|------|------|------|------|
| 적용 범위 | Claude + Codex 양쪽 | 두 클라이언트가 같은 서버를 띄우므로 효과 일치 | 동일 값이 두 파일에 중복 | ✅ |
| | Claude 또는 Codex 한쪽만 | 변경 최소 | 한쪽만 보호되는 비대칭 | ❌ |
| 힙 상한 값 | `8192`MB (8GB) | 무거운 힙 스냅샷까지 여유, host RAM 32GB의 25% | 다소 넉넉함 | ✅ |
| | `4096`MB (4GB) | 더 보수적 | 단발 heavy 작업 여유 부족 가능 | ❌ |
| 값 관리 구조 | 각 설정 파일에 인라인 + 주석 | 현 배포 구조에 부합 | 두 곳 동기화 필요 | ✅ |
| | `libraries/constants.nix` 상수화 | 단일 출처(SSOT) | **구조적으로 불가** — JSON은 `mkOutOfStoreSymlink` raw 심링크, TOML은 sync 스크립트가 문자열 그대로 transcribe하여 Nix 보간 경로가 없음 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/mcp.darwin.json` | `chrome-devtools.env`에 `NODE_OPTIONS` 추가 (JSON, 주석 불가) |
| `modules/shared/programs/codex/files/config.darwin.toml` | `[mcp_servers.chrome-devtools.env]`에 `NODE_OPTIONS` 추가 + 값 근거/npx 상속/동기화 규칙 주석 |
| `modules/shared/programs/claude/default.nix` | `mcp.json` 심링크 선언에 cross-reference 주석 (JSON 의도를 TOML 주석으로 안내) |

핵심 변경(Codex TOML):

```toml
[mcp_servers.chrome-devtools.env]
npm_config_registry = "https://registry.npmjs.org/"
# chrome-devtools-mcp --autoConnect의 heavy 작업(큰 스냅샷·무거운 페이지) 시 V8 old-space OOM 방어.
# 8192MB(=8GB)는 점유가 아닌 상한이며, host RAM(32GB)의 25% 내에서 무거운 힙 스냅샷까지 여유를 두고 선정한다
# (4096MB로도 단발 OOM 방어엔 충분하나 여유분으로 8192MB 채택). NODE_OPTIONS는 npx install 단계를 포함한
# npx 프로세스 트리 전체에 상속되지만, 상한일 뿐이라 동작상 부작용은 없다. ...
# 동일 값이 Claude용 mcp.darwin.json env에도 중복 존재한다 — 한쪽 변경 시 반드시 양쪽을 함께 수정한다.
NODE_OPTIONS = "--max-old-space-size=8192"
```

darwin 전용 변경이다(NixOS는 `chrome-devtools` MCP 미구성 — 빈 `mcp.json` / mcp_servers 없는 `config.toml`). Codex의 `config.darwin.toml`은 sync 스크립트의 template-driven leaf 처리로 자동 반영되며, drift 검증·shell-script 테스트·flake-check 모두 통과 확인했다.

## 6. 참고 레퍼런스

- `ChromeDevTools/chrome-devtools-mcp#1192` — `--autoConnect` 메모리 누수(OOM) 이슈. upstream에서 수정 완료. 본 PR은 그와 별개로 단발 OOM 안전벨트.
- `ChromeDevTools/chrome-devtools-mcp#1094` — 장기 `--autoConnect` 세션에서 연결 끊김/반복 승인.
- `modules/nixos/programs/docker/karakeep.nix` — 이 repo의 기존 `NODE_OPTIONS=--max-old-space-size` 선례(컨테이너 컨텍스트, 값은 별개).

## 7. Human Test Plan

1. **적용**: 워크트리에서 `nrs`를 실행한다.
   - 기대: 빌드 성공, launchd/Hammerspoon 재시작 정상.
2. **반영 확인**: `cat ~/.claude/mcp.json`과 `cat ~/.codex/config.toml`에서 `chrome-devtools` 서버의 `env`에 `NODE_OPTIONS=--max-old-space-size=8192`가 보이는지 확인.
   - 기대: 두 파일 모두 키 존재. (Codex는 sync 후 `~/.codex/config.toml`에 transcribe됨)
3. **상속 검증**: chrome-devtools MCP를 한 번 기동시킨 뒤, 해당 node 프로세스에서 `node -e "console.log(require('v8').getHeapStatistics().heap_size_limit)"`를 `NODE_OPTIONS=--max-old-space-size=8192` 환경으로 실행해 상한이 ~8.4GB로 잡히는지 확인.
   - 기대: `heap_size_limit`이 기본값(~4.3GB)이 아니라 ~8.4GB.
4. **회귀 없음 확인**: chrome-devtools MCP로 평소 디버깅/스냅샷 작업을 수행.
   - 기대: 평소와 동일하게 동작(상한일 뿐 점유 무관). 무거운 작업에서 OOM 사망 빈도 감소.
- **실패 시 진단**: `~/.codex/config.toml`에 키가 없으면 sync 스크립트 로그 확인; MCP가 여전히 죽으면 `Transport closed`의 다른 축(클라이언트 stdio 재연결 부재 등)일 수 있으므로 메모리 외 원인을 분리 점검.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated Chrome DevTools memory configuration in Claude and Codex, setting a maximum allocation of 8GB to optimize resource usage during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->