### PR TITLE
feat(wt): 비대화형 셸 100% 호환 + dead-path 가지치기

### DIFF
--- a/.claude/skills/configuring-git/SKILL.md
+++ b/.claude/skills/configuring-git/SKILL.md
@@ -26,6 +26,7 @@ Home Manager 기반 Git 설정과 lazygit/delta 통합, 충돌 복구 절차를 
 | 기본 정책 | `push.autoSetupRemote=true`, `merge.conflictStyle=zdiff3` |
 | rebase 역순 | Interactive rebase에서 최신 커밋이 위로 |
 | git-cleanup | 오래된/삭제된 브랜치 정리 |
+| worktree (`wt`) | git worktree 생성/이동/정리 — 비대화형/LLM 사용법은 프로젝트 `CLAUDE.md`의 "Worktree (wt)" 참조 |
 
 ### delta 설정 확인
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,15 @@ Environment 섹션의 `Platform` 값으로 현재 환경을 판별한다.
 
 home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이 외부 프로세스의 atomic rename으로 일반 파일이 되면 `home-manager.backupCommand`가 자가 치유한다 (regular file은 unlink + 콘솔 한 줄 echo, directory는 timestamped backup). 사이드이펙트로, symlink가 깨진 시간 동안 사용자가 home 쪽에서 의도 변경한 내용도 silent 손실될 수 있다 (예: VSCode UI에서 keybinding 추가 후 settings.json이 깨진 상태에서 한 후속 변경). 정상 symlink 흐름에서는 source 직접 수정 = git 추적이 정상 동작한다. 본 정책은 사용자 명시 동의 범위 내. 정책 본체는 `modules/darwin/home.nix`.
 
+## Worktree (wt)
+
+`wt`로 git worktree를 생성/이동/정리한다 (`.claude/worktrees/<dir>`, 현재 HEAD 기준 분기). 비대화형 셸(LLM Bash tool 등)에서는 zsh 함수 래퍼가 없어 `~/.local/bin/wt` 바이너리가 직접 실행되고 자동으로 비대화형 모드가 된다 (fzf/번호 선택/tmux attach 비활성; `WT_NONINTERACTIVE=1`로 강제 가능). 비대화형 사용 규칙:
+
+- 생성: `wt <branch>`. 기존 worktree/브랜치와 충돌하면 비대화형은 **안전하게 실패**하므로 의도를 `--if-exists=reuse|recreate|fail`로 명시한다.
+- 이동: 비대화형은 cd 불가 — 경로를 stdout으로 출력하므로 `cd "$(wt cd <name>)"`로 쓴다. 인자 없는 `wt cd`는 실패하니 이름을 지정한다.
+- 목록: `wt ls --json` (name/branch/path/pr/dirty/unpushed/current/committedAt/age 구조화 출력, jq 파싱용).
+- 정리: `wt cleanup --auto` (MERGED 자동) 또는 `wt cleanup <name>...` (이름 지정). dirty/unpushed 확인 우회는 `--yes`.
+
 ## Bash tool 환경
 
 Bash tool의 inline 스크립트는 zsh에서 실행된다. 아래 bash 전용 문법은 zsh에서 `bad substitution`으로 실패하므로 사용하지 않는다.

--- a/libraries/packages.nix
+++ b/libraries/packages.nix
@@ -17,7 +17,6 @@
 
     # TUI 도구
     pkgs.btop # 프로세스 모니터 (그래프/디스크/네트워크 통합 TUI)
-    pkgs.gum # TUI 컴포넌트 (wt 워크트리 관리)
     pkgs.htop # 프로세스 모니터 (트리뷰/SSH 친화 TUI)
 
     # 미디어 도구

--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -58,12 +58,16 @@ _bootstrap_worktree() {
 _open_worktree() {
   local wt_path="$1" window_name="$2" stay="$3" run_claude="$4" use_tmux_session="${5:-false}"
 
-  # --tmux: tmux 밖에서만 세션 모드 활성화 (tmux 안이면 윈도우 모드로 fallback — 의도적 정책)
+  # --tmux: tmux 밖 + 대화형에서만 세션 모드 (tmux 안이면 윈도우 모드 fallback — 의도적 정책)
+  # 비대화형(LLM/스크립트)은 exec tmux attach 불가 → 무시하고 경로 stdout으로 fallback
   if [[ "$use_tmux_session" == "true" ]] && [[ -z "${TMUX:-}" ]]; then
-    local session_name
-    session_name=$(_wt_session_name "$window_name")
-    _wt_tmux_session_open "$wt_path" "$session_name" "$stay" "$run_claude"
-    return
+    if _wt_interactive; then
+      local session_name
+      session_name=$(_wt_session_name "$window_name")
+      _wt_tmux_session_open "$wt_path" "$session_name" "$stay" "$run_claude"
+      return
+    fi
+    _warn "비대화형: --tmux 무시 (경로 출력으로 fallback)"
   fi
 
   if [[ -n "${TMUX:-}" ]]; then

--- a/modules/shared/scripts/lib/wt/cleanup.sh
+++ b/modules/shared/scripts/lib/wt/cleanup.sh
@@ -3,12 +3,15 @@
 
 cmd_cleanup() {
   local auto=false
+  local names_filter=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --auto) auto=true ;;
+      --auto)    auto=true ;;
+      --yes|-y)  export WT_ASSUME_YES=1 ;;  # ui.sh _confirm이 소비 (cross-file)
       -h|--help) show_help; return 0 ;;
-      *) _die "알 수 없는 옵션: $1" ;;
+      -*)        _die "알 수 없는 옵션: $1" ;;
+      *)         names_filter+=("$1") ;;
     esac
     shift
   done
