### PR TITLE
feat(claude): plans transient buffer GC SessionEnd hook (#756 P1)

### DIFF
--- a/.claude/plans/README.md
+++ b/.claude/plans/README.md
@@ -10,11 +10,11 @@
 
 ## Transient buffer 식별 기준
 
-파일명이 `<prefix>-<8hex>.md` 형식 (8자리 hex suffix) 이면 plan-mode runtime이 자동 생성한 transient plan buffer다. plan-with-questions 스킬 문서는 이 buffer를 새 SSOT plan으로 **승격하지 말라**고만 규정하고 (`modes/for_action.md:136`, `references/runtime-boundaries.md:76-78`), 정리(GC) 주체는 명시하지 않는다. 따라서 buffer는 무한 누적되는 경향이 있다 (#756 P1이 정리 정책/훅을 다룰 예정).
+파일명이 `<prefix>-<8hex>.md` 형식 (8자리 hex suffix) 이면 plan-mode runtime이 자동 생성한 transient plan buffer다. plan-with-questions 스킬 문서는 이 buffer를 새 SSOT plan으로 **승격하지 말라**고만 규정하고 (`modes/for_action.md:136`, `references/runtime-boundaries.md:76-78`), 정리(GC)는 `modules/shared/programs/claude/files/hooks/plans-gc.sh` (#756 P1) 가 SessionEnd 시 담당한다 — mtime 7일 초과 + untracked 8hex buffer만 삭제하고, canonical·tracked·최근 buffer는 보존한다. 기존 누적분은 P1 착수 시 일회성으로 정리했다.
 
 본 README 작성 시점 실측: hex 변종 누적이 가장 많은 prefix는 동일 topic의 SSOT plan canonical과 공존한다. canonical 식별은 아래 snippet 출력의 prefix 중 `<prefix>.md` (suffix 없음) 가 디렉토리에 존재하면 그것이 canonical SSOT plan이다.
 
-`-agent-<NHex>` 같은 다른 패턴 (예: `cosmic-booping-peach-agent-a1cbb08.md`) 도 일부 존재하나 2026-02-28 이후 추가 생성되지 않는 historical artifacts다 (과거 Claude Code sub-agent 산출물). 본 README의 식별 기준에 포함하지 않는다. P1에서 별도 일회성 정리 대상으로 분리한다.
+`-agent-<NHex>` 같은 다른 패턴 (suffix hex 길이 가변, 예: `...-agent-a6bbadcd76d351e67.md`) 도 일부 존재하나 2026-02-28 이후 추가 생성되지 않는 historical artifacts다 (과거 Claude Code sub-agent 산출물). 끝 8자 앞이 `-`가 아니라 hook의 8hex 정규식에 매칭되지 않으므로 지속 GC 대상이 아니며, 본 README의 식별 기준에도 포함하지 않는다. P1 착수 시 일회성으로 정리했다.
 
 ## Prefix별 hex 변종 집계 snippet
 

--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -154,6 +154,8 @@ in
     # Hooks - mkOutOfStoreSymlink로 nrs 없이 즉시 반영 (소스 파일에 chmod +x 필수)
     ".claude/hooks/nrs-session-cleanup.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/nrs-session-cleanup.sh";
+    ".claude/hooks/plans-gc.sh".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/plans-gc.sh";
     ".claude/hooks/worktree-path-guard.sh".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/hooks/worktree-path-guard.sh";
     ".claude/hooks/session-init-icons.sh".source =

--- a/modules/shared/programs/claude/files/hooks/plans-gc.sh
+++ b/modules/shared/programs/claude/files/hooks/plans-gc.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Claude Code SessionEnd hook: .claude/plans/ transient plan buffer GC (#756)
+#
+# plan-mode runtime이 .claude/plans/에 떨어뜨리는 transient plan buffer
+# (<prefix>-<8hex>.md)는 SSOT plan으로 승격되지 않고 무한 누적되는 경향이 있다.
+# 스킬 문서는 "비승격"만 규정하고 정리 주체를 두지 않으므로, 세션 종료 시
+# mtime 임계를 넘긴 오래된 transient buffer만 정리하는 GC 주체를 둔다.
+#
+# 보존 대상:
+#   - canonical SSOT plan (<prefix>.md, 8hex suffix 없음 → 패턴 미매칭)
+#   - git-tracked 파일 (README.md 등 force-add → ls-files 확인으로 제외)
+#   - mtime 임계(GC_AGE_DAYS) 내 최근 buffer (활성/최근 세션 보호)
+#   - 끝 8자(hex) 직전에 리터럴 '-'가 오지 않는 buffer. 정규식이 '-<8hex>.md$'를
+#     요구하므로 -agent-<7|17hex> 같은 historical은 끝 8자 앞이 hex라 미매칭되어
+#     보존된다. (주의: 끝이 정확히 '-<8hex>.md'이면 prefix 무관하게 GC 대상이다 —
+#     예: foo-agent-1a2b3c4d.md는 매칭됨.)
+#
+# 동작 위치: SessionEnd input의 .cwd가 속한 git repo의 .claude/plans/.
+# 정리 대상이 없으면 no-op. bash 3.2 호환 (mapfile 미사용).
+
+# 7일: 멀티데이 작업 중인 최근 buffer의 조기 삭제를 막는 보수적 여유. 정책적
+# 선택값이며, 줄이면 최근 buffer 보호 폭이 함께 좁아진다.
+GC_AGE_DAYS=7
+# 8자리 hex suffix transient buffer 식별 정규식 (.claude/plans/README.md #756 P0이
+# 정의한 SSOT 기준). unquoted 변수로 bash regex 매칭 (quote 시 literal 매칭됨).
+HEX_RE='-[0-9a-f]{8}\.md$'
+
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+[[ -z "$CWD" ]] && exit 0
+
+GIT_TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0
+PLANS_DIR="$GIT_TOPLEVEL/.claude/plans"
+[[ -d "$PLANS_DIR" ]] || exit 0
+
+# <prefix>-<8hex>.md + mtime > GC_AGE_DAYS 인 transient buffer만 삭제.
+# find -mtime은 BSD/GNU 공통. -name으로 '-' 포함 .md 후보를 거른 뒤 8hex 정규식으로
+# 정확히 재확인한다 (canonical <prefix>.md, suffix가 8 hex 아닌 -agent-<hex> 등 제외).
+while IFS= read -r f; do
+  [[ -n "$f" ]] || continue
+  base="${f##*/}"
+  [[ "$base" =~ $HEX_RE ]] || continue
+  # git-tracked 파일(README.md 등)은 보존
+  git -C "$GIT_TOPLEVEL" ls-files --error-unmatch "$f" >/dev/null 2>&1 && continue
+  rm -f "$f"
+done < <(find "$PLANS_DIR" -maxdepth 1 -type f -name '*-*.md' -mtime +"$GC_AGE_DAYS" 2>/dev/null)
+
+exit 0

--- a/modules/shared/programs/claude/files/settings.json
+++ b/modules/shared/programs/claude/files/settings.json
@@ -137,6 +137,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/nrs-session-cleanup.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/plans-gc.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `.claude/plans/` transient plan buffer(`<prefix>-<8hex>.md`)의 무한 누적을 정리하는 **SessionEnd hook `plans-gc.sh`** 신설 (#756 P1).
- 세션 종료 시 mtime 7일 초과 + untracked 8hex buffer만 GC. canonical SSOT plan·git-tracked 파일·최근 buffer·`-agent-<hex>` historical은 보존.
- 기존 누적분(8hex transient 89개 + agent historical 16개)은 P1 착수 시 일회성 정리 완료 (158 → 53).

Closes #756

## 기존 문제 / 배경

Claude Code harness의 plan-mode runtime은 `.claude/plans/`에 transient plan buffer(`<slug>-<8hex>.md`)를 떨어뜨린다. 이 buffer는 SSOT plan으로 승격되지 않지만(canonical `<prefix>.md`만 SSOT), 정리(GC) 주체가 어디에도 정의되지 않아 무한 누적됐다 — 착수 시점 main checkout `.claude/plans/`에 `*.md` 158개 중 8hex transient 89개가 쌓여 LLM이 디렉토리 조회 시 canonical을 판별하기 어려웠다.

#756 P0(README 정책 문서, #773 머지)은 식별 기준(8자리 hex suffix)을 SSOT로 정의하고 정리 주체는 P1로 미뤘다. 본 PR이 그 P1 — GC 주체 신설 — 을 담당한다.

## CIR (Change Intent Record)

- **생성 주체**: transient buffer 생성 주체는 (deprecated된) plan-with-questions 스킬이 아니라 Claude Code harness의 plan-mode runtime이다. 최근 7일 신규 생성은 0개지만 더 긴 기간으로 보면 다수가 활성이라 생성이 멈춘 것은 아니다. 일회성 청소만으로는 재누적되므로 지속 GC 주체가 필요하다.
- **트리거 위치**: transient buffer는 Claude Code 세션 산출물이므로 세션 lifecycle(SessionEnd)에 GC를 붙이는 것이 책임 귀속상 자연스럽다. 기존 `nrs-session-cleanup.sh`가 이미 SessionEnd에서 lock을 정리하는 선례를 따른다.
- **보존 안전성**: GC는 파일 삭제이므로 보존 경계를 다중으로 둔다 — 8hex 정규식(canonical·agent 미매칭) + mtime 임계(최근 buffer 보호) + `git ls-files --error-unmatch` 가드(tracked README.md 보존).
- **누적분 + agent**: hook은 미래 누적을 막고, 과거 누적(8hex 89개)과 README가 "별도 일회성 정리 대상"으로 분리한 agent historical(16개)은 P1 착수 시 일회성으로 청소했다. agent는 끝 8자 앞이 hex라 hook의 8hex 정규식에 매칭되지 않으므로 지속 GC 대상이 아니다.

## ADR (Architecture Decision Record)

### GC 트리거 위치

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| SessionEnd hook | 세션 종료 시 GC | 세션 산출물 lifecycle에 정렬, nrs-session-cleanup 선례 | cwd가 속한 repo만 정리 | ✅ |
| nrs (빌드 시점) | 재빌드 시 GC | 빌드와 함께 처리 | nrs는 빌드 도구라 plans 정리는 책임 밖, 드물게 실행되면 GC 지연 | ❌ |
| Stop hook | 매 turn 종료 시 | 더 빈번 | 과도한 빈도, plans 정리에 불필요 | ❌ |

### 정리 방식

| 대안 | 설명 | 결정 |
|------|------|------|
| hook(지속) + 일회성(과거) | 미래 누적 방지 + 과거 누적 청소 | ✅ (P1 완결) |
| hook만 | 미래 누적만 방지 | ❌ (과거 89개 미청소, DoD 미완) |
| 일회성만 | 과거만 청소 | ❌ (재누적) |

### mtime 임계

| 대안 | 결정 |
|------|------|
| 7일 | ✅ 활성/멀티데이 작업 buffer 조기 삭제 방지, 현재 누적분은 전부 7일 초과라 즉시 대상 |
| 1~2일 | ❌ 진행 중 작업 buffer 조기 삭제 위험 |
| 30일 | ❌ 누적이 한 달간 방치 |

## 구현 상세

| 파일 | 역할 | 변경 |
|------|------|------|
| `modules/shared/programs/claude/files/hooks/plans-gc.sh` | (신규) SessionEnd GC 훅 | 8hex + mtime>7일 + untracked transient만 삭제 |
| `modules/shared/programs/claude/default.nix` | hook 배포 | mkOutOfStoreSymlink 등록 |
| `modules/shared/programs/claude/files/settings.json` | hook 등록 | SessionEnd 배열에 추가 |
| `.claude/plans/README.md` | 정책 문서 | GC 주체(plans-gc.sh)·agent 처리 반영 |

핵심 로직 (보존 다중 가드):

```bash
while IFS= read -r f; do
  base="${f##*/}"
  [[ "$base" =~ $HEX_RE ]] || continue              # 8hex suffix만 (canonical·agent 제외)
  git -C "$GIT_TOPLEVEL" ls-files --error-unmatch "$f" >/dev/null 2>&1 && continue  # tracked 보존
  rm -f "$f"
done < <(find "$PLANS_DIR" -maxdepth 1 -type f -name '*-*.md' -mtime +"$GC_AGE_DAYS")
```

## 참고 레퍼런스

- #756 — 본 이슈 (P1)
- #773 — P0 README 정책 문서 (transient 식별 기준 SSOT)
- #847 — worktree bootstrap의 `git clean -fdX` tracked 보존 선례

## Human Test Plan

1. **hook 배포 확인**: 머지 후 `nrs` 실행 → `ls -la ~/.claude/hooks/plans-gc.sh`가 Nix store 심링크인지, `~/.claude/settings.json` SessionEnd에 plans-gc.sh가 등록됐는지 확인.
   - 실패 시: `modules/shared/programs/claude/default.nix`의 mkOutOfStoreSymlink 등록과 settings.json SessionEnd 항목을 점검.
2. **DoD 수렴 (착수 시 실측 완료)**: main checkout `.claude/plans/`에서 동일 prefix 8hex 변종이 1개 이하로 수렴.
   ```bash
   test -z "$(find .claude/plans -maxdepth 1 -type f -name '*-*.md' | sed -E 's|^.*/||' \
     | grep -E '\-[0-9a-f]{8}\.md$' | sed -E 's/-[0-9a-f]{8}\.md$//' | sort | uniq -d)"
   ```
   - 실측 결과: 158 → 53 파일, 8hex 변종 prefix 중복 0건 (PASS). (`-printf`는 GNU 전용이라 BSD 호환 `sed`로 basename 추출.)
3. **보존 검증**: `README.md`(tracked)와 canonical `<prefix>.md`(suffix 없음)가 보존됐는지 확인 (실측: README + canonical 53개 보존, 잔존 8hex/agent 0).
4. **SessionEnd 자동 GC (향후)**: 세션 종료 후 7일 초과 untracked 8hex buffer가 자동 정리되는지 — 새 transient를 만들고 mtime을 7일 이전으로 조정한 뒤 세션 종료 시 삭제, 최근 buffer·canonical·README 보존을 확인.
