### PR TITLE
docs: align skill runbooks with current config

### DIFF
--- a/.claude/skills/configuring-codex/SKILL.md
+++ b/.claude/skills/configuring-codex/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Trigger: 'Codex 설정', 'codex 스킬 인식', 'AGENTS.md 심링크', '.agents/skills 심링크', 'verify-ai-compat',
   'codex 권한', 'codex 업데이트', 'AI 도구 호환', 'codex 바이너리', 'approval_policy', 'sandbox_mode',
   'Codex 권한 프롬프트'.
-  NOT for harness 동기화 (use syncing-codex-harness). NOT for codex exec 실행 (use using-codex-exec).
+  NOT for harness 동기화 (use syncing-codex-harness). NOT for DA/감사 fan-out runtime mapping (use run-da/parallel-audit).
 ---
 
 # Codex CLI 설정
@@ -25,6 +25,7 @@ Codex CLI 호환 레이어와 프로젝트 스킬 발견 문제를 다룹니다.
 - `.agents/skills/*` 디렉토리 심링크 검증
 - `nrs`(또는 동등 activation) 이후 결과 검증
 - Claude Code / Codex CLI 등 AI 에이전트별 동작 차이 정리
+- 런타임별 fan-out 실행 경로는 `modules/shared/programs/claude/files/skills/run-da/references/runtime-mapping.md`를 따른다.
 
 ## 빠른 진단 체크리스트
 

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -6,17 +6,49 @@
 - 대상 프로젝트: `/Users/green/Workspace/nixos-config`
 - 문제 유형: Codex CLI가 global(user) 스코프 스킬은 인식하지만 project 스코프(`.agents/skills`) 스킬을 안정적으로 인식하지 못함
 
-## 증상
+## 현재 운영 기준
+
+- `.agents/skills/<name>`는 `.claude/skills/<name>`를 가리키는 디렉토리 심링크다.
+- 정책 SoT는 `modules/shared/programs/codex/default.nix`, 검증 SoT는 `scripts/ai/verify-ai-compat.sh`다.
+- 스킬 노출 정책을 바꾼 뒤에는 `nrs`(또는 동등 activation)로 out-of-store symlink를 갱신한 뒤 검증한다.
+
+### 현재 검증 절차
+
+정본 판정은 `./scripts/ai/verify-ai-compat.sh` 결과를 따른다. 아래 `git status`와 `find`는 사람이 상태를 빠르게 확인하기 위한 보조 절차이며, 디렉토리 심링크 target 검증은 정본 스크립트가 수행한다.
+
+```bash
+# 1) 구조 검증
+./scripts/ai/verify-ai-compat.sh
+
+# 2) SKILL.md 도구-중립성 lint fixture 검증
+./scripts/ai/verify-ai-compat.sh --run-fixture-tests
+
+# 3) staged/untracked 포함 skill docs 변경 확인
+git status --porcelain=v1 --untracked-files=all -- .claude/skills
+
+# 4) 디렉토리 심링크 projection 빠른 확인
+find .agents/skills -mindepth 1 -maxdepth 1 -type l -exec test -d {} \; -print | wc -l
+find .agents/skills -mindepth 1 -maxdepth 1 ! -type l -print
+
+# 5) 선택: 런타임 smoke test가 필요할 때만 실행
+codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' available in this workspace?"
+```
+
+## 2026-02-08 incident 기록 (historical)
+
+아래 기록은 당시 파일-copy 임시 해결 과정을 설명한다. 현재 운영 기준은 상단 "현재 운영 기준"과 "회귀 방지 체크리스트"를 따른다.
+
+### 증상
 
 1. Codex에서 `.agents/skills/<name>/SKILL.md` 기반 스킬이 일부/전부 누락됨
 2. `verify-ai-compat.sh` 기준으로는 구조가 있어 보이는데 런타임 인식이 불안정함
 3. 별개로, 권한 승인 프롬프트가 반복적으로 나타남 (정책 기본값 영향)
 
-## 재현 조건
+### 재현 조건
 
 - `.agents/skills/*/SKILL.md`가 심링크일 때 환경에 따라 project-scope 스캔이 누락됨
 
-## 원인 분석
+### 원인 분석
 
 1. SKILL.md 투영 방식 (근본 원인)
 - 기존 투영은 `.claude/skills/<name>/SKILL.md`를 `.agents/skills/<name>/SKILL.md`로 심링크했다.
@@ -29,9 +61,11 @@
 - 승인 프롬프트 문제(`approval_policy`, `sandbox_mode`)와 Skills 발견 문제를 한 원인으로 혼동하기 쉬웠다.
 - 실제로 Skills 누락의 근본 원인은 `trust`가 아니라 `SKILL.md` 심링크였다.
 
-## 해결 내용
+### 당시 해결 내용
 
