### PR TITLE
fix(shell): non-interactive zsh codex 노출 회귀 (snapshot shims 누락)

### DIFF
--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -64,10 +64,10 @@ mise는 두 계층으로 활성화된다:
 
 | 계층 | 파일 | 명령어 | 용도 |
 |------|------|--------|------|
-| `.zshenv` | `shell/default.nix` envExtra | `mise activate zsh --shims` | 비대화형 SSH 세션 (PATH에 shim만 추가) |
-| `.zshrc` | `shell/default.nix` initContent | `mise activate zsh` | 대화형 셸 (cd 시 자동 버전 전환 등 전체 훅) |
+| `.zshenv` | `shell/default.nix` envExtra | `mise activate zsh --shims` | snapshot 미경유 비대화형(SSH `zsh -c` 등)에서 PATH에 shim 추가 |
+| `.zshrc` | `shell/default.nix` initContent | `mise activate zsh` + shims prepend | 대화형 훅(cd-time 버전 전환) + Claude Code snapshot 경유 비대화형 보강 |
 
-`MISE_SHELL` 환경변수로 중복 활성화를 방지한다.
+중복 활성화 방지 가드는 shims 경로의 PATH 실재 여부로 판단한다 (`[[ ":$PATH:" != *":$shims:"* ]]`). 과거 `MISE_SHELL` 기반 가드는 부모 대화형 셸의 `MISE_SHELL`이 자식 비대화형 셸로 상속되어 shims 활성화를 조기 스킵하는 회귀를 만들어 폐기됐다. `.zshrc`에서 추가로 shims를 prepend하는 이유는 Claude Code 같은 도구가 세션 시작 시 interactive 셸 PATH를 snapshot으로 박제하고 비대화형 호출마다 그 PATH를 복원하기 때문이다 — snapshot 캡처 시점에는 `_mise_hook`이 발동 전이라 hook 모드의 install-bins도 PATH에 없는 baseline이 박제되므로, shim 노출 도구(mise npm backend)는 명시적 prepend 없이는 비대화형에 노출되지 않는다.
 
 ## 핵심 절차
 

--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -67,7 +67,12 @@ mise는 두 계층으로 활성화된다:
 | `.zshenv` | `shell/default.nix` envExtra | `mise activate zsh --shims` | snapshot 미경유 비대화형(SSH `zsh -c` 등)에서 PATH에 shim 추가 |
 | `.zshrc` | `shell/default.nix` initContent | `mise activate zsh` + shims prepend | 대화형 훅(cd-time 버전 전환) + Claude Code snapshot 경유 비대화형 보강 |
 
