### PR TITLE
fix(hooks): gitleaks hook을 nix 경유로 해석해 비대화형 셸 PATH 누락 방어

### DIFF
--- a/scripts/ai/run-gitleaks-staged-policy.sh
+++ b/scripts/ai/run-gitleaks-staged-policy.sh
@@ -109,9 +109,22 @@ fi
 require_executable_materialized_helper "$VALIDATOR_PATH" "$validator_tmp"
 python3 "$validator_tmp" --snapshot "$snapshot" --git-dir "$abs_git_dir" --index "$temp_index"
 
+# gitleaks 런처 결정: PATH 우선(direnv 활성 인터랙티브 셸), 없으면 nix 경유(direnv
+# 미활성 비대화형 AI 에이전트/CI 셸). gitleaks는 flake devShell에만 있어, 비대화형
+# 셸에서는 PATH에 없어 이 hook이 exit 127로 커밋을 차단했다(#826). statusline-bats
+# (lefthook.yml)와 동일하게 --inputs-from으로 repo flake.lock의 nixpkgs를 재사용해
+# 임시 registry fetch와 프로젝트 pin 우회를 피한다. PATH에 있으면 nix 평가 없이 직접 실행.
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks_cmd=(gitleaks)
+else
+  command -v nix >/dev/null 2>&1 \
+    || fail "gitleaks not on PATH and nix unavailable to bootstrap it (enter devShell or install gitleaks)"
+  gitleaks_cmd=(nix shell --inputs-from "$REPO_ROOT" nixpkgs#gitleaks --command gitleaks)
+fi
+
 (
   cd "$snapshot"
-  with_staged_git_env gitleaks protect --staged --source . --no-banner --redact \
+  with_staged_git_env "${gitleaks_cmd[@]}" protect --staged --source . --no-banner --redact \
     --config ./.gitleaks.toml \
     --gitleaks-ignore-path ./.gitleaksignore
 )


### PR DESCRIPTION
## Summary

- 비대화형 셸(AI 에이전트/CI, direnv 미활성)에서 `gitleaks`가 PATH에 없어 lefthook `pre-commit`의 gitleaks hook이 `command not found`(exit 127)로 커밋 전체를 차단하던 문제를 해결한다.
- `scripts/ai/run-gitleaks-staged-policy.sh`가 `gitleaks`를 PATH 우선으로, 없으면 `nix shell --inputs-from "$REPO_ROOT" nixpkgs#gitleaks`로 해석하도록 견고화한다. 인터랙티브 사용자는 동작·성능 변화가 없고, 비대화형 셸만 nix 경유로 보강된다.

Closes #826

## 기존 문제/배경

`gitleaks`는 flake devShell 패키지로만 제공된다(`flake.nix`의 devShell `buildInputs`). 사람이 쓰는 인터랙티브 셸은 direnv가 셸 진입 시 devShell을 활성화해 `gitleaks`가 PATH에 들어오므로 문제가 드러나지 않는다.

반면 AI 코딩 에이전트(Claude Code/Codex)의 도구 실행 셸이나 CI 같은 **비대화형 컨텍스트**에서는 direnv hook(인터랙티브 셸 precmd)이 동작하지 않는다. 실측 결과 이 환경에서 `DIRENV_DIR`/`IN_NIX_SHELL`이 모두 비어 있고 `gitleaks`가 PATH에 없어, hook이 다음과 같이 실패하며 커밋이 abort된다:

```
./scripts/ai/run-gitleaks-staged-policy.sh: gitleaks: command not found
exit status 127
```

사람의 인터랙티브 셸에서는 재현되지 않아 "내 환경에선 되는데"식으로 원인 파악이 지연되는 silent 함정이다. AI 에이전트 주도 개발에서는 커밋마다 수동으로 도구 경로를 보충해야 하는 반복 마찰이 된다.

## CIR (Change Intent Record)

- **발견 경위**: 비대화형 셸에서 커밋이 `gitleaks: command not found`로 연속 차단되어 발견.
- **범위 재확정**: 이슈 초안은 `nixfmt`/`shellcheck`도 같은 증상으로 추정했으나, 실측 결과 두 도구는 home 프로필로 PATH에 상주(`nixfmt`는 neovim 모듈, `shellcheck`는 `libraries/packages.nix`의 공통 패키지)해 비대화형에서도 정상 동작한다. **실제로 깨지는 도구는 `gitleaks` 단독**이므로 범위를 gitleaks로 한정했다.
- **구현 방식 선택**: lefthook `pre-commit` 명령은 `scripts/ai/check-lefthook-staged-config.sh`가 하드코딩된 expected 블록과 글자 단위로 diff 검증한다(staged-config guard). 따라서 `lefthook.yml`의 hook 명령을 `nix shell`로 감싸는 방식은 guard의 expected 블록까지 동기화해야 하고, 인터랙티브 사용자도 매 커밋 nix 평가 비용을 진다. 대신 gitleaks가 거치는 스크립트 내부에서 도구를 해석하도록 하여 `lefthook.yml`과 staged-config guard를 건드리지 않는 방식을 택했다.

**trade-off**: 비대화형 셸의 첫 커밋에서 nix 평가 비용(warm 캐시 기준 약 1초)이 추가된다. 인터랙티브 사용자는 PATH에 gitleaks가 있어 분기 없이 기존과 동일하게 실행되므로 영향이 없다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 스크립트 내부 PATH fallback | `run-gitleaks-staged-policy.sh`에서 PATH 우선, 없으면 `nix shell --inputs-from`으로 해석 | `lefthook.yml`/staged-config guard 무변경, 인터랙티브 0 오버헤드, 비대화형만 nix 경유 | gitleaks가 스크립트를 경유하기에 가능한 방식(범용 아님) | ✅ |
| `lefthook.yml` hook 명령 nix wrap | `statusline-bats`처럼 hook 명령을 `nix shell ... --command`로 감쌈 | 기존 pre-push 패턴과 표면적으로 동일 | staged-config guard의 expected 블록 동기화 필요(회귀 위험↑), 인터랙티브도 항상 nix 평가 | ❌ |
| nixfmt/shellcheck도 함께 견고화 | 세 도구 모두 nix 경유 보강 | 시스템 프로필 의존 제거 | 두 도구는 현재 home 프로필로 동작 → 실익 없음(YAGNI), guard 동기화 비용 동반 | ❌ |

선례: `lefthook.yml`의 `statusline-bats`/`shell-script-tests` hook이 이미 `nix shell --inputs-from .`으로 devShell 도구를 PATH 독립적으로 해석한다. 본 변경은 같은 원리를 gitleaks가 경유하는 스크립트 내부에 적용한 것이다.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `scripts/ai/run-gitleaks-staged-policy.sh` | 수정 | gitleaks 실행 launcher를 PATH 우선 + nix fallback으로 결정하는 분기 추가, 호출부를 배열 전개로 전환 |

### 핵심 코드

```bash
# gitleaks 런처 결정: PATH 우선(direnv 활성 인터랙티브 셸), 없으면 nix 경유.
if command -v gitleaks >/dev/null 2>&1; then
  gitleaks_cmd=(gitleaks)
else
  command -v nix >/dev/null 2>&1 \
    || fail "gitleaks not on PATH and nix unavailable to bootstrap it (enter devShell or install gitleaks)"
  gitleaks_cmd=(nix shell --inputs-from "$REPO_ROOT" nixpkgs#gitleaks --command gitleaks)
fi

(
  cd "$snapshot"
  with_staged_git_env "${gitleaks_cmd[@]}" protect --staged --source . --no-banner --redact \
    --config ./.gitleaks.toml \
    --gitleaks-ignore-path ./.gitleaksignore
)
```

`--inputs-from "$REPO_ROOT"`는 repo의 `flake.lock`에 고정된 nixpkgs를 재사용해 임시 registry fetch와 프로젝트 pin 우회를 피한다. PATH에 gitleaks가 있으면 `gitleaks_cmd=(gitleaks)`로 환원되어 기존 호출과 토큰 단위로 동일하다.

## 참고 레퍼런스

- Issue #826 — 본 이슈(비대화형 셸 gitleaks PATH 누락)
- `lefthook.yml` `statusline-bats` hook — `nix shell --inputs-from .`로 devShell 도구를 PATH 독립적으로 해석하는 선례 패턴
- `scripts/ai/check-lefthook-staged-config.sh` — pre-commit 명령을 글자 단위로 검증하는 staged-config guard(대안 비교의 근거)

## Human Test Plan

### 비대화형 경로 검증 (핵심)

1. direnv/devShell이 비활성인 셸에서 `DIRENV_DIR`·`gitleaks` 부재를 확인한다.
   ```bash
   echo "DIRENV_DIR=${DIRENV_DIR:-<empty>}"; command -v gitleaks || echo "gitleaks NOT on PATH"
   ```
   - **기대**: `DIRENV_DIR` 비어 있음, gitleaks NOT on PATH.
2. 임의의 staged 변경을 만든 뒤 같은 셸에서 `git commit`을 실행한다.
   - **기대**: gitleaks hook이 nix 경유로 스캔(`no leaks found`)하고 커밋이 성공한다.
   - **실패 시**: `nix shell --inputs-from "$(git rev-parse --show-toplevel)" nixpkgs#gitleaks --command gitleaks version`을 직접 실행해 nix 해석이 되는지 확인한다.

### 인터랙티브 경로 회귀

3. direnv 활성(devShell 진입) 셸에서 동일하게 커밋한다.
   - **기대**: `gitleaks`가 PATH에 있어 nix 평가 없이 기존과 동일하게 스캔·통과한다.

### Negative / 보안 게이트 회귀

4. gitleaks와 nix가 모두 없는 셸을 가정한 경로 점검.
   - **기대**: 모호한 exit 127 대신 명시적 메시지(`gitleaks not on PATH and nix unavailable to bootstrap it`)로 실패한다.
5. 시크릿 패턴이 포함된 staged 변경으로 커밋을 시도한다.
   - **기대**: gitleaks가 leak을 탐지해 비-0 exit으로 커밋이 정상 차단된다(보안 게이트가 fallback 경로에서도 유지됨).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the gitleaks detection script to dynamically select the appropriate execution method based on available system dependencies, improving tool reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->