### PR TITLE
perf(lefthook): codex-hook-fixtures·eval-tests를 glob 조건부 실행으로 전환

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,11 +28,32 @@ pre-commit:
       glob: "*.sh"
       run: shellcheck -S warning {staged_files}
     eval-tests:
+      # glob: *.nix/flake.lock 은 평가 입력, tests/run-eval-tests.sh 는 runner 래퍼(로직 변경이 검증 동작을 바꿈).
+      # glob 변경 시 scripts/ai/check-lefthook-staged-config.sh 의 expected 블록도 함께 갱신한다 (미동기화 시 staged-config guard fail).
+      glob:
+        - "*.nix"
+        - "flake.lock"
+        - "tests/run-eval-tests.sh"
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./tests/run-eval-tests.sh
     codex-hook-fixtures:
       # deterministic 모드 (live fixture 미실행). runner 자체가 scripts/ai/lib/tomlkit-bootstrap.sh를
       # source하여 repo-pinned pythonWithTomlkit으로 self-wrap하므로 lefthook에서 추가 nix shell
       # wrap이 불필요하다. live propagation 검증은 manual/scheduled에 위임.
+      # glob: runner 가 source/cp 하는 의존 경로 집합과 동기화 필수. 새 의존 경로가 생기면 여기와
+      # scripts/ai/check-lefthook-staged-config.sh 의 expected 블록을 함께 갱신한다 (누락 시 해당
+      # 커밋에서 이 검사가 silent skip 된다; pre-push 가 glob 없이 전체 재검증하므로 push 에서 안전망).
+      # runner 래퍼(tests/test-codex-hook-fixtures.sh) 자신도 멤버 — runner 로직 변경이 검증 동작을 바꾼다.
+      glob:
+        - "modules/shared/programs/codex/**"
+        - "modules/shared/programs/claude/files/hooks/**"
+        - "modules/shared/programs/claude/files/lib/**"
+        - "modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh"
+        - "tests/fixtures/codex-hooks/**"
+        - "tests/test-codex-hook-fixtures.sh"
+        - "tests/lib/**"
+        - "scripts/ai/commit-msg-pinning.sh"
+        - "scripts/ai/lib/tomlkit-bootstrap.sh"
+        - "modules/shared/scripts/codex-exec-supervised.sh"
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./tests/test-codex-hook-fixtures.sh --no-live
     skill-noise-check:
       # shared skill projection (modules/shared/programs/claude/files/skills) 의 LLM 노이즈 syntax

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -78,6 +78,9 @@ awk '
 ' "$index_file" > "$normalized_precommit"
 
 expected_precommit="$tmp_dir/pre-commit.expected"
+# 이 heredoc 블록은 lefthook.yml 의 pre-commit 섹션을 위 awk normalize(빈 줄·주석 제거)한 결과와
+# 1바이트 일치해야 한다. lefthook.yml 의 glob 을 변경하면 아래 블록도 동시에 갱신한다.
+# 의도/동기화 설명 주석은 awk 가 제거하므로 이 heredoc 안이 아니라 lefthook.yml 쪽에 둔다.
 cat > "$expected_precommit" <<'EOF'
 pre-commit:
   parallel: true
@@ -102,8 +105,23 @@ pre-commit:
       glob: "*.sh"
       run: shellcheck -S warning {staged_files}
     eval-tests:
+      glob:
+        - "*.nix"
+        - "flake.lock"
+        - "tests/run-eval-tests.sh"
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./tests/run-eval-tests.sh
     codex-hook-fixtures:
+      glob:
+        - "modules/shared/programs/codex/**"
+        - "modules/shared/programs/claude/files/hooks/**"
+        - "modules/shared/programs/claude/files/lib/**"
+        - "modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh"
+        - "tests/fixtures/codex-hooks/**"
+        - "tests/test-codex-hook-fixtures.sh"
+        - "tests/lib/**"
+        - "scripts/ai/commit-msg-pinning.sh"
+        - "scripts/ai/lib/tomlkit-bootstrap.sh"
+        - "modules/shared/scripts/codex-exec-supervised.sh"
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./tests/test-codex-hook-fixtures.sh --no-live
     skill-noise-check:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/check-skill-noise.sh


### PR DESCRIPTION
## Summary

- lefthook pre-commit의 최대 병목 `codex-hook-fixtures`(로컬 실측 155~200초)와 2번째 `eval-tests`(34초)에 `glob`을 걸어, 관련 파일이 staged된 커밋에서만 실행하도록 전환한다.
- 무관한 커밋(문서·에디터 설정 등)에서는 두 검사가 skip되어 pre-commit이 ~155초 → ~8.5초로 단축된다 (이 PR 자체 커밋도 ~10초에 통과).
- `check-lefthook-staged-config.sh`의 expected 블록을 1바이트 일치하도록 동반 갱신한다.

Closes #828

## 기존 문제/배경

pre-commit은 9개 command를 `parallel: true`로 실행해 wall-clock이 가장 느린 단일 command로 수렴한다. 로컬 실측에서 `codex-hook-fixtures`가 155~200초로 전체의 ~99%를 차지했고(81개 fixture가 fixture마다 sandbox를 `mktemp -d` + hooks/lib `cp -L`로 재구성하는 누적 I/O), `eval-tests`가 34초였다. 두 검사는 검사 대상(codex/claude hook 소스, nix 설정)과 무관한 커밋에서도 staged 파일이 하나라도 있으면 전체로 실행되어, 매 커밋이 1.5~3.5분 걸렸다.

기존 `nixfmt`(glob `*.nix`)·`shellcheck`(glob `*.sh`)는 이미 glob 조건부다. 같은 메커니즘을 두 병목에 확장한다.

