### PR TITLE
fix(git): Mac GitHub 원격 인증을 https + gh PAT로 통일

### DIFF
--- a/modules/shared/programs/git/default.nix
+++ b/modules/shared/programs/git/default.nix
@@ -176,7 +176,21 @@ in
   programs.gh = {
     enable = true;
     settings = {
-      git_protocol = "ssh";
+      # GitHub 인증 프로토콜. Mac은 https(아래 darwin 전용 git insteadOf + gh PAT
+      # credential helper로 통일), NixOS(MiniPC)는 opnix/ssh 경로라 기존 ssh 유지.
+      git_protocol = if pkgs.stdenv.isDarwin then "https" else "ssh";
     };
+  };
+
+  # Mac 전용 GitHub git 인증: git@github.com SSH URL을 https로 rewrite한다.
+  # rewrite된 https remote는 gh credential helper(gh auth git-credential —
+  # programs.gh.enable이 자동 주입)로 인증된다. 이 helper는 별도 gh 프로세스로 실행돼
+  # shell의 gh wrapper(alias/함수)를 거치지 않으며, keyring의 PAT(gh auth login) 또는
+  # git 프로세스 환경에 export된 GH_TOKEN으로 토큰을 조회한다 — git이 GH_TOKEN을 직접
+  # 읽는 것이 아니다. SSH 키 등록 불필요.
+  # NixOS(MiniPC)는 opnix github-pat + 기존 ssh 경로라 제외(darwin 한정 — git
+  # credential helper에 토큰 공급원이 다름).
+  programs.git.settings.url = lib.mkIf pkgs.stdenv.isDarwin {
+    "https://github.com/".insteadOf = "git@github.com:";
   };
 }


### PR DESCRIPTION
## Summary

- Mac에서 `git@github.com:` SSH URL을 https로 투명 rewrite(`url.insteadOf`)하고, `gh git_protocol`을 https로 전환한다.
- GitHub git 트래픽을 gh credential helper(`gh auth git-credential`, PAT) 경로로 일관화하여 SSH 키 등록 의존을 제거한다.
- NixOS(MiniPC)는 기존 SSH/opnix 경로를 그대로 유지 — `pkgs.stdenv.isDarwin` 가드로 darwin 한정 적용.

## 기존 문제/배경

1Password SSH agent 도입(#833) 이후, 기존에 GitHub에 등록돼 있던 SSH 공개키가 agent가 관리하는 디바이스 키로 교체됐다. 이 디바이스 키들은 GitHub 계정에 등록돼 있지 않아, `git@github.com:` 형식 remote에 대한 SSH 인증이 `Permission denied (publickey)`로 실패했다. 그 결과 해당 remote에서 `git pull`/`git fetch`가 불가능해졌다.

## CIR (Change Intent Record)

- **발견 경위**: SSH agent 전환 후 기존 `git@github.com:` remote의 SSH 인증이 실패하여 fetch/pull이 막혔다.
- **설계 의도**: 누락된 디바이스 키를 GitHub에 재등록하는 대신, GitHub git 트래픽을 https + gh credential helper(PAT)로 통일한다. SSH 키를 재등록하면 인증 시점마다 Touch ID 팝업이 발생하는데, 이는 현재 별도로 개선 중인 gh 팝업 UX 작업(#848)과 정면으로 충돌한다. https 경로는 SSH를 전혀 사용하지 않으므로 팝업이 발생하지 않는다.
- **인증 동작**: rewrite된 https remote는 별도 gh 프로세스인 credential helper로 인증된다. 이 helper는 shell의 gh wrapper(alias/함수)를 거치지 않고, keyring의 PAT(`gh auth login`) 또는 git 프로세스 환경에 export된 `GH_TOKEN`을 조회한다 — git이 `GH_TOKEN`을 직접 읽는 것이 아니다.
- **범위 조정**: 초기에는 shared 모듈에서 양 플랫폼 공통 적용을 검토했으나, MiniPC(NixOS)는 credential helper의 토큰 공급원이 Mac과 다르다(opnix가 주입하는 github-pat 기반이며, shell의 `GH_TOKEN` wrapper를 별도 gh 프로세스가 우회). 공통 적용 시 MiniPC에서 인증이 실패할 위험이 있어 darwin 한정으로 좁혔다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| A. SSH 키 재등록 | agent 디바이스 키를 GitHub 계정에 등록 | 기존 SSH 흐름 유지 | 인증 시점마다 Touch ID 팝업 재발 → #848 개선과 모순 | ❌ |
| B. https + gh PAT (darwin 한정) | SSH URL을 https로 rewrite + gh credential helper 인증 | SSH/팝업 미사용, 키 등록 불필요, 기존 `git@github.com:` remote도 그대로 동작 | 플랫폼 분기 필요 | ✅ |
| C. shared 공통 적용 | insteadOf/https를 darwin·nixos 공통 적용 | 단일 코드 경로 | MiniPC credential helper 토큰 공급원 불일치로 인증 실패 위험 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/git/default.nix` | `git_protocol` 플랫폼 분기 + darwin 한정 `url.insteadOf` rewrite |

```nix
# gh 인증 프로토콜: Mac은 https, NixOS는 기존 ssh 유지
programs.gh.settings.git_protocol = if pkgs.stdenv.isDarwin then "https" else "ssh";

# Mac 전용: git@github.com SSH URL을 https로 rewrite → gh credential helper(PAT)로 인증
programs.git.settings.url = lib.mkIf pkgs.stdenv.isDarwin {
  "https://github.com/".insteadOf = "git@github.com:";
};
```

## 참고 레퍼런스

- #833 — 1Password SSH agent 도입 (이번 변경을 촉발한 배경)
- #848 — gh 팝업 UX 개선 (대안 A를 기각한 근거)
- [git `url.<base>.insteadOf` 공식 문서](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf)
- `gh auth git-credential` (gh credential helper)

## Human Test Plan

Mac에서 `nrs` 적용 후:

1. `git config --get url.https://github.com/.insteadOf` → `git@github.com:` 출력
2. `gh config get git_protocol` → `https`
3. `GIT_SSH_COMMAND=false git ls-remote git@github.com:greenheadHQ/nixos-config.git HEAD` → SSH를 강제 차단해도 HEAD 해시 반환 (insteadOf rewrite + PAT 인증, SSH 미사용 입증)
4. 기존 `git@github.com:` remote에서 `git pull` → Touch ID 팝업 없이 성공

**실패 시 진단**: `gh auth status`로 PAT 유효성/스코프를 확인하고, 필요 시 `gh auth login`으로 재인증한다.

## Deferred follow-up

MiniPC(NixOS)는 이번 darwin 한정 변경의 범위 밖이며, GitHub git 인증에 여전히 SSH/opnix github-pat 경로를 사용한다. 향후 MiniPC의 GitHub git 인증도 동일한 https+PAT로 통일하려면, credential helper의 토큰 공급원이 플랫폼마다 다르므로(별도 gh 프로세스가 shell의 `GH_TOKEN` wrapper를 우회) 별도 설계가 필요하다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git protocol handling: macOS systems now use HTTPS by default, while other systems use SSH for GitHub operations.
  * Added automatic URL rewriting on macOS to transparently convert Git SSH URLs to HTTPS, improving remote repository handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->