### PR TITLE
feat(1password): Phase 2b — gh 1Password Shell Plugin alias 전환

### DIFF
--- a/.claude/prds/prd-1password-migration.md
+++ b/.claude/prds/prd-1password-migration.md
@@ -4,7 +4,7 @@
 
 - Status: In Progress
 - File Mode: Split
-- Current Phase: Phase 1 merged (PR #824) — Phase 2a/2b/3 ready (선택 대기)
+- Current Phase: Phase 2b Done (PR 대기) — Phase 1 merged (#824), Phase 2a/3 ready (선택 대기)
 - Active Phase File: [Phase 1](./prd-1password-migration/phase-01-foundation.md)
 - Last Updated: 2026-05-25
 - PRD File: `.claude/prds/prd-1password-migration.md`
@@ -170,7 +170,7 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 |---|---|---|---|---|
 | Phase 1: Foundation | Done (merged #824) | Mac 1Password 설치, Automation vault, gh PAT rotation, op_get helper, SA token | nrs darwin + gh API + op CLI 동작 | [phase-01-foundation.md](./prd-1password-migration/phase-01-foundation.md) |
 | Phase 2a: Mac SSH | Not Started | IdentityAgent + emergency fallback + 디바이스별 키 inventory | ssh minipc 동작 + 1Password quit 후 fallback 실측 | [phase-02a-mac-ssh.md](./prd-1password-migration/phase-02a-mac-ssh.md) |
-| Phase 2b: Shell plugin gh | Not Started | Home Manager declarative plugin 등록 | gh pr list 동작 (biometric prompt 1회) | [phase-02b-shell-plugin-gh.md](./prd-1password-migration/phase-02b-shell-plugin-gh.md) |
+| Phase 2b: Shell plugin gh | Done (PR 대기) | Home Manager declarative plugin 등록 | gh pr list 동작 (biometric prompt 1회) | [phase-02b-shell-plugin-gh.md](./prd-1password-migration/phase-02b-shell-plugin-gh.md) |
 | Phase 3: MiniPC opnix | Not Started | opnix 모듈 + SA token + MiniPC gh 전환 | nrs minipc + ssh minipc 'gh pr list' 동작 | [phase-03-minipc-opnix.md](./prd-1password-migration/phase-03-minipc-opnix.md) |
 | Phase 4: Apple Passwords | Not Started | CSV 매트릭스 실측, import, iCloud disable, TOTP/passkey 정책 | iOS 자동채움 1Password 우선 동작 | [phase-04-apple-passwords.md](./prd-1password-migration/phase-04-apple-passwords.md) |
 | Phase 5: Skill 리팩토링 | Not Started | managing-secrets routing 매트릭스 + inventory + queries.json | evals/queries.json 통과 + SKILL.md ≤ 250줄 | [phase-05-skill-refactor.md](./prd-1password-migration/phase-05-skill-refactor.md) |
@@ -206,3 +206,4 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 - 2026-05-17: Initial PRD created. grill-me 결정사항 + DA review findings 반영. 사용자 추가 결정: routing 트리를 2단계로 단순화하고 mirror 패턴 폐기, 디바이스별 SSH key 4개 (mac/iphone/ipad/emergency), iCloud Keychain AutoFill 비활성화, envScript 패턴은 다른 컨테이너에서 자연 보존.
 - 2026-05-24: Phase 1 구현 완료 (PR 대기). Mac 1Password(Homebrew Cask) 설치, Automation vault, gh PAT 발급+1Password 저장+retrieval 검증 (login greenheadHQ), op_get helper (op read secret reference + 멀티계정 --account 고정), SA token (`nixos-automation-minipc`, 전역 공유·minipc 단일 저장, host key 전용 recipient) agenix 보관, opnix stub + expiry record. 발견: 1Password Individual은 SA 자동 만료 미지원 → 정책 90일 cadence (만료 목표 2026-08-22, NFR-4 준수); op CLI 필드 조회는 op read secret reference 권장; op CLI 멀티 계정(개인+회사) 환경은 --account 고정 필요. 사용자 신규 결정: SA 운영 모델은 전역 공유 1개 (Mac은 biometric이라 SA 미사용, 실 소비처 minipc). 회사 맥북 SSH 키 분리는 별 세션 의제로 이관 (FR-10 확장 후보).
 - 2026-05-25: Phase 1 PR #824로 squash merge. 리뷰 반영 — agenix host key·opnix expiry 경로를 constants.nix로 중앙화, SA token user shell bridge를 잠정 설계로 마킹하고 해결 후보 3종(systemd+polkit / wrapper binary / derived credential) 나열, constants.onePassword.account hard-pin 추가. merge 후 nrs 로컬 적용 + E2E 전 항목 통과 (op_get retrieval → gh api user=greenheadHQ, op_get 함수 활성화, 에러 처리 2/127, opnix stub 비활성, flake check). Phase 2a/2b/3 진입 가능.
+- 2026-05-25: Phase 2b 구현 완료 (PR 대기). gh를 1Password Shell Plugin alias로 전환 — `shell/default.nix`에 plugins.sh file-guard source chunk + `op plugin init gh`(global default, github-pat) + nrs. `gh api user`=greenheadHQ(op plugin 경유 github-pat 주입) 검증, hosts.yml 평문 oauth_token 0건(yq 제거+백업), git history leak 0건, 구 PAT 없음 확인, keyring `gho_` unused fallback 유지 결정. Phase 2a/3 진입 가능.

--- a/.claude/prds/prd-1password-migration/phase-02b-shell-plugin-gh.md
+++ b/.claude/prds/prd-1password-migration/phase-02b-shell-plugin-gh.md
@@ -1,8 +1,8 @@
 # Phase 2b: Shell Plugin gh
 
 Parent PRD: [PRD: Bitwarden(Vaultwarden) → 1Password 마이그레이션 + LLM 주도 개발 생태계](../prd-1password-migration.md)
-Status: Not Started
-Last Updated: 2026-05-17
+Status: Done (PR 대기)
+Last Updated: 2026-05-25
 
 ## Objective
 
@@ -110,7 +110,12 @@ Last Updated: 2026-05-17
 ## Discoveries / Decisions
 
 - 확장 트리거 텍스트 (Phase 5에 박제 예정): "추가 shell plugin 도입 조건 = (a) 해당 도구 secret을 .env로 export하는 패턴 ≥ 2건 발생 OR (b) agenix 평문 노출 위험 보고 1건"
+- **op plugin 인증 모드**: `op plugin init gh`에서 github-pat(Automation) credential + "Use as global default on my system" 채택 — gh는 디렉토리 무관 범용 도구이고 LLM 자동화 cwd가 다양하므로 directory-scoped보다 global이 적합.
+- **plugins.sh declarative sourcing**: op이 안내하는 `echo "source ..." >> ~/.zshrc`는 회피 — `~/.zshrc`가 Home Manager nix store 심링크(read-only)라 직접 append 시 깨진다. `programs.zsh.initContent`에 file-guard source chunk로 declarative 등록 (`shell/default.nix`).
+- **hosts.yml 제거 후 keyring fallback**: hosts.yml 평문 oauth_token 제거 시 gh가 keyring의 구 `gho_` OAuth로 fallback한다. 단 op plugin alias가 `GH_TOKEN`(github-pat)을 우선 주입하므로 실 인증은 github-pat이고, keyring `gho_`는 unused fallback(OS 암호화, 평문 아님)이라 사용자 결정으로 유지.
+- **구 PAT 부재**: 기존 gh 인증은 OAuth(`gho_`)였고 Phase 1의 `ghp_`가 첫 PAT라 GitHub 측에 revoke할 구 PAT가 없음 (사용자 확인). FR-3 "구 PAT revoke"는 대상 없음으로 충족.
 
 ## Phase Change Log
 
 - 2026-05-17: Phase file created.
+- 2026-05-25: Phase 2b 구현 완료 (PR 대기). `shell/default.nix` initContent에 plugins.sh file-guard source chunk 추가 + `op plugin init gh`(global default, github-pat) + nrs 적용. 검증: `type gh`=alias(op plugin run -- gh), `gh api user`=greenheadHQ(op plugin 경유 github-pat 주입). hosts.yml 평문 oauth_token 0건(yq 제거+백업). git history leak 0건. 구 PAT 없음 확인, keyring `gho_` unused fallback 유지 결정. 확장 트리거는 Phase 5 reserved.

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -354,6 +354,17 @@ in
           fi
         }
       ''
+
+      #─────────────────────────────────────────────────────────────────────────
+      # 1Password Shell Plugins (op plugin init gh → ~/.config/op/plugins.sh)
+      # gh = "op plugin run -- gh" alias로 wrapping — github-pat을 호출 시점에 주입 (PRD #780 Phase 2b)
+      # guard: plugins.sh 부재 시 silent skip (op plugin init 전·CI·MiniPC 등 — Mac 전용 자산)
+      #─────────────────────────────────────────────────────────────────────────
+      (lib.mkAfter ''
+        if [ -f "$HOME/.config/op/plugins.sh" ]; then
+          source "$HOME/.config/op/plugins.sh"
+        fi
+      '')
     ];
   };
 


