### PR TITLE
fix(codex): 비대화형 셸 codex sync·실행 회귀 2건 (awk + mise shims)

### DIFF
--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
@@ -271,14 +271,22 @@ agents_override() {
 
   if [ -f "$override_file" ]; then
     if grep -qxF "$start_marker" "$override_file" && grep -qxF "$end_marker" "$override_file"; then
-      # Replace between markers, preserve content outside
+      # Replace between markers, preserve content outside.
+      # auto_content(멀티라인)는 -v가 아니라 환경변수+ENVIRON[]로 awk에 넘긴다: BSD awk
+      # (/usr/bin/awk — devShell 비활성 비대화형 셸의 PATH 폴백)는 -v 값의 리터럴 개행을
+      # "newline in string"으로 거부하지만, ENVIRON[] 경유는 BSD/GNU awk 모두 안전하다.
+      # 또한 local 선언과 할당을 분리해 command-substitution 실패가 local의 exit 0에 가려지지
+      # 않게 하고, awk 성공 시에만 기록한다(실패 시 빈 출력으로 사용자 custom 섹션 손실 방지).
       local new_content
-      new_content="$(awk -v start="$start_marker" -v end="$end_marker" \
-        -v replacement="$auto_content" '
-        $0 == start { print; printf "%s", replacement; skip=1; next }
+      if ! new_content="$(REPLACEMENT="$auto_content" awk \
+        -v start="$start_marker" -v end="$end_marker" '
+        $0 == start { print; printf "%s", ENVIRON["REPLACEMENT"]; skip=1; next }
         $0 == end   { skip=0; print; next }
         !skip { print }
-      ' "$override_file")"
+      ' "$override_file")"; then
+        echo "Warning: AGENTS.override.md marker replacement failed; existing file preserved" >&2
+        return 1
+      fi
       printf '%s\n' "$new_content" > "$override_file"
     else
       local legacy_preserved

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -146,10 +146,17 @@ in
       share = true;
     };
 
-    # .zshenv: SSH 비대화형 세션을 위한 mise shims PATH 추가
+    # .zshenv: SSH·비대화형 세션을 위한 mise shims PATH 추가
     # (대화형 훅은 .zshrc에서 활성화)
+    # 가드는 MISE_SHELL 유무가 아니라 shims의 PATH 실재 여부로 판단한다: 부모 대화형 셸이
+    # hook 모드(`mise activate zsh`)로 MISE_SHELL을 set한 채 자식 비대화형 셸로 상속시키면,
+    # 기존 `[[ -z "$MISE_SHELL" ]]` 가드가 --shims를 스킵해 shims가 PATH에서 누락됐다.
+    # hook 모드는 도구 install bin만 PATH에 넣고 shims는 넣지 않으므로, shim으로만 노출되는
+    # mise npm backend 도구(codex 등)가 command not found가 된다(#814 mise 전환 이후
+    # codex가 shim 의존이 되며 발현).
     envExtra = ''
-      if command -v mise >/dev/null 2>&1 && [[ -z "$MISE_SHELL" ]]; then
+      if command -v mise >/dev/null 2>&1 \
+         && [[ ":$PATH:" != *":$HOME/.local/share/mise/shims:"* ]]; then
         eval "$(mise activate zsh --shims)"
       fi
 


### PR DESCRIPTION
## Summary

비대화형 셸(LLM Bash tool, `wt` bootstrap 등 devShell 비활성 환경)에서 codex 관련 동작이 깨지던 회귀 2건을 수정한다.

- **codex harness 동기화**: `sync.sh`의 `agents_override`가 멀티라인 문자열을 `awk -v`로 넘겨, BSD `/usr/bin/awk` 폴백 시 `newline in string`으로 깨지며 `AGENTS.override.md`를 빈 파일로 오염시키던 문제 → 환경변수+`ENVIRON[]` 전달 + 실패 시 파일 보존.
- **codex 실행**: `.zshenv`의 mise shims 가드가 상속된 `MISE_SHELL` 때문에 `--shims`를 스킵해, 비대화형 셸에서 `codex`가 `command not found`가 되던 문제 → 가드를 shims의 PATH 실재 여부 기반으로 변경.

## 기존 문제 / 배경

한 작업 세션에서 worktree 생성 시 codex 동기화가 다음 에러를 3회 출력하는 것이 관찰됐다:

```
awk: newline in string
## 스킬 사용
... at source line 1
```

조사 결과 독립적이지만 같은 뿌리(devShell 비활성 비대화형 셸의 PATH)를 가진 회귀 2건이 드러났다.

1. **awk 깨짐**: `agents_override`가 `## 스킬 사용`으로 시작하는 멀티라인 `auto_content`를 `awk -v replacement=`로 넘긴다. 대화형 셸은 direnv로 devShell이 활성화돼 nix gawk가 PATH 우선이라 무사하지만, 비대화형 셸은 `/usr/bin/awk`(BSD awk 20200816)로 폴백된다. BSD awk는 `-v` 값의 리터럴 개행을 거부한다(exit 2). 게다가 `local new_content="$(awk …)"`의 `local`이 awk의 비정상 종료를 exit 0으로 가려 `set -e`를 무력화하므로, 빈 출력이 그대로 파일을 덮어써 사용자 custom 섹션이 소실됐다.