@@ -134,7 +137,15 @@ cmd_cleanup() {
 
   local selected_names=()
 
-  if _has_fzf; then
+  if (( ${#names_filter[@]} > 0 )); then
+    # 위치 인자로 정리 대상 지정 (대화형/비대화형 공통)
+    selected_names=("${names_filter[@]}")
+  elif ! _wt_interactive; then
+    _info "정리 가능한 worktree:"
+    local _it
+    for _it in "${items[@]}"; do _info "  $_it"; done
+    _die "비대화형: 정리할 이름을 인자로 지정하거나 --auto를 사용하세요 (예: wt cleanup <name>...)"
+  elif _has_fzf; then
     local fzf_input=""
     for ((i=0; i<${#items[@]}; i++)); do
       fzf_input+="${items[$i]}"$'\t'"${item_paths[$i]}"$'\n'

--- a/modules/shared/scripts/lib/wt/create.sh
+++ b/modules/shared/scripts/lib/wt/create.sh
@@ -6,6 +6,7 @@ cmd_create() {
   local run_claude=false
   local use_tmux_session=false
   local branch_name=""
+  local if_exists=""
 
   # 옵션 파싱
   while [[ $# -gt 0 ]]; do
@@ -13,6 +14,8 @@ cmd_create() {
       --stay)   stay=true ;;
       --claude) run_claude=true ;;
       --tmux)   use_tmux_session=true ;;
+      --yes|-y) export WT_ASSUME_YES=1 ;;  # ui.sh _confirm이 소비 (cross-file)
+      --if-exists=*) if_exists="${1#--if-exists=}" ;;
       -h|--help) show_help; return 0 ;;
       -*)       _die "알 수 없는 옵션: $1" ;;
       *)
@@ -23,12 +26,17 @@ cmd_create() {
     shift
   done
 
-  [[ -z "$branch_name" ]] && _die "브랜치명을 지정하세요. 사용법: wt [--stay] [--claude] [--tmux] <branch>"
+  case "$if_exists" in
+    ""|reuse|recreate|fail) ;;
+    *) _die "--if-exists 값은 reuse|recreate|fail 중 하나여야 합니다 (받음: $if_exists)" ;;
+  esac
+
+  [[ -z "$branch_name" ]] && _die "브랜치명을 지정하세요. 사용법: wt [--stay] [--claude] [--tmux] [--yes] [--if-exists=reuse|recreate|fail] <branch>"
 
   local git_root
   git_root=$(_get_repo_root) || _die "Git 저장소가 아닙니다"
 
-  # 현재 브랜치 기록 (.wt-parent용)
+  # 현재 브랜치 (분기 출처 표시용)
   local parent_branch
   parent_branch=$(git branch --show-current 2>/dev/null)
   if [[ -z "$parent_branch" ]]; then
@@ -49,7 +57,7 @@ cmd_create() {
   # 기존 디렉토리 처리
   if [[ -d "$worktree_dir" ]]; then
     if [[ -f "$worktree_dir/.git" ]]; then
-      _handle_existing_worktree "$worktree_dir" "$branch_name" "$git_root" "$parent_branch" "$stay" "$run_claude" "$use_tmux_session"
+      _handle_existing_worktree "$worktree_dir" "$branch_name" "$git_root" "$parent_branch" "$stay" "$run_claude" "$use_tmux_session" "$if_exists"
       return $?
     fi
     _die "유효하지 않은 기존 디렉토리가 있습니다: $worktree_dir"
@@ -57,7 +65,7 @@ cmd_create() {
 
   # 기존 브랜치 존재 확인
   if git show-ref --verify --quiet "refs/heads/$branch_name" 2>/dev/null; then
-    _handle_existing_branch "$worktree_dir" "$branch_name" "$git_root" "$parent_branch" "$stay" "$run_claude" "$use_tmux_session"
+    _handle_existing_branch "$worktree_dir" "$branch_name" "$git_root" "$parent_branch" "$stay" "$run_claude" "$use_tmux_session" "$if_exists"
     return $?
   fi
 
@@ -65,7 +73,6 @@ cmd_create() {
   mkdir -p "$(dirname "$worktree_dir")"
   git worktree add -b "$branch_name" "$worktree_dir" >&2 || _die "worktree 생성 실패"
 
-  echo "$parent_branch" > "$worktree_dir/.wt-parent"
   _bootstrap_worktree "$worktree_dir" "$git_root"
 
   _info "worktree 생성: $branch_name (from $parent_branch)"
@@ -76,12 +83,22 @@ cmd_create() {
 
 # 기존 worktree 처리
 _handle_existing_worktree() {
-  local worktree_dir="$1" branch_name="$2" git_root="$3" parent_branch="$4" stay="$5" run_claude="$6" use_tmux_session="${7:-false}"
+  local worktree_dir="$1" branch_name="$2" git_root="$3" parent_branch="$4" stay="$5" run_claude="$6" use_tmux_session="${7:-false}" if_exists="${8:-}"
   local dir_name
   dir_name=$(basename "$worktree_dir")
 
   local choice
-  choice=$(_choose "worktree '$branch_name'이(가) 이미 존재합니다" "기존 열기" "재생성" "취소") || return 1
+  if [[ -n "$if_exists" ]]; then
+    case "$if_exists" in
+      reuse)    choice="기존 열기" ;;
+      recreate) choice="재생성" ;;
+      fail)     _die "worktree '$branch_name'이(가) 이미 존재합니다 (--if-exists=fail)" ;;
+    esac
+  elif ! _wt_interactive; then
+    _die "worktree '$branch_name'이(가) 이미 존재합니다 — 비대화형에서는 --if-exists=reuse|recreate|fail로 명시하세요"
+  else
+    choice=$(_choose "worktree '$branch_name'이(가) 이미 존재합니다" "기존 열기" "재생성" "취소") || return 1
+  fi
 
   case "$choice" in
     "기존 열기")
@@ -131,7 +148,6 @@ _handle_existing_worktree() {
       git branch -D "$branch_name" >&2 2>/dev/null || true
 
       git worktree add -b "$branch_name" "$worktree_dir" >&2 || _die "worktree 재생성 실패"
-      echo "$parent_branch" > "$worktree_dir/.wt-parent"
       _bootstrap_worktree "$worktree_dir" "$git_root"
       _info "worktree 재생성: $branch_name (from $parent_branch)"
       _wt_record_last_path "$git_root"
@@ -146,7 +162,7 @@ _handle_existing_worktree() {
 
 # 기존 브랜치 처리 (worktree 없음)
 _handle_existing_branch() {
-  local worktree_dir="$1" branch_name="$2" git_root="$3" parent_branch="$4" stay="$5" run_claude="$6" use_tmux_session="${7:-false}"
+  local worktree_dir="$1" branch_name="$2" git_root="$3" parent_branch="$4" stay="$5" run_claude="$6" use_tmux_session="${7:-false}" if_exists="${8:-}"
   local dir_name
   dir_name=$(basename "$worktree_dir")
 
@@ -165,13 +181,22 @@ _handle_existing_branch() {
   fi
 
   local choice
-  choice=$(_choose "브랜치 '$branch_name'이(가) 이미 존재합니다 (worktree 없음)" "기존 브랜치 사용" "새로 생성" "취소") || return 1
+  if [[ -n "$if_exists" ]]; then
+    case "$if_exists" in
+      reuse)    choice="기존 브랜치 사용" ;;
+      recreate) choice="새로 생성" ;;
+      fail)     _die "브랜치 '$branch_name'이(가) 이미 존재합니다 (--if-exists=fail)" ;;
+    esac
+  elif ! _wt_interactive; then
+    _die "브랜치 '$branch_name'이(가) 이미 존재합니다 — 비대화형에서는 --if-exists=reuse|recreate|fail로 명시하세요"
+  else
+    choice=$(_choose "브랜치 '$branch_name'이(가) 이미 존재합니다 (worktree 없음)" "기존 브랜치 사용" "새로 생성" "취소") || return 1
+  fi
 
   case "$choice" in
     "기존 브랜치 사용")
       mkdir -p "$(dirname "$worktree_dir")"
       git worktree add "$worktree_dir" "$branch_name" >&2 || _die "worktree 생성 실패"
-      echo "$parent_branch" > "$worktree_dir/.wt-parent"
       _bootstrap_worktree "$worktree_dir" "$git_root"
       _info "worktree 생성 (기존 브랜치): $branch_name"
       _wt_record_last_path "$git_root"
@@ -188,7 +213,6 @@ _handle_existing_branch() {
       git branch -D "$branch_name" >&2 2>/dev/null || true
       mkdir -p "$(dirname "$worktree_dir")"
       git worktree add -b "$branch_name" "$worktree_dir" >&2 || _die "worktree 생성 실패"
-      echo "$parent_branch" > "$worktree_dir/.wt-parent"
       _bootstrap_worktree "$worktree_dir" "$git_root"
       _info "worktree 생성 (브랜치 재생성): $branch_name (from $parent_branch)"
       _wt_record_last_path "$git_root"

--- a/modules/shared/scripts/lib/wt/navigate.sh
+++ b/modules/shared/scripts/lib/wt/navigate.sh
@@ -1,6 +1,37 @@
 # shellcheck shell=bash
 # ── 서브커맨드: cd / ls ─────────────────────────────────────────────────────
 
+# wt ls --json: worktree 상태를 JSON 배열로 출력 (LLM/스크립트 파싱용; stdout)
+# 필드: name, branch, path, pr, committedAt(epoch), age, dirty, unpushed, current
+_wt_ls_json() {
+  local tmp="$1" current_wt="$2"
+  shift 2
+  local worktrees=("$@")
+  command -v jq &>/dev/null || _die "--json은 jq가 필요합니다"
+
+  local objs=()
+  local wt
+  for wt in "${worktrees[@]}"; do
+    local name branch ts age pr_status dirty unpushed is_current
+    name=$(basename "$wt")
+    branch=$(_wt_branch "$wt")
+    ts=$(_wt_last_commit_ts "$wt")
+    age=$(_relative_age "$ts")
+    pr_status="NONE"
+    [[ -f "$tmp/$name.pr" ]] && pr_status=$(cat "$tmp/$name.pr")
+    dirty=false; _wt_is_dirty "$wt" && dirty=true
+    unpushed=false; _wt_has_unpushed "$wt" && unpushed=true
+    is_current=false; [[ "$wt" == "$current_wt" ]] && is_current=true
+    objs+=("$(jq -n \
+      --arg name "$name" --arg branch "$branch" --arg path "$wt" \
+      --arg pr "$pr_status" --arg age "$age" --argjson ts "${ts:-0}" \
+      --argjson dirty "$dirty" --argjson unpushed "$unpushed" \
+      --argjson current "$is_current" \
+      '{name:$name, branch:$branch, path:$path, pr:$pr, committedAt:$ts, age:$age, dirty:$dirty, unpushed:$unpushed, current:$current}')")
+  done
+  printf '%s\n' "${objs[@]}" | jq -s 'sort_by(-.committedAt)'
+}
+
 cmd_cd() {
   local git_root
   git_root=$(_get_repo_root) || _die "Git 저장소가 아닙니다"
@@ -44,12 +75,15 @@ cmd_cd() {
     # 현재 위치 저장 후 이동
     _wt_record_last_path "$git_root"
 
-    # --tmux: 세션 모드 (tmux 밖에서만)
+    # --tmux: 세션 모드 (tmux 밖 + 대화형에서만; 비대화형은 exec tmux 불가)
     if [[ "$use_tmux_session" == "true" ]] && [[ -z "${TMUX:-}" ]]; then
-      local session_name
-      session_name=$(_wt_session_name "$(basename "$last_path")")
-      _wt_tmux_session_open "$last_path" "$session_name" "false" "false"
-      return 0
+      if _wt_interactive; then
+        local session_name
+        session_name=$(_wt_session_name "$(basename "$last_path")")
+        _wt_tmux_session_open "$last_path" "$session_name" "false" "false"
+        return 0
+      fi
+      _warn "비대화형: --tmux 무시 (경로만 출력)"
     fi
 
     echo "$last_path"
@@ -72,6 +106,14 @@ cmd_cd() {
     done
     [[ -z "$target_path" ]] && _die "매치하는 worktree 없음: $search"
   else
+    # 인자 없이 호출 = 대화형 선택. 비대화형은 이름을 인자로 요구(안전 실패).
+    if ! _wt_interactive; then
+      _info "사용 가능한 worktree:"
+      local _wt
+      for _wt in "${worktrees[@]}"; do _info "  $(basename "$_wt")"; done
+      _die "비대화형: worktree 이름을 인자로 지정하세요 (예: wt cd <name>)"
+    fi
+
     # 인터랙티브 선택 (fzf + preview)
     local names=()
     for wt in "${worktrees[@]}"; do
@@ -106,12 +148,15 @@ cmd_cd() {
   # 이전 worktree 경로 저장 (wt cd - 용)
   _wt_record_last_path "$git_root"
 
-  # --tmux: 세션 attach/생성 (tmux 밖에서만)
+  # --tmux: 세션 attach/생성 (tmux 밖 + 대화형에서만; 비대화형은 exec tmux 불가)
   if [[ "$use_tmux_session" == "true" ]] && [[ -z "${TMUX:-}" ]]; then
-    local session_name
-    session_name=$(_wt_session_name "$(basename "$target_path")")
-    _wt_tmux_session_open "$target_path" "$session_name" "false" "false"
-    return 0
+    if _wt_interactive; then
+      local session_name
+      session_name=$(_wt_session_name "$(basename "$target_path")")
+      _wt_tmux_session_open "$target_path" "$session_name" "false" "false"
+      return 0
+    fi
+    _warn "비대화형: --tmux 무시 (경로만 출력)"
   fi
 
   # tmux 안이면 윈도우 전환 시도
@@ -128,6 +173,16 @@ cmd_cd() {
 }
 
 cmd_ls() {
+  local as_json=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)    as_json=true ;;
+      -h|--help) show_help; return 0 ;;
+      *)         _die "알 수 없는 옵션: $1" ;;
+    esac
+    shift
+  done
+
   local git_root
   git_root=$(_get_repo_root) || _die "Git 저장소가 아닙니다"
 
@@ -160,6 +215,12 @@ cmd_ls() {
 
   # PR 상태 병렬 조회
   _fetch_pr_statuses "$git_root" "$_wt_ls_tmp" "${worktrees[@]}"
+
+  # --json: 구조화 출력 (LLM/스크립트 파싱용; stdout, 로그는 stderr)
+  if [[ "$as_json" == "true" ]]; then
+    _wt_ls_json "$_wt_ls_tmp" "$current_wt" "${worktrees[@]}"
+    return 0
+  fi
 
   # 데이터 수집 + 정렬 (age 기준, 최신 우선)
   local entries=()
@@ -195,24 +256,12 @@ cmd_ls() {
 
   IFS=$'\n' read -r -d '' -a sorted < <(printf '%s\n' "${entries[@]}" | sort -t'|' -k1 -rn && printf '\0') || true
 
-  if _has_gum; then
-    local header="NAME,BRANCH,AGE,PR,DIRTY"
-    local rows=""
-    for entry in "${sorted[@]}"; do
-      IFS='|' read -r _ name branch age pr dirty <<< "$entry"
-      (( ${#branch} > 25 )) && branch="${branch:0:22}..."
-      rows+="$name,$branch,$age,$pr,$dirty"$'\n'
-    done
-    gum style --bold --border double --padding "0 1" "Worktrees (${#sorted[@]})" >&2
-    echo "${header}"$'\n'"${rows%$'\n'}" | gum table --print >&2
-  else
-    _info "Worktrees (${#sorted[@]})"
-    printf "  %-30s %-25s %-5s %-12s %s\n" "NAME" "BRANCH" "AGE" "PR" "DIRTY" >&2
-    printf "  " >&2; printf '%.0s─' {1..78} >&2; echo >&2
-    for entry in "${sorted[@]}"; do
-      IFS='|' read -r _ name branch age pr dirty <<< "$entry"
-      (( ${#branch} > 25 )) && branch="${branch:0:22}..."
-      printf "  %-30s %-25s %-5s %-12s %s\n" "$name" "$branch" "$age" "$pr" "$dirty" >&2
-    done
-  fi
+  _info "Worktrees (${#sorted[@]})"
+  printf "  %-30s %-25s %-5s %-12s %s\n" "NAME" "BRANCH" "AGE" "PR" "DIRTY" >&2
+  printf "  " >&2; printf '%.0s─' {1..78} >&2; echo >&2
+  for entry in "${sorted[@]}"; do
+    IFS='|' read -r _ name branch age pr dirty <<< "$entry"
+    (( ${#branch} > 25 )) && branch="${branch:0:22}..."
+    printf "  %-30s %-25s %-5s %-12s %s\n" "$name" "$branch" "$age" "$pr" "$dirty" >&2
+  done
 }

--- a/modules/shared/scripts/lib/wt/ui.sh
+++ b/modules/shared/scripts/lib/wt/ui.sh
@@ -1,6 +1,12 @@
 # shellcheck shell=bash
 _has_fzf() { command -v fzf &>/dev/null; }
-_has_gum() { command -v gum &>/dev/null; }
+
+# 비대화형 여부: WT_NONINTERACTIVE가 set이거나 stdin이 tty가 아니면 비대화형.
+# LLM/스크립트/파이프(예: claude Bash tool)에서 fzf·read 프롬프트가 hang하거나
+# EOF로 빈 입력을 받아 의도와 다르게 자동 취소되는 것을 막는 게이트.
+_wt_interactive() {
+  [[ -z "${WT_NONINTERACTIVE:-}" ]] && [[ -t 0 ]]
+}
 
 # worktree 내부에서도 항상 main repo root를 정확히 찾음
 _get_repo_root() {
@@ -42,8 +48,7 @@ _die() {
 }
 
 # CIR: echo → printf ANSI 선택 — echo "$*"는 간결하지만 스타일링 불가.
-#   gum style은 표시 전용에는 적합하나 매 호출마다 프로세스 fork 부담.
-#   printf + 인라인 ANSI가 fork 없이 즉시 출력되어 가장 효율적.
+#   printf + 인라인 ANSI가 외부 TUI 바이너리 fork 없이 즉시 출력되어 가장 효율적.
 _info() {
   printf '\033[38;5;179m› \033[38;5;245m%s\033[0m\n' "$*" >&2
 }
@@ -52,20 +57,32 @@ _warn() {
   printf '\033[38;5;215m! \033[38;5;245m%s\033[0m\n' "$*" >&2
 }
 
-# y/N 확인 프롬프트 (gum confirm 대체)
+# y/N 확인 프롬프트
+# 비대화형: WT_ASSUME_YES(--yes로 set)면 승인, 아니면 안전하게 거부 + 안내.
 _confirm() {
   local msg="$1"
+  [[ -n "${WT_ASSUME_YES:-}" ]] && return 0
+  if ! _wt_interactive; then
+    _warn "비대화형: 확인 필요 — '$msg'. 승인하려면 --yes (또는 WT_ASSUME_YES=1)."
+    return 1
+  fi
   printf "%s (y/N): " "$msg" >&2
   local yn
   read -r yn
   [[ "$yn" =~ ^[yY] ]]
 }
 
-# 단일 선택 (fzf 사용, fallback: 번호 선택)
+# 단일 선택 (대화형 전용: fzf 또는 번호 입력)
+# 비대화형에서는 선택 불가 → 호출자가 명시 플래그로 결정해야 한다(예: create의 --if-exists).
 _choose() {
   local header="${1:-선택}"
   shift
   local options=("$@")
+
+  if ! _wt_interactive; then
+    _warn "비대화형: '$header' 선택 불가 — 명시 플래그(예: --if-exists)로 결정하세요."
+    return 1
+  fi
 
   if _has_fzf; then
     printf '%s\n' "${options[@]}" | fzf --no-multi --height ~$((${#options[@]} + 4)) \

--- a/modules/shared/scripts/wt.sh
+++ b/modules/shared/scripts/wt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # wt: Git worktree 관리 도구 (fzf TUI, tmux 통합)
-# 사용법: wt [--stay] [--claude] [--tmux] <branch> | wt cd [--tmux] [-|name] | wt ls | wt cleanup [--auto]
+# 사용법: wt [--stay|--claude|--tmux|--yes|--if-exists=MODE] <branch> | wt cd [--tmux] [-|name] | wt ls [--json] | wt cleanup [--auto|--yes] [name...]
 
 # === Change Intent Record ===
 # v1 (2025년 초~): 커스텀 wt/wt-cleanup 셸 함수 838줄 (zsh, fzf 기반)
@@ -26,6 +26,14 @@
 #    세션 이름: wt-<repo>-<dir_name> (repo별 네임스페이스 — 멀티 repo 충돌 방지)
 #    핵심 제약: 래퍼의 subshell $() 안에서 exec tmux 불가 → --tmux 감지 시 우회
 #    tmux 안에서 --tmux: 기존 윈도우 모드로 fallback (의도적 정책 — 세션 전환보다 윈도우가 워크플로우에 적합)
+# v7 (이번 변경): 비대화형(LLM/스크립트) 호환 + dead-path 가지치기
+#    배경: 비대화형 셸은 wt 함수 래퍼 없이 ~/.local/bin/wt 직행 → _confirm/_choose가 stdin EOF로
+#          자동 취소되어 create 충돌 처리·cd 선택·cleanup 선택이 막혔다.
+#    감지: _wt_interactive() = [[ -t 0 ]] && WT_NONINTERACTIVE unset. fzf/read/exec tmux 게이트.
+#    플래그: create --if-exists=reuse|recreate|fail (비대화형 충돌 기본=안전 실패) + --yes,
+#           cleanup [name...] 위치 인자 + --yes, ls --json 구조화 출력.
+#    제거: .wt-parent (write-only dead data, 읽는 코드 0곳) / gum 의존 (wt ls 표시 전용 잔재,
+#         plain printf fallback이 동등; packages.nix에서도 제거).
 
 set -euo pipefail
 
@@ -85,37 +93,47 @@ show_help() {
   cat << 'EOF'
 사용법: wt [옵션] <command|branch>
 
-Git worktree 관리 도구 (fzf TUI, tmux 통합)
+Git worktree 관리 도구 (fzf TUI, tmux 통합; 비대화형/LLM 셸 호환)
 
 서브커맨드:
   wt <branch>             현재 HEAD 기준 worktree 생성
   wt cd [name|-]          worktree로 이동 (fuzzy 검색, - = 이전)
-  wt ls                   worktree 목록 (PR 상태, age, dirty)
-  wt cleanup [--auto]     worktree 정리 (인터랙티브/자동)
+  wt ls [--json]          worktree 목록 (PR 상태, age, dirty)
+  wt cleanup [--auto]     worktree 정리 (인터랙티브/자동/이름 지정)
 
 옵션 (create):
   --stay                  tmux 윈도우를 백그라운드로 생성
   --claude                worktree 생성 후 Claude Code 자동 실행
-  --tmux                  독립 tmux 세션 생성+attach (tmux 밖에서)
+  --tmux                  독립 tmux 세션 생성+attach (tmux 밖, 대화형)
+  --if-exists=MODE        충돌 시 동작: reuse|recreate|fail (비대화형 충돌 시 필수)
+  --yes, -y               확인 프롬프트 자동 승인
 
 옵션 (cd):
-  --tmux                  worktree를 tmux 세션으로 열기 (tmux 밖에서)
+  --tmux                  worktree를 tmux 세션으로 열기 (tmux 밖, 대화형)
+
+옵션 (ls):
+  --json                  JSON 배열로 출력 (name/branch/path/pr/dirty/unpushed/...)
 
 옵션 (cleanup):
   --auto                  MERGED 상태 worktree 자동 정리
+  --yes, -y               dirty/unpushed 확인 자동 승인
+  [name...]               정리할 worktree 이름 직접 지정
+
+비대화형 (LLM/스크립트):
+  stdin이 tty가 아니거나 WT_NONINTERACTIVE=1이면 비대화형 모드.
+  fzf/번호선택/tmux attach 대신 명시 플래그·인자가 필요하다.
+  생성/이동 경로는 stdout으로 출력되므로 cd "\$(wt cd <name>)" 형태로 사용.
 
 예시:
-  wt feature-login        feature-login 브랜치 + worktree 생성
-  wt --claude fix-bug     worktree 생성 + claude 실행
-  wt --tmux feature-x     worktree 생성 + tmux 세션 attach
-  wt --tmux --claude pr   worktree + tmux 세션 + claude 실행
-  wt --tmux --stay test   tmux 세션 detached 생성
-  wt cd login             "login" 포함 worktree로 이동
-  wt cd --tmux login      worktree를 tmux 세션으로 열기
-  wt cd -                 이전 worktree로 이동
-  wt ls                   전체 worktree 상태 확인
-  wt cleanup              인터랙티브 정리
-  wt cleanup --auto       MERGED 자동 정리
+  wt feature-login              feature-login 브랜치 + worktree 생성
+  wt --if-exists=reuse feat-x   있으면 재사용, 없으면 생성 (비대화형 안전)
+  wt --claude fix-bug           worktree 생성 + claude 실행
+  wt --tmux feature-x           worktree 생성 + tmux 세션 attach
+  cd "\$(wt cd login)"           "login" worktree 경로로 이동 (비대화형)
+  wt cd -                       이전 worktree로 이동
+  wt ls --json                  worktree 상태 JSON 출력
+  wt cleanup --auto             MERGED 자동 정리
+  wt cleanup feat_x issue_3     지정 worktree 정리 (비대화형)
 EOF
 }
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1362,6 +1362,108 @@ test_wt_cd_by_name_returns_target_path() {
   assert_contains "$output" "$expected_path"
 }
 
+test_wt_create_conflict_noninteractive_requires_if_exists() {
+  local sandbox home_dir repo_root output rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  rc=0
+  output=$(
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$FIXTURE_DIR/bin:$PATH" \
+      WT_NONINTERACTIVE=1 \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" feature_one
+      ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" -ne 0 ]] || fail "expected non-zero exit for noninteractive conflict"
+  assert_contains "$output" "--if-exists"
+  assert_not_contains "$output" "선택>"
+}
+
+test_wt_create_if_exists_reuse_returns_path() {
+  local sandbox home_dir repo_root output expected_path
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  expected_path="$repo_root/.claude/worktrees/feature_one"
+  output=$(
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$FIXTURE_DIR/bin:$PATH" \
+      WT_NONINTERACTIVE=1 \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" --if-exists=reuse feature_one
+      ' 2>&1
+  )
+
+  assert_contains "$output" "$expected_path"
+}
+
+test_wt_ls_json_outputs_parseable_array() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  output=$(
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$FIXTURE_DIR/bin:$PATH" \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" ls --json
+      ' 2>/dev/null
+  )
+
+  echo "$output" | jq -e 'type == "array" and any(.[]; .name == "feature_one" and (.dirty | type == "boolean") and (.unpushed | type == "boolean"))' >/dev/null \
+    || fail "wt ls --json must be a JSON array containing feature_one with boolean flags: $output"
+}
+
+test_wt_cd_noninteractive_requires_name() {
+  local sandbox home_dir repo_root output rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  rc=0
+  output=$(
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$FIXTURE_DIR/bin:$PATH" \
+      WT_NONINTERACTIVE=1 \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" cd
+      ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" -ne 0 ]] || fail "expected non-zero exit for noninteractive cd without name"
+  assert_contains "$output" "이름을 인자로"
+}
+
 test_shadow_paths_do_not_override_managed_helpers() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)
@@ -1525,12 +1627,11 @@ EOF
 }
 
 test_wt_recreate_guard_uses_physical_paths() {
-  local sandbox home_dir repo_root link_root target_path fzf_dir origin_dir output
+  local sandbox home_dir repo_root link_root target_path origin_dir output
   sandbox=$(new_sandbox)
   home_dir="$sandbox/home"
   repo_root="$sandbox/repo"
   link_root="$sandbox/link"
-  fzf_dir="$sandbox/fzf-bin"
   origin_dir="$sandbox/origin.git"
 
   create_git_fixture_repo "$repo_root"
@@ -1542,21 +1643,15 @@ test_wt_recreate_guard_uses_physical_paths() {
   ln -s "$repo_root" "$link_root"
   target_path="$link_root/.claude/worktrees/feature_one"
 
-  mkdir -p "$fzf_dir"
-  cat > "$fzf_dir/fzf" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '재생성\n'
-EOF
-  chmod +x "$fzf_dir/fzf"
-
   output=$(
-    HOME="$home_dir" \
-    PATH="$fzf_dir:$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$FIXTURE_DIR/bin:$PATH" \
+      WT_NONINTERACTIVE=1 \
+      bash -c '
       set -euo pipefail
       cd "'"$target_path"'"
-      "'"$home_dir/.local/bin/wt"'" feature/one
+      "'"$home_dir/.local/bin/wt"'" --if-exists=recreate feature/one
     ' 2>&1 || true
   )
 
@@ -2174,6 +2269,10 @@ run_test "rebuild-common exports public API" test_rebuild_common_exports_public_
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
 run_test "wt cd returns target path by name" test_wt_cd_by_name_returns_target_path
 run_test "wt ls lists deployed worktrees" test_wt_ls_from_deployed_layout_lists_worktrees
+run_test "wt ls --json outputs parseable array" test_wt_ls_json_outputs_parseable_array
+run_test "wt create conflict requires if-exists when noninteractive" test_wt_create_conflict_noninteractive_requires_if_exists
+run_test "wt create if-exists=reuse returns path" test_wt_create_if_exists_reuse_returns_path
+run_test "wt cd requires name when noninteractive" test_wt_cd_noninteractive_requires_name
 run_test "shadow paths do not override managed helpers" test_shadow_paths_do_not_override_managed_helpers
 run_test "wt symlink alias does not load adjacent helpers" test_wt_symlink_alias_does_not_load_adjacent_helpers
 run_test "rebuild-common symlink alias does not load adjacent helpers" test_rebuild_common_symlink_alias_does_not_load_adjacent_helpers


### PR DESCRIPTION
## Summary

- 비대화형 셸(LLM Bash tool, 스크립트, 파이프)에서 `wt`의 모든 서브커맨드를 사용 가능하게 한다 — 감지 게이트 + 명시 플래그(`--if-exists`, `--yes`, `--json`, 위치 인자).
- 더 이상 쓰이지 않는 경로를 정리한다 — `.wt-parent`(write-only) 및 gum 의존 제거.
- 충돌 시 비대화형 기본 동작은 **안전 실패**(데이터 보호 우선).

## 기존 문제 / 배경

`wt`는 caller 셸의 `cd`를 위해 zsh 함수 래퍼 + 본체 바이너리(`~/.local/bin/wt`)로 구성된다. 그런데 zsh 함수 래퍼는 **대화형 셸에만** 로드되므로, 비대화형 셸(LLM의 Bash tool 등)에서는 바이너리가 직접 실행된다. 이때:

- 충돌 처리(`_choose`)·확인(`_confirm`)·선택(`cd`/`cleanup`의 fzf)이 `read`/fzf에 의존하는데, 비대화형 stdin은 즉시 EOF를 만나 **빈 입력 → 자동 취소/실패**로 귀결됐다.
- 결과적으로 `wt <branch>`(충돌 시)·`wt cd`(인자 없이)·`wt cleanup`(선택)이 비대화형에서 막혀, 기능의 절반을 LLM이 쓸 수 없었다.

또한 조사 중 두 건의 drift를 확인했다:
- `.wt-parent`: 4곳에서 기록하지만 읽는 코드가 없는 write-only 데이터(초기 구현 잔재).
- `gum`: 과거 TUI 백엔드였으나 이후 fzf로 전환되어 `wt ls` 표시용으로만 남았고, plain `printf` fallback이 이미 동등.

## CIR (Change Intent Record)

`wt`의 정체·효용·drift를 조사하던 중 비대화형 차단이 드러났다. Claude Code 내장 worktree가 일부 개선됐지만(현재 HEAD 기준 분기 옵션 등), 이전 worktree 복귀·PR 상태 통합 목록·안전한 정리가 여전히 부족하고, 무엇보다 이 저장소의 nrs 심링크/codex 부트스트랩 통합을 대체하지 못해 `wt`는 계속 효용이 있다고 판단했다.

설계 의도:
- **감지 + 명시 플래그 병행**: tty 부재나 `WT_NONINTERACTIVE`로 자동 감지하되, 동작은 플래그로 명시하게 한다. LLM이 의도를 명확히 표현할 수 있고 자동 추론의 오작동을 피한다.
- **충돌 시 안전 실패**: 비대화형에서 기존 worktree/브랜치와 충돌하면 자동으로 열거나 재생성하지 않고 명확히 실패시킨다. `--if-exists`로 의도를 강제해 의도치 않은 worktree 사용·삭제를 막는다.
- **범위 분리**: codex projection(plugin/MCP)의 외과적 정리는 영향 범위가 넓어 이 변경에서 분리했다(아래 ADR).

## ADR (Architecture Decision Record)

| 결정 | 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 비대화형 감지 방식 | 자동 감지(tty)만 | 플래그 불필요 | 충돌 시 동작 제어 불가 | ❌ |
| | 명시 플래그만 | 명확 | 매번 플래그 필요, 깜빡 시 차단 | ❌ |
| | 감지 + 플래그 병행 | 자동+명시 균형 | 약간 복잡 | ✅ |
| 충돌 기본 동작 | 자동 열기(편의) | 흐름 매끄러움 | 의도와 다른 worktree 사용 위험 | ❌ |
| | 안전 실패 | 데이터 보호, 의도 강제 | 플래그 필요 | ✅ |
| gum 처리 | 유지 | 표 렌더링 | wt 전용 패키지인데 표시용 잔재 | ❌ |
| | 제거(plain printf) | 의존 축소 | 표 스타일 단순화 | ✅ |
| codex projection 정리 | 이번 변경 포함 | 한 번에 처리 | 영향 범위 큼(스킬/테스트/검증) | ❌ |
| | 별도 작업 | 안전, 검증 분리 | 후속 필요 | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `lib/wt/ui.sh` | `_wt_interactive()` 게이트, `_confirm`(--yes/비대화형 거부), `_choose`(비대화형 거부), `_has_gum` 제거 |
| `lib/wt/create.sh` | `--if-exists=reuse\|recreate\|fail` + `--yes`, 충돌 시 비대화형 안전 실패, `.wt-parent` write 제거 |
| `lib/wt/navigate.sh` | `cd` 인자 필수화/`--tmux` 경로 fallback, `ls --json` + `_wt_ls_json`, gum 분기 제거 |
| `lib/wt/cleanup.sh` | 위치 인자 `<name>...` + `--yes` |
| `lib/wt/bootstrap.sh` | `_open_worktree`의 `--tmux` 비대화형 가드 |
| `wt.sh` | help/CIR 갱신 |
| `libraries/packages.nix` | `gum` 제거 |
| `CLAUDE.md`, `.claude/skills/configuring-git/SKILL.md` | LLM용 wt 비대화형 문서 |
| `tests/shell-script-tests.sh` | 비대화형 회귀 테스트 4개 + recreate 가드 전환 |

핵심 게이트:
```bash
_wt_interactive() {
  [[ -z "${WT_NONINTERACTIVE:-}" ]] && [[ -t 0 ]]
}
```

## 참고 레퍼런스

- wt 변천사: 자체 구현 부활(#205), gum→fzf 전환(#207), `--tmux` 추가(#209), helper 책임 분리(#416)
- nrs worktree 심링크 자동 전환/복원(#239)
- 후속(별도 작업 예정): codex projection(plugin/`--user-mcp`)의 외과적 분리 — OpenAI Codex CLI가 plugin/skills/MCP를 native 지원하고(공식 문서, 2026-05 기준), 이 저장소에서 plugin projection은 이미 비활성이며 `--user-mcp`는 activation writer(`sync-codex-config.py`)와 같은 `~/.codex/config.toml`을 다투기 때문. skills/agents projection은 codex 동작에 필수이므로 유지.

## 실측 비교 (native `--worktree` vs `wt`)

코드·히스토리 분석만으로는 부족하여 claude v2.1.150 native worktree와 1:1 E2E 실측을 진행했다. 측정: `claude -p --worktree` 헤드리스 호출(격리 임시 repo + 실제 repo) + `wt.sh` 직접 실행 + `--help`/git 추적 상태 확인. `worktree.baseRef: "head"` 설정 상태.

| # | 기능 | native (`claude -w`) | `wt` | 판정 | 근거 |
|---|---|---|---|---|---|
| ① | 생성 | ✓ 세션 동반(API 토큰·지연) | ✓ 즉시 | 용도차 | 실측 |
| ② | 분기 base | head/fresh(전역 settings 택1) | 항상 현재 HEAD | 양쪽 head 가능, native에 fresh 옵션 | 실측(head)+문서(fresh) |
| ③④ | cd / cd-(이전) | ✗ 없음 | ✓ | wt | 실측 |
| ⑤ | ls(+PR/age/dirty/`--json`) | ✗ (`git worktree list`뿐) | ✓ | wt | 실측 |
| ⑥ | cleanup | ✗ 관리 명령 없음 | ✓ MERGED자동/선택/prune | wt | 실측(`--help` 부재) |
| ⑦ | bootstrap | gitignored(`settings.local.json`·`.codex`) **미복사**; tracked(`.agents/skills`·`AGENTS.md`)는 양쪽 git checkout | gitignored도 복사 | wt(gitignored 설정 한정) | 실측(1차 결론 정정) |
| ⑧ | nrs 심링크 자동 전환/복원 | ✗ | ✓ | wt | 코드+실측 |
| ⑨ | tmux | ✓ iTerm2 native panes/classic | ✓ 독립 tmux 세션 | 양쪽 제공 | `--help`/코드(동작 깊이 미측정) |
| ⑩ | 안전장치 | 관리 명령 부재로 가드 없음 | cwd/활성프로세스/dirty·unpushed/branch-reuse 가드 | wt | 실측 |
| ⑪ | 비대화형·LLM | △ 생성만 `-p` 가능, 관리 불가 | ✓ 전 기능 | wt | 실측 |
| ⑫ | 충돌 처리 | 조용히 기존 재사용(의도 불명) | `--if-exists` 명시 | wt | 실측(1회) |
| ★ | **상호운용** | wt worktree 관리 불가 | **native worktree까지 ls/cd/cleanup** | **wt = 상위집합** | 실측 |

**결론**: `wt ls/cd`가 native 생성 worktree(`worktree-*`)를 그대로 인식·관리한다(★). native는 "생성 + claude 세션 통합"(①⑨)에 특화됐고 worktree 관리 명령이 없으므로 **wt는 native의 상위집합**이다. 과거 wt의 명분이던 default-분기 한계(②)는 `baseRef:"head"`로 해소됐으나 이는 12축 중 1축이며, 나머지에서 wt가 우위다.

**근거 한계(정직성)**: ⑨ tmux 실제 동작 깊이는 헤드리스로 미측정(양쪽 "제공"만 확인). native의 외부 보고(무경고 worktree 삭제 등)는 본 비교에서 직접 재현하지 않아 매트릭스에서 제외했다. ⑦은 1차 결론("native bootstrap 전무")이 부정확했음을 실측으로 정정 — `.agents/skills`·`AGENTS.md`는 tracked라 git이 양쪽에 checkout하며, wt 고유 가치는 gitignored 설정(`settings.local.json`·`.codex`) 복사로 한정된다.

## Human Test Plan

검증 환경: 비대화형 셸(예: `bash -c`). 모든 명령은 worktree가 있는 repo에서 실행.

1. **비대화형 충돌 안전 실패**: 기존 worktree 디렉토리명으로 `wt <name>` → exit≠0 + "비대화형에서는 --if-exists로 명시" 메시지. 기대: worktree 미생성/미변경. 실패 시: `_wt_interactive` 게이트와 create.sh 충돌 분기 확인.
2. **`--if-exists`**: `wt --if-exists=reuse <기존>` → 기존 경로 stdout + exit 0. `--if-exists=fail <기존>` → 명확한 실패. `--if-exists=bad x` → 값 검증 에러.
3. **`ls --json`**: `wt ls --json | jq .` → name/branch/path/pr/dirty/unpushed/current/committedAt/age 필드를 가진 배열. 실패 시: jq 설치 여부와 `_wt_ls_json` 확인.
4. **`cd` 인자 필수**: 비대화형 `wt cd`(인자 없이) → 후보 목록 안내 + 실패. `cd "$(wt cd <name>)"` → 해당 경로로 이동.
5. **`cleanup`**: `wt cleanup --auto`(MERGED 자동), `wt cleanup <name>...`(지정 삭제), dirty 대상은 `--yes` 필요.
6. **대화형 회귀**: 실제 터미널에서 기존 fzf 흐름(`wt cd`, `wt cleanup`)이 그대로 동작하는지.
7. **빌드**: `nix build .#darwinConfigurations.<host>.system`(gum 제거 반영) 성공.
