### PR TITLE
perf(lefthook): staged-snapshot 공유 캐시로 checkout-index 6중복 제거

### DIFF
--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -142,6 +142,7 @@ done < <(awk '/^[A-Za-z0-9_.-]+:/ { print $1 }' "$index_file")
 
 repo_scripts=(
   "scripts/ai/run-staged-snapshot.sh"
+  "scripts/ai/lib/staged-snapshot-cache.sh"
   "scripts/ai/warn-skill-consistency.sh"
   "scripts/ai/run-gitleaks-staged-policy.sh"
   "tests/run-eval-tests.sh"

--- a/scripts/ai/lib/staged-snapshot-cache.sh
+++ b/scripts/ai/lib/staged-snapshot-cache.sh
@@ -43,6 +43,9 @@ STAGED_SNAPSHOT_CACHE_TTL_SECONDS="${STAGED_SNAPSHOT_CACHE_TTL_SECONDS:-3600}" #
 
 # release/wrapper 가 참조하는 상태
 _SSC_HELD_LOCK=""
+# 이번 호출이 보유한 lock 의 owner 토큰. timeout takeover 후 successor 가 같은 경로에 만든 lock 을
+# 원 builder 가 훼손하지 않도록, unlock 시 lockdir/owner 와 대조한다.
+_SSC_LOCK_TOKEN=""
 _SSC_BUILD_DIR=""
 # write-tree 키 계산과 checkout-index materialize 가 공유하는 pinned index. wrapper 가 정리한다.
 _SSC_PINNED_INDEX=""
@@ -60,6 +63,18 @@ _ssc_rm_tree() {
   [ -n "$1" ] || return 0
   chmod -R u+w "$1" 2>/dev/null || true
   rm -rf "$1" 2>/dev/null || true
+}
+
+# 자기 token 이 기록된 lock 만 해제한다. timeout takeover(rm -rf)로 successor 가 같은 경로에 새
+# lock 을 만든 경우, 원 builder 가 그 successor lock 을 rmdir 해 직렬화가 붕괴되는 것을 막는다.
+_ssc_unlock() {
+  [ -n "${_SSC_HELD_LOCK:-}" ] || return 0
+  if [ -f "$_SSC_HELD_LOCK/owner" ] \
+    && [ "$(cat "$_SSC_HELD_LOCK/owner" 2>/dev/null)" = "${_SSC_LOCK_TOKEN:-}" ]; then
+    rm -f "$_SSC_HELD_LOCK/owner" 2>/dev/null
+    rmdir "$_SSC_HELD_LOCK" 2>/dev/null || true
+  fi
+  _SSC_HELD_LOCK=""
 }
 
 # 경로 16자 해시 (per-worktree 캐시 격리 키)
@@ -135,19 +150,21 @@ _ssc_acquire() {
     if [ -f "$cache_dir/.ready" ] && [ -d "$cache_dir/worktree" ]; then
       return 0
     fi
-    if mkdir "$lockdir" 2>/dev/null; then
-      # 빌더 (lock 은 빈 디렉토리 — owner 메타 없이 mkdir/rmdir 만으로 직렬화)
+    _SSC_LOCK_TOKEN="${BASHPID:-$$}.$RANDOM.$(date +%s)"
+    if mkdir "$lockdir" 2>/dev/null && printf '%s\n' "$_SSC_LOCK_TOKEN" > "$lockdir/owner" 2>/dev/null; then
+      # 빌더. lockdir/owner 에 이번 호출 token 을 적어, 해제 시 자기 lock 만 제거한다(아래 timeout
+      # takeover 가 만든 successor lock 을 원 builder 가 rmdir 하지 않게 함 → 직렬화 붕괴 방지).
       _SSC_HELD_LOCK="$lockdir"
       _SSC_BUILD_DIR="$build_dir"
       if ! mkdir -p "$build_dir/worktree" 2>/dev/null; then
         _ssc_rm_tree "$build_dir"; _SSC_BUILD_DIR=""
-        rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+        _ssc_unlock
         _ssc_die "build dir mkdir failed: $build_dir"
         return 1
       fi
       if ! GIT_INDEX_FILE="$src_index" git -C "$repo_root" checkout-index --all --prefix="$build_dir/worktree/" 2>/dev/null; then
         _ssc_rm_tree "$build_dir"; _SSC_BUILD_DIR=""
-        rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+        _ssc_unlock
         _ssc_die "git checkout-index failed"
         return 1
       fi
@@ -160,7 +177,7 @@ _ssc_acquire() {
       # 실패하면 build 를 폐기해 .ready 없는 cache_dir 이 publish 를 영구 막는 일이 없게 한다.
       if ! : > "$build_dir/.ready" 2>/dev/null; then
         _ssc_rm_tree "$build_dir"; _SSC_BUILD_DIR=""
-        rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+        _ssc_unlock
         _ssc_die "ready marker write failed"
         return 1
       fi
@@ -177,7 +194,7 @@ _ssc_acquire() {
         _ssc_rm_tree "$build_dir"
         _SSC_BUILD_DIR=""
       fi
-      rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+      _ssc_unlock
       if [ -f "$cache_dir/.ready" ] && [ -d "$cache_dir/worktree" ]; then
         return 0
       fi
@@ -267,6 +284,9 @@ _ssc_provide_impl() {
   _ssc_acquire "$repo_root" "$trees_dir/$tree_hash" "$locks_dir/$tree_hash" \
     "$builds_dir/$tree_hash.$nonce" "$_SSC_PINNED_INDEX" || return 1
   [ -d "$trees_dir/$tree_hash/worktree" ] || { _ssc_die "cache worktree missing"; return 1; }
+  # cache hit/build 후 mtime 을 갱신(touch)해, 사용 중인 캐시가 다른 호출의 GC(mtime TTL) 대상이
+  # 되지 않게 한다. lease 추적의 경량 대체다(touch~GC 사이의 극단적 동시 race 는 알려진 한계).
+  touch "$trees_dir/$tree_hash" 2>/dev/null || true
   # shellcheck disable=SC2034  # source 한 호출자가 읽는 출력 변수
   STAGED_SNAPSHOT_CACHE_WORKTREE="$trees_dir/$tree_hash/worktree"
   return 0
@@ -278,10 +298,7 @@ staged_snapshot_cache_release() {
     _ssc_rm_tree "$_SSC_BUILD_DIR"
     _SSC_BUILD_DIR=""
   fi
-  if [ -n "${_SSC_HELD_LOCK:-}" ]; then
-    rmdir "$_SSC_HELD_LOCK" 2>/dev/null || true
-    _SSC_HELD_LOCK=""
-  fi
+  _ssc_unlock
   if [ -n "${_SSC_PINNED_INDEX:-}" ]; then
     rm -f "$_SSC_PINNED_INDEX" "$_SSC_PINNED_INDEX.lock" 2>/dev/null
     _SSC_PINNED_INDEX=""

--- a/scripts/ai/lib/staged-snapshot-cache.sh
+++ b/scripts/ai/lib/staged-snapshot-cache.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# scripts/ai/lib/staged-snapshot-cache.sh
+#
+# 공유 staged-snapshot 캐시 provider.
+#
+# 문제: pre-commit(lefthook, parallel:true)의 여러 command가 각자 `git checkout-index --all`로
+#   staged 트리(~752파일)를 임시 디렉토리에 복제해 디스크 I/O 경합을 일으켰다.
+# 해법: `git write-tree` 해시를 키로 staged 트리를 1회만 materialize 하고, 동일 index 내용을
+#   보는 모든 command가 그 결과를 공유한다.
+#
+# 메커니즘 (flock 부재 — macOS/devShell 실측):
+#   - mkdir atomic lock + `.ready` 완료 마커로 첫 호출만 build, 나머지는 대기 후 공유.
+#   - build 는 builds/ 임시 경로에서 완성한 뒤 trees/<hash> 로 rename(`mv`; dest 부재 시 atomic
+#     publish). 반쯤 채워진 트리가 노출되지 않는다.
+#   - 공유 worktree 는 chmod a-w(read-only). consumer 가 실수로 쓰면 즉시 드러난다.
+#   - lock holder 가 죽거나 과도하게 느리면 대기자가 타임아웃 후 lock 을 제거하고 직접
+#     빌드한다(정교한 PID 판정 없음 — 최악은 중복 checkout 1회로, 정확성은 유지된다).
+#   - 캐시 정리는 OS 임시디렉토리 정책(macOS /var/folders, /tmp 청소 등)에 위임한다. 같은 staged
+#     내용은 같은 hash 로 재사용되고, 다른 hash 누적은 OS tmp 청소로 회수된다.
+#
+# 사용:
+#   . "$REPO_ROOT/scripts/ai/lib/staged-snapshot-cache.sh"
+#   staged_snapshot_cache_provide "$REPO_ROOT"               # 기본: repo 의 현재 index 로
+#   staged_snapshot_cache_provide "$REPO_ROOT" "$src_index"  # explicit: 주어진 index(의 복사본)로
+#   trap 'staged_snapshot_cache_release' EXIT                # 정리는 호출자(trap) 책임
+#
+# 계약:
+#   - 성공 시 $STAGED_SNAPSHOT_CACHE_WORKTREE 가 read-only 공유 트리를 가리킨다. 절대 쓰지 않는다.
+#   - 2번째 인자(caller-owned src index)를 주면, provide 가 그것을 즉시 private copy 로 떠서
+#     write-tree 키와 checkout-index materialize 의 단일 소스로 쓴다 — 인자 파일 자체가 아니라 그
+#     복사본이 소스다(호출자가 같은 src 로 만든 자기 index 작업과 동일 staged tree 를 보게 하려는 용도).
+#     생략하면 repo 현재 index(`git rev-parse --git-path index`, GIT_INDEX_FILE 반영)를 복사한다.
+#   - 그 private copy(_SSC_PINNED_INDEX)와 umask 는 provide wrapper 가 정리/복구한다.
+
+# lock 대기 타임아웃(초). 초과 시 holder 가 죽었거나 과부하로 보고 lock 을 제거한 뒤 직접 빌드한다.
+_SSC_LOCK_TIMEOUT_SECONDS="${STAGED_SNAPSHOT_CACHE_LOCK_TIMEOUT_SECONDS:-120}"
+# polling 간격(초)
+_SSC_POLL_INTERVAL="0.1"
+# 오래된 캐시 GC TTL(초). provide 진입 시 현재 hash 를 제외하고 이보다 오래된(mtime) trees/builds
+# 를 제거한다. gitleaks 가 막은 staged secret 사본의 잔존과 tree-hash 별 디스크 누적을 OS tmp
+# 청소에만 의존하지 않고 정리하기 위함이다(기존 per-run 의 즉시 정리 동작에 근접).
+STAGED_SNAPSHOT_CACHE_TTL_SECONDS="${STAGED_SNAPSHOT_CACHE_TTL_SECONDS:-3600}" # 1h
+
+# release/wrapper 가 참조하는 상태
+_SSC_HELD_LOCK=""
+_SSC_BUILD_DIR=""
+# write-tree 키 계산과 checkout-index materialize 가 공유하는 pinned index. wrapper 가 정리한다.
+_SSC_PINNED_INDEX=""
+
+# 결과 (provide 가 설정)
+STAGED_SNAPSHOT_CACHE_WORKTREE=""
+
+_ssc_die() {
+  echo "staged-snapshot-cache: $*" >&2
+  return 1
+}
+
+# read-only(chmod a-w) 트리도 지울 수 있도록 u+w 복구 후 rm
+_ssc_rm_tree() {
+  [ -n "$1" ] || return 0
+  chmod -R u+w "$1" 2>/dev/null || true
+  rm -rf "$1" 2>/dev/null || true
+}
+
+# 경로 16자 해시 (per-worktree 캐시 격리 키)
+_ssc_hash16() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | cut -c1-16
+  else
+    shasum -a 256 | cut -c1-16
+  fi
+}
+
+# 소유 uid (GNU stat -c vs BSD /usr/bin/stat -f)
+_ssc_owner_uid() {
+  local ou
+  if ou="$(stat -c %u "$1" 2>/dev/null)" && [ -n "$ou" ]; then
+    printf '%s' "$ou"
+  else
+    /usr/bin/stat -f %u "$1" 2>/dev/null
+  fi
+}
+
+# 파일/디렉토리 mtime epoch (GNU stat -c vs BSD /usr/bin/stat -f)
+_ssc_mtime() {
+  local mt
+  if mt="$(stat -c %Y "$1" 2>/dev/null)" && [ -n "$mt" ]; then
+    printf '%s' "$mt"
+  else
+    /usr/bin/stat -f %m "$1" 2>/dev/null
+  fi
+}
+
+# best-effort GC: 현재 hash 를 제외하고, mtime 이 TTL 보다 오래된 trees/builds 항목을 제거한다.
+# lease 추적 없이 mtime 만 보므로(단일 사용자 전제) 막 빌드됐거나 방금 쓰인 캐시(mtime 최신)는
+# 건드리지 않는다. secret 사본 잔존과 디스크 누적을 OS tmp 청소에만 의존하지 않고 줄인다.
+_ssc_gc() {
+  local trees_dir="$1" builds_dir="$2" keep_hash="$3"
+  local now entry mt base
+  now="$(date +%s)"
+  for entry in "$trees_dir"/* "$builds_dir"/*; do
+    [ -d "$entry" ] || continue
+    base="$(basename "$entry")"
+    [ "$base" = "$keep_hash" ] && continue
+    mt="$(_ssc_mtime "$entry")" || continue
+    [ -n "$mt" ] || continue
+    if [ $(( now - mt )) -ge "$STAGED_SNAPSHOT_CACHE_TTL_SECONDS" ]; then
+      _ssc_rm_tree "$entry"
+    fi
+  done
+  return 0
+}
+
+# 심링크 거부 + mkdir -p + 소유권 검증 (predictable /tmp path 방어)
+_ssc_safe_mkdir() {
+  local dir="$1" owner
+  if [ -L "$dir" ]; then
+    _ssc_die "refusing symlinked cache path: $dir"
+    return 1
+  fi
+  mkdir -p "$dir" 2>/dev/null || { _ssc_die "mkdir failed: $dir"; return 1; }
+  owner="$(_ssc_owner_uid "$dir")"
+  if [ -n "$owner" ] && [ "$owner" != "$(id -u)" ]; then
+    _ssc_die "cache path not owned by uid $(id -u): $dir (owner uid $owner)"
+    return 1
+  fi
+  return 0
+}
+
+# 캐시가 준비될 때까지 빌드(획득)하거나 대기한다. 성공 시 0.
+_ssc_acquire() {
+  local repo_root="$1" cache_dir="$2" lockdir="$3" build_dir="$4" src_index="$5"
+  local start
+  while true; do
+    if [ -f "$cache_dir/.ready" ] && [ -d "$cache_dir/worktree" ]; then
+      return 0
+    fi
+    if mkdir "$lockdir" 2>/dev/null; then
+      # 빌더 (lock 은 빈 디렉토리 — owner 메타 없이 mkdir/rmdir 만으로 직렬화)
+      _SSC_HELD_LOCK="$lockdir"
+      _SSC_BUILD_DIR="$build_dir"
+      if ! mkdir -p "$build_dir/worktree" 2>/dev/null; then
+        _ssc_rm_tree "$build_dir"; _SSC_BUILD_DIR=""
+        rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+        _ssc_die "build dir mkdir failed: $build_dir"
+        return 1
+      fi
+      if ! GIT_INDEX_FILE="$src_index" git -C "$repo_root" checkout-index --all --prefix="$build_dir/worktree/" 2>/dev/null; then
+        _ssc_rm_tree "$build_dir"; _SSC_BUILD_DIR=""
+        rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+        _ssc_die "git checkout-index failed"
+        return 1
+      fi
+      # 테스트 가시성: 실제 checkout-index(=캐시 빌드) 횟수 기록. env 미설정 시 무동작.
+      if [ -n "${STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG:-}" ]; then
+        printf '%s\n' "$build_dir" >> "$STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG" 2>/dev/null || true
+      fi
+      chmod -R a-w "$build_dir/worktree" 2>/dev/null || true
+      # .ready 는 build_dir 안에 만들어 publish(mv) 로 cache_dir 과 함께 원자 게시한다. 생성에
+      # 실패하면 build 를 폐기해 .ready 없는 cache_dir 이 publish 를 영구 막는 일이 없게 한다.
+      if ! : > "$build_dir/.ready" 2>/dev/null; then
+        _ssc_rm_tree "$build_dir"; _SSC_BUILD_DIR=""
+        rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+        _ssc_die "ready marker write failed"
+        return 1
+      fi
+      # atomic publish: lock 직렬화로 cache_dir 은 보통 부재이며, dest 가 없을 때 `mv <dir>
+      # <nonexistent>` 는 rename(2) 한 번으로 원자적이다(BSD mv 라 -T 미지원). 단 타임아웃 탈취로
+      # 중복 빌더가 생겨 경쟁자가 검사~mv 사이에 먼저 publish 하면, BSD mv 는 build_dir 를
+      # cache_dir/<basename> 안으로 넣는다(rename 아님). 그 loser 잔여를 감지해 정리하고, 어느
+      # 경로든 완성된 cache_dir 트리(winner)를 공유한다.
+      local _bd_name; _bd_name="$(basename "$build_dir")"
+      if [ ! -e "$cache_dir" ] && mv "$build_dir" "$cache_dir" 2>/dev/null && [ ! -e "$cache_dir/$_bd_name" ]; then
+        _SSC_BUILD_DIR=""
+      else
+        _ssc_rm_tree "$cache_dir/$_bd_name"
+        _ssc_rm_tree "$build_dir"
+        _SSC_BUILD_DIR=""
+      fi
+      rmdir "$lockdir" 2>/dev/null || true; _SSC_HELD_LOCK=""
+      if [ -f "$cache_dir/.ready" ] && [ -d "$cache_dir/worktree" ]; then
+        return 0
+      fi
+      _ssc_die "staged snapshot publish failed (cache_dir=$cache_dir)"
+      return 1
+    fi
+    # 대기자: 다른 호출이 빌드 중. .ready 를 polling 하고, 타임아웃 초과 시 lock 을 제거해
+    # 직접 빌드 경로로 넘어간다(holder 사망/과부하 추정 — 최악은 중복 checkout 1회).
+    start="$SECONDS"
+    while [ ! -f "$cache_dir/.ready" ]; do
+      sleep "$_SSC_POLL_INTERVAL"
+      if [ -f "$cache_dir/.ready" ] && [ -d "$cache_dir/worktree" ]; then
+        return 0
+      fi
+      if [ ! -d "$lockdir" ]; then
+        break
+      fi
+      if [ $(( SECONDS - start )) -ge "$_SSC_LOCK_TIMEOUT_SECONDS" ]; then
+        rm -rf "$lockdir" 2>/dev/null || true
+        break
+      fi
+    done
+  done
+}
+
+# 메인 진입점 (wrapper). umask 와 pinned index 의 수명을 관리하고 본체는 _ssc_provide_impl 에 둔다.
+# - umask 077 을 캐시 생성 구간에만 적용하고, 같은 프로세스에서 이어 실행되는 consumer 에
+#   누수시키지 않도록 호출 전 umask 로 복구한다.
+# - pinned index(write-tree 키 + checkout-index 공통 소스)를 모든 종료 경로에서 정리한다.
+staged_snapshot_cache_provide() {
+  local _saved_umask _rc
+  _saved_umask="$(umask)"
+  umask 077
+  _ssc_provide_impl "$@"
+  _rc=$?
+  umask "$_saved_umask"
+  if [ -n "${_SSC_PINNED_INDEX:-}" ]; then
+    rm -f "$_SSC_PINNED_INDEX" "$_SSC_PINNED_INDEX.lock" 2>/dev/null
+    _SSC_PINNED_INDEX=""
+  fi
+  return "$_rc"
+}
+
+# 본체. 성공 시 $STAGED_SNAPSHOT_CACHE_WORKTREE 를 설정한다. umask/pinned 정리는 wrapper 책임.
+_ssc_provide_impl() {
+  local repo_root="$1"
+  [ -n "$repo_root" ] || { _ssc_die "repo_root argument required"; return 1; }
+
+  # 1. 캐시 키 = git write-tree 해시. 같은 pinned index 를 write-tree(키)와 이후 checkout-index
+  #    (materialize)에 모두 써서 캐시 키와 worktree 내용이 동일 staged tree 를 가리키게 한다
+  #    (index.lock 경쟁/부작용도 격리). 2번째 인자가 있으면 그 index 기준, 없으면 repo 현재 index.
+  local src_index tree_hash
+  src_index="${2:-}"
+  if [ -z "$src_index" ]; then
+    src_index="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path index 2>/dev/null)"
+  fi
+  [ -f "$src_index" ] || { _ssc_die "index not found: $src_index"; return 1; }
+  _SSC_PINNED_INDEX="$(mktemp "${TMPDIR:-/tmp}/ssc-index.XXXXXX")" || { _ssc_die "mktemp failed"; return 1; }
+  cp "$src_index" "$_SSC_PINNED_INDEX" 2>/dev/null || { _ssc_die "index copy failed"; return 1; }
+  if ! tree_hash="$(GIT_INDEX_FILE="$_SSC_PINNED_INDEX" git -C "$repo_root" write-tree 2>/dev/null)"; then
+    _ssc_die "git write-tree failed — resolve merge conflicts before commit"
+    return 1
+  fi
+  [ -n "$tree_hash" ] || { _ssc_die "empty tree hash"; return 1; }
+
+  # 2. 캐시 base (per-repo_id 격리 + umask 077 + 소유권 검증). 정리는 OS tmp 정책에 위임.
+  local base repo_id cache_root trees_dir builds_dir locks_dir
+  base="${TMPDIR:-/tmp}"
+  base="${base%/}/staged-snapshot-cache"
+  repo_id="$(printf '%s' "$repo_root" | _ssc_hash16)"
+  cache_root="$base/$repo_id"
+  trees_dir="$cache_root/trees"
+  builds_dir="$cache_root/builds"
+  locks_dir="$cache_root/locks"
+  _ssc_safe_mkdir "$base" || return 1
+  _ssc_safe_mkdir "$cache_root" || return 1
+  _ssc_safe_mkdir "$trees_dir" || return 1
+  _ssc_safe_mkdir "$builds_dir" || return 1
+  _ssc_safe_mkdir "$locks_dir" || return 1
+
+  # 오래된 캐시 정리 (secret 사본 잔존·디스크 누적 방지). 현재 tree_hash 는 보존한다.
+  _ssc_gc "$trees_dir" "$builds_dir" "$tree_hash" || true
+
+  # 3. 획득/빌드
+  local nonce
+  nonce="$$.$(date +%s).${RANDOM}${RANDOM}"
+  _ssc_acquire "$repo_root" "$trees_dir/$tree_hash" "$locks_dir/$tree_hash" \
+    "$builds_dir/$tree_hash.$nonce" "$_SSC_PINNED_INDEX" || return 1
+  [ -d "$trees_dir/$tree_hash/worktree" ] || { _ssc_die "cache worktree missing"; return 1; }
+  # shellcheck disable=SC2034  # source 한 호출자가 읽는 출력 변수
+  STAGED_SNAPSHOT_CACHE_WORKTREE="$trees_dir/$tree_hash/worktree"
+  return 0
+}
+
+# 호출자 trap 에서 호출. 빌드 중이던 lock/build 잔여와 pinned index 를 정리한다.
+staged_snapshot_cache_release() {
+  if [ -n "${_SSC_BUILD_DIR:-}" ]; then
+    _ssc_rm_tree "$_SSC_BUILD_DIR"
+    _SSC_BUILD_DIR=""
+  fi
+  if [ -n "${_SSC_HELD_LOCK:-}" ]; then
+    rmdir "$_SSC_HELD_LOCK" 2>/dev/null || true
+    _SSC_HELD_LOCK=""
+  fi
+  if [ -n "${_SSC_PINNED_INDEX:-}" ]; then
+    rm -f "$_SSC_PINNED_INDEX" "$_SSC_PINNED_INDEX.lock" 2>/dev/null
+    _SSC_PINNED_INDEX=""
+  fi
+}

--- a/scripts/ai/lib/tomlkit-bootstrap.sh
+++ b/scripts/ai/lib/tomlkit-bootstrap.sh
@@ -36,11 +36,32 @@ tomlkit_bootstrap_require() {
     return 0
   fi
 
-  # (2) nix 가용 → 무조건 repo-pinned runtime으로 재실행 (hermetic 강제)
+  # flake root 결정: staged-snapshot 안에서 실행되면 repo_root/self_path 가 임시 snapshot
+  # 경로다. 그대로 `nix shell <snapshot>#pythonWithTomlkit` 하면 snapshot 트리 전체가 nix
+  # store 로 복사·평가된다 (E2E 실측 ~42s). run-staged-snapshot.sh 가 STAGED_SNAPSHOT_SOURCE_ROOT
+  # 로 실제 repo 경로를 넘기면 그 flake 를 쓴다.
+  # pythonWithTomlkit 은 검사 대상이 아니라 tomlkit 포함 interpreter 일 뿐이라 안전하며,
+  # flake.nix / libraries/python-runtimes.nix 의 staged 변경 검증은 eval-tests(glob: *.nix)가
+  # 책임진다.
+  # override 는 staged-snapshot consumer 안에서 실행될 때만 적용한다. run-staged-snapshot.sh 는
+  # cwd 를 공유 캐시 worktree 로 바꾸면서 STAGED_SNAPSHOT_ROOT(worktree)와 STAGED_SNAPSHOT_SOURCE_ROOT
+  # (실제 repo)를 generic context 로 함께 export 한다. 조건은 (a) STAGED_SNAPSHOT_SOURCE_ROOT 존재,
+  # (b) repo_root == STAGED_SNAPSHOT_ROOT, (c) repo_root 가 실제 git repo 가 아님(materialized snapshot
+  # 은 checkout-index 결과라 .git 이 없어 `rev-parse --git-dir` 가 실패) 을 모두 만족할 때만이다.
+  # (c) 가드가 pre-push/실제 repo/임의 경로에서 ambient STAGED_SNAPSHOT_* env 로 외부 flake 를 주입하는
+  # spoof 를 막는다. cache 경로 구현 세부나 runner 의 tomlkit 전용 변수에 의존하지 않는 명시적 계약이다.
+  local flake_root="$repo_root"
+  if [ -n "${STAGED_SNAPSHOT_SOURCE_ROOT:-}" ] && [ "$repo_root" = "${STAGED_SNAPSHOT_ROOT:-}" ] \
+    && ! git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1; then
+    flake_root="$STAGED_SNAPSHOT_SOURCE_ROOT"
+  fi
+
+  # (2) nix 가용 → repo-pinned runtime으로 재실행 (hermetic 강제). 스크립트 자체는 self_path
+  #     (snapshot 경로 가능)에서 계속 실행하고, flake root 만 실제 repo 로 고정한다.
   if command -v nix >/dev/null 2>&1; then
-    echo "  tomlkit bootstrap: nix shell ${repo_root}#pythonWithTomlkit --command bash $self_path" >&2
+    echo "  tomlkit bootstrap: nix shell ${flake_root}#pythonWithTomlkit --command bash $self_path" >&2
     export _TOMLKIT_BOOTSTRAP_READY=1
-    exec nix shell "${repo_root}#pythonWithTomlkit" --command bash "$self_path" "$@"
+    exec nix shell "${flake_root}#pythonWithTomlkit" --command bash "$self_path" "$@"
   fi
 
   # (3) nix 부재 fallback — ambient python3에 tomlkit이 있으면 경고 후 진행

--- a/scripts/ai/lib/tomlkit-bootstrap.sh
+++ b/scripts/ai/lib/tomlkit-bootstrap.sh
@@ -50,9 +50,12 @@ tomlkit_bootstrap_require() {
   # 은 checkout-index 결과라 .git 이 없어 `rev-parse --git-dir` 가 실패) 을 모두 만족할 때만이다.
   # (c) 가드가 pre-push/실제 repo/임의 경로에서 ambient STAGED_SNAPSHOT_* env 로 외부 flake 를 주입하는
   # spoof 를 막는다. cache 경로 구현 세부나 runner 의 tomlkit 전용 변수에 의존하지 않는 명시적 계약이다.
+  # (d) source root 가 실제 git checkout 일 때만 override. 환경변수가 stale/malformed 면
+  #     `nix shell <bad>#pythonWithTomlkit` 으로 hard-fail 하는 대신 repo_root 로 안전 fallback.
   local flake_root="$repo_root"
   if [ -n "${STAGED_SNAPSHOT_SOURCE_ROOT:-}" ] && [ "$repo_root" = "${STAGED_SNAPSHOT_ROOT:-}" ] \
-    && ! git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1; then
+    && ! git -C "$repo_root" rev-parse --git-dir >/dev/null 2>&1 \
+    && git -C "$STAGED_SNAPSHOT_SOURCE_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
     flake_root="$STAGED_SNAPSHOT_SOURCE_ROOT"
   fi
 

--- a/scripts/ai/run-gitleaks-staged-policy.sh
+++ b/scripts/ai/run-gitleaks-staged-policy.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 # Run gitleaks against staged content while pinning policy files to staged material.
+#
+# staged 트리는 scripts/ai/lib/staged-snapshot-cache.sh 의 공유 캐시(read-only)를
+# 재사용한다(pre-commit 의 checkout-index 중복 제거). 정책 파일(.gitleaks.toml 등)을
+# staged index 에 고정하는 temp_index / GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE 핀은
+# 그대로 유지한다. 공유 worktree 는 read-only 라 그 안에 임시 파일을 쓰지 않는다.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,22 +31,35 @@ else
 fi
 [ -f "$intended_index" ] || fail "index not found: $intended_index"
 
+# shellcheck disable=SC1091  # repo 내부 고정 경로
+. "$SCRIPT_DIR/lib/staged-snapshot-cache.sh"
+
 tmp_base="/private/tmp"
 [ -d "$tmp_base" ] || tmp_base="${TMPDIR:-/tmp}"
 tmp_base="$(cd "$tmp_base" && pwd -P)"
 
 tmp_dir="$(mktemp -d "$tmp_base/gitleaks-staged.XXXXXX")"
-snapshot="$tmp_dir/worktree"
 temp_index="$tmp_dir/index"
 validator_tmp="$tmp_dir/validate-gitleaks-staged-policy.py"
+empty_gitleaksignore="$tmp_dir/empty-gitleaksignore"
 
 cleanup() {
+  staged_snapshot_cache_release
   rm -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
-mkdir -p "$snapshot"
+# 단일 source index: temp_index 를 먼저 만들고 그것을 provider 에 넘긴다. provider 는 temp_index 를
+# 자기 private copy 로 떠서 snapshot 을 빌드하고, gitleaks/validator 는 GIT_INDEX_FILE=temp_index 를
+# 쓴다 — 둘 다 같은 temp_index 내용에서 비롯되므로 snapshot 과 검증 입력이 동일 staged tree 를
+# 가리킨다. provider 를 호출한 뒤 index 를 따로 복사하면 두 복사 시점 사이 index 변경 시 갈라질 수
+# 있어, 복사를 provider 호출보다 앞에 둔다. checkout-index 는 provider 가 1회만 수행하고, 표준
+# 케이스에서는 run-staged-snapshot 소비자들과 동일한 캐시 키를 공유한다.
 cp "$intended_index" "$temp_index"
+staged_snapshot_cache_provide "$REPO_ROOT" "$temp_index" \
+  || fail "failed to provide staged snapshot cache"
+snapshot="$STAGED_SNAPSHOT_CACHE_WORKTREE"
+[ -d "$snapshot" ] || fail "staged snapshot worktree missing: $snapshot"
 
 local_git_env_vars=()
 while IFS= read -r var; do
@@ -97,13 +115,16 @@ require_executable_materialized_helper() {
   with_staged_git_env git show ":$path" > "$output"
 }
 
-with_staged_git_env git checkout-index --all --prefix="$snapshot/"
-
+# checkout-index 는 공유 캐시 provider 가 이미 1회 수행했다(중복 제거). snapshot 은 read-only.
 require_index_mode ".gitleaks.toml" "100644"
+
+# .gitleaksignore: staged 면 공유 snapshot 의 것을 검증해 쓰고, 없으면 per-command 빈 파일을
+# 쓴다. 공유 snapshot 은 read-only 계약이라 그 안에 빈 파일을 만들지 않는다(캐시 오염 방지).
+: > "$empty_gitleaksignore"
+gitleaksignore_path="$empty_gitleaksignore"
 if index_entry ".gitleaksignore" >/dev/null && [ -n "$(index_entry ".gitleaksignore")" ]; then
   require_index_mode ".gitleaksignore" "100644"
-else
-  : > "$snapshot/.gitleaksignore"
+  gitleaksignore_path="$snapshot/.gitleaksignore"
 fi
 
 require_executable_materialized_helper "$VALIDATOR_PATH" "$validator_tmp"
@@ -126,5 +147,5 @@ fi
   cd "$snapshot"
   with_staged_git_env "${gitleaks_cmd[@]}" protect --staged --source . --no-banner --redact \
     --config ./.gitleaks.toml \
-    --gitleaks-ignore-path ./.gitleaksignore
+    --gitleaks-ignore-path "$gitleaksignore_path"
 )

--- a/scripts/ai/run-staged-snapshot.sh
+++ b/scripts/ai/run-staged-snapshot.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # Run a command from a materialized copy of the current staged index.
+#
+# staged 트리(~752파일)는 scripts/ai/lib/staged-snapshot-cache.sh 가 git write-tree
+# 해시를 키로 1회만 materialize 하여 공유한다(parallel pre-commit 의 checkout-index
+# 중복 제거). 공유 worktree 는 read-only 이므로 consumer 는 읽기 전용으로 다룬다.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,24 +24,36 @@ if ! git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
   fail "not inside a git repository"
 fi
 
-tmp_base="/private/tmp"
-[ -d "$tmp_base" ] || tmp_base="${TMPDIR:-/tmp}"
-tmp_base="$(cd "$tmp_base" && pwd -P)"
+# shellcheck disable=SC1091  # repo 내부 고정 경로
+. "$SCRIPT_DIR/lib/staged-snapshot-cache.sh"
 
-tmp_dir="$(mktemp -d "$tmp_base/staged-snapshot.XXXXXX")"
-snapshot="$tmp_dir/worktree"
-staged_files_file="$tmp_dir/staged-files.nul"
-staged_name_status_file="$tmp_dir/staged-name-status.nul"
+# staged 메타데이터는 매번 생성한다. `git diff --cached` 는 HEAD↔index diff 라 tree
+# hash(=index 내용)만으로 캐시하면 HEAD 변동 시 stale 위험이 있다. 생성 비용은
+# checkout-index 에 비해 작아 공유 이득을 해치지 않는다.
+meta_dir="$(mktemp -d "${TMPDIR:-/tmp}/staged-snapshot-meta.XXXXXX")"
+staged_files_file="$meta_dir/staged-files.nul"
+staged_name_status_file="$meta_dir/staged-name-status.nul"
 
 cleanup() {
-  rm -rf "$tmp_dir"
+  staged_snapshot_cache_release
+  rm -rf "$meta_dir"
 }
 trap cleanup EXIT
 
-mkdir -p "$snapshot"
-git -C "$REPO_ROOT" diff --cached -z --name-only > "$staged_files_file"
-git -C "$REPO_ROOT" diff --cached -z --name-status > "$staged_name_status_file"
-git -C "$REPO_ROOT" checkout-index --all --prefix="$snapshot/"
+# metadata(diff)와 snapshot 이 같은 index 시점을 보도록, 현재 index 를 먼저 private copy 로 pin 하고
+# diff 와 provider 모두 그 동일 pinned index 로 실행한다. 둘을 각각 현재 index 에서 읽으면 두 시점
+# 사이 index 가 바뀔 때 STAGED_SNAPSHOT_*(metadata)와 STAGED_SNAPSHOT_ROOT(worktree)가 갈라질 수 있다.
+intended_index="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-path index)"
+pinned_index="$meta_dir/index"
+cp "$intended_index" "$pinned_index"
+GIT_INDEX_FILE="$pinned_index" git -C "$REPO_ROOT" diff --cached -z --name-only > "$staged_files_file"
+GIT_INDEX_FILE="$pinned_index" git -C "$REPO_ROOT" diff --cached -z --name-status > "$staged_name_status_file"
+
+# 공유 캐시에서 staged 트리를 확보한다 (없으면 1회 build, 있으면 재사용). 위 pinned index 를 넘겨
+# metadata 와 동일한 staged tree 를 materialize 한다.
+staged_snapshot_cache_provide "$REPO_ROOT" "$pinned_index" || fail "failed to provide staged snapshot cache"
+snapshot="$STAGED_SNAPSHOT_CACHE_WORKTREE"
+[ -d "$snapshot" ] || fail "staged snapshot worktree missing: $snapshot"
 
 unset_repo_git_env() {
   local var
@@ -51,6 +67,11 @@ unset_repo_git_env() {
   export STAGED_SNAPSHOT_ROOT="$snapshot"
   export STAGED_SNAPSHOT_STAGED_FILES_NUL_FILE="$staged_files_file"
   export STAGED_SNAPSHOT_STAGED_NAME_STATUS_NUL_FILE="$staged_name_status_file"
+  # 실제 repo source root(snapshot 임시 경로가 아닌)를 generic context 로 노출한다. cwd 가
+  # snapshot 이라 nix self-wrap 시 repo_root 가 snapshot 으로 잡혀 트리 전체가 store 로 복사되는
+  # 것을, 소비자(tomlkit-bootstrap 등)가 이 값을 읽어 실제 repo flake 를 쓰게 함으로써 막는다.
+  # runner 는 소비자별 전용 변수를 두지 않고 generic source root 만 노출한다.
+  export STAGED_SNAPSHOT_SOURCE_ROOT="$REPO_ROOT"
   cd "$snapshot"
   "$@"
 )

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -173,6 +173,11 @@ new_hook_sandbox() {
   cp -L "$HOOK_RUNTIME_LIB_REPO_FILE" "$sandbox/home/.codex/lib/"
   cp -L "$HOOK_RUNTIME_LIB_REPO_FILE" "$sandbox/home/.claude/lib/"
 
+  # 공유 staged-snapshot 캐시(REPO_ROOT)가 read-only(chmod a-w)이면 cp -L 사본도
+  # read-only 로 복제된다. sandbox 안에서는 mock 교체(install_mock_subscripts_with_log)
+  # 등 쓰기가 필요하므로 사본 권한을 복구한다(공유 캐시 자체는 건드리지 않는다).
+  chmod -R u+w "$sandbox"
+
   printf '%s\n' "$sandbox"
 }
 

--- a/tests/test-precommit-staged-snapshot.sh
+++ b/tests/test-precommit-staged-snapshot.sh
@@ -385,6 +385,9 @@ test_staged_snapshot_cache_stale_lock_takeover() {
       bash ./scripts/ai/run-staged-snapshot.sh -- true ) || fail "seed snapshot run failed"
   repo_path="$(find "$dir/.cache-tmp/staged-snapshot-cache" -mindepth 1 -maxdepth 1 -type d | head -1)"
   hash="$(find "$repo_path/trees" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | head -1)"
+  # 파생 경로가 비면(레이아웃 변경 등) destructive rm 이 의도치 않은 대상을 지울 수 있으므로 가드.
+  [ -n "$repo_path" ] && [ -d "$repo_path" ] || fail "stale-lock test: cache repo_id dir not found"
+  [ -n "$hash" ] && [ -d "$repo_path/trees/$hash" ] || fail "stale-lock test: cache tree not found"
   # 완성 트리 제거 + holder 가 점유 중인 것처럼 빈 lock 디렉토리를 심는다.
   chmod -R u+w "$repo_path/trees/$hash"; rm -rf "$repo_path/trees/$hash"
   mkdir -p "$repo_path/locks/$hash"

--- a/tests/test-precommit-staged-snapshot.sh
+++ b/tests/test-precommit-staged-snapshot.sh
@@ -18,7 +18,11 @@ cleanup() {
   local dir
   if [ -f "$TEST_TMP_FILE" ]; then
     while IFS= read -r dir; do
-      [ -n "$dir" ] && rm -rf "$dir"
+      if [ -n "$dir" ]; then
+        # 공유 스냅샷 캐시의 read-only(chmod a-w) worktree 까지 지울 수 있게 u+w 복구
+        chmod -R u+w "$dir" 2>/dev/null || true
+        rm -rf "$dir"
+      fi
     done < "$TEST_TMP_FILE"
     rm -f "$TEST_TMP_FILE"
   fi
@@ -101,6 +105,7 @@ EOF
   copy_file "tests/run-eval-tests.sh" "$dir/tests/run-eval-tests.sh"
   copy_file "tests/test-codex-hook-fixtures.sh" "$dir/tests/test-codex-hook-fixtures.sh"
   copy_file "scripts/ai/lib/tomlkit-bootstrap.sh" "$dir/scripts/ai/lib/tomlkit-bootstrap.sh"
+  copy_file "scripts/ai/lib/staged-snapshot-cache.sh" "$dir/scripts/ai/lib/staged-snapshot-cache.sh"
 
   mkdir -p "$dir/.claude/skills/existing" "$dir/.agents/skills"
   mkdir -p "$dir/modules/shared/programs/claude/files/skills/existing"
@@ -327,6 +332,71 @@ test_installer_idempotent_and_worktree_local() {
   bash -n "$hook_path"
 }
 
+# 공유 staged-snapshot 캐시: 같은 index 를 보는 호출은 checkout-index 를 1회만 수행하고
+# 결과 worktree 를 read-only 로 공유한다. TMPDIR 을 repo 안으로 격리해 캐시도 함께 정리된다.
+test_staged_snapshot_cache_hit_and_readonly() {
+  local dir log builds
+  dir="$(make_repo)"
+  printf 'cache probe\n' > "$dir/cache-probe.txt"
+  git -C "$dir" add cache-probe.txt
+  mkdir -p "$dir/.cache-tmp"
+  log="$dir/.cache-tmp/build.log"
+  : > "$log"
+  ( cd "$dir" && TMPDIR="$dir/.cache-tmp" STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG="$log" \
+      bash ./scripts/ai/run-staged-snapshot.sh -- true ) || fail "first snapshot run failed"
+  ( cd "$dir" && TMPDIR="$dir/.cache-tmp" STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG="$log" \
+      bash ./scripts/ai/run-staged-snapshot.sh -- true ) || fail "second snapshot run failed"
+  builds="$(wc -l < "$log" | tr -d ' ')"
+  [ "$builds" = "1" ] || fail "expected 1 checkout-index build after cache hit, got $builds"
+  ( cd "$dir" && TMPDIR="$dir/.cache-tmp" \
+      bash ./scripts/ai/run-staged-snapshot.sh -- bash -c 'test ! -w "$STAGED_SNAPSHOT_ROOT"' ) \
+    || fail "shared snapshot worktree must be read-only"
+}
+
+# parallel pre-commit 모사: 동시 호출이 경쟁해도 mkdir lock 직렬화로 build 는 정확히 1회.
+test_staged_snapshot_cache_concurrent_single_build() {
+  local dir log builds
+  dir="$(make_repo)"
+  printf 'concurrent probe\n' > "$dir/concurrent-probe.txt"
+  git -C "$dir" add concurrent-probe.txt
+  mkdir -p "$dir/.cache-tmp"
+  log="$dir/.cache-tmp/build.log"
+  : > "$log"
+  for _ in 1 2 3 4 5 6; do
+    ( cd "$dir" && TMPDIR="$dir/.cache-tmp" STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG="$log" \
+        bash ./scripts/ai/run-staged-snapshot.sh -- true ) &
+  done
+  wait
+  builds="$(wc -l < "$log" | tr -d ' ')"
+  [ "$builds" = "1" ] || fail "expected exactly 1 build under concurrency, got $builds"
+}
+
+# 멈춘/죽은 빌더의 lock(단순 버전은 owner 메타 없는 빈 디렉토리)은 대기자가 타임아웃 후 제거하고
+# 직접 빌드해 승계한다. checkout 은 다시 1회 일어난다.
+test_staged_snapshot_cache_stale_lock_takeover() {
+  local dir log repo_path hash builds
+  dir="$(make_repo)"
+  printf 'stale probe\n' > "$dir/stale-probe.txt"
+  git -C "$dir" add stale-probe.txt
+  mkdir -p "$dir/.cache-tmp"
+  log="$dir/.cache-tmp/build.log"
+  : > "$log"
+  ( cd "$dir" && TMPDIR="$dir/.cache-tmp" STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG="$log" \
+      bash ./scripts/ai/run-staged-snapshot.sh -- true ) || fail "seed snapshot run failed"
+  repo_path="$(find "$dir/.cache-tmp/staged-snapshot-cache" -mindepth 1 -maxdepth 1 -type d | head -1)"
+  hash="$(find "$repo_path/trees" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | head -1)"
+  # 완성 트리 제거 + holder 가 점유 중인 것처럼 빈 lock 디렉토리를 심는다.
+  chmod -R u+w "$repo_path/trees/$hash"; rm -rf "$repo_path/trees/$hash"
+  mkdir -p "$repo_path/locks/$hash"
+  : > "$log"
+  ( cd "$dir" && TMPDIR="$dir/.cache-tmp" STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG="$log" \
+      STAGED_SNAPSHOT_CACHE_LOCK_TIMEOUT_SECONDS=2 \
+      bash ./scripts/ai/run-staged-snapshot.sh -- true ) || fail "stale-lock takeover run failed"
+  builds="$(wc -l < "$log" | tr -d ' ')"
+  [ "$builds" = "1" ] || fail "expected 1 rebuild after stale lock takeover, got $builds"
+  [ -d "$repo_path/trees/$hash/worktree" ] || fail "worktree not rebuilt after takeover"
+}
+
 test_ai_skills_consistency_cross_file
 test_ai_skills_consistency_without_git_metadata
 test_ai_skills_consistency_rejects_malformed_name_status_metadata
@@ -340,5 +410,8 @@ test_gitleaks_validator_tomlkit_fallback_unwraps_extend
 test_installed_guard_rejects_lefthook_drift_and_env
 test_guard_rejects_unsupported_command_shape
 test_installer_idempotent_and_worktree_local
+test_staged_snapshot_cache_hit_and_readonly
+test_staged_snapshot_cache_concurrent_single_build
+test_staged_snapshot_cache_stale_lock_takeover
 
 echo "All pre-commit staged snapshot tests passed."


### PR DESCRIPTION
## Summary

- pre-commit(lefthook, `parallel: true`)의 staged-snapshot 소비 command가 각자 `git checkout-index --all`로 staged 트리(~752파일)를 복제하던 것을, `git write-tree` 해시를 키로 **1회만 materialize 하고 공유**하도록 전환한다 (checkout-index 6회 → 1회).
- `codex-hook-fixtures`가 snapshot 임시 경로를 nix store로 복사·평가하던 비용(E2E 실측 ~42초)을, 실제 repo flake를 쓰도록 바꿔 사실상 제거한다 (~0.66초, store 캐시 히트).
- 기존 `STAGED_SNAPSHOT_*` 인터페이스와 pre-commit 트리거/skip 동작은 불변.

Closes #832

## 기존 문제 / 배경

선행 작업으로 무관 커밋에서 일부 검사를 glob으로 skip하게 한 뒤에도(#828), staged-snapshot을 쓰는 command들은 각자 전체 staged 트리를 임시 디렉토리에 복제했다. `parallel: true`에서 이들이 동시에 디스크에 ~752파일을 6중으로 쓰며 I/O 경합을 일으켰다.

추가로 `codex-hook-fixtures`는 cwd가 임시 snapshot 경로로 바뀐 상태에서 `nix shell <snapshot>#pythonWithTomlkit`을 호출했다. snapshot은 매번 다른 임시 경로라 nix가 그 트리 전체를 store로 복사·평가했고(캐시 불가), 트리거마다 ~42초가 들었다.

## CIR (Change Intent Record)

`git write-tree`는 index 내용이 같으면 동일 해시를 내므로, 같은 staged 상태를 보는 모든 command가 이 해시를 키로 단일 복사본을 공유할 수 있다. 첫 호출만 `checkout-index`로 트리를 만들고, 나머지는 그 결과를 읽기만 한다.

`flock`이 macOS/devShell 양쪽에 없어(실측), 동시 호출 직렬화는 `mkdir` atomic lock으로 구현한다. 빌드는 임시 경로에서 완성한 뒤 `mv` rename으로 한 번에 게시(atomic publish)해 반쯤 채워진 트리가 노출되지 않게 한다.

store copy 제거는 nix가 쓰는 flake 위치를 임시 snapshot이 아니라 실제 repo 경로로 고정해 해결한다. `pythonWithTomlkit`은 검사 대상이 아니라 tomlkit이 포함된 Python 인터프리터일 뿐이고, flake 정의 자체의 staged 변경 검증은 `*.nix` glob을 가진 eval-tests가 책임지므로 이 절충은 안전하다.

설계 과정에서 처음에는 장기 공유 캐시에 맞춘 견고한 동시성 장치 — 소비자 임대(lease) 기반 GC, 죽은 빌더의 정교한 승계(프로세스 시작 시각 검증·원자적 탈취), 캐시 버전 태그 — 를 넣었다. 그러나 이 장치들이 단일 사용자가 짧게 실행하는 pre-commit에 비해 과하고, 오히려 미묘한 경쟁 조건의 표면을 계속 늘린다고 판단했다. 핵심 목표(같은 hook 실행 안에서 checkout-index 중복 제거)에 필요한 최소 구성만 남기고, 정리는 단순한 mtime 기반 GC로 좁히는 방향으로 수렴했다.

별도 전수조사에서, 캐시를 비우지 않으면 gitleaks가 차단한 staged secret의 사본이 임시 디렉토리에 OS 청소 전까지 남고 디스크가 누적된다는 점을 발견해, 현재 해시를 보존하되 오래된 캐시를 제거하는 단순 GC를 다시 넣었다. 또 nix flake 경로 override가 snapshot 밖(pre-push 등)에서 외부 환경변수로 주입될 여지를 막기 위해, override를 "실제 git repo가 아닌 materialized snapshot일 때"로 한정했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 현행 per-command checkout | 각 command가 자체 `checkout-index` | 단순, 격리 | ~752파일 6중복 I/O 경합 | ❌ |
| 견고 공유 캐시 | lease GC + 정교한 stale 승계 + 버전 태그 | 장기·고동시성에 견고 | 경쟁 조건 표면↑, 복잡도↑ (priority:low에 과설계) | ❌ |
| 단순 공유 캐시 | write-tree 키 + mkdir lock + `.ready` + atomic publish + 단순 mtime GC + read-only | 6→1 달성, 경쟁 표면 최소, 코드 단순 | lock holder 사망 시 타임아웃 후 중복 빌드 1회 가능(정확성 유지) | ✅ |
| gitleaks만 per-run 분리 | secret scanner만 공유 캐시 미사용 | secret 사본 즉시 정리 | checkout-index 6→2에 그침 | ❌ |
| store copy: 경로 안정화에 위임 | 경로 고정으로 nix eval 캐시 기대 | 추가 코드 없음 | path-flake NAR 재해시 잔존, 불완전 | ❌ |
| store copy: 실제 repo flake 고정 | nix가 실제 repo flake를 평가 | store copy 제거(고정 경로 캐시) | snapshot 밖 오용 방지 가드 필요 | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `scripts/ai/lib/staged-snapshot-cache.sh` (신규) | 공유 캐시 provider. write-tree 키, mkdir lock + `.ready`, build→trees atomic publish, read-only(`chmod a-w`), 타임아웃 후 lock 제거 + 직접 빌드, 단순 mtime GC, per-repo_id 격리 + umask 077 + 소유권 검증 |
| `scripts/ai/run-staged-snapshot.sh` | 공유 캐시 사용. metadata와 snapshot이 같은 index 시점을 보도록 index를 private copy로 pin. 실제 repo 경로를 `STAGED_SNAPSHOT_SOURCE_ROOT`로 export |
| `scripts/ai/run-gitleaks-staged-policy.sh` | 공유 캐시 재사용. `temp_index`를 단일 소스로(provider 호출 전 복사). 빈 `.gitleaksignore`는 공유본 대신 per-command tmp에 생성. index 핀 정책 유지 |
| `scripts/ai/lib/tomlkit-bootstrap.sh` | flake root override(`STAGED_SNAPSHOT_SOURCE_ROOT`)로 store copy 제거. snapshot(= 실제 git repo 아님)일 때만 적용하는 spoof 가드 |
| `scripts/ai/check-lefthook-staged-config.sh` | guard의 무결성 검증 목록(`repo_scripts`)에 새 lib 추가 |
| `tests/test-precommit-staged-snapshot.sh` | 캐시 히트(checkout-index 1회)/동시 직렬화/stale lock 승계 테스트 추가 |
| `tests/test-codex-hook-fixtures.sh` | read-only 공유본을 cp한 sandbox 사본의 쓰기 권한 복구(공유본은 read-only 유지) |

핵심 흐름:

```sh
# provider: write-tree 해시 키 → 첫 호출만 build, 나머지는 .ready 대기 후 공유
tree_hash="$(GIT_INDEX_FILE="$pinned" git -C "$repo" write-tree)"
if mkdir "$lockdir"; then
  checkout-index --all --prefix="$build/worktree/"; chmod -R a-w "$build/worktree"
  : > "$build/.ready"; mv "$build" "$cache_dir"   # atomic publish (dest 부재)
fi
```

## 참고 레퍼런스

- #832 — 본 작업 추적 이슈
- #828 — 선행 작업: codex-hook-fixtures·eval-tests의 glob 조건부 실행 (본 작업의 전제)

## Human Test Plan

1. **공유 동작**: 임의의 파일을 `git add` 후 `git commit`. pre-commit hook이 통과하고, staged-snapshot 소비 command(ai-skills-consistency, gitleaks, skill-noise ×2 등)가 동시에 돌아도 `checkout-index`는 1회만 일어난다.
   - 진단: `STAGED_SNAPSHOT_CACHE_DEBUG_BUILD_LOG=/tmp/bl bash scripts/ai/run-staged-snapshot.sh -- true`를 두 번 실행 후 `wc -l /tmp/bl`이 `1`이면 캐시 히트.
2. **store copy 제거**: codex 관련 파일(`modules/shared/programs/codex/**` 등)을 staged한 커밋에서 `codex-hook-fixtures`가 트리거된다. 로그에 `nix shell <실제 repo 경로>#pythonWithTomlkit`이 보이고(임시 snapshot 경로가 아님), 매 트리거의 store copy 비용이 사라진다.
3. **read-only 계약**: `bash scripts/ai/run-staged-snapshot.sh -- bash -c 'test ! -w "$STAGED_SNAPSHOT_ROOT" && echo ro'` → `ro` 출력(공유본 쓰기 차단).
4. **통합 테스트**: `direnv exec . bash tests/test-precommit-staged-snapshot.sh` → `All pre-commit staged snapshot tests passed.`
   - 실패 시: 캐시 잔여가 read-only일 수 있으니 `chmod -R u+w "${TMPDIR}/staged-snapshot-cache"; rm -rf` 후 재시도.

### 알려진 한계 (수용)

- **캐시 정리 모델**: 현재 hash 제외 + mtime 1시간 초과분만 단순 GC하고 나머지는 OS 임시디렉토리 정책에 위임한다. 소비자 lease 추적이 없어, "여러 프로세스가 1시간 넘은 동일 캐시를 정확히 같은 순간에 GC/사용"하는 극단적 경쟁은 구조적으로 막지 않는다(단일 사용자 pre-commit 전제에서 무시 가능).
- **lock holder 사망**: 타임아웃 후 대기자가 lock을 제거하고 직접 빌드하므로, 최악의 경우 `checkout-index`가 1회 중복될 수 있다(정확성·내용 동일성은 유지).
- **alternate index 빈 경로**: `GIT_INDEX_FILE`이 아직 생성되지 않은 경로를 가리키는 빈 staged 시나리오는 빈 트리로 진행하지 않고 명확히 실패한다(표준 pre-commit 경로에서는 발생하지 않음).
- **테스트 커버리지**: 타임아웃 후 동시 중복 빌더의 publish 경쟁 경로는 통합 테스트가 직접 재현하지 않는다(단위 동작으로는 검증됨).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented staged snapshot caching to improve performance during pre-commit validation.
  * Integrated shared cache mechanism into security policy checks and metadata generation.
  * Enhanced concurrent operation handling through serialized cache building.

* **Tests**
  * Added comprehensive tests for staged snapshot cache functionality, including cache hits, concurrency, and lock management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->