-### 1) SKILL.md 투영 정책 변경
+> 현재 정책은 하단 "2026-02-19 재검증"의 디렉토리 심링크 projection이다. 이 섹션은 당시 임시 해결 기록이며, 현재 검증 기준으로 사용하지 않는다.
+
+#### 1) SKILL.md 투영 정책 변경
 
 - 파일: `modules/shared/programs/codex/default.nix`
 - 변경: `.agents/skills/<name>/SKILL.md`를 심링크가 아니라 실파일 복사로 생성
@@ -39,15 +73,15 @@
 
 > 2026-02-19 업데이트: 이후 디렉토리 심링크로 전환됨. 하단 "2026-02-19 재검증" 섹션 참조.
 
-### 2) 검증 스크립트 기준 변경
+#### 2) 검증 스크립트 기준 변경
 
 - 파일: `scripts/ai/verify-ai-compat.sh`
-- 변경:
+- 당시 변경:
   - `SKILL.md`가 일반 파일인지 확인
   - 심링크면 실패 처리
   - 원본과 `cmp`로 내용 일치 확인
 
-### 3) 실행 정책 기본값 반영 (권한 프롬프트 대응)
+#### 3) 실행 정책 기본값 반영 (권한 프롬프트 대응)
 
 - 파일: `modules/shared/programs/codex/files/config.toml`
 - 반영 상태:
@@ -57,29 +91,12 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 ```
 
-### 4) trust 항목 정리
+#### 4) trust 항목 정리
 
 - 프로젝트별 절대경로 trust 항목은 환경 이식성(`$HOME`/OS 차이) 문제를 만들 수 있어 기본 구성에서 제거했다.
 - 필요 시 호스트별/로컬 오버라이드로만 추가한다.
 
-## 검증 절차
-
-```bash
-# 1) 구조 검증
-./scripts/ai/verify-ai-compat.sh
-
-# 2) SKILL.md 도구-중립성 lint fixture 검증
-./scripts/ai/verify-ai-compat.sh --run-fixture-tests
-
-# 3) SKILL.md 타입 검증
-find .agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -type l | wc -l
-find .agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -type f | wc -l
-
-# 4) 런타임 인식 검증
-codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' available in this workspace?"
-```
-
-## 2026-02-08 확인 결과
+### 확인 결과
 
 - 심링크 수: `0`
 - 일반 파일 수: `18` (2026-02-08 당시 기준)
@@ -89,7 +106,7 @@ codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' 
   - project 스킬 목록이 응답에 포함됨
 - 새 Git 프로젝트에서도 승인 선택지 미노출(`approval_policy = "never"`, `sandbox_mode = "danger-full-access"` 적용 후)
 
-## codex trust 관련 메모
+### codex trust 관련 메모
 
 - `codex-cli 0.122.0` 기준 `codex trust` 독립 서브커맨드는 확인되지 않았다.
 - trust 관리는 CLI 서브커맨드가 아니라 `config.toml` 프로젝트 엔트리로만 가능하다.

--- a/.claude/skills/hosting-copyparty/SKILL.md
+++ b/.claude/skills/hosting-copyparty/SKILL.md
@@ -66,7 +66,7 @@ sudo copyparty-update --dry-run   # 수행 예정 작업 확인
 sudo copyparty-update             # 실제 업데이트 (pull → digest 비교 → 재시작 → 헬스체크)
 ```
 
-- 이미지에 버전 레이블이 없으므로 GitHub latest 추적 + 이미지 digest 비교 방식
+- GitHub latest는 알림/참고용. 실제 업데이트는 Nix module의 configured image reference pull + digest 비교 방식
 - 백업 불필요 (설정은 Nix 관리, 데이터는 HDD 볼륨)
 - ERR trap에서 컨테이너 자동 복구
 - 통합 업데이트 시스템 상세: `running-containers` 스킬의 [service-update-system.md](../running-containers/references/service-update-system.md) 참조
@@ -139,8 +139,8 @@ localhost 바인딩 (Caddy 연동)
 - 캐시 위치: SSD (`/var/lib/docker-data/copyparty/hists`)
 - `th-maxsize` 옵션은 존재하지 않음 (사용 금지)
 
-이미지 태그
-- `copyparty/ac:latest` 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
+컨테이너 이미지 기준 위치
+- `modules/nixos/programs/docker/copyparty.nix`의 configured image reference 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
 - 기본 `copyparty/copyparty` 이미지는 썸네일 미지원
 
 세션 데이터 영속성