-중복 활성화 방지 가드는 shims 경로의 PATH 실재 여부로 판단한다 (`[[ ":$PATH:" != *":$shims:"* ]]`). 과거 `MISE_SHELL` 기반 가드는 부모 대화형 셸의 `MISE_SHELL`이 자식 비대화형 셸로 상속되어 shims 활성화를 조기 스킵하는 회귀를 만들어 폐기됐다. `.zshrc`에서 추가로 shims를 prepend하는 이유는 Claude Code 같은 도구가 세션 시작 시 interactive 셸 PATH를 snapshot으로 박제하고 비대화형 호출마다 그 PATH를 복원하기 때문이다 — snapshot 캡처 시점에는 `_mise_hook`이 발동 전이라 hook 모드의 install-bins도 PATH에 없는 baseline이 박제되므로, shim 노출 도구(mise npm backend)는 명시적 prepend 없이는 비대화형에 노출되지 않는다.
+가드와 `.zshrc` 추가 prepend의 배경:
+
+- 가드 기반: shims 경로의 PATH 실재 여부로 중복 활성화를 판단한다 (`[[ ":$PATH:" != *":$shims:"* ]]`). shims 경로 fallback은 mise 공식 우선순위 `MISE_DATA_DIR` → `$XDG_DATA_HOME/mise` → `$HOME/.local/share/mise`를 따른다 (`libraries/constants.nix`의 `mise.shimsDirExpr`이 SoT).
+- 옛 `MISE_SHELL` 가드 폐기 (#845): 부모 대화형 셸의 `MISE_SHELL`이 자식 비대화형 셸로 상속되어 shims 활성화를 조기 스킵하는 회귀를 만들어 폐기됐다.
+- `.zshrc`에서 shims prepend가 추가로 필요한 이유 (#857): Claude Code 같은 도구가 세션 시작 시 interactive 셸 PATH를 snapshot으로 박제하고 비대화형 호출마다 그 PATH를 복원한다. `mise activate zsh`(hook 모드)는 호출 끝에 `_mise_hook`을 즉시 발동시켜 install-bins를 PATH에 prepend하지만, hook 모드 정책상 shims는 PATH에 prepend하지 않는다 (shims는 `--shims` 플래그 경유에서만 PATH에 들어간다). 결과적으로 snapshot에는 install-bins는 들어가도 shims가 빠진 baseline이 박제되어, shim으로만 노출되는 도구(mise npm backend의 codex 등)는 비대화형에 미노출된다. `.zshrc`에서 shims를 명시적으로 prepend하면 snapshot에 shims도 포함되어 비대화형 호출이 동작한다.
+- 위험·우려와 fallback 후보: 이 fix는 Claude Code snapshot 캡처 메커니즘에 간접 의존한다. 향후 캡처 방식 변경(예: sanitized PATH 기록) 시 회귀 재발 가능. fallback 후보는 (a) `~/.claude/settings.json`의 `env.PATH`에 shims를 직접 prepend, (b) login shell init(`.zprofile`/`.zlogin`)에 shims 보강, (c) `command -v codex` 자가 검사를 `verify-ai-compat`에 추가하여 회귀 조기 감지.
 
 ## 핵심 절차
 

--- a/.claude/skills/managing-mise/references/troubleshooting.md
+++ b/.claude/skills/managing-mise/references/troubleshooting.md
@@ -48,9 +48,12 @@ programs.zsh.initContent = lib.mkBefore ''
 programs.zsh = {
   # .zshenv: SSH 비대화형 세션을 위한 mise shims PATH 추가
   envExtra = ''
-    if command -v mise >/dev/null 2>&1 && [[ -z "$MISE_SHELL" ]]; then
+    _mise_shims="''${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+    if command -v mise >/dev/null 2>&1 \
+       && [[ ":$PATH:" != *":$_mise_shims:"* ]]; then
       eval "$(mise activate zsh --shims)"
     fi
+    unset _mise_shims
   '';
 
   # .zshrc: 대화형 셸을 위한 전체 훅 활성화
@@ -78,7 +81,7 @@ $ ssh minipc 'cd /home/greenhead/Workspace/my-project && pnpm --version'
 9.15.4
 ```
 
-참고: darwin(Mac)과 NixOS 모두 동일한 설정을 사용하므로, 이 변경은 양쪽에 영향을 줍니다. `MISE_SHELL` 환경변수 체크로 중복 활성화를 방지합니다.
+참고: darwin(Mac)과 NixOS 모두 동일한 설정을 사용하므로, 이 변경은 양쪽에 영향을 줍니다. 중복 활성화 방지는 shims 경로의 PATH 실재 여부 가드로 한다 — 과거 `MISE_SHELL` 기반 가드는 부모 대화형 셸의 `MISE_SHELL`이 자식 비대화형 셸로 상속되어 shims 활성화를 조기 스킵하는 회귀를 만들어 폐기됐다.
 
 ---
 

--- a/.claude/skills/managing-mise/references/troubleshooting.md
+++ b/.claude/skills/managing-mise/references/troubleshooting.md
@@ -41,14 +41,18 @@ programs.zsh.initContent = lib.mkBefore ''
 '';
 ```
 
-해결: `.zshenv`에 mise shims 활성화 추가, `.zshrc`에 대화형 훅 유지.
+해결: `.zshenv`에 mise shims 활성화 추가, `.zshrc`에 대화형 훅 + Claude Code snapshot 보강용 shims prepend 유지. shims 경로 표현은 `libraries/constants.nix`의 `mise.shimsDirExpr`에서 SoT로 관리한다.
 
 ```nix
 # modules/shared/programs/shell/default.nix
+let
+  # constants.mise.shimsDirExpr 우선순위: MISE_DATA_DIR → XDG_DATA_HOME/mise → $HOME/.local/share/mise
+  miseShimsDecl = ''_mise_shims="${constants.mise.shimsDirExpr}"'';
+in
 programs.zsh = {
-  # .zshenv: SSH 비대화형 세션을 위한 mise shims PATH 추가
+  # .zshenv: snapshot 미경유 비대화형 세션을 위한 mise shims PATH 추가
   envExtra = ''
-    _mise_shims="''${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+    ${miseShimsDecl}
     if command -v mise >/dev/null 2>&1 \
        && [[ ":$PATH:" != *":$_mise_shims:"* ]]; then
       eval "$(mise activate zsh --shims)"
@@ -56,11 +60,14 @@ programs.zsh = {
     unset _mise_shims
   '';
 
-  # .zshrc: 대화형 셸을 위한 전체 훅 활성화
+  # .zshrc: 대화형 훅 + Claude Code snapshot 경유 비대화형 보강용 shims prepend
   initContent = lib.mkMerge [
     (lib.mkBefore ''
       if command -v mise >/dev/null 2>&1; then
         eval "$(mise activate zsh)"
+        ${miseShimsDecl}
+        [[ ":$PATH:" != *":$_mise_shims:"* ]] && export PATH="$_mise_shims:$PATH"
+        unset _mise_shims
       fi
     '')
   ];
@@ -72,7 +79,7 @@ programs.zsh = {
 | 활성화 방식 | 용도 | 기능 |
 |-----------|------|------|
 | `mise activate zsh --shims` | 비대화형 | PATH에 shim 디렉토리만 추가 |
-| `mise activate zsh` | 대화형 | 전체 훅 (cd 시 자동 버전 전환 등) |
+| `mise activate zsh` + shims prepend | 대화형 + Claude Code snapshot 보강 | 전체 훅 (cd 시 자동 버전 전환 등) + 직후 shims를 PATH 맨 앞에 박아 snapshot 캡처 시점에 포함되도록 보장 |
 
 확인:
 
@@ -82,6 +89,8 @@ $ ssh minipc 'cd /home/greenhead/Workspace/my-project && pnpm --version'
 ```
 
 참고: darwin(Mac)과 NixOS 모두 동일한 설정을 사용하므로, 이 변경은 양쪽에 영향을 줍니다. 중복 활성화 방지는 shims 경로의 PATH 실재 여부 가드로 한다 — 과거 `MISE_SHELL` 기반 가드는 부모 대화형 셸의 `MISE_SHELL`이 자식 비대화형 셸로 상속되어 shims 활성화를 조기 스킵하는 회귀를 만들어 폐기됐다.
+
+추가 회귀 경로 — Claude Code Bash tool 비대화형 (#857): Claude Code는 세션 시작 시 interactive 셸 PATH를 `~/.claude/shell-snapshots/snapshot-zsh-*.sh`에 박제하고 Bash tool 호출마다 그 snapshot.sh를 source해 PATH를 복원한다. `mise activate zsh`(hook 모드)는 호출 끝에 `_mise_hook`을 즉시 발동시켜 install-bins를 PATH에 prepend하지만, hook 모드 정책상 shims는 prepend 안 한다 — snapshot에 install-bins는 들어가도 shim 의존 도구(mise npm backend의 codex 등)는 비대화형에서 미노출된다. `.zshrc`에서 `mise activate zsh` 직후 shims를 명시적으로 PATH에 prepend하면 snapshot에 shims가 포함되어 비대화형 호출이 동작한다. 회귀 메커니즘과 fallback 후보의 SoT는 `managing-mise/SKILL.md`의 "셸 활성화 구조" 섹션이다.
 
 ---
 

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -198,6 +198,18 @@
   };
 
   # ═══════════════════════════════════════════════════════════════
+  # mise (런타임 버전 관리자) — shims 경로 SoT
+  # ═══════════════════════════════════════════════════════════════
+  # shims 디렉토리 우선순위 (mise 공식 규약):
+  #   MISE_DATA_DIR → $XDG_DATA_HOME/mise → $HOME/.local/share/mise
+  # 사용처: modules/shared/programs/shell/default.nix envExtra/initContent의 PATH 가드.
+  # shell expansion 문자열로 저장 — nix는 literal로 흘려보내고 zsh가 평가한다.
+  # 본 저장소는 MISE_DATA_DIR과 XDG_DATA_HOME 둘 다 명시 설정하지 않아 기본 경로가 사용된다.
+  mise = {
+    shimsDirExpr = "\${MISE_DATA_DIR:-\${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims";
+  };
+
+  # ═══════════════════════════════════════════════════════════════
   # 온도 모니터링 임계값
   # 하드웨어 기준: CPU crit=105°C, NVMe crit=94.8°C
   # 소프트웨어 임계값은 하드웨어 대비 ~10°C 마진으로 조기 대응

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -10,6 +10,9 @@
 
 let
   sharedScriptsDir = ../../scripts;
+  # mise shims 경로 변수 선언 — envExtra/initContent 공통 SoT.
+  # 경로는 constants.mise.shimsDirExpr 우선순위(MISE_DATA_DIR → XDG_DATA_HOME/mise → $HOME/.local/share/mise).
+  miseShimsDecl = ''_mise_shims="${constants.mise.shimsDirExpr}"'';
 in
 {
   home.file.".local/bin/atuin-clean-kr" = {
@@ -148,16 +151,13 @@ in
 
     # .zshenv: snapshot 미경유 비대화형 세션(SSH `zsh -c` 등)에서 mise 도구를
     # 노출하기 위해 PATH에 shims를 보장한다. 이 경로는 .zshrc를 로드하지 않아
-    # `mise activate zsh`가 install bin도 prepend하지 못한다 — shims가 없으면
+    # `mise activate zsh`가 install-bins도 prepend하지 못하므로 shims가 없으면
     # mise 도구가 노출되지 않는다.
-    # (대화형 훅 + Claude Code snapshot 경유 비대화형 보강은 .zshrc에서 처리.)
-    # 가드는 MISE_SHELL 유무가 아니라 shims의 PATH 실재 여부로 판단한다: 부모 대화형 셸이
-    # hook 모드(`mise activate zsh`)로 MISE_SHELL을 set한 채 자식 비대화형 셸로 상속시키면,
-    # 기존 `[[ -z "$MISE_SHELL" ]]` 가드가 --shims를 스킵해 shims가 PATH에서 누락된다.
-    # shims 경로는 `MISE_DATA_DIR`(기본 `$HOME/.local/share/mise`)/`shims` 규약을 따른다.
-    # (#814 mise 전환 이후 codex가 mise npm backend로 옮겨가며 발현.)
+    # 대화형 훅 + Claude Code snapshot 경유 비대화형 보강은 .zshrc에서 처리한다.
+    # 회귀 메커니즘(MISE_SHELL 가드 폐기 / hook 모드 정책상 shims 미prepend)의
+    # SoT는 .claude/skills/managing-mise/SKILL.md "셸 활성화 구조" 섹션.
     envExtra = ''
-      _mise_shims="''${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+      ${miseShimsDecl}
       if command -v mise >/dev/null 2>&1 \
          && [[ ":$PATH:" != *":$_mise_shims:"* ]]; then
         eval "$(mise activate zsh --shims)"
@@ -176,20 +176,13 @@ in
         # cd-time 자동 버전 전환은 `mise activate zsh`(hook 모드)가 처리한다.
         # 직후 shims를 PATH에 prepend하여 Claude Code snapshot이 캡처하는
         # interactive PATH에 shims가 포함되도록 한다.
-        #
-        # 이유: Claude Code Bash tool은 매 호출마다 snapshot.sh를 source해
-        # 그 시점의 interactive PATH를 비대화형 셸에서 복원한다. snapshot
-        # 캡처 시점에는 _mise_hook이 발동 전이라 install-bins도 PATH에 없는
-        # baseline이 박제된다. interactive 단계에 shims를 강제 prepend하면
-        # snapshot에 shims가 포함되어 비대화형 codex 호출이 동작한다.
-        #
-        # 위험/우려: 이 fix는 Claude Code snapshot 캡처 메커니즘에 간접
-        # 의존한다. 향후 캡처 방식 변경(예: sanitized PATH 기록) 시 회귀
-        # 재발 가능. snapshot 미경유 비대화형은 envExtra 가드가 보완한다.
-        # (#814 mise 전환: codex가 mise npm backend로 옮겨가며 shim 의존 발현.)
+        # 회귀 메커니즘(snapshot baseline에 shims 누락 — hook 모드 정책상
+        # install-bins만 prepend되고 shims는 prepend 안 됨) + 위험/우려 +
+        # fallback 후보(.claude/settings.json env.PATH, login shell init 등)의
+        # SoT는 .claude/skills/managing-mise/SKILL.md "셸 활성화 구조" 섹션.
         if command -v mise >/dev/null 2>&1; then
           eval "$(mise activate zsh)"
-          _mise_shims="''${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+          ${miseShimsDecl}
           [[ ":$PATH:" != *":$_mise_shims:"* ]] && export PATH="$_mise_shims:$PATH"
           unset _mise_shims
         fi

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -146,19 +146,23 @@ in
       share = true;
     };
 
-    # .zshenv: SSH·비대화형 세션을 위한 mise shims PATH 추가
-    # (대화형 훅은 .zshrc에서 활성화)
+    # .zshenv: snapshot 미경유 비대화형 세션(SSH `zsh -c` 등)에서 mise 도구를
+    # 노출하기 위해 PATH에 shims를 보장한다. 이 경로는 .zshrc를 로드하지 않아
+    # `mise activate zsh`가 install bin도 prepend하지 못한다 — shims가 없으면
+    # mise 도구가 노출되지 않는다.
+    # (대화형 훅 + Claude Code snapshot 경유 비대화형 보강은 .zshrc에서 처리.)
     # 가드는 MISE_SHELL 유무가 아니라 shims의 PATH 실재 여부로 판단한다: 부모 대화형 셸이
     # hook 모드(`mise activate zsh`)로 MISE_SHELL을 set한 채 자식 비대화형 셸로 상속시키면,
-    # 기존 `[[ -z "$MISE_SHELL" ]]` 가드가 --shims를 스킵해 shims가 PATH에서 누락됐다.
-    # hook 모드는 도구 install bin만 PATH에 넣고 shims는 넣지 않으므로, shim으로만 노출되는
-    # mise npm backend 도구(codex 등)가 command not found가 된다(#814 mise 전환 이후
-    # codex가 shim 의존이 되며 발현).
+    # 기존 `[[ -z "$MISE_SHELL" ]]` 가드가 --shims를 스킵해 shims가 PATH에서 누락된다.
+    # shims 경로는 `MISE_DATA_DIR`(기본 `$HOME/.local/share/mise`)/`shims` 규약을 따른다.
+    # (#814 mise 전환 이후 codex가 mise npm backend로 옮겨가며 발현.)
     envExtra = ''
+      _mise_shims="''${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
       if command -v mise >/dev/null 2>&1 \
-         && [[ ":$PATH:" != *":$HOME/.local/share/mise/shims:"* ]]; then
+         && [[ ":$PATH:" != *":$_mise_shims:"* ]]; then
         eval "$(mise activate zsh --shims)"
       fi
+      unset _mise_shims
 
       # 비대화형 셸 기본값: side-by-side 비활성화
       # (대화형 셸에서는 .zshrc의 precmd 훅이 터미널 너비에 따라 동적 제어)
@@ -168,9 +172,26 @@ in
     # 공통 초기화 스크립트 (.zshrc)
     initContent = lib.mkMerge [
       (lib.mkBefore ''
-        # Mise 활성화 (대화형 셸: cd 시 자동 버전 전환 등)
+        # Mise 활성화 (대화형 셸)
+        # cd-time 자동 버전 전환은 `mise activate zsh`(hook 모드)가 처리한다.
+        # 직후 shims를 PATH에 prepend하여 Claude Code snapshot이 캡처하는
+        # interactive PATH에 shims가 포함되도록 한다.
+        #
+        # 이유: Claude Code Bash tool은 매 호출마다 snapshot.sh를 source해
+        # 그 시점의 interactive PATH를 비대화형 셸에서 복원한다. snapshot
+        # 캡처 시점에는 _mise_hook이 발동 전이라 install-bins도 PATH에 없는
+        # baseline이 박제된다. interactive 단계에 shims를 강제 prepend하면
+        # snapshot에 shims가 포함되어 비대화형 codex 호출이 동작한다.
+        #
+        # 위험/우려: 이 fix는 Claude Code snapshot 캡처 메커니즘에 간접
+        # 의존한다. 향후 캡처 방식 변경(예: sanitized PATH 기록) 시 회귀
+        # 재발 가능. snapshot 미경유 비대화형은 envExtra 가드가 보완한다.
+        # (#814 mise 전환: codex가 mise npm backend로 옮겨가며 shim 의존 발현.)
         if command -v mise >/dev/null 2>&1; then
           eval "$(mise activate zsh)"
+          _mise_shims="''${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+          [[ ":$PATH:" != *":$_mise_shims:"* ]] && export PATH="$_mise_shims:$PATH"
+          unset _mise_shims
         fi
 
         # tmux 내부에서 clear 시 history buffer도 함께 삭제


### PR DESCRIPTION
## Summary

Claude Code Bash tool 같은 non-interactive zsh 호출에서 mise npm backend로 설치된 codex가 `command not found`가 되던 회귀를 fix한다.

원인은 Claude Code가 세션 시작 시 박제하는 interactive 셸 PATH snapshot이 mise hook 모드의 install-bins만 담고 shims는 누락한다는 점. `.zshrc`에서 `mise activate zsh` 직후 shims를 PATH에 명시적으로 prepend하여 snapshot에 shims가 포함되도록 한다.

## 변경

코드:
- `modules/shared/programs/shell/default.nix` initContent에 shims prepend 추가 + envExtra/initContent let 추출로 DRY.
- shims 경로 fallback을 `${MISE_DATA_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/mise}/shims` 3단계로 확장 (mise 공식 우선순위).
- `libraries/constants.nix`에 `mise.shimsDirExpr` SoT 추가 (CLAUDE.md "하드코딩 경로는 constants.nix" 정책 정합).

문서:
- `managing-mise/SKILL.md`: 본문 단락을 가드 기반 / `MISE_SHELL` 폐기 / `.zshrc` prepend 이유 / 위험·fallback 후보 4 bullet 분해.
- `managing-mise/references/troubleshooting.md`: 차이점 표 + 해결 코드 블록 갱신 + Claude Code Bash tool snapshot 회귀 경로 참고 절 추가.

## 회귀 메커니즘 (정정)

이 PR 두 번째 commit에서 인과 설명을 정정했다.

- 잘못된 설명: "snapshot 캡처 시점에 `_mise_hook` 발동 전이라 install-bins도 PATH에 없는 baseline 박제"
- 정확한 설명: `mise activate zsh`는 호출 끝에 `_mise_hook`을 즉시 발동시켜 install-bins를 PATH에 prepend한다. 그러나 hook 모드 정책상 shims는 PATH에 prepend 안 한다 (shims는 `--shims` 플래그 경유에서만 들어감). 결과적으로 snapshot에 install-bins는 들어가도 shims만 빠진 baseline이 박제되어 shim 노출 도구(mise npm backend의 codex 등)는 비대화형에 미노출된다.

## 검증

자동:
- `nix-instantiate --parse default.nix / constants.nix` → OK
- `bash tests/run-eval-tests.sh` → All eval tests passed
- pre-commit lefthook (eval-tests, nixfmt, gitleaks, skill-noise, ai-skills-consistency) 통과 (TMPDIR=/private/tmp 우회 사용 — lefthook staged-snapshot 환경 버그 회피)

## Test plan (적용 후 사용자 host)

- [ ] `nrs` 실행
- [ ] Claude Code 재시작 (snapshot 재생성)
- [ ] `grep mise/shims ~/.claude/shell-snapshots/<latest>.sh` — snapshot에 shims 포함 확인
- [ ] Bash tool에서 `command -v codex` 성공 확인
- [ ] Bash tool에서 `codex --version` → 0.134.0 확인
- [ ] (선택) `chmod 700 ~/.claude/shell-snapshots && chmod 600 ~/.claude/shell-snapshots/*.sh` — snapshot 권한 강화

## Follow-up 후보

- envExtra/initContent eval 통일 (`--shims` 일원화) — cd-time hook 비활성 trade-off
- `codex/default.nix`의 `$HOME/.local/share/mise` 매직 path도 `constants.mise.shimsDirExpr` 참조로 통일
- `verify-ai-compat`에 `command -v codex` 자가 검사 추가 — 회귀 조기 감지
- `~/.claude/settings.json` `env.PATH` fallback prepend — snapshot 메커니즘 변경 대비
- `_mise_shims` → `_mise_shims_dir` 변수명 명확화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell shim activation in non-interactive sessions and SSH contexts.

* **Documentation**
  * Enhanced documentation with detailed shell activation structure explanations and fallback mechanisms.
  * Expanded troubleshooting guide for command resolution issues in SSH sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->