2. **codex command not found**: `.zshenv`는 비대화형 셸에 mise shims를 보장하려 `mise activate zsh --shims`를 두지만, 가드가 `[[ -z "$MISE_SHELL" ]]`였다. 부모 대화형 셸이 hook 모드로 `MISE_SHELL`을 set한 채 자식 비대화형 셸로 상속시키면 이 가드가 `--shims`를 스킵해 shims가 PATH에서 누락된다. hook 모드는 install bin만 PATH에 넣고 shims는 넣지 않으므로, shim으로만 노출되는 mise npm backend 도구(codex)가 실행 불가가 됐다.

## CIR (Change Intent Record)

- **발견 경위**: 세션 로그에서 codex 동기화의 awk 에러 3회 + `AGENTS.override.md` 비정상 수정 부산물을 확인. `/usr/bin/awk`로 정확한 입력을 재현해 BSD awk의 `newline in string`을 바이트 단위로 일치 확인. devShell awk는 gawk 5.4.0이고 비대화형 셸은 BSD awk임을 실측 대조했다.
- **2차 발견**: codex 바이너리 실행 가능 여부를 점검하다 `which codex`가 `command not found`임을 확인. mise에는 codex 0.133.0이 설치돼 있고 `mise exec`로는 실행되나, shims가 비대화형 PATH에 없음을 특정. `MISE_SHELL` 상속이 `.zshenv` 가드를 무력화함을 확증했다.
- **설계 의도**: awk 코드는 2026-02부터 무변경이므로 코드 회귀가 아니라 환경 회귀다. 따라서 awk 자체를 PATH-robust하게(환경변수 전달) 만들고, mise 가드를 환경 상속에 영향받지 않는 조건(shims의 PATH 실재)으로 바꾸는 최소 수정을 택했다. local 함정 제거 + 실패 시 파일 보존은 동일 결함이 재발하더라도 사용자 데이터를 잃지 않게 하는 방어 계층이다.

## ADR (Architecture Decision Record)

### awk 멀티라인 전달

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| gawk 절대경로 고정 | nix gawk store path 하드코딩 | 명확 | mkOutOfStoreSymlink 스킬이라 store path 박제 불가 | ✗ |
| `command -v gawk \|\| awk` 폴백 | gawk 있으면 사용 | 단순 | 비대화형 PATH엔 gawk 없음 → 여전히 BSD awk | ✗ |
| **환경변수 + `ENVIRON[]`** | `-v` 대신 env로 멀티라인 전달 | BSD/GNU awk 모두 안전, PATH 무관 | 없음 | ✓ |

### mise shims 가드

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| shims 경로 직접 prepend | mise 실행 없이 PATH에 추가 | 빠름 | mise data dir 커스텀 시 경로 불일치 | ✗ |
| **가드를 shims-in-PATH로 변경** | `mise activate --shims` 유지, 조건만 수정 | 원 의도 유지, mise가 경로 결정 | 첫 셸 1회 mise fork | ✓ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh` | `agents_override`의 awk를 `REPLACEMENT=… awk … ENVIRON["REPLACEMENT"]`로 전환 + local 선언/할당 분리 + 실패 시 `return 1`로 파일 보존 |
| `modules/shared/programs/shell/default.nix` | `.zshenv` mise shims 가드를 `[[ -z "$MISE_SHELL" ]]` → shims의 PATH 실재 여부로 변경 |

핵심 스니펫 (sync.sh):

```sh
local new_content
if ! new_content="$(REPLACEMENT="$auto_content" awk \
  -v start="$start_marker" -v end="$end_marker" '
  $0 == start { print; printf "%s", ENVIRON["REPLACEMENT"]; skip=1; next }
  $0 == end   { skip=0; print; next }
  !skip { print }
' "$override_file")"; then
  echo "Warning: AGENTS.override.md marker replacement failed; existing file preserved" >&2
  return 1
fi
printf '%s\n' "$new_content" > "$override_file"
```

## 참고 레퍼런스

- mise npm backend 전환(#814) 이후 codex가 shim 의존이 되며 2번 회귀가 발현했다.
- 후속 PATH fix들(#815, #821, #823)은 home-manager activation 단계의 PATH를 다뤘고, 본 PR은 런타임(`.zshenv`) 노출과 sync awk를 다룬다 — 같은 "비대화형/제한 PATH" 결함 클래스의 다른 표면이다.

## Human Test Plan

1. `nrs`로 본 변경을 적용한 뒤 **새 로그인 셸**(또는 새 터미널 탭)을 연다.
2. **codex 노출 확인** — `zsh -c 'command -v codex'` → shims 경로(`~/.local/share/mise/shims/codex`)가 나와야 한다. (이전: `command not found`)
3. **awk 동기화 확인** — 새 worktree 생성(`wt <branch>`) 시:
   - `awk: newline in string` 에러가 더 이상 출력되지 않아야 한다.
   - 생성된 worktree의 `AGENTS.override.md`가 빈 파일이 아니라 정상 AUTO-GENERATED 내용 + 사용자 custom 섹션 보존이어야 한다.
4. **실패 시 진단**:
   - codex 여전히 not found → `echo $PATH | tr ':' '\n' | grep mise/shims`로 shims 누락 확인, `echo $MISE_SHELL` 상속 여부 점검.
   - awk 에러 지속 → `which awk`가 BSD `/usr/bin/awk`인지 확인 후 `nrs`로 sync.sh 갱신이 반영됐는지 점검.