### PR DESCRIPTION
## Summary

- Phase 2b: `gh` CLI를 1Password Shell Plugin alias로 전환해, `~/.config/gh/hosts.yml` 평문 oauth_token 의존을 제거하고 LLM 자동화가 `gh` 호출 시 Automation vault의 `github-pat`을 투명하게 주입받게 한다.
- declarative source guard(`shell/default.nix`) + `op plugin init gh`(사용자, global default) + hosts.yml 평문 제거 + 구 PAT 부재 확인.

Part of #780

## 기존 문제/배경

Phase 1에서 gh PAT를 1Password Automation vault(`github-pat`)에 저장하고 retrieval까지 검증했지만, 실제 `gh` 인증은 여전히 `~/.config/gh/hosts.yml`의 평문 `oauth_token`(gho_)과 keyring에 의존했다. LLM 자동화(Claude Code)가 `gh pr create` 등을 호출할 때 평문 토큰을 거치는 구조라, 평문 노출 표면이 남아 있었다.

## CIR (Change Intent Record)

- **plugins.sh sourcing 방식**: `op plugin init gh`는 마지막에 `echo "source ..." >> ~/.zshrc`를 안내하지만, `~/.zshrc`가 Home Manager nix store 심링크(read-only)라 직접 append하면 실패·선언적 관리 붕괴. → `programs.zsh.initContent`에 **file-guard source chunk**로 declarative 등록(plugins.sh 부재 시 silent skip).
- **op plugin 인증 모드**: `this directory or subdirectories`(scoped) 대신 **`Use as global default`** 채택 — gh는 디렉토리 무관 범용 도구이고 LLM 자동화 cwd가 다양하므로.
- **hosts.yml 제거 후 keyring fallback 발견**: 평문 oauth_token 제거 시 gh가 keyring 구 `gho_`로 fallback하나, op plugin alias가 `GH_TOKEN`(github-pat)을 우선 주입하므로 실 인증은 github-pat. keyring `gho_`는 unused fallback(OS 암호화)이라 유지 결정.
- **구 PAT 부재 확인**: 기존은 OAuth(`gho_`) 인증이었고 Phase 1의 `ghp_`가 첫 PAT → revoke할 구 PAT 없음. FR-3의 "구 PAT revoke"는 대상 없음으로 충족.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `echo >> ~/.zshrc` (op 기본 안내) | zshrc에 직접 append | 즉시 | home-manager 심링크 read-only → 실패·관리 붕괴 | ❌ |
| `initContent` file-guard source | 선언적 source chunk | nix 관리 일관, guard로 안전 | nrs 필요 | ✅ |
| op plugin scoped (directory) | 특정 디렉토리만 | scope 제한 | gh 범용성·LLM cwd 다양성과 불일치 | ❌ |
| op plugin global default | 시스템 전역 | gh 어디서나 자동 인증 | (biometric 세션으로 보완) | ✅ |
| keyring gho_ 정리 | gh auth logout | 구 credential 제거 | shren207 재로그인 등 부작용, op plugin 우선이라 무해 | ❌ |
| keyring gho_ 유지 | unused fallback 잔존 | 부작용 없음, OS 암호화 | 구 OAuth 잔존 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/shell/default.nix` | 수정 | initContent mkMerge에 1Password Shell Plugin file-guard source chunk 추가 |
| `.claude/prds/prd-1password-migration*` | 수정 | phase-02b Status→Done(PR 대기) + 발견 박제, master Phase Index/Current Phase/Change Log |

로컬 작업(이 PR diff에 없음, 사용자/환경 단): `op plugin init gh`(global default, github-pat) 실행 → `~/.config/op/plugins.sh` 생성, `~/.config/gh/hosts.yml` 평문 oauth_token 제거(yq + 백업 `.bak-phase2b`).

### 핵심 코드

```nix
# 1Password Shell Plugins (op plugin init gh → ~/.config/op/plugins.sh)
(lib.mkAfter ''
  if [ -f "$HOME/.config/op/plugins.sh" ]; then
    source "$HOME/.config/op/plugins.sh"
  fi
'')
```

## 참고 레퍼런스

- #780 — Bitwarden→1Password 마이그레이션 epic (이 PR은 Phase 2b)
- #824 — Phase 1 Foundation (gh PAT를 Automation vault에 저장)
- [1Password Shell Plugins](https://developer.1password.com/docs/cli/shell-plugins/) / [Nix 통합](https://developer.1password.com/docs/cli/shell-plugins/nix/) / [GitHub](https://developer.1password.com/docs/cli/shell-plugins/github/)

## Human Test Plan

### 정상 동작 검증

1. `nrs` 후 새 zsh 세션에서 `type gh`.
   - **기대**: `gh is an alias for op plugin run -- gh`.
   - **실패 시**: `~/.zshrc`에 plugins.sh source guard 반영 확인 + `~/.config/op/plugins.sh` 존재 확인.

2. `gh api user --jq .login` (biometric 1회 가능).
   - **기대**: `greenheadHQ` (op plugin이 github-pat 주입).
   - **실패 시**: `op plugin run -- gh api user` 직접 실행해 op plugin 동작 확인.

3. 30분 내 두 번째 `gh pr list`.
   - **기대**: biometric 없이 통과 (세션 캐시).

### Negative / 회귀 검증

4. `grep -i oauth_token ~/.config/gh/hosts.yml`.
   - **기대**: 0건 (평문 토큰 부재).
   - **실패 시**: 백업 `~/.config/gh/hosts.yml.bak-phase2b`에서 비교.

5. `git log -p --all -- '**/hosts.yml' '**/*.env' | rg 'gh[opsu]_[A-Za-z0-9]{30,}'`.
   - **기대**: 0건 (git history 평문 leak 부재).

6. plugins.sh 부재 환경(CI/MiniPC)에서 nrs 평가.
   - **기대**: source guard가 silent skip (file 부재 가드) → 빌드 영향 없음.