## CIR (Change Intent Record)

병목을 단계별 timestamp로 측정해 `codex-hook-fixtures`가 pre-commit 전체를 지배함을 확인했다. 처리 방향으로 (a) pre-commit에서 제거, (b) glob 조건부 실행, (c) fixture sandbox 최적화를 검토했고 (b)를 택했다 — 무관 커밋에서 통째로 skip하면서도 pre-push가 glob 없이 전체를 재검증하므로, glob 목록이 의존 경로를 놓쳐도 최악의 경우가 "push 시점에 잡힘"으로 degrade될 뿐 회귀를 통과시키지 않기 때문이다.

glob 목록은 fixture 러너가 실제로 source/cp/실행하는 의존 경로 집합과 1:1로 맞췄다. 설계 검토 과정에서 러너가 source하는 expectation oracle(`tests/lib/codex-hook-expectations.sh`)과 eval-tests 러너 래퍼(`tests/run-eval-tests.sh`)가 초기 후보에서 빠져 있어 추가했다 — 전자는 최근 80커밋 중 8회 단독 수정된 실재 의존성이고, 후자가 빠지면 래퍼 단독 수정 시 검증이 skip된다.

경로 정밀도는 정밀 목록(의존 경로만)과 보수적 광범위(상위 디렉토리 전체) 중 정밀을 택했다 — 최근 80커밋 기준 무관 커밋 skip 비율이 정밀 ~64% vs 보수적 ~29%로 2배 높고, 누락은 pre-push 안전망이 커버한다. 동기화 의무(glob ↔ check 스크립트 expected 블록)는 awk normalize가 주석을 제거하는 특성상 lefthook.yml 쪽 주석과 heredoc 바깥 셸 주석으로만 표현했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| glob 조건부 실행 | 의존 경로 staged 시만 실행 | 무관 커밋 skip, 커버리지 유지 | glob 목록 수동 유지보수 | ✅ 채택 |
| pre-commit에서 제거 | pre-push에만 유지 | 가장 단순 | 커밋 시점 검증 완전 상실, push 전 회귀 누적 시 bisect 필요 | ❌ |
| fixture sandbox 최적화 | sandbox 템플릿 재사용 | 매 커밋 유지하며 빠름 | 구현 복잡, nix 부트스트랩·snapshot 비용 잔존 | ❌ (별도 검토) |
| 정밀 glob | 의존 경로만 명시 | skip 비율 2배(~64%) | 의존 추가 시 동기화 필요 | ✅ 채택 |
| 보수적 광범위 glob | 상위 디렉토리 전체 | 누락 위험 낮음 | skip 비율 절반(~29%) | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `lefthook.yml` | `codex-hook-fixtures`(full path 10경로)·`eval-tests`(`*.nix`/`flake.lock`/`tests/run-eval-tests.sh`)에 glob + 동기화 why 주석 추가 |
| `scripts/ai/check-lefthook-staged-config.sh` | expected pre-commit 블록에 동일 glob 1바이트 반영 + heredoc 바깥 셸 주석 추가 |

핵심 설계:
- 두 command의 `run`은 `{staged_files}`를 사용하지 않으므로 glob은 "실행 여부 게이트"로만 작동한다. 트리거되면 러너가 전체 스위트를 실행하므로 부분 커버리지 위험이 없다 (all-or-nothing skip).
- pre-push의 `codex-hook-fixtures`는 glob 없이 유지된다(안전망).
- `gitleaks`(시크릿 전수 스캔)·commit-msg `pinning`은 glob과 무관하게 항상 실행된다.
- `check-lefthook-staged-config.sh`는 lefthook.yml의 pre-commit 블록을 awk normalize(빈 줄·주석 제거)한 결과와 expected heredoc을 1바이트 `diff`로 대조하므로, glob 변경 시 양쪽을 동시에 갱신해야 한다.

## 참고 레퍼런스

- Closes #828
- glob 선례: `lefthook.yml`의 `nixfmt`(`glob: "*.nix"`)·`shellcheck`(`glob: "*.sh"`)

## Human Test Plan

1. **무관 커밋 skip 확인** — 비-nix/비-codex 파일(예: `README.md`)만 staged 후 devShell에서 `lefthook run pre-commit` 실행.
   - 기대: `codex-hook-fixtures (skip) no matching staged files`, `eval-tests (skip) no matching staged files` 출력, 전체 ~8-10초 완료.
   - 실패 시: glob이 과다 매칭됨 — `lefthook.yml`의 glob 경로 리터럴 확인.
2. **codex 트리거 확인** — `modules/shared/programs/codex/files/` 하위 파일(또는 `tests/lib/codex-hook-expectations.sh`)을 staged 후 pre-commit 실행.
   - 기대: `codex-hook-fixtures`가 `(skip)` 없이 실행됨.
   - 실패 시: glob이 해당 경로를 미매칭 — full path와 `**` 표기 확인.
3. **eval 트리거 확인** — 임의 `.nix` 파일을 staged 후 pre-commit 실행.
   - 기대: `eval-tests`가 실행되어 `Running eval tests... All eval tests passed` 출력.
   - 실패 시: `*.nix` glob 매칭 확인.
4. **staged-config guard 1바이트 일치** — `lefthook.yml`과 `scripts/ai/check-lefthook-staged-config.sh`를 staged 후 `bash scripts/ai/check-lefthook-staged-config.sh "$(git rev-parse --show-toplevel)"` 실행.
   - 기대: exit 0 (awk normalize 결과 ↔ expected 블록 1바이트 일치).
   - 실패 시: lefthook.yml glob과 expected heredoc 블록이 어긋남 — 양쪽 동기화 확인.
