### PR TITLE
fix(wt): bootstrap plans 정리를 README 보존형으로 (worktree 부산물 제거)

### DIFF
--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -25,8 +25,14 @@ _bootstrap_worktree() {
     cp -r "$src_codex" "$wt_path/.codex"
   fi
 
-  # .claude/plans/ 제거 (worktree에서는 불필요)
-  rm -rf "$wt_path/.claude/plans"
+  # .claude/plans/: tracked README.md(디렉토리 정책 문서, #756/#773)는 보존하고,
+  # 새어든 untracked/ignored transient plan buffer만 정리한다. worktree는 git
+  # checkout이라 ignored buffer(.claude/plans/*)가 따라오지 않아 평소엔 no-op이지만,
+  # 과거 `rm -rf .claude/plans`는 유일하게 checkout되는 tracked README.md까지 지워
+  # worktree마다 deleted 부산물 + `git add -A` 시 정책 문서 소실 위험을 만들었다.
+  if [ -d "$wt_path/.claude/plans" ]; then
+    git -C "$wt_path" clean -fdX -- .claude/plans >/dev/null 2>&1 || true
+  fi
 
   # Claude → Codex projection 재실행 (plugin-aware worktree bootstrap 복구)
   local script_dir codex_sync_sh=""


### PR DESCRIPTION
## Summary

worktree 생성 시 `wt` bootstrap이 `.claude/plans/`를 `rm -rf`로 통째 삭제해, **tracked 파일 `.claude/plans/README.md`(디렉토리 정책 문서)까지 지우던 회귀**를 수정한다.

- `rm -rf "$wt_path/.claude/plans"` → `git clean -fdX -- .claude/plans`로 변경.
- ignored transient plan buffer만 제거하고 tracked README.md는 git-aware하게 보존한다.

## 기존 문제 / 배경

worktree를 만들 때마다 `git status`에 `.claude/plans/README.md`가 `deleted`로 떠, 매번 수동 `git restore`가 필요했다. 더 심각하게는 worktree에서 `git add -A` 후 커밋하면 **정책 문서 삭제가 main에 머지될 위험**이 있었다.

`.gitignore`는 plans를 정교하게 분기한다:

```
!.claude/plans            # 글로벌 **/.claude/plans 차단 해제
.claude/plans/*           # 내용물(transient buffer) ignore
!.claude/plans/README.md  # README.md만 tracked 예외
```

즉 HEAD가 tracked하는 plans 파일은 `README.md` 단 하나다. worktree는 git checkout이라 **tracked README.md만** 체크아웃되고 ignored transient buffer는 따라오지 않는다. 그런데 직후 bootstrap의 `rm -rf`가 그 유일한 파일을 지웠다.

## CIR (Change Intent Record)

- **발견 경위**: codex 비대화형 회귀 수정(#845) 작업 중, worktree 생성 시 `.claude/plans/README.md` 삭제 + `AGENTS.override.md` 오염이 반복 부산물로 나타나는 것을 관찰. `bootstrap.sh`의 `rm -rf "$wt_path/.claude/plans"`를 직접 원인으로 특정하고, `git ls-tree HEAD .claude/plans/`로 tracked 파일이 README.md 하나뿐임을 확인했다.
- **시점 충돌**: bootstrap의 plans 제거는 plans에 tracked 파일이 없던 시절(#416 등) 도입됐다. 이후 #756/#773에서 README.md를 tracked로 추가하면서, 이 rm이 보호 효과 없이 README.md만 지우는 동작으로 변질됐다.
- **설계 의도**: "worktree에 plan 잔재 없게"라는 원 의도는 유지하되, tracked 파일을 git이 인지해 보존하도록 `git clean -fdX`로 교체했다. worktree git checkout이 ignored buffer를 가져오지 않으므로 평소엔 no-op이고, 혹시 새어들면 정리하는 방어 동작이다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| L28-29 완전 제거 | rm 줄 삭제 | 가장 단순 | "plan 잔재 정리" 의도 상실, transient가 새어들면 미정리 | ✗ |
| `find ! -name README.md -delete` | README만 남기고 삭제 | 명시적 | tracked 파일이 더 늘면 일일이 예외, git-unaware | ✗ |
| **`git clean -fdX -- .claude/plans`** | ignored만 제거, tracked 보존 | git-aware(tracked 자동 보존), 원 의도 유지 | — | ✓ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/scripts/lib/wt/bootstrap.sh` | `rm -rf "$wt_path/.claude/plans"` → tracked 보존형 `git clean -fdX -- .claude/plans` + 사유 주석 |

```sh
if [ -d "$wt_path/.claude/plans" ]; then
  git -C "$wt_path" clean -fdX -- .claude/plans >/dev/null 2>&1 || true
fi
```

## 참고 레퍼런스

- README.md tracked 도입: #756 (P0), 머지 #773.
- bootstrap의 plans 제거 도입: #416 (및 이전 wt 정비 #180/#205).
- 자매 PR #845: 같은 "비대화형 worktree 부산물" 조사에서 함께 드러난 codex sync(awk)·실행(mise shims) 회귀. 본 PR은 그중 plans/README 삭제 축을 분리해 다룬다.

## Human Test Plan

1. `nrs`로 본 변경을 적용한다(`wt` 바이너리가 갱신된 bootstrap을 번들).
2. 새 worktree 생성: `wt <branch>`.
3. **확인**: 생성된 worktree에서 `git -C <worktree> status --short`에 `.claude/plans/README.md`의 `deleted`가 **더 이상 뜨지 않아야** 한다.
4. `cat <worktree>/.claude/plans/README.md`로 정책 문서가 보존됐는지 확인.
5. 실패 시 진단: `git -C <worktree> ls-files .claude/plans/`로 README.md tracked 여부, `git -C <worktree> check-ignore .claude/plans/README.md`로 예외 적용 점검.
