### PR TITLE
fix(codex): 글로벌 gitignore의 Codex 산출물 제거 + gitignore_check 정리 (#76)

### DIFF
--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/SKILL.md
@@ -24,7 +24,6 @@ Codex CLI 호환 구조(`.agents/`, `.codex/`)로 프로젝션한다.
 | 로컬 스킬만 | `bash "$SYNC_SH" project-skills "$PWD/.claude/skills" "$PWD/.agents/skills"` |
 | 프로젝트 MCP 섹션만 | 아래 "MCP 섹션 가드 예시" 참조 |
 | User-scope MCP 투영 | 아래 "MCP 섹션 가드 예시" 참조 |
-| .gitignore 점검 | `bash "$SYNC_SH" gitignore-check "$PWD"` |
 
 ### MCP 섹션 가드 예시
 
@@ -198,22 +197,19 @@ bash "$SYNC_SH" all "$PWD" "${ARGS[@]}"
 진행상황이 stderr로 출력된다:
 ```text
 === syncing-codex-harness: Full Sync ===
- [1/8] Initialized .agents/ and .codex/
- [2/8] AGENTS.md: symlinked|copied|skipped
- [3/8] Local skills: N
- [4/8] Plugin skills: N, Agents: N
- [5/8] Rules -> AGENTS.override.md: N
- [6/8] MCP config updated|no sources found
- [7/8] Trust: trusted|already-trusted|skipped
- [8/8] .gitignore OK|Missing .gitignore entries: ...
+ [1/7] Initialized .agents/ and .codex/
+ [2/7] AGENTS.md: symlinked|copied|skipped
+ [3/7] Local skills: N
+ [4/7] Plugin skills: N, Agents: N
+ [5/7] Rules -> AGENTS.override.md: N
+ [6/7] MCP config updated|no sources found
+ [7/7] Trust: trusted|already-trusted|skipped
 === Sync complete ===
 ```
 
-### .gitignore 누락 처리
+### Codex 산출물의 git 추적
 
-`.agents/`와 `.codex/`는 글로벌 gitignore에서 관리된다.
-`AGENTS.md`와 `AGENTS.override.md`가 누락으로 보고되면 사용자에게 프로젝트 `.gitignore`에 추가를 제안한다.
-자동으로 수정하지 않는다.
+`.agents/`(스킬 심링크 트리), `AGENTS.md`, `AGENTS.override.md`는 Codex가 자동 발견하려면 프로젝트에 존재해야 하므로 커밋하는 것이 기본 운영 방식이다. 반면 `.codex/`는 프로젝트 MCP 설정(`config.toml`)을 담고 `mcp-config`가 `.mcp.json`의 env 시크릿을 평문 기록할 수 있어 글로벌 gitignore에서 계속 무시한다. 특정 산출물의 추적 여부를 바꾸려면 프로젝트 `.gitignore`에서 조정한다.
 
 ### User-scope MCP 투영 (Claude -> Codex)
 
@@ -253,7 +249,6 @@ fi
 | `agents-md` | AGENTS.md 생성 (심링크/복사) |
 | `agents-override` | AGENTS.override.md 생성 (마커 기반) |
 | `mcp-config` | 프로젝트/유저 대상 config.toml MCP 섹션 생성 |
-| `gitignore-check` | .gitignore 누락 확인 |
 
 상세 사용법은 `sync.sh` 상단 Usage 참조.
 
@@ -275,7 +270,6 @@ fi
 
 - `installPath` 해석 실패 시 플러그인 캐시 경로 존재 여부를 먼저 확인한다.
 - 동기화 후 스킬이 안 보이면 `.agents/skills/<name>`이 디렉토리 심링크인지 확인한다.
-- `.gitignore` 경고는 자동수정하지 않고 누락 항목을 수동 반영한다.
 - `chrome-devtools-mcp` 사용 시 동일 탭을 다른 도구(예: Claude in Chrome)와 동시 제어하지 않는다.
 
 ## 참조 문서

--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/codex-structure.md
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/codex-structure.md
@@ -16,7 +16,7 @@ project-root/
 │   └── <agent-name>.md          # Agent files (real copies)
 ├── .codex/
 │   └── config.toml              # MCP server config (TOML format)
-└── .gitignore                   # Should include AGENTS.md, AGENTS.override.md (.agents/, .codex/ are in global gitignore)
+└── .gitignore                   # .agents/, AGENTS.md, AGENTS.override.md are committed; .codex/ stays in global gitignore (may hold plaintext MCP secrets)
 ```
 
 ## Key Differences from Claude Code

--- a/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
+++ b/modules/shared/programs/claude/files/skills/syncing-codex-harness/references/sync.sh
@@ -9,7 +9,6 @@
 #   sync.sh agents-override   <project-root> [--plugin-install-path=PATH:NAME]...
 #   sync.sh mcp-config        <project-root> [--project-mcp=PATH] [--plugin-mcp=PATH:INSTALL_PATH:NAME]... [--user-mcp=PATH] [--user-codex-config=PATH]
 #   sync.sh trust-project     <project-root>
-#   sync.sh gitignore-check   <project-root>
 #   sync.sh all               <project-root> [--local-skills-dir=DIR] [--plugin-install-path=PATH:NAME]... [--plugin-claude-md=PATH] [--user-mcp=PATH] [--user-codex-config=PATH]
 
 set -euo pipefail
@@ -148,40 +147,6 @@ init_agents_dir() {
   # CIR: clear stale repo-local hook artifacts left behind by the retired
   # Claude-to-Codex projection path so old worktrees cannot invoke removed hooks.
   rm -f "$project_root/.codex/hooks.json" "$project_root/.codex/hooks.compatibility.json"
-}
-
-# ─── gitignore-check: check entries ───
-# All Codex projection artifacts (.agents/, .codex/, AGENTS.md, AGENTS.override.md)
-# are expected in global gitignore (see git/default.nix).
-# This function verifies they are actually ignored (via global or project gitignore).
-gitignore_check() {
-  local project_root="$1"
-  local missing=()
-  local entries=(".agents/" ".codex/" "AGENTS.md" "AGENTS.override.md")
-
-  if git -C "$project_root" rev-parse --git-dir >/dev/null 2>&1; then
-    for entry in "${entries[@]}"; do
-      if ! git -C "$project_root" check-ignore -q "$entry" 2>/dev/null; then
-        missing+=("$entry")
-      fi
-    done
-  else
-    # Fallback for non-git directories
-    local gitignore="$project_root/.gitignore"
-    if [ ! -f "$gitignore" ]; then
-      printf '%s\n' "${entries[@]}"
-      return
-    fi
-    for entry in "${entries[@]}"; do
-      if ! grep -qxF "$entry" "$gitignore" 2>/dev/null; then
-        missing+=("$entry")
-      fi
-    done
-  fi
-
-  if [ ${#missing[@]} -gt 0 ]; then
-    printf '%s\n' "${missing[@]}"
-  fi
 }
 
 # ─── agents-md: create AGENTS.md ───
@@ -594,19 +559,19 @@ sync_all() {
 
   # 1. Init
   init_agents_dir "$project_root"
-  echo "[1/8] Initialized .agents/ and .codex/" >&2
+  echo "[1/7] Initialized .agents/ and .codex/" >&2
 
   # 2. AGENTS.md
   local md_result
   md_result="$(agents_md "$project_root" "$plugin_claude_md")"
-  echo "[2/8] AGENTS.md: $md_result" >&2
+  echo "[2/7] AGENTS.md: $md_result" >&2
 
   # 3. Local skills
   local local_count=0
   if [ -n "$local_skills_dir" ] && [ -d "$project_root/$local_skills_dir" ]; then
     local_count=$(project_skills "$project_root/$local_skills_dir" "$project_root/.agents/skills")
   fi
-  echo "[3/8] Local skills: $local_count" >&2
+  echo "[3/7] Local skills: $local_count" >&2
 
   # 4. Plugin skills + agents
   local plugin_skill_count=0
@@ -638,12 +603,12 @@ sync_all() {
       mcp_args+=("--plugin-mcp=$ipath/.mcp.json:$ipath:$pname")
     fi
   done
-  echo "[4/8] Plugin skills: $plugin_skill_count, Agents: $agent_count" >&2
+  echo "[4/7] Plugin skills: $plugin_skill_count, Agents: $agent_count" >&2
 
   # 5. AGENTS.override.md
   local rule_count
   rule_count=$(agents_override "$project_root" "${override_args[@]}")
-  echo "[5/8] Rules -> AGENTS.override.md: $rule_count" >&2
+  echo "[5/7] Rules -> AGENTS.override.md: $rule_count" >&2
 
   # 6. MCP config
   local project_mcp_arg=""
@@ -660,7 +625,7 @@ sync_all() {
   # project-scope sources -> <project>/.codex/config.toml
   if [ ${#project_mcp_args[@]} -gt 0 ]; then
     mcp_config "$project_root" "${project_mcp_args[@]}"
-    echo "[6/8] MCP config updated (project)" >&2
+    echo "[6/7] MCP config updated (project)" >&2
     did_mcp_update=1
   fi
 
@@ -670,31 +635,21 @@ sync_all() {
     [ -n "$user_codex_config" ] && user_mcp_args+=("--user-codex-config=$user_codex_config")
     mcp_config "$project_root" "${user_mcp_args[@]}"
     if [ ${#project_mcp_args[@]} -gt 0 ]; then
-      echo "[6b/8] MCP config updated (user)" >&2
+      echo "[6b/7] MCP config updated (user)" >&2
     else
-      echo "[6/8] MCP config updated (user)" >&2
+      echo "[6/7] MCP config updated (user)" >&2
     fi
     did_mcp_update=1
   fi
 
   if [ "$did_mcp_update" -eq 0 ]; then
-    echo "[6/8] MCP config: no sources found" >&2
+    echo "[6/7] MCP config: no sources found" >&2
   fi
 
   # 7. Trust project in global config
   local trust_result
   trust_result="$(ensure_project_trusted "$project_root")"
-  echo "[7/8] Trust: $trust_result" >&2
-
-  # 8. Gitignore check
-  local missing
-  missing="$(gitignore_check "$project_root")"
-  if [ -n "$missing" ]; then
-    echo "[8/8] Missing .gitignore entries:" >&2
-    echo "$missing" >&2
-  else
-    echo "[8/8] .gitignore OK" >&2
-  fi
+  echo "[7/7] Trust: $trust_result" >&2
 
   echo "=== Sync complete ===" >&2
 }
@@ -720,9 +675,6 @@ case "${1:-}" in
   init)
     init_agents_dir "$2"
     ;;
-  gitignore-check)
-    gitignore_check "$2"
-    ;;
   agents-md)
     agents_md "$2" "${3:-}"
     ;;
@@ -739,7 +691,7 @@ case "${1:-}" in
     sync_all "$2" "${@:3}"
     ;;
   *)
-    echo "Usage: sync.sh {project-skills|plugin-skills|agents|agents-md|agents-override|mcp-config|trust-project|init|gitignore-check|all} ..." >&2
+    echo "Usage: sync.sh {project-skills|plugin-skills|agents|agents-md|agents-override|mcp-config|trust-project|init|all} ..." >&2
     exit 1
     ;;
 esac

--- a/modules/shared/programs/git/default.nix
+++ b/modules/shared/programs/git/default.nix
@@ -161,11 +161,9 @@ in
       "mise.local.toml"
       ".mise.local.toml"
 
-      # Codex CLI (syncing-codex-harness 프로젝션 산출물)
-      ".agents/"
+      # Codex CLI: .codex/config.toml은 MCP env 시크릿을 평문 담을 수 있어 글로벌 무시 유지.
+      # .agents/·AGENTS.md·AGENTS.override.md는 Codex 자동발견용으로 커밋이 기본이라 무시하지 않는다.
       ".codex/"
-      "AGENTS.md"
-      "AGENTS.override.md"
 
       # Python
       "__pycache__/"


### PR DESCRIPTION
## Summary

- 글로벌 gitignore(`programs.git.ignores`)에서 커밋이 의도된 Codex 산출물 3개(`.agents/`·`AGENTS.md`·`AGENTS.override.md`)를 제거해 `git add -f` 강제 자기모순을 해소.
- `.codex/`는 MCP env 시크릿을 평문 담을 수 있어 글로벌 무시를 **유지** (보안 안전망).
- `sync.sh`의 `gitignore_check()` 및 `.gitignore` 점검 단계를 제거하고(8→7단계), 관련 문서(SKILL.md·codex-structure.md)를 동기화.

Closes #76

## 기존 문제 / 배경

`modules/shared/programs/git/default.nix`의 `programs.git.ignores`가 `.agents/`·`.codex/`·`AGENTS.md`·`AGENTS.override.md`를 글로벌 gitignore(`~/.config/git/ignore`)에 넣었다. 그런데 `.agents/`(스킬 심링크 트리)·`AGENTS.md`·`AGENTS.override.md`는 Codex가 자동 발견하려면 프로젝트에 **존재(커밋)**해야 하는 파일이다. 결과적으로 nixos-config 자신을 포함한 모든 repo에서 이 파일들을 커밋하려면 `git add -f`가 필요한 자기모순이 발생했다.

`sync.sh`의 `gitignore_check()`는 이 4개가 ignore되는지 검증하고 `sync.sh all`의 `[8/8]` 단계로 보고했는데, 정작 커밋이 의도이므로 검증 자체가 모순이었다.

## CIR (Change Intent Record)

- **자기모순 구조**: sync.sh는 "이 파일들이 무시되어야 한다"고 검증하면서, 실제 운영은 커밋이다. 4개 파일의 올바른 git 상태가 단일하지 않다 — `.agents/`·`AGENTS.md`·`AGENTS.override.md`는 커밋 의도, `.codex/`는 무시 가능.
- **`.codex/` 유지 결정**: `.codex/config.toml`은 `sync.sh mcp-config`가 `.mcp.json`의 env 시크릿을 평문 기록할 수 있는 파일이다. 글로벌 무시를 없애면 프로젝트가 로컬 `.gitignore`에 넣지 않는 한 토큰이 커밋될 위험이 생긴다. nixos-config 자신도 `.codex/`는 로컬 `.gitignore`로 무시 중(=커밋 의도 아님)이라, 자기모순의 실제 대상은 나머지 3개뿐이다. 따라서 `.codex/`는 글로벌 무시를 유지한다.
- **`gitignore_check()` 완전 제거**: 검증 대상의 올바른 상태가 단일하지 않아 일률 검증이 불가능하고, sync.sh의 책임은 Codex 호환 구조 투영이지 gitignore 정책 강제가 아니다. 함수·`[8/8]` 단계·dispatch case·usage·헤더 주석을 모두 제거하고 단계 번호를 `[1/7]`~`[7/7]`로 재조정했다.
- **문서 동기화**: `gitignore-check` 서브커맨드 제거에 맞춰 SKILL.md(빠른참조·출력 예시·서브커맨드 표·트러블슈팅·운영 방식 섹션)와 codex-structure.md(레이아웃 주석)의 폐기된 글로벌 gitignore 전제를 정리.

## ADR (Architecture Decision Record)

### `gitignore_check()` 처리

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 완전 제거 | 함수·`[8/8]`·dispatch·usage 제거, `[1/7]`~`[7/7]` 재번호 | sync.sh 책임을 투영으로 한정, 검증 대상 비단일성 해소 | `[8/8]` 단계 소멸(경고도 함께 소멸) | ✅ |
| 의미 전환 | 4개가 ignore되면 "커밋 막힘" 경고 | 단계 유지 | `.codex/`처럼 무시가 옳은 파일에 false positive, sync.sh가 gitignore 정책 의견 유지 | ❌ |

### `.codex/` 처리

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `.codex/` 유지 (3개만 제거) | 글로벌 무시 유지 | MCP env 시크릿 평문 노출 안전망 보존, 자기모순(커밋 의도 3개)만 정확히 해소 | 이슈 AC의 `.codex/` 항목 조정 필요 | ✅ |
| 4개 모두 제거 | 이슈 AC 그대로 | AC 문구 일치 | `.codex/config.toml` 시크릿이 각 repo 로컬 `.gitignore` 누락 시 커밋 위험 | ❌ |

## 구현 상세

| 파일 | 역할 | 변경 |
|------|------|------|
| `modules/shared/programs/git/default.nix` | git 전역 설정 | `ignores`에서 `.agents/`·`AGENTS.md`·`AGENTS.override.md` 제거, `.codex/`는 보안 주석과 함께 유지 |
| `.../syncing-codex-harness/references/sync.sh` | Codex 투영 스크립트 | `gitignore_check()`·`[8/8]` 단계·dispatch·usage·헤더 제거, `[1/7]`~`[7/7]` 재번호 |
| `.../syncing-codex-harness/SKILL.md` | 스킬 문서 | gitignore-check 참조 제거, 출력 예시 `[N/8]`→`[N/7]`, 운영 방식 섹션 갱신 |
| `.../syncing-codex-harness/references/codex-structure.md` | 구조 레퍼런스 | 레이아웃 주석을 새 정책(`.agents/`/`AGENTS.md` 커밋, `.codex/` 무시)에 맞춤 |

## 참고 레퍼런스

- #76 — 본 이슈

## Human Test Plan

> 글로벌 gitignore(`~/.config/git/ignore`)는 Nix store 심링크라 `nrs` 재빌드 후에만 반영된다. 아래 AC는 머지 후 `nrs` 적용 시 검증한다.

1. **글로벌 ignore 정리 (AC1)**: `nrs` 후 `cat ~/.config/git/ignore` → `.agents/`·`AGENTS.md`·`AGENTS.override.md` 없음, `.codex/`는 **존재**(시크릿 안전망 유지).
2. **커밋 정상화 (AC2)**: nixos-config에서 `git add .agents/ AGENTS.md AGENTS.override.md`가 `-f` 없이 성공.
3. **새 프로젝트 (AC3)**: 임의 git repo에서 `sync.sh all` 후 `.agents/`를 `git add` 가능 (`.gitignore`에 별도 추가 안 한 경우).
4. **sync 단계 (AC4, 스모크 완료)**: `sync.sh all` 실행 시 `[1/7]`~`[7/7]`로 정상 종료, `.gitignore` 경고 단계 없음. (격리 환경 실측: `[1/7]`~`[7/7]` 출력 확인, 제거된 `gitignore-check` 서브커맨드는 usage 에러로 거부.)
   - 실패 시 진단: `bash sync.sh all <repo>` stderr에서 `[*/8]` 잔재나 `gitignore` 문자열이 있으면 재발.
