### PR TITLE
feat(1password): Phase 2a Mac SSH — 1Password agent + emergency fallback + 디바이스 키 4개

### DIFF
--- a/.claude/prds/prd-1password-migration.md
+++ b/.claude/prds/prd-1password-migration.md
@@ -4,7 +4,7 @@
 
 - Status: In Progress
 - File Mode: Split
-- Current Phase: Phase 2b merged (#827) — Phase 1 merged (#824), Phase 2a/3 ready (선택 대기)
+- Current Phase: Phase 2a Done (PR 대기) — Phase 1·2b merged (#824·#827), Phase 3 ready (선택 대기)
 - Active Phase File: [Phase 1](./prd-1password-migration/phase-01-foundation.md)
 - Last Updated: 2026-05-25
 - PRD File: `.claude/prds/prd-1password-migration.md`
@@ -169,7 +169,7 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 | Phase | Status | Objective | Validation Focus | File |
 |---|---|---|---|---|
 | Phase 1: Foundation | Done (merged #824) | Mac 1Password 설치, Automation vault, gh PAT rotation, op_get helper, SA token | nrs darwin + gh API + op CLI 동작 | [phase-01-foundation.md](./prd-1password-migration/phase-01-foundation.md) |
-| Phase 2a: Mac SSH | Not Started | IdentityAgent + emergency fallback + 디바이스별 키 inventory | ssh minipc 동작 + 1Password quit 후 fallback 실측 | [phase-02a-mac-ssh.md](./prd-1password-migration/phase-02a-mac-ssh.md) |
+| Phase 2a: Mac SSH | Done (PR 대기) | IdentityAgent + emergency fallback + 디바이스별 키 inventory | ssh minipc 동작 + 1Password quit 후 fallback 실측 | [phase-02a-mac-ssh.md](./prd-1password-migration/phase-02a-mac-ssh.md) |
 | Phase 2b: Shell plugin gh | Done (merged #827) | Home Manager declarative plugin 등록 | gh pr list 동작 (biometric prompt 1회) | [phase-02b-shell-plugin-gh.md](./prd-1password-migration/phase-02b-shell-plugin-gh.md) |
 | Phase 3: MiniPC opnix | Not Started | opnix 모듈 + SA token + MiniPC gh 전환 | nrs minipc + ssh minipc 'gh pr list' 동작 | [phase-03-minipc-opnix.md](./prd-1password-migration/phase-03-minipc-opnix.md) |
 | Phase 4: Apple Passwords | Not Started | CSV 매트릭스 실측, import, iCloud disable, TOTP/passkey 정책 | iOS 자동채움 1Password 우선 동작 | [phase-04-apple-passwords.md](./prd-1password-migration/phase-04-apple-passwords.md) |
@@ -207,3 +207,4 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 - 2026-05-24: Phase 1 구현 완료 (PR 대기). Mac 1Password(Homebrew Cask) 설치, Automation vault, gh PAT 발급+1Password 저장+retrieval 검증 (login greenheadHQ), op_get helper (op read secret reference + 멀티계정 --account 고정), SA token (`nixos-automation-minipc`, 전역 공유·minipc 단일 저장, host key 전용 recipient) agenix 보관, opnix stub + expiry record. 발견: 1Password Individual은 SA 자동 만료 미지원 → 정책 90일 cadence (만료 목표 2026-08-22, NFR-4 준수); op CLI 필드 조회는 op read secret reference 권장; op CLI 멀티 계정(개인+회사) 환경은 --account 고정 필요. 사용자 신규 결정: SA 운영 모델은 전역 공유 1개 (Mac은 biometric이라 SA 미사용, 실 소비처 minipc). 회사 맥북 SSH 키 분리는 별 세션 의제로 이관 (FR-10 확장 후보).
 - 2026-05-25: Phase 1 PR #824로 squash merge. 리뷰 반영 — agenix host key·opnix expiry 경로를 constants.nix로 중앙화, SA token user shell bridge를 잠정 설계로 마킹하고 해결 후보 3종(systemd+polkit / wrapper binary / derived credential) 나열, constants.onePassword.account hard-pin 추가. merge 후 nrs 로컬 적용 + E2E 전 항목 통과 (op_get retrieval → gh api user=greenheadHQ, op_get 함수 활성화, 에러 처리 2/127, opnix stub 비활성, flake check). Phase 2a/2b/3 진입 가능.
 - 2026-05-25: Phase 2b 구현 완료 → PR #827 squash merge. gh를 1Password Shell Plugin alias로 전환 — `shell/default.nix`에 plugins.sh file-guard source chunk + `op plugin init gh`(global default, github-pat) + nrs. `gh api user`=greenheadHQ(op plugin 경유 github-pat 주입) 검증, hosts.yml 평문 oauth_token 0건(yq 제거+백업), git history leak 0건, 구 PAT 없음 확인, keyring `gho_` unused fallback 유지 결정. merge 후 main을 nrs로 적용 + E2E 전항목 통과(type gh=alias, gh api user=greenheadHQ, hosts.yml 평문 0건, gh pr list 정상). Phase 2a/3 진입 가능.
+- 2026-05-25: Phase 2a 구현 완료 (PR 대기). Mac SSH를 1Password agent로 전환 — 디바이스 키 4개(mac-ssh/iphone/ipad/emergency, `constants.sshDeviceKeys`)를 MiniPC authorizedKeys에 배포, ssh config에 IdentityAgent(group container socket)·agent.toml(Automation vault 노출)·minipc-emergency Host·ControlPersist 600(ControlMaster 유지 — #710 analyzing-da-sessions 회귀 방지) 추가, id_ed25519 archive(agent 전용 정리). 검증: ssh minipc=mac-ssh agent 인증(Touch ID), emergency fallback 실측(1Password quit→emergency 접속→ssh minipc 실패→재시작 복귀), id_ed25519 처분 후 agent-only 인증. 발견: ControlPersist 영구는 무인 파이프 hang(→600), agent socket은 group container 경로, agent.toml로 키 노출 명시 필수. Phase 3 진입 가능.

--- a/.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md
+++ b/.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md
@@ -1,8 +1,8 @@
 # Phase 2a: Mac SSH Integration
 
 Parent PRD: [PRD: Bitwarden(Vaultwarden) → 1Password 마이그레이션 + LLM 주도 개발 생태계](../prd-1password-migration.md)
-Status: Not Started
-Last Updated: 2026-05-17
+Status: Done (PR 대기)
+Last Updated: 2026-05-25
 
 ## Objective
 
@@ -135,8 +135,13 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 
 ## Discoveries / Decisions
 
-- ControlPersist 정책 결정 (영구 vs daemon master) — Phase 진행 중 사용자 워크플로 측정 후 박제
+- **ControlPersist 정책**: 600 유지 (영구/daemon 채택 안 함). 영구(yes)는 무인 파이프 호출(`ssh minipc | grep`, Claude Code Bash 캡처 포함)에서 master가 stdout을 점유해 hang을 유발한다. ControlMaster auto + ControlPersist 600은 #710 analyzing-da-sessions의 K=8 worker pool SSH multiplexing이 의존하므로 ControlMaster 제거 불가(제거 시 그 스킬이 fetch skip → 5분 budget 회귀).
+- **1Password agent socket 경로**: macOS는 group container 경로(`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`)가 실제 socket. phase-02a가 가정한 `~/.1password/agent.sock` symlink는 자동 생성되지 않으므로, ssh config `IdentityAgent`에 group container 경로를 직접 지정(공백 포함이라 quote).
+- **agent.toml 필수**: 1Password SSH agent는 SSH 키를 자동 노출하지 않는다(GUI에 "SSH 키가 설정되지 않았습니다"). `~/.config/1Password/ssh/agent.toml`에 노출 vault를 명시해야 ssh-add -l에 키가 뜬다 → `vault = "Automation"`. `home.file`로 declarative 박제.
+- **useOpAgent let + 최종 cleanup**: phase-02a가 명시한 "옵션" 대신 모듈 let 상수로 구현(토글 수요 없어 YAGNI). id_ed25519 처분 시 launchd ssh-add-keys 경로 전체가 dead가 되어 useOpAgent/launchd/sshAddScript/sshKeyPath까지 함께 제거 → ssh/default.nix가 1Password agent 전용으로 단순화.
+- **id_ed25519 처분**: minipc 외 미사용 확인(github는 HTTPS git, MiniPC는 mac-ssh) → `~/.ssh/id_ed25519.archive`(chmod 000)로 mv. ssh config identityFile 제거 후 `ssh minipc`가 mac-ssh agent만으로 인증됨을 실측. darwin의 Mac 접속용 authorizedKeys(macbook 공개키)는 별개라 보존.
 
 ## Phase Change Log
 
 - 2026-05-17: Phase file created.
+- 2026-05-25: Phase 2a 구현 완료 (PR 대기). 디바이스 키 4개(mac-ssh/iphone/ipad/emergency)를 `constants.sshDeviceKeys`로 정의하고 MiniPC authorizedKeys에 배포(nrs minipc). Mac ssh config: IdentityAgent(group container socket) + agent.toml(Automation vault 노출) + minipc-emergency Host + ControlPersist 600(ControlMaster 유지). id_ed25519 archive. 검증: `ssh minipc`=mac-ssh agent 인증(Touch ID), emergency fallback 실측(1Password quit→emergency 접속 성공→ssh minipc Permission denied→재시작 복귀), id_ed25519 처분 후 agent-only 인증. 발견: ControlPersist 영구는 무인 hang(→600 유지), agent socket은 group container 경로, agent.toml로 키 노출 명시 필수.

--- a/hosts/greenhead-minipc/default.nix
+++ b/hosts/greenhead-minipc/default.nix
@@ -15,9 +15,14 @@
     ./disko.nix
   ];
 
-  # SSH 공개키 (Mac 접속용)
-  users.users.${username}.openssh.authorizedKeys.keys = [
-    constants.sshKeys.macbook
+  # SSH 공개키 — 디바이스별 4개 (PRD #780 Phase 2a)
+  # mac-ssh(1Password SSH agent) + iphone/ipad(Termius) + emergency(1Password 장애 fallback).
+  # 기존 macbook(id_ed25519)은 mac-ssh로 대체 — id_ed25519는 FR-8에서 처분.
+  users.users.${username}.openssh.authorizedKeys.keys = with constants.sshDeviceKeys; [
+    macSsh
+    iphone
+    ipad
+    emergency
   ];
 
   # Wake-on-LAN (같은 LAN 전용)

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -78,6 +78,19 @@
   };
 
   # ═══════════════════════════════════════════════════════════════
+  # 디바이스별 SSH 공개키 — MiniPC authorized_keys 등록용 (PRD #780 Phase 2a)
+  # 1Password Automation vault `ssh` tag inventory와 일관. agenix recipient(sshKeys)와는 분리.
+  # private 보관: macSsh = 1Password vault(SSH agent), emergency = ~/.ssh + 1Password backup,
+  #   iphone/ipad = Termius 디바이스 keychain.
+  # ═══════════════════════════════════════════════════════════════
+  sshDeviceKeys = {
+    macSsh = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGijyrxefX4n5oRJ2775QDOFtBfjPeNzjym2i7TJx9qr mac-ssh";
+    iphone = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMBwI6UCcwfwcnwHIer2GACL1S8qW7azfwGigAcngj3X iphone-ssh";
+    ipad = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFF+/kpJu3NOOFvjPZAKPqjT+IG8Q2cMKYi/YV4yR355 ipad-ssh";
+    emergency = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMM0hYpFqehy7U96Ms4348SStVue7pYbR3+B3PlGV+de emergency-fallback";
+  };
+
+  # ═══════════════════════════════════════════════════════════════
   # 컨테이너 리소스 제한
   # ═══════════════════════════════════════════════════════════════
   containers = {

--- a/modules/darwin/programs/ssh/default.nix
+++ b/modules/darwin/programs/ssh/default.nix
@@ -20,6 +20,12 @@ let
     fi
     /usr/bin/ssh-add "${sshKeyPath}" 2>&1
   '';
+
+  # PRD #780 Phase 2a: Mac SSH를 1Password SSH agent로 인증. true이면 ssh-add launchd agent 비활성.
+  # (옵션 대신 let 상수 — 토글 수요 없어 YAGNI. 필요 시 options로 승격)
+  useOpAgent = true;
+  # 1Password macOS SSH agent socket (group container 경로 — ~/.1password/agent.sock symlink는 자동생성 안 됨)
+  onePasswordAgentSock = "${homeDir}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
 in
 {
   programs.ssh = {
@@ -31,6 +37,8 @@ in
         identityFile = sshKeyPath;
         extraOptions = {
           AddKeysToAgent = "yes";
+          # 1Password SSH agent (group container socket — 공백 포함 경로라 quote 필요)
+          IdentityAgent = "\"${onePasswordAgentSock}\"";
         };
       };
     }
@@ -43,13 +51,24 @@ in
         extraOptions = {
           ControlMaster = "auto";
           ControlPath = "~/.ssh/cm-%h-%p-%r";
-          ControlPersist = "600";
+          # Phase 2a Decision: 600 → 영구. ssh minipc 빈번 워크플로에서 Touch ID 빈도·무인 hang 최소화
+          ControlPersist = "yes";
+        };
+      };
+      # 1Password 장애(데스크탑 quit/Touch ID 고장/계정 잠금) fallback (PRD #780 Phase 2a, FR-9)
+      "minipc-emergency" = {
+        hostname = constants.network.minipcTailscaleIP;
+        user = "greenhead";
+        identityFile = "${homeDir}/.ssh/emergency_ed25519";
+        extraOptions = {
+          IdentityAgent = "none"; # 1Password agent 우회 — emergency key 직접 사용
         };
       };
     };
   };
 
-  launchd.agents.ssh-add-keys = {
+  # useOpAgent=true이면 ssh-add launchd agent 정의 자체가 빠짐 (1Password agent가 키 관리)
+  launchd.agents.ssh-add-keys = lib.mkIf (!useOpAgent) {
     enable = true;
     config = {
       Label = "com.green.ssh-add-keys";

--- a/modules/darwin/programs/ssh/default.nix
+++ b/modules/darwin/programs/ssh/default.nix
@@ -1,6 +1,5 @@
 {
   config,
-  pkgs,
   lib,
   constants,
   hostType,
@@ -8,33 +7,18 @@
 }:
 let
   homeDir = config.home.homeDirectory;
-
-  # 단일 소스: 키 이름만 정의하면 모든 곳에서 참조
-  sshKeyName = "id_ed25519";
-  sshKeyPath = "${homeDir}/.ssh/${sshKeyName}";
-
-  sshAddScript = pkgs.writeShellScript "ssh-add-keys" ''
-    if /usr/bin/ssh-add -l 2>/dev/null | grep -q "${sshKeyName}"; then
-      echo "SSH key already loaded"
-      exit 0
-    fi
-    /usr/bin/ssh-add "${sshKeyPath}" 2>&1
-  '';
-
-  # PRD #780 Phase 2a: Mac SSH를 1Password SSH agent로 인증. true이면 ssh-add launchd agent 비활성.
-  # (옵션 대신 let 상수 — 토글 수요 없어 YAGNI. 필요 시 options로 승격)
-  useOpAgent = true;
   # 1Password macOS SSH agent socket (group container 경로 — ~/.1password/agent.sock symlink는 자동생성 안 됨)
   onePasswordAgentSock = "${homeDir}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
 in
 {
+  # Mac SSH는 1Password SSH agent로 인증 (PRD #780 Phase 2a).
+  # 구 id_ed25519는 1Password mac-ssh로 대체되어 archive됨 (FR-8) → identityFile/ssh-add launchd 제거.
   programs.ssh = {
     enable = true;
     # home-manager의 기본 SSH 설정 비활성화 (deprecated 경고 방지)
     enableDefaultConfig = false;
     matchBlocks = {
       "*" = {
-        identityFile = sshKeyPath;
         extraOptions = {
           AddKeysToAgent = "yes";
           # 1Password SSH agent (group container socket — 공백 포함 경로라 quote 필요)
@@ -47,12 +31,12 @@ in
       "minipc" = {
         hostname = constants.network.minipcTailscaleIP;
         user = "greenhead";
-        identityFile = sshKeyPath;
         extraOptions = {
           ControlMaster = "auto";
           ControlPath = "~/.ssh/cm-%h-%p-%r";
-          # Phase 2a Decision: 600 → 영구. ssh minipc 빈번 워크플로에서 Touch ID 빈도·무인 hang 최소화
-          ControlPersist = "yes";
+          # ControlPersist 600 유지 — #710 analyzing-da-sessions의 ControlMaster 다중화(K=8 worker pool)가 의존.
+          # 영구(yes)는 무인 파이프 호출에서 master가 stdout을 점유해 hang을 유발하므로, 600으로 master 자동 종료를 보장한다.
+          ControlPersist = "600";
         };
       };
       # 1Password 장애(데스크탑 quit/Touch ID 고장/계정 잠금) fallback (PRD #780 Phase 2a, FR-9)
@@ -67,18 +51,11 @@ in
     };
   };
 
-  # useOpAgent=true이면 ssh-add launchd agent 정의 자체가 빠짐 (1Password agent가 키 관리)
-  launchd.agents.ssh-add-keys = lib.mkIf (!useOpAgent) {
-    enable = true;
-    config = {
-      Label = "com.green.ssh-add-keys";
-      ProgramArguments = [ "${sshAddScript}" ];
-      RunAtLoad = true;
-      EnvironmentVariables = {
-        HOME = homeDir;
-      };
-      StandardOutPath = "${homeDir}/Library/Logs/ssh-add-keys.log";
-      StandardErrorPath = "${homeDir}/Library/Logs/ssh-add-keys.error.log";
-    };
-  };
+  # 1Password SSH agent 키 노출 설정 (PRD #780 Phase 2a)
+  # 1Password는 SSH 키를 agent에 자동 노출하지 않으므로, 노출할 vault를 agent.toml에 명시해야 한다.
+  # Automation vault의 SSH 키(mac-ssh)를 노출 → ssh가 IdentityAgent 경유로 mac-ssh 사용.
+  home.file.".config/1Password/ssh/agent.toml".text = ''
+    [[ssh-keys]]
+    vault = "Automation"
+  '';
 }


### PR DESCRIPTION
## Summary

- Phase 2a: Mac SSH 인증을 **1Password SSH agent(mac-ssh)**로 이관하고, 1Password 장애(데스크탑 quit/Touch ID 고장)에 대비한 **emergency ed25519 fallback**을 둔다.
- 디바이스별 SSH 키 4개(mac-ssh/iphone/ipad/emergency)를 MiniPC authorizedKeys + 1Password Automation vault에 inventory하고, 구 `id_ed25519`(단일 평문 키)를 처분해 ssh가 1Password agent 전용으로 인증하게 한다.

Part of #780

## 기존 문제/배경

Mac SSH는 `~/.ssh/id_ed25519` 단일 평문 키에 의존했다. 1Password 통합(biometric·SSH agent)이 없어 키가 디스크에 평문으로 상주했고, 1Password 장애 시 fallback 경로도, 디바이스별 키 inventory도 없었다. Phase 1에서 1Password를 설치했으니 SSH를 agent로 옮길 차례다.

## CIR (Change Intent Record)

- **agent socket 경로**: phase-02a는 `~/.1password/agent.sock`(symlink)를 가정했으나, macOS 실제 socket은 group container 경로(`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`)이고 symlink는 자동 생성되지 않았다 → `IdentityAgent`에 group container 경로를 직접 지정(공백 포함이라 quote).
- **agent.toml 필수**: 1Password SSH agent가 SSH 키를 자동 노출하지 않아 ssh-add -l이 비어 있었다 → `~/.config/1Password/ssh/agent.toml`에 `vault = "Automation"`을 명시(home.file로 박제).
- **ControlPersist 영구→600 정정**: 처음 ControlPersist를 영구(yes)로 바꿨으나, 무인 파이프 호출(`ssh minipc | grep`, 자동화 캡처)에서 영구 master가 stdout을 점유해 hang을 유발함을 발견. ControlMaster auto+600은 #710 analyzing-da-sessions의 K=8 worker pool이 의존하므로, **ControlMaster는 유지하고 ControlPersist만 600으로 복원**.
- **id_ed25519 처분 + cleanup**: minipc 외 미사용 확인(github는 HTTPS git) → archive. id_ed25519가 빠지면 launchd ssh-add-keys 경로(useOpAgent=true라 이미 dead)가 무의미해져 useOpAgent/launchd/sshAddScript/sshKeyPath까지 함께 제거 → ssh/default.nix를 1Password agent 전용으로 단순화.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| ControlMaster 제거 | minipc 다중화 제거 | 무인 hang 근본 차단 | #710 analyzing-da-sessions 회귀(fetch skip) | ❌ |
| ControlMaster 유지 + ControlPersist 600 | 다중화 유지, 영구 아님 | #710 보존, 무인 hang 600초 후 해소 | 600초간은 hang 가능 | ✅ |
| ControlPersist 영구(yes) | master 영구 | Touch ID 최소 | 무인 파이프 영구 hang | ❌ |
| agent.toml `vault` | Automation vault 전체 노출 | 키 추가 시 재설정 불필요 | vault 전체 노출 | ✅ |
| `~/.1password/agent.sock` symlink | 편의 경로 | 짧음 | 자동 생성 안 됨 | ❌ |
| group container 경로 직접 | 실제 socket | symlink 의존 없음 | 경로 길고 공백 quote | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `libraries/constants.nix` | 추가 | `sshDeviceKeys`(mac-ssh/iphone/ipad/emergency 4개 pubkey, agenix recipient와 분리) |
| `hosts/greenhead-minipc/default.nix` | 수정 | authorizedKeys를 macbook(id_ed25519) → 디바이스 키 4개로 교체 |
| `modules/darwin/programs/ssh/default.nix` | 수정 | IdentityAgent(group container)·minipc-emergency Host(IdentityAgent none)·ControlPersist 600·agent.toml(home.file). id_ed25519 의존(identityFile/launchd/sshAddScript/useOpAgent) 제거 |
| (로컬, diff 외) | — | `op plugin` 아님. `~/.ssh/id_ed25519` → `.archive`(chmod 000), `~/.config/1Password/ssh/agent.toml` 생성 |
| `.claude/prds/prd-1password-migration*` | 수정 | phase-02a Done(PR 대기) + 발견 박제, master 갱신 |

## 참고 레퍼런스

- #780 — 1Password 마이그레이션 epic (이 PR은 Phase 2a)
- #824 — Phase 1 Foundation, #827 — Phase 2b Shell plugin gh
- #710 — analyzing-da-sessions SSH multiplexing (ControlMaster auto+ControlPersist 600 도입 — 이 PR이 보존)
- [1Password SSH agent](https://developer.1password.com/docs/ssh/agent/) / [agent config](https://developer.1password.com/docs/ssh/agent/config/)

## Human Test Plan

### 정상 동작
1. `ssh minipc` → 1Password Touch ID → **성공**(greenhead-minipc). mac-ssh agent로 인증.
   - **실패 시**: `SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock ssh-add -l`에 mac-ssh 뜨는지(없으면 agent.toml 확인), 1Password 데스크탑 unlock 확인.
2. `ssh-add -l`(1Password socket) → mac-ssh·emergency-ssh 노출.

### emergency fallback (exit gate)
3. 1Password 데스크탑 완전 종료(Quit) → `ssh minipc-emergency` → passphrase → **성공**.
4. (1Password 종료 상태) `ssh minipc` → **Permission denied**(agent 없음, 정상).
5. 1Password 재시작 → `ssh minipc` → **복귀 성공**.

### Negative / 회귀
6. `ls ~/.ssh/id_ed25519` → 없음(`.archive`로 이동, chmod 000). `ssh minipc`가 agent-only로 동작.
7. analyzing-da-sessions 등 ControlMaster 의존 흐름: `ssh -O check minipc`로 master 활성 확인 가능(ControlPersist 600 유지).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH authentication is now managed through 1Password, providing centralized key management and improved security.
  * Added support for SSH access from multiple devices including Mac, iPhone, and iPad.
  * Implemented an emergency SSH key fallback for system access when primary methods are unavailable.

* **Improvements**
  * Enhanced SSH connection stability through improved multiplexing and connection persistence settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->