### PR TITLE
docs: add Termius SSH follow-up plan

### DIFF
--- a/.claude/prds/prd-1password-migration.md
+++ b/.claude/prds/prd-1password-migration.md
@@ -4,9 +4,9 @@
 
 - Status: In Progress
 - File Mode: Split
-- Current Phase: Phase 1·2a·2b·3 merged (#824·#833·#827·#842) + Phase 4 GUI/박제 완료(PR 대기) — Phase 5·6 남음
+- Current Phase: Phase 1·2a·2b·3 merged (#824·#833·#827·#842) + Phase 4 GUI/박제 완료(PR 대기) — Phase 5·6 남음 + Phase 2a mobile SSH follow-up 열림(non-blocking)
 - Active Phase File: [Phase 4](./prd-1password-migration/phase-04-apple-passwords.md)
-- Last Updated: 2026-05-26
+- Last Updated: 2026-05-27
 - PRD File: `.claude/prds/prd-1password-migration.md`
 - Issue: [#780](https://github.com/greenheadHQ/nixos-config/issues/780)
 - Purpose: Living PRD / 실행 source of truth. 여기에서 작업을 체크 off 하고, 구현 중 새 사실이 드러나면 이 문서를 갱신하고, 계획이 바뀌면 진행 전에 후속 phase를 수정한다.
@@ -68,12 +68,13 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 - Actor: 사용자 (iPhone Scriptable + Termius 워크플로)
 - Trigger: Immich 업로드 → 경로 클립보드 복사 → Termius SSH → Claude Code 전달
 - Expected outcome: iPhone Termius가 보유한 `iphone_ed25519` private key로 인증. Mac과 별개 키. MiniPC `authorized_keys`에 등록되어 있어 동작. 1Password가 down되어도 영향 없음.
+- Follow-up validation: canonical gates and evidence format live in [Phase 2a post-merge remediation](./prd-1password-migration/phase-02a-mac-ssh.md#post-merge-remediation-termius-mobile-key-mismatch).
 
 ### Scenario 5: 디바이스 분실
 
 - Actor: 사용자
 - Trigger: iPad 분실
-- Expected outcome: `modules/nixos/users/<user>/authorized_keys.nix`에서 ipad 라인 1개 제거 → `nrs minipc`. 1Password Automation vault에 백업된 `ipad_ed25519` item을 `revoked` tag. Mac/iPhone 영향 0.
+- Expected outcome: `hosts/greenhead-minipc/default.nix`의 MiniPC authorizedKeys 목록에서 iPad key를 제거하고, source value는 `libraries/constants.nix`의 `constants.sshDeviceKeys.ipad`와 대조 → `nrs minipc`. 1Password Automation vault에 백업된 `ipad_ed25519` item을 `revoked` tag. Mac/iPhone 영향 0.
 
 ### Scenario 6: SA token rotation (90일)
 
@@ -90,7 +91,7 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 ## Discovery Summary
 
 - Reviewed: `modules/nixos/programs/docker/vaultwarden.nix`, `modules/nixos/programs/docker/vaultwarden-backup.nix`, `modules/nixos/programs/vaultwarden-update/default.nix`, `modules/nixos/programs/caddy.nix`, `modules/nixos/programs/smoke-test.nix`, `modules/darwin/programs/ssh/default.nix`, `secrets/secrets.nix`, `libraries/constants.nix`, `tests/eval-tests.nix`, `.claude/skills/managing-secrets/SKILL.md`, `.claude/skills/hosting-vaultwarden/SKILL.md`, `.claude/skills/running-containers/references/scriptable-immich-upload.md`
-- Current system: Vaultwarden Podman 컨테이너 (`vaultwarden/server:1.35.4`, port 8222, vaultwarden.greenhead.dev, Tailscale 내부 전용, Caddy reverse proxy). 매일 04:30 KST SQLite + rsync 백업, 30일 보존. agenix `.age` 23개 (`secrets/secrets.nix`), 그중 `vaultwarden-admin-token` + `pushover-vaultwarden`이 Vaultwarden 의존. Mac SSH: `~/.ssh/id_ed25519` + `launchd.agents.ssh-add-keys` (`modules/darwin/programs/ssh/default.nix:16-21, 52-64`). `programs.gh` enable (`modules/shared/programs/git/default.nix:176`). gh 호출 빈도: MiniPC Claude Code 단일 세션 39회.
+- Discovery baseline at PRD creation (2026-05-17): Vaultwarden Podman 컨테이너 (`vaultwarden/server:1.35.4`, port 8222, vaultwarden.greenhead.dev, Tailscale 내부 전용, Caddy reverse proxy). 매일 04:30 KST SQLite + rsync 백업, 30일 보존. agenix `.age` 23개 (`secrets/secrets.nix`), 그중 `vaultwarden-admin-token` + `pushover-vaultwarden`이 Vaultwarden 의존. Mac SSH는 당시 `~/.ssh/id_ed25519` + `launchd.agents.ssh-add-keys` 경로였다. 이후 변경은 각 phase change log가 canonical이다.
 - Validation surface: `nrs` (nix-darwin/nixos-rebuild) + `nix flake check --no-build --all-systems` + `tests/eval-tests.nix` + `smoke-test.nix` + `managing-secrets/evals/queries.json`. 1Password 동작은 GUI + `op` CLI 명령 + Touch ID 응답으로 manual 검증.
 - Design implications: (a) 1Password Service Account가 Individual 플랜에서 GUI 노출됨을 사용자가 GUI 스크린샷으로 확인 (2026-05-17). (b) Mac은 Homebrew Cask `1password`, NixOS는 nixpkgs `_1password-cli`만. (c) opnix canonical은 `brizzbuzz/opnix` (mrjones2014는 archived, brizzbuzz README가 명시). (d) envScript 패턴은 vaultwarden뿐 아니라 karakeep·awesome-anki에서도 사용 중 → 별도 references 이관 불필요.
 - Confidence / gaps: Apple Passwords CSV의 TOTP/passkey 보존 여부는 Phase 4에서 sample 3개 사전 실측으로 확정한다. 1Password Individual은 Events API audit log 없음 — 구조적 한계로 vault separation + rotation cadence로 보완.
@@ -105,10 +106,10 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 - FR-4: `libraries/constants.nix`에 `onePassword.vaults.{personal, automation}` 상수를 등록한다.
 - FR-5: `op_get <name> <field> [<vault>]` helper (zsh function 또는 shell library)를 작성한다. vault 기본값은 `constants.onePassword.vaults.automation`.
 - FR-6: 1Password Service Account를 발급하고 토큰을 `secrets/opnix-service-account-token.age`로 agenix에 보관한다 (Phase 1). 90일 rotation systemd timer + Pushover 알림(만료 N-14일)은 MiniPC 시스템 구성이므로 Phase 3에서 구현·activation 검증한다.
-- FR-7: Mac `~/.ssh/config`에 `IdentityAgent ~/.1password/agent.sock` 추가. ControlPersist 정책 결정 (영구 또는 daemon master).
+- FR-7: Mac `~/.ssh/config`에 1Password group container socket(`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`)을 `IdentityAgent`로 추가. ControlPersist 정책 결정 (영구 또는 daemon master).
 - FR-8: `launchd.agents.ssh-add-keys.enable = false` 또는 동등 게이트. `~/.ssh/id_ed25519` 처분 결정 (archive 또는 1Password vault item으로 이관 후 file 삭제).
 - FR-9: Emergency ed25519 fallback key (`emergency_ed25519`) 생성 + `~/.ssh/config` Host 분기 + MiniPC `authorized_keys` 등록 + 실측 acceptance ("1Password 데스크탑 quit 후 emergency key로 ssh minipc 성공").
-- FR-10: 디바이스별 SSH 키 4개 (`mac_ed25519` agent-managed, `iphone_ed25519`, `ipad_ed25519`, `emergency_ed25519`). 1Password Automation vault `ssh` tag에 backup copy + revocation 절차 박제. MiniPC `modules/nixos/users/<user>/authorized_keys.nix`에 declarative 등록.
+- FR-10: 디바이스별 SSH 키 4개 (`mac_ed25519` agent-managed, `iphone_ed25519`, `ipad_ed25519`, `emergency_ed25519`). 1Password Automation vault `ssh` tag에 backup copy + revocation 절차 박제. MiniPC authorized key source는 `libraries/constants.nix`의 `constants.sshDeviceKeys`와 이를 소비하는 `hosts/greenhead-minipc/default.nix`의 `users.users.${username}.openssh.authorizedKeys.keys`이다.
 - FR-11: `op plugin init gh` 실행 후 `~/.config/op/plugins.sh`를 `programs.zsh.initContent`에 declarative source 등록 (Home Manager).
 - FR-12: `modules/nixos/programs/opnix/default.nix`에 opnix `services.onepassword-secrets`(1Password Go SDK root oneshot)를 설정해 SA token으로 `op://` reference를 tmpfs에 owner-scoped materialize한다. SA token을 user shell로 export하는 EnvironmentFile/profile.d 방식은 폐기(user shell 노출 방지).
 - FR-13: macOS Passwords 앱에서 sample 3개 (password-only / TOTP / passkey 항목 각 1개) 사전 export → CSV field 매트릭스 PRD에 박제 → 정책 결정 (TOTP 별도 sub-phase로 분리 여부) → 일괄 import 실행.
@@ -146,7 +147,7 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 
 ## Risks / Edge Cases
 
-- iPhone/iPad SSH key file 보유 패턴은 1Password 의도와 보안 모델이 다름 (A-2). 디바이스 분실 시 즉시 `authorized_keys.nix`에서 해당 라인 revoke.
+- iPhone/iPad SSH key file 보유 패턴은 1Password 의도와 보안 모델이 다름 (A-2). 디바이스 분실 시 즉시 `hosts/greenhead-minipc/default.nix`의 authorizedKeys 소비 목록에서 해당 디바이스 key를 제거하고, `libraries/constants.nix`의 `constants.sshDeviceKeys` 값과 vault item 상태를 대조한다.
 - emergency ed25519 fallback이 일상적으로 사용되면 "emergency"가 아님. 사용 빈도 모니터링 필요 (사용자가 수동 인지).
 - Apple Passwords CSV의 TOTP/passkey 보존이 실패할 경우 TOTP는 별도 sub-phase로 분리하여 서비스별 재설정.
 - Vaultwarden 컨테이너 종료 후 2-6개월 사이 backup 모니터링 부재 (smoke-test 게이트 제거). 6개월 만료 시점 사용자 manual integrity check.
@@ -169,14 +170,14 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 | Phase | Status | Objective | Validation Focus | File |
 |---|---|---|---|---|
 | Phase 1: Foundation | Done (merged #824) | Mac 1Password 설치, Automation vault, gh PAT rotation, op_get helper, SA token | nrs darwin + gh API + op CLI 동작 | [phase-01-foundation.md](./prd-1password-migration/phase-01-foundation.md) |
-| Phase 2a: Mac SSH | Done (merged #833) | IdentityAgent + emergency fallback + 디바이스별 키 inventory | ssh minipc 동작 + 1Password quit 후 fallback 실측 | [phase-02a-mac-ssh.md](./prd-1password-migration/phase-02a-mac-ssh.md) |
+| Phase 2a: Mac SSH | Done (merged #833) + mobile follow-up open | IdentityAgent + emergency fallback + 디바이스별 키 inventory | ssh minipc 동작 + 1Password quit 후 fallback 실측 + mobile post-merge remediation gate | [phase-02a-mac-ssh.md](./prd-1password-migration/phase-02a-mac-ssh.md) |
 | Phase 2b: Shell plugin gh | Done (merged #827) | Home Manager declarative plugin 등록 | gh pr list 동작 (biometric prompt 1회) | [phase-02b-shell-plugin-gh.md](./prd-1password-migration/phase-02b-shell-plugin-gh.md) |
 | Phase 3: MiniPC opnix | Done (merged #842) | opnix native materialization + SA token + gh GH_TOKEN wrapper | nrs minipc + ssh minipc E2E 전항목 통과 | [phase-03-minipc-opnix.md](./prd-1password-migration/phase-03-minipc-opnix.md) |
 | Phase 4: Apple Passwords | Done (GUI/박제 — PR 대기) | CSV 매트릭스 실측, 62개 import, iCloud AutoFill OFF, passkey(기존 1Password) | 분기 A + TOTP 동작 + secure delete 게이트 통과 | [phase-04-apple-passwords.md](./prd-1password-migration/phase-04-apple-passwords.md) |
 | Phase 5: Skill 리팩토링 | Not Started | managing-secrets routing 매트릭스 + inventory + queries.json | evals/queries.json 통과 + SKILL.md ≤ 250줄 | [phase-05-skill-refactor.md](./prd-1password-migration/phase-05-skill-refactor.md) |
 | Phase 6: Vaultwarden EOL | Not Started | vaultwarden-touch 파일 atomic 삭제·수정 단일 PR + rg 잔존 0건 + 6개월 백업 정책 | nrs minipc + eval-tests + rg | [phase-06-vaultwarden-eol.md](./prd-1password-migration/phase-06-vaultwarden-eol.md) |
 
-의존성 그래프: Phase 1 → Phase 2a, Phase 2b, Phase 3. Phase 3 → (Phase 5 일부). Phase 4와 Phase 6은 서로 무관. Phase 5는 Phase 1-3 완료 후 시작 (1Password 운영 패턴이 안정되어야 inventory/routing 매트릭스 작성 가능).
+의존성 그래프: Phase 1 → Phase 2a, Phase 2b, Phase 3. Phase 3 → (Phase 5 일부). Phase 4와 Phase 6은 서로 무관. Phase 5는 Phase 1-3 완료 후 시작 (1Password 운영 패턴이 안정되어야 inventory/routing 매트릭스 작성 가능). Phase 2a mobile SSH follow-up은 Phase 5의 blocking dependency가 아니다. 해당 상태별 Phase 5 gate는 [Phase 5 Mobile SSH Integration Policy](./prd-1password-migration/phase-05-skill-refactor.md#phase-2a-mobile-ssh-integration-policy)가 canonical이다.
 
 ## Appendix: 최종 secrets.nix 변경 요약
 
@@ -194,6 +195,7 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 ## Open Questions
 
 - Phase 2c (git commit signing 통합) 도입 시점과 범위는 별도 epic으로 분리할지 본 PRD에서 다룰지. 현재는 Out of Scope.
+- Phase 2a mobile SSH follow-up: iPhone Tailscale IP에서 MiniPC `sshd`까지 연결은 도달했지만 PAM 인증 실패로 종료됐고, 당시 MiniPC는 `kbdinteractiveauthentication yes` 상태였다. 직전 iPhone 성공 기록의 accepted publickey fingerprint는 현재 등록된 `iphone-ssh`가 아니라 retired `macbook` key와 일치했다(2026-05-26). 결정 질문의 상세 SSOT는 [Phase 2a post-merge remediation](./prd-1password-migration/phase-02a-mac-ssh.md#post-merge-remediation-termius-mobile-key-mismatch)이다.
 - ~~Phase 4의 TOTP 별도 sub-phase 범위 (서비스 카운트 N건 임계)~~ **[해소 — 2026-05-26]**: CSV에 otpauth 포함(분기 A) 실측 확인 → 별도 sub-phase 불필요, generic CSV import로 일괄(OTPAuth→`one-time password` 라벨).
 - ~~SA token user shell bridge 설계 (Phase 3)~~ **[해소됨 — 2026-05-25 설계 확정, 기술 자문 교차검증]**: **opnix native materialization** 채택. opnix system module(`services.onepassword-secrets` — op CLI 래퍼가 아니라 1Password Go SDK 기반 root oneshot)이 SA token(`/run/agenix/opnix-service-account-token`, **0400 root 유지**)을 읽어 `op://Automation/github-pat/token`을 user-readable 파일(`/run/opnix/greenhead/github-pat`, tmpfs, owner=greenhead mode 0400)로 materialize한다. gh는 `GH_TOKEN` wrapper로 그 파일을 읽어 인증 → **SA token은 user shell/프로세스에 노출 0**(opnix root oneshot만 SA token 사용, user는 결과물 github-pat만 받음).
     - 기각된 후보: (1) systemd+polkit — 정책 복잡 + SA token이 여전히 user 도달, (2) wrapper binary(setuid/capability) — 보안 표면·감사 부담, (3) derived limited-scope credential — 1Password SA가 정적 JWT(AUK+SRP+keyset 직렬화)라 child token 발급 미지원.
@@ -211,3 +213,4 @@ Vaultwarden self-host는 Mac/iOS 자동채움 UX·passkey·SSH agent·shell plug
 - 2026-05-26: Phase 3 PR #842 squash merge → MiniPC 배포(main pull + nrs, 29s) + E2E 전항목 통과. opnix-secrets.service active(exited, 부팅 자동 활성), github-pat materialize `/run/opnix/greenhead/github-pat`=400 greenhead:users(tmpfs), SA tokenFile=640 root:onepassword-secrets(users 비움 → 실질 root-only), gh GH_TOKEN wrapper로 `gh api user`=greenheadHQ·`gh pr list` 정상, SA token user shell 노출 0(env grep), opnix-rotate-check.timer 등록(다음 2026-06-01) + dry-run exit 0(만료 2026-08-22, 87일 → silent). Phase 4(Apple Passwords)·5(skill 리팩토링)·6(Vaultwarden EOL) 남음. 후속 개선: Mac 비대화형/LLM gh가 op Shell Plugin biometric으로 매 호출 Touch ID 마찰 → #848 등록(GH_TOKEN 우회 경로, Mac 한정). SSH ControlMaster·MiniPC GH_TOKEN wrapper는 무관 확인.
 - 2026-05-26: Phase 4 (Apple Passwords) GUI/실기 완료 + PRD 박제 (PR 대기). 외부 조사(Apple/1Password/FIDO 공식 교차검증)로 PRD 가정 2건 정정 — (1) macOS 1Password는 시스템 AutoFill provider 미등록 설계라 Phase 4d "1Password ON 토글" 불성립(iCloud AutoFill OFF + 브라우저 extension으로 재정의; iOS는 시스템 토글 유효), (2) macOS 1Password는 FIDO Credential Exchange import 미구현(iOS 26·Android 14+만 수신)이라 CXP 직접 이전 불가 → CSV 경로 확정. CSV 매트릭스 실측(헤더 Title/URL/Username/Password/Notes/OTPAuth 6컬럼, 68 records, TOTP는 OTPAuth 컬럼 otpauth로 포함 → 분기 A). generic CSV import(Safari importer는 TOTP 버림 회피, OTPAuth→one-time password 라벨)로 62개(68−6 선별) 개인 vault 적재 + TOTP 6자리 코드 동작 검증 + green.com SSH·Twitch 중복 정리. CSV `/bin/rm -P` secure delete + 종료 게이트 0건(TM 백업 미설정 → N/A). passkey는 Google 1개가 기존 1Password passkey(2024-09)로 이미 충족 → Phase 4e lazy migration 정책 + 90일 calendar 폐기(YAGNI). SC-5 달성. Phase 5·6 남음.
 - 2026-05-26: Phase 2a(#833) SSH agent 이관 후속 fix → PR #853 squash merge. 디바이스 키를 1Password agent로 이관하며 기존 GitHub 등록 키가 교체돼 GitHub 미등록 상태가 되자 `git@github.com:` remote의 SSH 인증이 `Permission denied (publickey)`로 실패(fetch/pull 차단). Mac 한정 https+gh credential helper(PAT) 경로로 통일 — `programs.gh.settings.git_protocol`을 darwin=https/nixos=ssh로 분기 + `url."https://github.com/".insteadOf="git@github.com:"`를 `pkgs.stdenv.isDarwin` 가드(`modules/shared/programs/git/default.nix`). SSH 키 GitHub 재등록 대신 gh credential helper 경로를 채택한 이유: 키 등록·관리 부담 제거 + #848 gh Touch ID 마찰 회피(SSH 경로 미사용). credential helper는 별도 gh 프로세스로 keyring PAT 또는 git 프로세스의 GH_TOKEN을 조회한다(git이 GH_TOKEN을 직접 읽지 않음 — #848 GH_TOKEN 주입이 적용되면 git transport도 무인 이득). MiniPC는 토큰 공급원이 달라(opnix github-pat) darwin 한정으로 좁힘 — 동일 통일 시 별도 설계 필요(deferred). merge 후 main nrs 적용 + E2E 전항목 통과(SSH 강제 차단 `GIT_SSH_COMMAND=false`에도 `git@github.com:` URL 연산 성공, nrs closure delta +0, insteadOf·git_protocol 활성). PRD 사각지대 보강: 그동안 SC-2가 `gh` 명령 인증만, SC-3/4·FR-10이 SSH 키를 원격 호스트 접속 용도로만 다뤄 GitHub git transport 인증 경로가 누락됐던 것을 SC-2에 명시.
+- 2026-05-26: Phase 2a(#833) SSH agent 이관 후속 사각지대 발견 — iPhone Termius 접속은 MiniPC까지 도달했으나 인증 단계에서 실패했다. MiniPC `sshd` 로그는 iPhone Tailscale IP에서 PAM 인증 실패를 반복했고, 당시 MiniPC는 `kbdinteractiveauthentication yes` 상태였다. 직전 iPhone 성공 기록의 accepted publickey fingerprint는 현재 등록된 `iphone-ssh`가 아니라 retired `macbook` key와 일치했다. Phase 2a에 mobile Termius remediation checklist와 사용자 결정 질문을 추가. 향후 closeout은 Termius actual connection identity + server-side accepted fingerprint를 동시에 확인해야 한다.

--- a/.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md
+++ b/.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md
@@ -1,8 +1,8 @@
 # Phase 2a: Mac SSH Integration
 
 Parent PRD: [PRD: Bitwarden(Vaultwarden) → 1Password 마이그레이션 + LLM 주도 개발 생태계](../prd-1password-migration.md)
-Status: Done (merged #833)
-Last Updated: 2026-05-25
+Status: Done (merged #833) + mobile follow-up open
+Last Updated: 2026-05-27
 
 ## Objective
 
@@ -18,9 +18,9 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 ## Phase Discovery Gate
 
 코드 편집 전에 재확인한다:
-- [ ] 관련 코드/파일: `modules/darwin/programs/ssh/default.nix` (특히 `sshAddScript` 16-21줄 + `launchd.agents.ssh-add-keys` 52-64줄 + `matchBlocks.minipc` ControlMaster 44-47줄), `modules/nixos/programs/ssh/default.nix` (서버측 sshd 설정), `modules/nixos/users/<user>/authorized_keys.nix` (없으면 신규 작성)
+- [ ] 관련 코드/파일: `modules/darwin/programs/ssh/default.nix` (`programs.ssh`, `matchBlocks.minipc` ControlMaster, `matchBlocks.minipc-emergency`, 1Password `agent.toml`), `modules/nixos/programs/ssh.nix` (서버측 sshd 설정), `libraries/constants.nix` (`constants.sshDeviceKeys`), `hosts/greenhead-minipc/default.nix` (MiniPC authorizedKeys consumer)
 - [ ] 관련 테스트/fixture: 없음 (manual smoke)
-- [ ] 관련 docs/spec/외부 참조: https://developer.1password.com/docs/ssh/agent/, https://developer.1password.com/docs/ssh/agent/config/, https://developer.1password.com/docs/ssh/manage-keys/
+- [ ] 관련 docs/spec/외부 참조: https://developer.1password.com/docs/ssh/agent/, https://developer.1password.com/docs/ssh/agent/config/, https://developer.1password.com/docs/ssh/manage-keys/, https://termius.com/documentation/generate-ssh-key, https://termius.com/documentation/copy-ssh-key-to-server
 - [ ] 관련 command 또는 도구: `nrs darwin`, `ssh-keygen`, `ssh -v minipc`, `ssh-add -l`, `op` CLI
 - [ ] Master PRD의 assumption A-2 (iOS Termius local key file 영구 유지)가 여전히 유효함
 - [ ] Phase 1의 Automation vault + naming convention이 완료되었음
@@ -33,54 +33,64 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 - `mac_ed25519` key 생성: 1Password GUI → New Item → SSH Key → Generate (Ed25519) → title `mac-ssh` → tag `ssh`. private key는 1Password vault 자체 보관, public key 캡처
 - `iphone_ed25519`, `ipad_ed25519` key 생성: 각각 디바이스에서 직접 ssh-keygen으로 생성 후 1Password Automation vault에 `iphone-ssh`, `ipad-ssh` item으로 backup copy 저장 (Termius는 디바이스 local file 보유)
 - `emergency_ed25519` key 생성: `ssh-keygen -t ed25519 -C "emergency-fallback" -f ~/.ssh/emergency_ed25519` (passphrase 강). 1Password Automation vault `emergency-ssh` item에 backup
-- 4개 public key를 `modules/nixos/users/<user>/authorized_keys.nix` (또는 적합한 위치)에 declarative 등록
+- 4개 public key를 `libraries/constants.nix`의 `constants.sshDeviceKeys`에 선언하고 `hosts/greenhead-minipc/default.nix`의 MiniPC authorizedKeys 목록에서 소비
 - Mac `~/.ssh/config`: 
-  - 전역 `IdentityAgent ~/.1password/agent.sock` (1Password macOS agent socket symlink — 1Password 데스크탑 앱이 자동 생성)
+  - 전역 `IdentityAgent`는 1Password group container socket(`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`) 사용
   - `Host minipc-emergency` 분기 → `Hostname <minipc>` + `IdentityFile ~/.ssh/emergency_ed25519` + `IdentityAgent none`
 - ControlPersist 정책 결정 + 적용: 현재 600초 → 영구(`yes`) 또는 launchd으로 master daemon 띄우는 패턴 중 1개 선택 (사용자 워크플로 모니터링 후 결정)
-- `cfg.useOpAgent` 옵션 신설 + 정확한 Nix 표현 (SSOT 1개): `launchd.agents.ssh-add-keys = lib.mkIf (!cfg.useOpAgent) { ... 기존 정의 그대로 ... };` — 즉 useOpAgent=true이면 launchd agent 정의 자체가 빠짐. `.enable = ...` attribute 패턴은 사용하지 않음 (의미 충돌 방지)
+- Mac ssh module cleanup: 기존 `launchd.agents.ssh-add-keys`/`sshAddScript`/`sshKeyPath`/identityFile 경로를 제거하고, 1Password agent 전용 `programs.ssh` + `agent.toml` 구성으로 정리. 별도 `cfg.useOpAgent` 옵션은 최종 구현에서 도입하지 않음(Discoveries / Decisions 참조)
 - `~/.ssh/id_ed25519` 파일 처분: 1Password vault에 backup item으로 저장 후 file 삭제 (또는 `~/.ssh/id_ed25519.archive`로 mv + chmod 000)
 - `programs.ssh.matchBlocks."*".identityFile`가 1Password agent와 충돌하지 않게 검토 (필요 시 identityFile 라인 제거)
 
 ### Out of Scope
 
-- iPhone/iPad Termius 디바이스 자체에 새 key 등록 (사용자 GUI 작업, 본 phase에서 가이드만 제공)
+- Original Phase 2a scope에서는 iPhone/iPad Termius 디바이스 자체에 새 key 등록을 사용자 GUI 작업으로 두고 가이드만 제공했다. Post-Merge Remediation은 이 범위의 예외이며 mobile identity/import/rotation 검증을 별도 후속으로 추적한다.
 - MiniPC opnix 도입 (Phase 3)
 - Shell plugin gh (Phase 2b)
 - git commit signing 통합 (Out of Scope of full PRD)
 
+### Post-Merge Follow-Up Scope
+
+- Mobile actual connection identity는 server-side evidence로 닫는다. Canonical checklist, hardening gate, evidence format, and decision questions are in [Post-Merge Remediation](#post-merge-remediation-termius-mobile-key-mismatch).
+- iPad Termius도 동일 회귀 가능성이 있으므로 검증 범위에 포함할지 사용자 결정을 받는다.
+
 ## Implementation Checklist
 
-- [ ] 1Password 데스크탑 앱: Settings → Developer → "Use the SSH agent" ON 확인. `~/.1password/agent.sock` symlink 존재 확인 (`ls -la ~/.1password/agent.sock`)
+- [ ] 1Password 데스크탑 앱: Settings → Developer → "Use the SSH agent" ON 확인. group container socket 존재 확인: `test -S "$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"`
 - [ ] 1Password GUI에서 `mac-ssh` SSH Key item 생성 (Ed25519, Generate). public key 캡처
 - [ ] 직접 emergency key 생성 (passphrase는 interactive prompt — argv/shell history 노출 방지):
   - 명령: `ssh-keygen -t ed25519 -C "emergency-fallback-$(hostname)" -f ~/.ssh/emergency_ed25519` (`-N` 인자 사용 금지)
   - ssh-keygen이 "Enter passphrase" 프롬프트로 묻고 입력 시 화면·history에 echo 안 됨
   - 별도 단계: 1Password Automation vault `emergency-ssh` item을 GUI에서 생성하여 (a) private key (`cat ~/.ssh/emergency_ed25519`), (b) public key (`cat ~/.ssh/emergency_ed25519.pub`), (c) passphrase 3개 필드를 수동 입력. 명령줄 `op` 호출 안 함 (passphrase가 argv 노출 회피)
 - [ ] iPhone Termius / iPad Termius에서 각각 ssh-keygen 생성 (디바이스별로 사용자 수동). public key 캡처 → 1Password Automation vault `iphone-ssh`, `ipad-ssh` item에 backup
-- [ ] `modules/nixos/users/<user>/authorized_keys.nix` (또는 `modules/nixos/programs/ssh/authorized_keys.nix` 등 적절 위치) 신규 또는 확장:
+- [ ] `libraries/constants.nix`의 `constants.sshDeviceKeys` 신규 또는 확장 후, `hosts/greenhead-minipc/default.nix`의 MiniPC authorizedKeys 목록이 이를 소비하는지 확인:
   ```nix
-  { ... }: {
-    users.users.<user>.openssh.authorizedKeys.keys = [
-      "ssh-ed25519 AAA... mac-ssh"
-      "ssh-ed25519 AAA... iphone-ssh"
-      "ssh-ed25519 AAA... ipad-ssh"
-      "ssh-ed25519 AAA... emergency-fallback"
-    ];
-  }
+  sshDeviceKeys = {
+    macSsh = "ssh-ed25519 AAA... mac-ssh";
+    iphone = "ssh-ed25519 AAA... iphone-ssh";
+    ipad = "ssh-ed25519 AAA... ipad-ssh";
+    emergency = "ssh-ed25519 AAA... emergency-fallback";
+  };
+
+  users.users.${username}.openssh.authorizedKeys.keys = with constants.sshDeviceKeys; [
+    macSsh
+    iphone
+    ipad
+    emergency
+  ];
   ```
 - [ ] `modules/darwin/programs/ssh/default.nix` 수정:
-  - cfg.useOpAgent 옵션 신설 (default true)
-  - `launchd.agents.ssh-add-keys = lib.mkIf (!cfg.useOpAgent) { ... 기존 정의 그대로 ... };`로 정의 전체를 wrap. useOpAgent=true이면 agent 자체가 launchd에 등록되지 않음
-  - `programs.ssh.extraConfig` 또는 `matchBlocks."*".extraOptions`에 `IdentityAgent ~/.1password/agent.sock` 추가
+  - 기존 `launchd.agents.ssh-add-keys`/`sshAddScript`/`sshKeyPath`/identityFile 경로 제거
+  - `programs.ssh.matchBlocks."*".extraOptions.IdentityAgent`에 1Password group container socket 추가
+  - `home.file.".config/1Password/ssh/agent.toml"`에 Automation vault 노출 설정
   - `matchBlocks.minipc-emergency` 신규 (Hostname=minipc, IdentityFile=~/.ssh/emergency_ed25519, IdentityAgent=none)
   - ControlPersist 정책: 사용자 워크플로 검토 후 `"yes"` (영구) 또는 launchd master daemon 패턴 중 선택. Phase Decision으로 박제
-- [ ] launchd gate 동작 검증: `nrs darwin` 후 `launchctl list | grep ssh-add-keys` 결과가 빈 행이어야 정상 (useOpAgent=true 기본값에서 agent unload됨)
+- [ ] launchd cleanup 검증: `nrs darwin` 후 `rg 'ssh-add-keys|sshAddScript|sshKeyPath' modules/darwin/programs/ssh/default.nix` 결과가 0건이어야 정상
 - [ ] `nrs darwin` 빌드 + activate
-- [ ] **MiniPC authorized_keys 배포** — `authorized_keys.nix`가 NixOS 모듈이므로 MiniPC도 rebuild해야 새 키가 deploy됨:
+- [ ] **MiniPC authorized_keys 배포** — `constants.sshDeviceKeys`와 `hosts/greenhead-minipc/default.nix`의 authorizedKeys 목록은 NixOS config이므로 MiniPC도 rebuild해야 새 키가 deploy됨:
   - [ ] `nrs minipc` 실행 (Mac에서 트리거 가능)
-  - [ ] deployed-key presence check: `ssh minipc 'wc -l ~/.ssh/authorized_keys'` 결과가 신규 키 추가만큼 증가 (예: 기존 1줄 → 4줄)
-  - [ ] 키 indices 확인: `ssh minipc 'grep -c "mac-ssh\|iphone-ssh\|ipad-ssh\|emergency-fallback" ~/.ssh/authorized_keys'` 결과 = 4
+  - [ ] deployed-key presence check: `ssh minipc 'wc -l /etc/ssh/authorized_keys.d/greenhead'` 결과가 신규 키 추가만큼 증가 (예: 기존 1줄 → 4줄)
+  - [ ] 키 indices 확인: `ssh minipc 'grep -c "mac-ssh\|iphone-ssh\|ipad-ssh\|emergency-fallback" /etc/ssh/authorized_keys.d/greenhead'` 결과 = 4
 - [ ] `~/.ssh/id_ed25519` 처분:
   - 1Password Automation vault `mac-ssh-legacy` item 생성 (backup용)
   - file을 `~/.ssh/id_ed25519.archive`로 mv + `chmod 000`
@@ -97,6 +107,7 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 ## Validation Strategy
 
 - 일반 동작은 `ssh -v minipc`와 `ssh-add -l`로 검증. 1Password 데스크탑 quit 시 강제 실패 + emergency Host로 우회 가능함을 실측. ControlMaster cache 만료 후 첫 호출에서 popup 거부 시 timeout 동작 확인 (사용자가 수동 수용 가능 시간 측정).
+- Mobile Termius 후속 검증은 [Post-Merge Remediation](#post-merge-remediation-termius-mobile-key-mismatch)의 checklist와 evidence table을 canonical gate로 따른다.
 
 ## Validation Checklist
 
@@ -116,9 +127,86 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 - [ ] Phase objective 달성 (Mac SSH가 1Password agent 인증 + emergency fallback 검증 통과 + 디바이스별 4개 key inventory 완료)
 - [ ] FR-7, FR-8, FR-9, FR-10 모두 구현
 - [ ] Emergency fallback 실측 통과 (NFR-5)
-- [ ] iPhone/iPad Termius에 본인이 생성한 key가 등록되어 `ssh minipc` 정상 동작 (사용자 manual 보고)
+- [ ] Historical mobile gate: iPhone/iPad Termius `ssh minipc` 정상 동작은 사용자 manual 보고 기준이었다. Server-side accepted fingerprint 기준으로는 닫히지 않았으므로 Post-Merge Remediation에서 추적한다.
 - [ ] `~/.ssh/id_ed25519` 평문 file 처분 완료 (archive 또는 1Password vault 이관)
 - [ ] 다음 phase (Phase 2b)를 시작하지 못하게 막는 blocker 없음
+
+## Post-Merge Remediation: Termius Mobile Key Mismatch
+
+2026-05-26에 iPhone Termius 접속 실패를 분석한 결과, iPhone Tailscale IP에서 MiniPC `sshd`까지 연결은 도달했지만 PAM 인증 실패로 종료됐다. 당시 MiniPC는 `kbdinteractiveauthentication yes` 상태였다. 또한 직전 iPhone 성공 기록의 accepted publickey fingerprint는 현재 `iphone-ssh`가 아니라 retired `macbook` key와 일치했다. 따라서 Phase 2a의 server-side key 배포 확인만으로는 충분하지 않았고, mobile actual connection identity를 server-side accepted fingerprint로 검증하는 gate가 빠진 것이 사각지대다.
+
+### Decision Gate
+
+- [ ] Remediation checklist 실행 전에 [Required Before iPhone Remediation](#required-before-iphone-remediation) 질문을 먼저 닫는다.
+- [ ] Retired `macbook` key 임시 재등록을 실제로 사용할 때만 [Fallback Only](#fallback-only-retired-macbook-key-temporary-re-registration) decision set을 먼저 닫는다.
+
+### Remediation Checklist
+
+- [ ] 현재 MiniPC 등록 fingerprint 확인: `ssh-keygen -lf /etc/ssh/authorized_keys.d/greenhead`에서 `iphone-ssh`, `ipad-ssh`, `mac-ssh`, `emergency-fallback` fingerprint를 아래 fingerprint inventory table에 기록
+- [ ] MiniPC OpenSSH hardening: `modules/nixos/programs/ssh.nix`에 `services.openssh.settings.KbdInteractiveAuthentication = false` 추가 후 `nrs minipc` 적용
+- [ ] Server hardening 검증: MiniPC에서 `sudo -n sshd -T | rg '^(passwordauthentication|pubkeyauthentication|kbdinteractiveauthentication) '` 결과가 `passwordauthentication no`, `pubkeyauthentication yes`, `kbdinteractiveauthentication no`인지 확인
+- [ ] Termius iPhone host profile 확인: host는 MiniPC Tailscale endpoint, user는 `greenhead`, auth는 key identity 중심, identity는 `iphone-ssh`
+- [ ] iPhone에서 접속 시도 후 MiniPC 로그 확인: attempt time window를 KST ISO range로 정하고 같은 range를 `journalctl -u sshd.service --since ... --until ...`에 사용
+- [ ] Evidence log extraction: `journalctl -u sshd.service --since "<KST start>" --until "<KST end>" | rg 'for <user> from <device Tailscale IP>( port|$)' | rg 'Accepted publickey|keyboard-interactive|PAM|Failed publickey'` 결과에서 해당 device IP + user의 accepted log line/time과 PAM 여부를 evidence table에 기록. `<device Tailscale IP>`와 `<user>`는 evidence table 값과 같아야 하며, iPhone 기준 known values는 `100.76.27.1`과 `greenhead`이다.
+- [ ] Mobile regression check: evidence table의 accepted fingerprint가 expected fingerprint와 일치하고, 같은 device IP + user + attempt time window에 keyboard-interactive/PAM 실패 로그가 남지 않음
+- [ ] 실패 시 분기:
+  - Publickey accepted line 없이 PAM failure가 관찰되면 host profile의 identity binding을 수정
+  - accepted publickey fingerprint가 expected fingerprint와 다르면 accepted fingerprint의 출처를 식별하고 `iphone-ssh`로 교체
+  - accepted publickey line이 없고 key mismatch가 의심되면 MiniPC 기본 sshd 로그만으로 rejected key fingerprint를 단정하지 않는다. Evidence capture는 read-only public key view/copy 또는 client verbose log만 허용한다. Termius의 `Copy SSH Key to Server` / `Export to host`처럼 server `authorized_keys`를 변경할 수 있는 flow는 진단 중 사용 금지다. Read-only public key 파일을 확보한 경우 `ssh-keygen -lf <public-key-file>`로 fingerprint화해 `Rejected/mismatched key evidence`에 기록한다. Read-only public key 또는 fingerprint를 확인할 수 없으면 해당 field를 `unavailable`로 기록하고 `iphone-ssh` import 또는 rotation 중 하나를 선택한다.
+  - `iphone-ssh` private key가 Termius에 없으면 1Password Automation vault backup에서 복구한다. 새 iPhone keypair를 생성하는 경우에는 1Password Automation vault `iphone-ssh` item의 private key, public key, fingerprint와 `constants.sshDeviceKeys.iphone`를 함께 rotate한 뒤 `nrs`를 적용하고, MiniPC authorized_keys fingerprint와 vault 기록 fingerprint가 일치하는지 대조한다. Rotation 후에는 fingerprint inventory table의 `iphone-ssh` row를 새 MiniPC deployed fingerprint로 다시 채우고, evidence table의 expected fingerprint도 갱신된 row에서 가져온다.
+- [ ] iPad도 검증 범위로 선택되면 동일 절차를 `ipad-ssh`에 반복
+- [ ] 검증 완료 후 Phase 2a Change Log와 master PRD Open Questions/Change Log를 token/secret 없이 갱신. #780 comment는 선택적 mirror로만 사용
+
+표준 복구 경로는 `iphone-ssh` backup import 또는 새 iPhone keypair rotation이다. Retired `macbook` key 임시 재등록은 두 표준 경로가 막힌 경우의 최후수단이며, 허용 시 server-side source restriction(`from=` 또는 동등한 제한), TTL/removal gate, private key 보유 위치 확인, 제거 검증이 모두 필요하다.
+
+### Closed Status Definition
+
+이 follow-up의 `닫힘` 상태는 Phase 2a Post-Merge Remediation이 canonical이다. 최소 조건은 MiniPC OpenSSH `KbdInteractiveAuthentication = false` 적용, `sudo -n sshd -T`의 `kbdinteractiveauthentication no` 검증, iPhone accepted fingerprint match, 같은 device IP + user + attempt window의 keyboard-interactive/PAM 실패 로그 부재, Required Before iPhone Remediation 결정 완료, Phase 2a/master PRD 기록 완료다. iPad를 remediation 범위에 포함하기로 결정한 경우에는 iPad accepted fingerprint match도 `닫힘` 조건에 포함한다. Policy Follow-Up 질문은 immediate recovery `닫힘`을 막지 않는다. Fallback Only decision set은 fallback을 실제로 사용하기로 선택한 경우에만 `닫힘` 조건에 포함한다.
+
+### Fingerprint Inventory Table
+
+| Key label | SHA256 fingerprint | Source command |
+|---|---|---|
+| `iphone-ssh` | TBD | `ssh-keygen -lf /etc/ssh/authorized_keys.d/greenhead` |
+| `ipad-ssh` | TBD | `ssh-keygen -lf /etc/ssh/authorized_keys.d/greenhead` |
+| `mac-ssh` | TBD | `ssh-keygen -lf /etc/ssh/authorized_keys.d/greenhead` |
+| `emergency-fallback` | TBD | `ssh-keygen -lf /etc/ssh/authorized_keys.d/greenhead` |
+
+### Mobile Attempt Evidence Table
+
+이 표는 Phase 2a Change Log와 master PRD Open Questions/Change Log를 갱신하기 전의 canonical mobile attempt evidence 형식이다. `attempt time window`는 KST ISO range로 기록하고, 같은 범위를 `journalctl --since/--until`에 사용한다. `expected SHA256 fingerprint`는 fingerprint inventory table에서 가져오고, `accepted SHA256 fingerprint`와 `accepted log line/time`은 MiniPC `sshd` 로그에서 가져온다.
+
+| Device | User | Tailscale IP | Attempt time window | Expected key label | Expected SHA256 fingerprint | Accepted SHA256 fingerprint | Accepted log line/time | Rejected/mismatched key evidence | Keyboard-interactive/PAM observed | Result |
+|---|---|---|---|---|---|---|---|---|---|---|
+| iPhone | `greenhead` | TBD | TBD | `iphone-ssh` | TBD | TBD | TBD | TBD | TBD | TBD |
+| iPad (if in scope) | `greenhead` | TBD | TBD | `ipad-ssh` | TBD | TBD | TBD | TBD | TBD | TBD |
+
+### Questions For User Decision
+
+#### Required Before iPhone Remediation
+
+- [ ] 검증 범위: 이번 remediation 범위에서 iPhone만 닫을지, iPad Termius도 함께 포함할지?
+- [ ] `iphone-ssh` private key source: 기존 1Password Automation vault backup을 Termius에 import할지, iPhone에서 새 keypair를 생성해 1Password Automation vault `iphone-ssh` item(private key, public key, fingerprint)과 `constants.sshDeviceKeys.iphone`를 함께 rotate할지?
+- [ ] Rejected-key evidence path: Termius iOS에서 server-mutating export 없이 read-only public key/fingerprint 확인이 가능한지 사용자가 확인할지, 아니면 unavailable로 기록하고 import/rotation 경로로 바로 진행할지?
+
+#### Fallback Only: Retired `macbook` Key Temporary Re-Registration
+
+기본 복구 경로(`iphone-ssh` import 또는 rotation)가 가능하면 이 decision set은 열지 않는다.
+
+- [ ] Retired key 임시 재등록 허용 여부: old `macbook` public key 재등록을 최후수단으로 허용할지, 보안상 계속 금지하고 `iphone-ssh` import/rotation만 허용할지?
+- [ ] Retired key source restriction: MiniPC server-side 제한을 `from="<iPhone Tailscale IP>"` 또는 동등한 source restriction 중 무엇으로 둘지?
+- [ ] Retired key TTL: 임시 재등록 유지 시간을 무엇으로 둘지?
+- [ ] Retired key removal owner: 제거 실행 주체를 누구로 둘지?
+- [ ] Retired key removal verification command: 제거 검증 명령을 무엇으로 둘지? 기준은 `ssh-keygen -lf /etc/ssh/authorized_keys.d/greenhead`에서 old `macbook` fingerprint absent 확인이다.
+- [ ] Retired key private-key ownership check: old `macbook` private key가 어디에 남아 있는지 확인하고, 예상 밖 보유 위치가 발견되면 임시 재등록을 중단할지?
+
+#### Policy Follow-Up (Not Blocking Immediate Recovery)
+
+- [ ] Termius host canonical target: host 값을 `constants.network.minipcTailscaleIP`의 raw Tailscale IP로 고정할지, MagicDNS/hostname을 표준으로 둘지?
+- [ ] Termius profile policy: server-side `KbdInteractiveAuthentication = false` hardening을 필수로 둔 상태에서, Termius UI에서도 keyboard-interactive 또는 password/PAM prompt를 비활성 또는 미사용으로 둘지?
+- [ ] Evidence policy: mobile SSH key rotation/revoke 때마다 MiniPC `sshd` accepted fingerprint 대조를 mandatory gate로 둘지?
+- [ ] Inventory policy: 1Password `iphone-ssh`/`ipad-ssh` item에 public fingerprint와 Termius host profile 이름을 필드로 추가해 운영 인벤토리로 삼을지?
+- [ ] Issue/PR tracking: 이 후속 remediation을 PRD 문서 변경만으로 닫을지, 별도 GitHub issue를 열어 실기기 검증 완료 전까지 추적할지?
 
 ## Phase-End Multi-Pass Review
 
@@ -140,8 +228,10 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 - **agent.toml 필수**: 1Password SSH agent는 SSH 키를 자동 노출하지 않는다(GUI에 "SSH 키가 설정되지 않았습니다"). `~/.config/1Password/ssh/agent.toml`에 노출 vault를 명시해야 ssh-add -l에 키가 뜬다 → `vault = "Automation"`. `home.file`로 declarative 박제.
 - **useOpAgent let + 최종 cleanup**: phase-02a가 명시한 "옵션" 대신 모듈 let 상수로 구현(토글 수요 없어 YAGNI). id_ed25519 처분 시 launchd ssh-add-keys 경로 전체가 dead가 되어 useOpAgent/launchd/sshAddScript/sshKeyPath까지 함께 제거 → ssh/default.nix가 1Password agent 전용으로 단순화.
 - **id_ed25519 처분**: minipc 외 미사용 확인(github는 HTTPS git, MiniPC는 mac-ssh) → `~/.ssh/id_ed25519.archive`(chmod 000)로 mv. ssh config identityFile 제거 후 `ssh minipc`가 mac-ssh agent만으로 인증됨을 실측. darwin의 Mac 접속용 authorizedKeys(macbook 공개키)는 별개라 보존.
+- **Mobile Termius validation gap**: Phase 2a closeout은 Mac agent path와 emergency fallback을 강하게 검증했지만, iPhone/iPad Termius actual connection identity가 신규 device key인지 서버 로그 fingerprint 기준으로 닫지 못했다. 이후 mobile SSH 검증은 "client success + server accepted fingerprint match"를 함께 요구한다.
 
 ## Phase Change Log
 
 - 2026-05-17: Phase file created.
 - 2026-05-25: Phase 2a 구현 완료 → PR #833 squash merge. 디바이스 키 4개(mac-ssh/iphone/ipad/emergency)를 `constants.sshDeviceKeys`로 정의하고 MiniPC authorizedKeys에 배포(nrs minipc). Mac ssh config: IdentityAgent(group container socket) + agent.toml(Automation vault 노출) + minipc-emergency Host + ControlPersist 600(ControlMaster 유지). id_ed25519 archive. 검증: `ssh minipc`=mac-ssh agent 인증(Touch ID), emergency fallback 실측(1Password quit→emergency 접속 성공→ssh minipc Permission denied→재시작 복귀), id_ed25519 처분 후 agent-only 인증. merge 후 main nrs 적용 + E2E 전항목 재검증 통과. agent.toml vault를 constants 참조로 정정(SSOT). 발견: ControlPersist 영구는 무인 hang(→600 유지), agent socket은 group container 경로, agent.toml로 키 노출 명시 필수.
+- 2026-05-26: iPhone Termius 접속 실패 후속 분석 반영. iPhone Tailscale IP에서 MiniPC `sshd`까지 연결은 도달했지만 PAM 인증 실패로 종료됐고, 당시 MiniPC는 `kbdinteractiveauthentication yes` 상태였다. 직전 iPhone 성공 기록의 accepted publickey fingerprint는 현재 `iphone-ssh`가 아니라 retired `macbook` key와 일치했다. Post-Merge Remediation checklist와 사용자 결정 질문을 추가.

--- a/.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md
+++ b/.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md
@@ -38,7 +38,7 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
   - 전역 `IdentityAgent`는 1Password group container socket(`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`) 사용
   - `Host minipc-emergency` 분기 → `Hostname <minipc>` + `IdentityFile ~/.ssh/emergency_ed25519` + `IdentityAgent none`
 - ControlPersist 정책 결정 + 적용: 현재 600초 → 영구(`yes`) 또는 launchd으로 master daemon 띄우는 패턴 중 1개 선택 (사용자 워크플로 모니터링 후 결정)
-- Mac ssh module cleanup: 기존 `launchd.agents.ssh-add-keys`/`sshAddScript`/`sshKeyPath`/identityFile 경로를 제거하고, 1Password agent 전용 `programs.ssh` + `agent.toml` 구성으로 정리. 별도 `cfg.useOpAgent` 옵션은 최종 구현에서 도입하지 않음(Discoveries / Decisions 참조)
+- Mac ssh module cleanup: 기존 `launchd.agents.ssh-add-keys`/`sshAddScript`/`sshKeyPath`/identityFile 경로를 제거하고, 1Password agent 전용 `programs.ssh` + `agent.toml` 구성으로 정리. 별도 전환 옵션은 최종 구현에서 도입하지 않음(Discoveries / Decisions 참조)
 - `~/.ssh/id_ed25519` 파일 처분: 1Password vault에 backup item으로 저장 후 file 삭제 (또는 `~/.ssh/id_ed25519.archive`로 mv + chmod 000)
 - `programs.ssh.matchBlocks."*".identityFile`가 1Password agent와 충돌하지 않게 검토 (필요 시 identityFile 라인 제거)
 
@@ -213,7 +213,7 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 - [ ] 1. Intent/coverage — SC-3, SC-4 달성
 - [ ] 2. Correctness — happy path, 1Password quit, biometric 거부, ControlMaster 만료 후 무인 호출 hang 모두 처리
 - [ ] 3. Simplicity — IdentityAgent 1줄 + emergency Host 분기로 최소 변경
-- [ ] 4. Code quality — cfg.useOpAgent 옵션 이름/default가 nix-darwin 모듈 컨벤션 일치
+- [ ] 4. Code quality — `programs.ssh`/`agent.toml` 구조가 현재 모듈과 일치하고, 제거된 ssh-add launchd 경로가 completion criteria에 남지 않음
 - [ ] 5. Duplication/cleanup — ssh-add 관련 dead code (launchd ssh-add-keys 게이트로 비활성) 정리
 - [ ] 6. Security/privacy — `~/.ssh/id_ed25519` 평문 잔존 없음. emergency key passphrase 1Password vault 보관
 - [ ] 7. Performance — ControlPersist 정책으로 Touch ID popup 빈도 사용자 수용 범위 내
@@ -226,7 +226,7 @@ Mac SSH 인증을 1Password SSH agent로 이관하되, 단일 의존 실패 모�
 - **ControlPersist 정책**: 600 유지 (영구/daemon 채택 안 함). 영구(yes)는 무인 파이프 호출(`ssh minipc | grep`, Claude Code Bash 캡처 포함)에서 master가 stdout을 점유해 hang을 유발한다. ControlMaster auto + ControlPersist 600은 #710 analyzing-da-sessions의 K=8 worker pool SSH multiplexing이 의존하므로 ControlMaster 제거 불가(제거 시 그 스킬이 fetch skip → 5분 budget 회귀).
 - **1Password agent socket 경로**: macOS는 group container 경로(`~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock`)가 실제 socket. phase-02a가 가정한 `~/.1password/agent.sock` symlink는 자동 생성되지 않으므로, ssh config `IdentityAgent`에 group container 경로를 직접 지정(공백 포함이라 quote).
 - **agent.toml 필수**: 1Password SSH agent는 SSH 키를 자동 노출하지 않는다(GUI에 "SSH 키가 설정되지 않았습니다"). `~/.config/1Password/ssh/agent.toml`에 노출 vault를 명시해야 ssh-add -l에 키가 뜬다 → `vault = "Automation"`. `home.file`로 declarative 박제.
-- **useOpAgent let + 최종 cleanup**: phase-02a가 명시한 "옵션" 대신 모듈 let 상수로 구현(토글 수요 없어 YAGNI). id_ed25519 처분 시 launchd ssh-add-keys 경로 전체가 dead가 되어 useOpAgent/launchd/sshAddScript/sshKeyPath까지 함께 제거 → ssh/default.nix가 1Password agent 전용으로 단순화.
+- **전환 옵션 생략 + 최종 cleanup**: phase-02a가 명시한 전환 옵션 대신 모듈 let 상수로 구현(토글 수요 없어 YAGNI). id_ed25519 처분 시 launchd ssh-add-keys 경로 전체가 dead가 되어 legacy launchd/sshAddScript/sshKeyPath 경로까지 함께 제거 → ssh/default.nix가 1Password agent 전용으로 단순화.
 - **id_ed25519 처분**: minipc 외 미사용 확인(github는 HTTPS git, MiniPC는 mac-ssh) → `~/.ssh/id_ed25519.archive`(chmod 000)로 mv. ssh config identityFile 제거 후 `ssh minipc`가 mac-ssh agent만으로 인증됨을 실측. darwin의 Mac 접속용 authorizedKeys(macbook 공개키)는 별개라 보존.
 - **Mobile Termius validation gap**: Phase 2a closeout은 Mac agent path와 emergency fallback을 강하게 검증했지만, iPhone/iPad Termius actual connection identity가 신규 device key인지 서버 로그 fingerprint 기준으로 닫지 못했다. 이후 mobile SSH 검증은 "client success + server accepted fingerprint match"를 함께 요구한다.
 

--- a/.claude/prds/prd-1password-migration/phase-05-skill-refactor.md
+++ b/.claude/prds/prd-1password-migration/phase-05-skill-refactor.md
@@ -2,7 +2,7 @@
 
 Parent PRD: [PRD: Bitwarden(Vaultwarden) → 1Password 마이그레이션 + LLM 주도 개발 생태계](../prd-1password-migration.md)
 Status: Not Started
-Last Updated: 2026-05-17
+Last Updated: 2026-05-27
 
 ## Objective
 
@@ -24,6 +24,7 @@ Last Updated: 2026-05-17
 - [ ] 관련 command 또는 도구: skill router eval harness (있다면)
 - [ ] Phase 1-3가 완료되어 1Password 운영 패턴이 안정됨 (inventory 표 작성 가능)
 - [ ] Phase 2b에서 reserved한 "확장 트리거 텍스트" Discoveries 회수
+- [ ] Phase 2a mobile SSH follow-up 결정 상태 확인: 아래 "Phase 2a Mobile SSH Integration Policy"에 따라 분류
 
 ## Scope
 
@@ -33,6 +34,7 @@ Last Updated: 2026-05-17
 - Automation vault sub-folder 또는 tag 컨벤션 명문화 (`system/`, `dev/`, `ssh/`)
 - 통합 inventory 표 (SKILL.md inline 또는 `references/inventory.md`)
 - 1Password 운영 절차 추가: SA token rotation 5단계, Service Account 발급, vault 생성, item naming convention, `op_get` helper 사용법
+- SSH device key 운영 절차 추가(조건부): 아래 "Phase 2a Mobile SSH Integration Policy"를 따른다.
 - `evals/queries.json`은 **add-only**: 1Password 혼동 쌍을 신규 추가하고, 기존 vaultwarden 쌍 위에 `"comment": "DEPRECATED — Phase 6에서 삭제"` 표기만 추가. vaultwarden 쌍 자체의 삭제는 Phase 6 책임 (FR-17 분할 정책)
 - SKILL.md frontmatter trigger 키워드 확장: `'1password', '1Password', 'op CLI', 'opnix', 'service account token', 'Automation vault', 'biometric unlock'`
 - `NOT for Vaultwarden 비밀번호 관리자 (use hosting-vaultwarden)` line은 Phase 6에서 hosting-vaultwarden 스킬 삭제와 동시 제거 (본 phase에서는 변경하지 않음)
@@ -44,6 +46,14 @@ Last Updated: 2026-05-17
 - 새 managing-1password 스킬 신설 (NG-3)
 - hosting-vaultwarden 스킬 삭제 (Phase 6)
 - managing-secrets/evals/queries.json의 vaultwarden 쌍 완전 삭제 (Phase 6에서 처리, 본 phase에서는 1Password 쌍 신규 추가만)
+
+### Phase 2a Mobile SSH Integration Policy
+
+Phase 5는 Phase 2a mobile SSH follow-up 정책을 새로 결정하지 않는다.
+
+- 상태 판정은 Phase 2a [Closed Status Definition](./phase-02a-mac-ssh.md#closed-status-definition)을 따른다.
+- 결정 상태가 `닫힘`이면 [Phase 2a Post-Merge Remediation](./phase-02a-mac-ssh.md#post-merge-remediation-termius-mobile-key-mismatch)의 확정 절차를 SKILL.md 또는 `references/1password.md`에 반영한다.
+- 결정 상태가 `열림`이면 확정 Termius 절차 반영은 Phase 5 exit gate에서 제외하고, Phase 2a Post-Merge Remediation 링크와 follow-up tracking 위치 기록만 Phase 5 exit gate로 유지한다. 이때 tracking 위치는 master PRD Open Questions의 Phase 2a mobile SSH follow-up 항목과 Phase 2a Post-Merge Remediation anchor다. GitHub issue/#780 comment는 Phase 2a Policy Follow-Up의 Issue/PR tracking 질문이 닫히기 전까지 필수 tracking 위치가 아니다.
 
 ## Implementation Checklist
 
@@ -76,11 +86,13 @@ Last Updated: 2026-05-17
   | ... | ... | ... | ... | ... |
   | github-pat | 1Password | Automation | — | gh CLI (Mac + MiniPC) |
   | mac-ssh | 1Password | Automation | — | Mac SSH agent |
-  | iphone-ssh (backup copy) | 1Password | Automation | — | iPhone Termius (local file) |
-  | ipad-ssh (backup copy) | 1Password | Automation | — | iPad Termius (local file) |
+  | iphone-ssh (backup copy) | 1Password | Automation | — | intended iPhone Termius identity; per-device status pending/confirmed by Phase 2a remediation |
+  | ipad-ssh (backup copy) | 1Password | Automation | — | pending if included in Phase 2a remediation; otherwise not validated per Phase 2a scope decision |
   | emergency-ssh | 1Password | Automation | — | Mac fallback (~/.ssh/emergency_ed25519) |
   ```
 - [ ] SKILL.md에 1Password 운영 절차 추가 섹션 (Service Account 발급 5단계, vault 생성, item naming, `op_get` 사용법, 90일 rotation):
+- [ ] Phase 2a Mobile SSH Integration Policy 적용: 결정 상태가 `닫힘`이면 Phase 2a remediation anchor의 확정 Termius SSH 운영 절차를 추가
+- [ ] Phase 2a Mobile SSH Integration Policy 적용: 결정 상태가 `열림`이면 Phase 2a Post-Merge Remediation 링크와 master PRD Open Questions의 Phase 2a mobile SSH follow-up 항목만 tracking 위치로 기록
 - [ ] Phase 2b reserved 확장 트리거 텍스트 박제: "## Shell Plugin 확장 정책: 추가 shell plugin 도입 조건 = (a) 해당 도구 secret을 .env로 export하는 패턴 ≥ 2건 발생 OR (b) agenix 평문 노출 위험 보고 1건"
 - [ ] SKILL.md frontmatter trigger 키워드 확장 (1Password 관련 추가)
 - [ ] `evals/queries.json` 작업 (add-only):
@@ -117,6 +129,7 @@ Last Updated: 2026-05-17
 - [ ] FR-15, FR-16, FR-17 구현
 - [ ] NFR-3 (SKILL.md ≤ 250줄) 충족 또는 references/ 분할 완료
 - [ ] Phase 2b reserved 확장 트리거 텍스트 박제 완료
+- [ ] Phase 2a Mobile SSH Integration Policy 적용 결과 기록 완료
 - [ ] Phase 6 진행 시 vaultwarden 쌍 삭제만 남도록 정리됨
 
 ## Phase-End Multi-Pass Review
@@ -141,3 +154,4 @@ Last Updated: 2026-05-17
 ## Phase Change Log
 
 - 2026-05-17: Phase file created.
+- 2026-05-26: Phase 2a mobile SSH follow-up을 Phase 5 조건부 scope로 반영. Follow-up 결정이 닫혔으면 확정 Termius 운영 절차를 문서화하고, 열려 있으면 Phase 2a Post-Merge Remediation 링크와 master PRD Open Questions의 Phase 2a mobile SSH follow-up 항목만 Phase 5 exit gate로 요구한다.


### PR DESCRIPTION
## Summary
- Document the open iPhone Termius SSH follow-up in the 1Password migration PRD without blocking Phase 5.
- Add a canonical Phase 2a remediation gate that verifies mobile SSH by server-side accepted fingerprint evidence.
- Align stale SSH paths, socket paths, and tracking policy with the current repository state.

Closes: N/A — Refs #780

## 기존 문제/배경

Phase 2a closed the Mac 1Password SSH agent path and emergency fallback, but the mobile Termius path had only been treated as manual success. The later iPhone failure showed that the device reached MiniPC sshd, but authentication still failed, and the prior iPhone success log matched a retired `macbook` key rather than the intended `iphone-ssh` key.

That exposed a documentation gap: the PRD did not require mobile actual connection identity to be proven with server-side accepted fingerprint evidence. Some existing guidance also referenced stale SSH key locations and the old macOS agent socket assumption.

## CIR (Change Intent Record)

- **PR #833**: Migrated Mac SSH to 1Password agent, deployed device keys through `constants.sshDeviceKeys`, and validated Mac agent plus emergency fallback.
- **PR #853**: Clarified GitHub git transport after the SSH key migration, keeping MiniPC SSH key usage separate from Mac GitHub transport.
- **이번 변경**: Adds a post-merge mobile SSH remediation plan instead of treating the historical manual mobile gate as closed. The plan keeps Phase 2a as the canonical source and lets Phase 5 consume only the follow-up state.

**trade-off**: The PRD now has a longer Phase 2a follow-up section, but it avoids implicit assumptions about Termius identity selection and prevents future fixes from relying on client-side success alone.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Manual Termius success 유지 | 기존 사용자 보고만 유지 | 문서 변경 최소 | wrong key success를 놓칠 수 있음 | ❌ |
| Phase 2a remediation gate | user/IP-scoped sshd logs + accepted fingerprint match로 닫음 | 실제 인증 identity를 서버에서 검증 | 실기기 검증 절차가 길어짐 | ✅ |
| Phase 5에서 Termius 절차 확정 | managing-secrets 리팩토링 때 모바일 절차까지 확정 | 한 phase에서 문서화 가능 | Phase 5가 Phase 2a 정책을 새로 결정하게 됨 | ❌ |
| Retired key 임시 재등록 기본화 | old `macbook` key를 빠르게 되살림 | 즉시 복구 가능성 | 보안 표면 확대, 제거 누락 위험 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `.claude/prds/prd-1password-migration.md` | 수정 | Phase 2a mobile follow-up open 상태, current phase, Phase Index, Open Questions, SSH key source path 정정 |
| `.claude/prds/prd-1password-migration/phase-02a-mac-ssh.md` | 수정 | Post-Merge Remediation, evidence table, closed-status definition, user decision questions, stale path/socket 정정 |
| `.claude/prds/prd-1password-migration/phase-05-skill-refactor.md` | 수정 | Phase 2a Mobile SSH Integration Policy를 조건부 scope로 연결하고 tracking 위치 명확화 |

### 핵심 절차

```bash
# Server hardening gate
sudo -n sshd -T | rg '^(passwordauthentication|pubkeyauthentication|kbdinteractiveauthentication) '

# Mobile evidence gate
journalctl -u sshd.service --since "<KST start>" --until "<KST end>" \
  | rg 'for <user> from <device Tailscale IP>( port|$)' \
  | rg 'Accepted publickey|keyboard-interactive|PAM|Failed publickey'
```

The evidence command intentionally matches the sshd log context around both `user` and exact IP token, so overlapping IP strings do not contaminate the attempt window.

## 참고 레퍼런스

- Refs #780 — 1Password migration PRD / execution source of truth.
- PR #833 — Phase 2a Mac SSH integration and device key deployment.
- PR #853 — GitHub git transport follow-up after SSH key migration.
- [1Password SSH agent docs](https://developer.1password.com/docs/ssh/agent/) — SSH agent behavior and configuration.
- [Termius SSH key generation docs](https://termius.com/documentation/generate-ssh-key) — Termius key workflow reference.
- [Termius copy SSH key docs](https://termius.com/documentation/copy-ssh-key-to-server) — referenced to explicitly avoid server-mutating export flows during evidence capture.

## Human Test Plan

1. Read the Phase 2a remediation section.
   - **기대**: iPhone remediation has decision gate, server hardening gate, user/IP-scoped evidence extraction, accepted fingerprint comparison, and read-only Termius evidence constraints.
   - **실패 시**: Check the Phase 2a `Post-Merge Remediation: Termius Mobile Key Mismatch` anchor.

2. Verify stale path removal.
   - **기대**: executable guidance no longer points at `modules/nixos/users/<user>/authorized_keys.nix`, `~/.ssh/authorized_keys`, or `~/.1password/agent.sock`.
   - **실패 시**: compare with current `hosts/greenhead-minipc/default.nix`, `libraries/constants.nix`, and `modules/darwin/programs/ssh/default.nix`.

3. Verify Phase 5 behavior.
   - **기대**: Phase 5 treats open mobile SSH follow-up as non-blocking and records only the Phase 2a anchor plus master PRD Open Questions tracking location.
   - **실패 시**: inspect `Phase 2a Mobile SSH Integration Policy` in Phase 5.

4. Run markdown/diff validation.
   - **기대**: `git diff --check` passes.
   - **실패 시**: fix whitespace or markdown table formatting before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated 1Password migration PRD with progress tracking and expanded scenario documentation for mobile SSH remediation.
  * Revised Mac SSH integration phase with clarified device key inventory flow, emergency fallback procedures, and Termius mobile authentication resolution guidance.
  * Extended Phase 5 documentation to track mobile SSH follow-up decision status and policy implementation requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->