--- a/.claude/skills/hosting-copyparty/references/setup.md
+++ b/.claude/skills/hosting-copyparty/references/setup.md
@@ -42,10 +42,10 @@ copyparty = {
 
 핵심 구성요소:
 - copyparty-config oneshot 서비스: agenix 시크릿에서 비밀번호 추출 → INI 설정 파일 생성
-- copyparty Podman 컨테이너: `copyparty/ac:latest` 이미지
+- copyparty Podman 컨테이너: `modules/nixos/programs/docker/copyparty.nix`의 configured image reference
 - `--entrypoint=python3`: 이미지 기본 ENTRYPOINT 오버라이드 (initcfg 볼륨 충돌 방지)
 - cmd: `["-m" "copyparty" "-c" "/cfg/config.conf"]`
-- ConditionPathExists: 설정 파일 없으면 시작 방지
+- ConditionPathExists: agenix 비밀번호 secret 없으면 시작 방지. 설정 파일 생성 문제는 `copyparty-config` 서비스 확인
 - 127.0.0.1 바인딩: Caddy 리버스 프록시가 유일한 외부 진입점
 
 ### 5. 활성화
@@ -83,7 +83,7 @@ INI 스타일, 섹션별 구성:
 
 ## Docker 이미지 정보
 
-- 이미지: `copyparty/ac:latest` (thumbnailer for audio/video/images + transcoding)
+- 이미지: `modules/nixos/programs/docker/copyparty.nix`의 configured image reference (thumbnailer for audio/video/images + transcoding)
 - 기본 포트: 3923
 - 기본 ENTRYPOINT: `python3 -m copyparty -c /z/initcfg` ← 오버라이드 필수
 - 우리 설정: `--entrypoint=python3`, cmd: `-m copyparty -c /cfg/config.conf`

--- a/.claude/skills/hosting-karakeep/SKILL.md
+++ b/.claude/skills/hosting-karakeep/SKILL.md
@@ -33,7 +33,7 @@ Karakeep 웹 아카이버/북마크 관리 서비스 운영 스킬.
 
 | 컨테이너 | 이미지 | 역할 | 리소스 |
 |-----------|--------|------|--------|
-| `karakeep` | `ghcr.io/karakeep-app/karakeep:release` | Next.js 앱 (포트 3000) | 2GB / 1 CPU |
+| `karakeep` | `modules/nixos/programs/docker/karakeep.nix`의 configured image reference | Next.js 앱 (포트 3000) | 2GB / 1 CPU |
 | `karakeep-chrome` | `gcr.io/zenika-hub/alpine-chrome:124` | 헤드리스 Chrome (스크린샷) | 2GB / 1 CPU |
 | `karakeep-meilisearch` | `getmeili/meilisearch:v1.13.3` | 전문 검색 | 1GB / 0.5 CPU |
 

--- a/.claude/skills/hosting-karakeep/references/update-guide.md
+++ b/.claude/skills/hosting-karakeep/references/update-guide.md
@@ -12,7 +12,7 @@ Karakeep 버전 업데이트 후 반드시 아래 패턴이 유효한지 확인�
 
 검증이 누락되면 OOM/크롤 실패 시 Pushover 알림이 발송되지 않아, 크래시 루프를 사용자가 인지하지 못할 수 있다.
 
-의존 패턴 목록 (현재 기준: `ghcr.io/karakeep-app/karakeep:release`):
+의존 패턴 목록 (현재 기준: `modules/nixos/programs/docker/karakeep.nix`의 configured image reference):
 
 | 패턴 | 용도 | 변경 가능성 |
 |------|------|-----------|

--- a/.claude/skills/hosting-vaultwarden/references/known-issues.md
+++ b/.claude/skills/hosting-vaultwarden/references/known-issues.md
@@ -35,10 +35,10 @@
 
 ## 이미지 버전 고정 + 업데이트 자동화
 
-- `vaultwarden/server:1.35.2` (`:latest` 미사용)
+- `modules/nixos/programs/docker/vaultwarden.nix`의 configured image reference 사용 (`:latest` 미사용)
 - 재부팅 시 예기치 않은 버전 변경 방지
 - `homeserver.vaultwardenUpdate.enable = true`로 매일 06:30 자동 버전 체크 + Pushover 알림
-- 수동 업데이트: `sudo vaultwarden-update` (pinned tag pull -> digest 비교 -> 재시작 -> 헬스체크)
+- 수동 업데이트: `sudo vaultwarden-update` (configured image reference pull -> digest 비교 -> `vaultwarden-backup.service` 실행 -> 재시작 -> `/alive` 헬스체크)
 - 통합 업데이트 시스템 상세: `running-containers` 스킬의 [../running-containers/references/service-update-system.md](../../running-containers/references/service-update-system.md) 참조
 
 ## Master Password 복구 불가

--- a/.claude/skills/hosting-vaultwarden/references/setup.md
+++ b/.claude/skills/hosting-vaultwarden/references/setup.md
@@ -3,7 +3,7 @@
 ## 컨테이너 구성
 
 ```
-이미지: vaultwarden/server:1.35.2
+이미지: `modules/nixos/programs/docker/vaultwarden.nix`의 configured image reference
 포트: 127.0.0.1:8222:80 (localhost → Caddy)
 볼륨: /var/lib/docker-data/vaultwarden/data:/data
 리소스: memory=256m, cpus=0.5
@@ -76,8 +76,8 @@ curl -sf http://localhost:8222/alive && echo "OK"
 # 1. 릴리스 노트 확인
 # https://github.com/dani-garcia/vaultwarden/releases
 
-# 2. vaultwarden.nix에서 이미지 태그 변경
-# image = "vaultwarden/server:1.35.2" → "vaultwarden/server:X.Y.Z"
+# 2. modules/nixos/programs/docker/vaultwarden.nix에서 configured image reference 변경
+# image = "vaultwarden/server:<current>" → "vaultwarden/server:X.Y.Z"
 
 # 3. 빌드 & 적용
 nrs

--- a/.claude/skills/hosting-vaultwarden/references/troubleshooting.md
+++ b/.claude/skills/hosting-vaultwarden/references/troubleshooting.md
@@ -44,7 +44,7 @@ sudo podman logs vaultwarden
 흔한 원인:
 - 환경변수 파일 미존재 → `ConditionPathExists` 실패 → `vaultwarden-env` 서비스 확인
 - 포트 충돌 → `ss -tlnp | grep 8222`
-- 이미지 pull 실패 → `sudo podman pull vaultwarden/server:1.35.2`
+- 이미지 pull 실패 → `modules/nixos/programs/docker/vaultwarden.nix`의 configured image reference를 확인한 뒤 `sudo podman pull <image>` 실행
 
 ## 4. 백업 실패
 

--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: managing-macos
 description: |
-  Configure macOS/nix-darwin: Dock, Finder, Homebrew Cask, Folder Actions.
+  Configure macOS/nix-darwin: Dock, Finder, Homebrew, Folder Actions.
   Trigger: 'darwin-rebuild', 'shottr 설정', 'Folder Actions', 'compress-video', 'upload-immich'.
 ---
 
@@ -45,21 +45,18 @@ darwinOnly = [ ... pkgs.패키지명 ];
 | Dock | `configuration.nix` | 자동 숨김, 크기, 최근 앱 |
 | Finder | `configuration.nix` | 숨김 파일, 확장자, 네트워크 .DS_Store 방지 |
 | 키보드 | `configuration.nix` | 키 반복 속도 |
-| 트랙패드 | `configuration.nix` | 탭 클릭, 자연스러운 스크롤 |
+| 마우스/스크롤 | `configuration.nix` | 자연스러운 스크롤 비활성화 |
 
 ### Homebrew 관리
 
-`modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다 (personal 호스트만 적용).
+`modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다. 공통 Homebrew 항목은 모든 darwin 호스트에 적용되고, personal 전용 GUI 앱/Formula는 `hostType == "personal"` 블록에서 관리됩니다.
 
 ```nix
-# cleanup = "none" — 선언되지 않은 앱을 삭제하지 않음 (수동 설치 cask 보호)
-# upgrade = true + greedyCasks = true — 자체 업데이터 앱의 버전 드리프트 방지
-homebrew.casks = [
-  "ghostty" "raycast" "rectangle"
-  "hammerspoon" "homerow" "docker-desktop"
-  "fork" "monitorcontrol"
-];
-homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, 오디오 처리
+# modules/darwin/programs/homebrew.nix 구조:
+# - common block: 모든 darwin 호스트
+# - lib.mkIf (hostType == "personal"): personal 전용 GUI 앱/Formula,
+#   cleanup/upgrade/greedyCasks 정책
+# 전체 cask/formula inventory는 해당 모듈을 기준으로 확인.
 # shottr → Nix 패키지로 관리 (libraries/packages.nix darwinOnly)
 # codex → Nix 관리로 전환 (mise npm backend, modules/shared/programs/codex)
 # figma → Homebrew에서 제거 (자체 업데이터가 버전을 변경하여 adopt 시 버전 충돌)
@@ -68,7 +65,7 @@ homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, �
 
 새 Mac 세팅 시: 직접 설치된 앱은 `brew install --cask --adopt <앱>`으로 Homebrew 관리로 전환 필요.
 
-자세한 내용: [references/features.md](references/features.md#gui-앱-homebrew-casks)
+자세한 내용: [references/features.md](references/features.md#homebrew-관리)
 
 ### Shottr 선언 관리 (Nix + agenix)
 

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -16,7 +16,7 @@ macOS 관련 시스템 설정 및 Homebrew 관리입니다.
 - [키보드 단축키 (Symbolic Hotkeys)](#키보드-단축키-symbolic-hotkeys)
 - [키 바인딩 (백틱/원화)](#키-바인딩-백틱원화)
 - [폰트 관리](#폰트-관리)
-- [GUI 앱 (Homebrew Casks)](#gui-앱-homebrew-casks)
+- [Homebrew 관리](#homebrew-관리)
 - [폴더 액션 (launchd)](#폴더-액션-launchd)
 
 ---
@@ -318,11 +318,12 @@ fc-list | grep -i "JetBrains"
 fc-list | grep -i "D2Coding"
 ```
 
-## GUI 앱 (Homebrew Casks)
+## Homebrew 관리
 
 `modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다.
 
-- hostType 제한: `lib.mkIf (hostType == "personal")` — personal 호스트만 적용
+- 공통 항목: 모든 darwin 호스트에 적용
+- personal 항목: `lib.mkIf (hostType == "personal")` 블록에서 GUI 앱/Formula 관리
 - cleanup = "none": 선언되지 않은 앱을 자동 삭제하지 않음 (수동 설치 cask 보호)
 
 ### 서드파티 Tap Formula 주의사항
@@ -335,17 +336,9 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 # brews = [ "macism" ];  # ❌ homebrew/core에서 찾으려고 함 → 설치 안 됨
 ```
 
-### Cask 목록
+### Cask/Formula inventory 기준 위치
 
-| 앱             | 용도                       |
-| -------------- | -------------------------- |
-| Raycast        | 런처 (Spotlight 대체)      |
-| Rectangle      | 창 관리                    |
-| Hammerspoon    | 키보드 리매핑/자동화       |
-| Homerow        | 키보드 네비게이션          |
-| Docker Desktop | 컨테이너                   |
-| Fork           | Git GUI                    |
-| MonitorControl | 외부 모니터 밝기 조절      |
+현재 Homebrew inventory는 `modules/darwin/programs/homebrew.nix`가 기준입니다. 이 문서는 common/personal 분리 정책, adopt 절차, Nix 전환 예외만 설명하고 실제 목록은 복제하지 않습니다.
 
 ### Nix 패키지로 관리하는 GUI 앱
 
@@ -366,12 +359,12 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 
 ### 업그레이드 정책
 
-`onActivation.upgrade = true` + `greedyCasks = true` 조합으로 버전 드리프트를 방지합니다.
+personal 호스트에서는 `onActivation.upgrade = true` + `greedyCasks = true` 조합으로 버전 드리프트를 방지합니다.
 
-- upgrade = true: `nrs` 실행 시 `brew upgrade`를 자동 실행
-- greedyCasks = true: `auto_updates` 속성이 있는 cask도 `brew upgrade` 대상에 포함
+- upgrade = true: personal 호스트에서 `nrs` 실행 시 `brew upgrade`를 자동 실행
+- greedyCasks = true: personal 호스트에서 `auto_updates` 속성이 있는 cask도 `brew upgrade` 대상에 포함
 
-자체 업데이터가 있는 앱이 Homebrew와 독립적으로 버전을 변경해도, `nrs` 실행 시 Homebrew가 최신 버전으로 동기화합니다.
+자체 업데이터가 있는 앱이 Homebrew와 독립적으로 버전을 변경해도, personal 호스트에서는 `nrs` 실행 시 Homebrew가 최신 버전으로 동기화합니다.
 
 ### Homebrew 관리에서 제외한 앱
 
@@ -381,13 +374,6 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | Slack | 수동 설치 선호. 자체 업데이터에 위임. |
 
 > `cleanup = "none"`이므로 cask 목록에서 제거해도 기존 `/Applications/Figma.app`은 삭제되지 않습니다.
-
-### Brew Formula
-
-| Formula                    | 용도                              |
-| -------------------------- | --------------------------------- |
-| `laishulu/homebrew/macism` | macOS 입력 소스 전환 (Neovim 한영 전환) |
-| `sox`                      | 오디오 처리 (Claude Code /voice 모드) |
 
 ### 직접 설치 앱의 adopt 전환
 
@@ -427,10 +413,8 @@ brew install --cask --adopt docker-desktop:
 # 개별 앱 adopt
 brew install --cask --adopt docker-desktop
 
-# 여러 앱 일괄 adopt (Nix 패키지로 관리하는 shottr, vscode 제외)
-for cask in ghostty raycast rectangle hammerspoon homerow docker-desktop fork monitorcontrol; do
-  brew install --cask --adopt "$cask" || echo "FAILED: $cask"
-done
+# 여러 앱을 전환할 때는 modules/darwin/programs/homebrew.nix의 현재 cask id를 확인한 뒤 반복 실행
+# 예: for cask in <현재 cask id들>; do brew install --cask --adopt "$cask"; done
 
 # adopt 결과 확인
 brew list --cask

--- a/.claude/skills/running-containers/SKILL.md
+++ b/.claude/skills/running-containers/SKILL.md
@@ -14,7 +14,7 @@ description: |
 
 # 컨테이너 관리 (Podman/홈서버)
 
-Podman 컨테이너 및 홈서버 서비스 (immich, uptime-kuma, copyparty, vaultwarden, karakeep) 운영 가이드.
+Podman 컨테이너 및 홈서버 서비스 (immich, uptime-kuma, copyparty, vaultwarden, karakeep, awesome-anki 등) 운영 가이드.
 Caddy HTTPS 리버스 프록시를 통해 `*.greenhead.dev` 도메인으로 접근한다.
 
 ## 모듈 구조 (mkOption 기반)
@@ -39,8 +39,8 @@ homeserver.reverseProxy.enable = true;        # Caddy HTTPS 리버스 프록시
 |-----------|------|
 | `modules/nixos/options/homeserver.nix` | mkOption 정의 + 서비스 모듈 import |
 | `modules/nixos/programs/docker/runtime.nix` | Podman 런타임 공통 설정 |
-| `modules/nixos/programs/docker/<서비스>.nix` | 개별 컨테이너 정의 (immich, uptime-kuma, copyparty, vaultwarden, karakeep 등) |
-| `modules/nixos/programs/<서비스>-update/` | 버전 체크 + 업데이트 (immich, uptime-kuma, copyparty, vaultwarden, karakeep) |
+| `modules/nixos/programs/docker/<서비스>.nix` | 개별 컨테이너 정의 (immich, uptime-kuma, copyparty, vaultwarden, karakeep, awesome-anki 등) |
+| `modules/nixos/programs/<서비스>-update/` | 버전 체크 + 업데이트 (immich, uptime-kuma, copyparty, vaultwarden, karakeep 등) |
 | `modules/nixos/programs/caddy.nix` | Caddy HTTPS 리버스 프록시 |
 | `modules/nixos/lib/service-lib.sh` / `.nix` | 공통 셸 라이브러리 + Nix wrapper |
 | `modules/nixos/lib/mk-update-module.nix` | 업데이트 모듈 생성 헬퍼 |
@@ -65,6 +65,7 @@ Docker 서비스에서 사용하는 상수 (`libraries/constants.nix`):
 | Copyparty | `https://copyparty.greenhead.dev` | `127.0.0.1:3923` |
 | Vaultwarden | `https://vaultwarden.greenhead.dev` | `127.0.0.1:8222` |
 | Karakeep | `https://archive.greenhead.dev` | `127.0.0.1:3000` |
+| Awesome Anki | `https://anki.greenhead.dev` | `localhost:3100` |
 | Anki Sync | (Caddy 미경유) | `100.79.80.95:27701` |
 
 Caddy가 Cloudflare DNS-01 ACME로 Let's Encrypt 인증서를 자동 발급한다.
@@ -76,10 +77,10 @@ Tailscale IP (`100.79.80.95:443`)에만 바인딩되어 VPN 내부 전용이다.
 
 - OCI 백엔드 명시 필수: `runtime.nix`의 `backend = "podman"` 누락 시 Docker fallback 에러
 - immich ML OOM: CPU 버전 이미지 사용 (`release`, openvino 아님)
-- Tailscale IP 바인딩: `tailscale-wait.nix`로 60초 대기. Immich/Copyparty/Uptime Kuma/Vaultwarden은 `127.0.0.1` 바인딩 (Caddy 프록시)
-- Uptime Kuma `--network=host`: localhost 서비스 모니터링을 위해 호스트 네트워크 필수
+- Tailscale IP 바인딩: `tailscale-wait.nix`로 60초 대기. Caddy-backed localhost 서비스는 `127.0.0.1` 바인딩
+- Host network allowlist: Uptime Kuma는 localhost 서비스 모니터링 때문에, Awesome Anki는 AnkiConnect 접근 제약 때문에 `--network=host` 사용
 - Caddy HTTPS: Cloudflare DNS-01 ACME, Tailscale IP 전용 바인딩, `secrets/cloudflare-dns-api-token.age`
-- 방화벽: `trustedInterfaces = [ "tailscale0" ]` — 보안은 서비스 바인딩 주소에 의존
+- 방화벽: `trustedInterfaces = [ "tailscale0" ]`. 대부분의 웹 서비스는 localhost/service bind로 제한한다. Awesome Anki는 host-network + `0.0.0.0` 바인딩 예외라 tailnet 직접 노출을 Tailscale/방화벽 경계로 수용한다.
 - Immich DB 비밀번호: agenix `secrets/immich-db-password.age`, `POSTGRES_PASSWORD_FILE` 볼륨 마운트
 
 ## 빠른 참조
@@ -128,7 +129,7 @@ Immich: API 버전 조회 가능 → "현재 v2.5.5 → 최신 v2.6.0" 형태 �
 
 Immich DB 백업: `immich-db-backup` 서비스가 매일 05:30에 `podman exec immich-postgres pg_dump -Fc`로 커스텀 포맷 백업 생성. 디스크 공간 검사, pg_restore --list 무결성 검증, 원자적 파일 이동, 30일 보관. 실패 시 Pushover 알림 (`pushover-immich` 재사용). `sudo systemctl start immich-db-backup`으로 수동 실행.
 
-Uptime Kuma/Copyparty/Karakeep: 이미지에 버전 레이블 없음 → GitHub latest 추적 + 이미지 digest 비교 방식. 상세: [references/service-update-system.md](references/service-update-system.md)
+Uptime Kuma/Copyparty/Karakeep/Vaultwarden: GitHub latest는 알림/참고용이고, 수동 업데이트는 Nix module의 configured image reference pull + digest 비교 방식. 상세: [references/service-update-system.md](references/service-update-system.md)
 Karakeep 수동 업데이트는 `--ack-bridge-risk` 플래그가 필수다 (브릿지/로그 의존성 인지 강제).
 
 Karakeep 이벤트 알림: `karakeep-notify`가 웹훅→Pushover 브리지(socat)로 아카이빙 성공/실패 알림을 전송한다.
@@ -147,7 +148,7 @@ macOS에서 `~/FolderActions/upload-immich/`에 파일을 넣으면 Immich에 �
 2. ML OOM: CPU 버전 이미지로 변경
 3. IP 바인딩 실패: `tailscale-wait.nix`가 올바르게 import 되었는지 확인
 4. DB 비밀번호 오류: `secrets/immich-db-password.age` 존재 확인, `cd secrets && nix run github:ryantm/agenix -- -r` 재암호화
-5. Uptime Kuma에서 localhost 서비스 모니터링 불가: `--network=host` 필수 (기본 브릿지에서는 `127.0.0.1` 접근 불가)
+5. Host network 서비스 확인: Uptime Kuma는 localhost 모니터링용, Awesome Anki는 AnkiConnect 접근용. Awesome Anki는 현재 `0.0.0.0` 바인딩 제한 때문에 tailnet 직접 노출을 Tailscale/방화벽 경계로 수용
 6. Caddy HTTPS 인증서 발급 실패: Cloudflare API 토큰 확인 (`sudo cat /run/caddy/env`), `systemctl status caddy-env`
 
 ## 레퍼런스

--- a/.claude/skills/running-containers/references/service-update-system.md
+++ b/.claude/skills/running-containers/references/service-update-system.md
@@ -7,6 +7,9 @@ Immich, Uptime Kuma, Copyparty, Karakeep, Vaultwarden 5개 컨테이너 서비�
 - 버전 체크 (자동): 매일 GitHub Releases API로 최신 버전 확인 → Pushover 알림
 - 업데이트 (수동): `sudo <서비스>-update` 명령으로 안전한 업데이트
 
+이 문서에서 configured image reference는 `modules/nixos/programs/docker/<service>.nix`의
+`virtualisation.oci-containers.containers.<service>.image` 값을 뜻한다.
+
 ## 아키텍처
 
 ```
@@ -77,16 +80,18 @@ Immich는 Immich API로 현재 버전을 확인하는 고유 로직이 있어 �
 
 ### Uptime Kuma
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 자동 버전 체크: 이미지에 버전 레이블이 없어 GitHub latest 알림만 제공
+- 수동 업데이트: configured image reference를 pull하고 digest 비교. GitHub latest는 안내용으로 함께 표시
 - 알림 형태: "v2.1.0 출시됨" (현재 버전 미표시)
-- 메이저 불일치 감지: 이미지 태그 `:1`은 1.x만, GitHub latest가 2.x → 추가 안내 포함
+- 메이저 불일치 감지: configured image reference의 tag 부분 major와 GitHub latest major가 다르면 추가 안내 포함
 - 업데이트: 이미지 pull → digest 비교 → stop → SQLite 백업(`kuma.db` gzip) → start → HTTP 헬스체크
 - ERR trap 복구: 실패 시 컨테이너 자동 재시작 (모니터링 서비스 가용성 보장)
 - Tailscale 불필요: localhost + 인터넷만 사용
 
 ### Copyparty
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 자동 버전 체크: GitHub latest 알림
+- 수동 업데이트: configured image reference를 pull하고 digest 비교. GitHub latest는 안내용으로 함께 표시
 - 알림 형태: "v1.20.6 출시됨"
 - 업데이트: 이미지 pull → digest 비교 → 재시작 → HTTP 헬스체크 (백업 없음)
 - ERR trap 복구: 실패 시 컨테이너 자동 재시작
@@ -94,7 +99,8 @@ Immich는 Immich API로 현재 버전을 확인하는 고유 로직이 있어 �
 
 ### Karakeep
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 자동 버전 체크: GitHub latest 알림
+- 수동 업데이트: configured image reference를 pull하고 digest 비교. GitHub latest는 안내용으로 함께 표시
 - 알림 형태: "v0.x.y 출시됨"
 - 업데이트: 이미지 pull → digest 비교 → 재시작 → HTTP 헬스체크 (백업 없음)
 - 실행 명령: `sudo karakeep-update --ack-bridge-risk` (`--ack-bridge-risk` 없이 실행 불가)
@@ -106,9 +112,10 @@ Immich는 Immich API로 현재 버전을 확인하는 고유 로직이 있어 �
 
 ### Vaultwarden
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 자동 버전 체크: GitHub latest 알림
+- 수동 업데이트: configured image reference를 pull하고 digest 비교. GitHub latest는 안내용으로 함께 표시
 - 알림 형태: "v1.x.y 출시됨"
-- 메이저 불일치 감지: pinned tag와 GitHub latest 간 major version 불일치 시 추가 안내 포함
+- 메이저 불일치 감지: configured image reference의 tag 부분 major와 GitHub latest major가 다르면 추가 안내 포함
 - 업데이트: 이미지 pull → digest 비교 → vaultwarden-backup 서비스 실행 → 재시작 → HTTP 헬스체크 (`/alive`)
 - 실행 명령: `sudo vaultwarden-update`
 - ERR trap 복구: 실패 시 컨테이너 자동 재시작
@@ -167,8 +174,8 @@ cat /var/lib/<서비스>-update/last-notified-version
 
 ### 이미지 digest 변경 감지 안 됨
 
-`sudo <서비스>-update`에서 "Image unchanged" 출력 → 레지스트리에 새 이미지가 없는 것.
-GitHub에 새 릴리즈가 있더라도 이미지 빌드에 시간 소요.
+`sudo <서비스>-update`에서 "Image unchanged"가 출력되면 configured image reference의 digest가 바뀌지 않은 상태다.
+GitHub latest와 configured image reference의 tag 부분이 다르면 `modules/nixos/programs/docker/<service>.nix`의 image 값을 변경하고 `nrs`로 적용한 뒤, 다시 `sudo <서비스>-update`를 실행해 서비스별 백업/헬스체크/후속 점검 경로를 완료한다.
 
 ### 새 서비스 추가 시
 

--- a/.claude/skills/understanding-nix/references/features.md
+++ b/.claude/skills/understanding-nix/references/features.md
@@ -167,8 +167,9 @@ eval-tests (E2E 보안 검증):
 - 포트 충돌 없음 (homeserver.*.port 고유성)
 - 컨테이너 포트 localhost-only (127.0.0.1: 접두사 강제)
 - extraOptions에 -p/--publish/-P 우회 노출 금지
-- --network=host allowlist 강제 (현재: uptime-kuma만)
+- --network=host allowlist 강제 (현재: uptime-kuma, awesome-anki)
 - host network 컨테이너의 listen address 검증 (UPTIME_KUMA_HOST=127.0.0.1)
+- awesome-anki host network 예외: AnkiConnect 접근 때문에 허용. 앱은 현재 0.0.0.0 바인딩 제한이 있어 Tailscale/방화벽 경계로 수용
 - Caddy virtualHost listenAddresses = Tailscale IP 전용
 - Caddy globalConfig default_bind = Tailscale IP
 - anki-sync-server address/openFirewall 검증


### PR DESCRIPTION
## Summary

- Update Codex skill routing and projection runbooks to the current directory-symlink policy. Closes #836.
- Align service and platform skill docs with current configured image references, HTTPS routes, host-network exceptions, and Homebrew scope. Closes #838.
- Part of parent cleanup #834.

## 기존 문제/배경

Active skill docs still described older assumptions: file-level skill projection checks, hidden execution routing, literal service image tags, incomplete Caddy routes, and Homebrew behavior that no longer matched the Nix modules. That made the docs useful in the wrong direction: following them could recreate stale checks or miss current safety steps.

## CIR (Change Intent Record)

The intent is to make active runbooks point at stable sources of truth instead of copying fast-moving values. Service docs now describe configured image references and link back to the Nix modules, while historical Codex compatibility notes are separated from the current validation path. Alternatives considered were keeping literal image tags for readability or updating only the stale literals. Both would keep the same drift pattern, so the docs now prefer stable module paths and concise policy wording.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
| --- | --- | --- | --- | --- |
| Adopted: reference current modules | Describe configured image references, directory symlink projection, and Homebrew scope by pointing at module paths | Reduces repeated drift and matches runtime config | Reader may need to open the module for exact values | Adopted |
| Rejected: refresh literal versions | Replace stale tags with newer literal tags in docs | Immediately readable | Will drift again on the next service update | Rejected |
| Rejected: change scripts instead | Modify validation/update scripts to match old docs | Avoids doc edits | Runtime behavior was already the current source of truth | Rejected |

## 구현 상세

| 영역 | 변경 |
| --- | --- |
| `configuring-codex` | Replaced stale file-level projection checks with current directory-symlink validation and moved old incident details under historical context. |
| `running-containers` | Added Awesome Anki route and host-network notes, clarified Caddy-backed localhost services, and defined configured image reference wording. |
| service skills | Updated Copyparty, Karakeep, and Vaultwarden docs to reference Nix module image values and current update safety steps. |
| `managing-macos` | Clarified common vs personal Homebrew scope and removed duplicated package inventory from docs. |
| `understanding-nix` | Aligned host-network allowlist notes with Uptime Kuma and Awesome Anki. |

Core wording now treats service images as:

```text
configured image reference = modules/nixos/programs/docker/<service>.nix image value
```

## 참고 레퍼런스

- Parent tracking issue: #834
- Codex skill routing/projection cleanup: #836
- Service/platform runbook alignment: #838

## Human Test Plan

1. Run `./scripts/ai/verify-ai-compat.sh`.
   Expected: complete pass with no `.claude/skills` source warning after commit.
2. Run `nix eval --impure --file tests/eval-tests.nix`.
   Expected: returns `true`.
3. Run `bash tests/run-shell-script-tests.sh`.
   Expected: all shell script tests pass.
4. Push the branch.
   Expected: pre-push hooks pass, including hook fixtures, flake check, shell script tests, and statusline tests.
