### PR TITLE
fix(lefthook): staged-snapshot cache base realpath 정규화 (nix 2.20+ parent symlink 거부 회피)

### DIFF
--- a/scripts/ai/lib/staged-snapshot-cache.sh
+++ b/scripts/ai/lib/staged-snapshot-cache.sh
@@ -261,8 +261,15 @@ _ssc_provide_impl() {
   [ -n "$tree_hash" ] || { _ssc_die "empty tree hash"; return 1; }
 
   # 2. 캐시 base (per-repo_id 격리 + umask 077 + 소유권 검증). 정리는 OS tmp 정책에 위임.
+  # 부모 디렉토리 symlink는 nix 2.20+ flake fetcher의 path: input 검증에서 거부된다
+  # (NixOS/nix#11941, #3513 등). macOS의 /tmp -> /private/tmp symlink가 그대로
+  # 전파되면 캐시 worktree를 path: input으로 잡는 모든 nix eval(예: tests/eval-tests.nix의
+  # builtins.getFlake (toString ./..))이 "path '//tmp' is a symlink" 에러로 깨진다.
+  # pwd -P로 캐시 base를 미리 정규화해 cwd·STAGED_SNAPSHOT_ROOT까지 자동으로 real path를 받게 한다.
   local base repo_id cache_root trees_dir builds_dir locks_dir
   base="${TMPDIR:-/tmp}"
+  base="$(cd "$base" 2>/dev/null && pwd -P)" \
+    || _ssc_die "cannot resolve TMPDIR=${TMPDIR:-/tmp}" || return 1
   base="${base%/}/staged-snapshot-cache"
   repo_id="$(printf '%s' "$repo_root" | _ssc_hash16)"
   cache_root="$base/$repo_id"


### PR DESCRIPTION
## Summary

macOS에서 staged-snapshot wrapper 경유 lefthook hook (`eval-tests` pre-commit, `codex-hook-fixtures` pre-push 등)이 다음 에러로 실패하던 환경 회귀를 fix한다.

```
error: path '//tmp' is a symlink
... while fetching the input 'path:/tmp/claude-501/staged-snapshot-cache/.../worktree'
```

## Root cause

- `scripts/ai/lib/staged-snapshot-cache.sh`가 캐시 base를 `${TMPDIR:-/tmp}` 그대로 사용.
- macOS의 `/tmp`는 `/private/tmp`로의 symlink.
- nix 2.20+ flake fetcher의 `path:` input 검증이 parent 디렉토리가 symlink인 경로를 hard-reject하도록 정책 강화 — 관련 upstream issue:
  - [NixOS/nix#3513](https://github.com/NixOS/nix/issues/3513) — `path is a symlink; this is not allowed`
  - [NixOS/nix#11941](https://github.com/NixOS/nix/issues/11941) — nix-prefetch-git symlink error on macOS
  - [NixOS/nixpkgs#358685](https://github.com/NixOS/nixpkgs/pull/358685) — fix nix-prefetch-* on macOS (동일 패턴, `realpath`로 해소)
  - [NixOS/nix#11567](https://github.com/NixOS/nix/issues/11567) — `path:` flake reference weird behavior
- 결과: `tests/eval-tests.nix`의 `builtins.getFlake (toString ./..)`가 `/tmp/claude-501/staged-snapshot-cache/.../worktree`를 path: input으로 잡는 순간 거부 → eval-tests pre-commit hook이 staged-snapshot 경유에서만 깨진다.
- 직접 `bash tests/run-eval-tests.sh`는 repo cwd가 symlink 없는 경로(`/Users/glen/Workspace/nixos-config/...`)라 무관하게 통과 — 그래서 hook 환경 특정 회귀로 보였다.

## Fix

`pwd -P`로 cache base를 미리 정규화. macOS에서 `/tmp` → `/private/tmp`가 풀려 `cache_root`, `trees_dir`, `STAGED_SNAPSHOT_ROOT`, wrapper cwd까지 자동으로 realpath를 받는다. 결과적으로 nix flake fetcher의 path: input이 `/private/tmp/...`로 시작해 parent symlink 거부에 걸리지 않는다.

회귀 추적 단서를 주석에 박제 (관련 nix issue 번호).

## 검증

- `bash ./scripts/ai/run-staged-snapshot.sh -- bash tests/run-eval-tests.sh`
  - base (fix 전): `Eval tests FAILED: path '//tmp' is a symlink`
  - fix 후: `All eval tests passed`
- cache base가 `/private/tmp` 아래로 만들어짐 (cwd, `STAGED_SNAPSHOT_ROOT` 모두 정규화 확인).
- `git push`의 pre-push hook도 동일 메커니즘 회복.

## Test plan

- [ ] `nrs` 미필요 (셸 스크립트 한 줄 변경, 다음 hook 실행부터 자동 적용)
- [ ] 일반 `git commit`이 `TMPDIR=/private/tmp` 우회 없이 pre-commit eval-tests를 통과하는지 다음 nix 변경 시 확인

## 별도 follow-up (이 PR 범위 밖)

- `tests/test-codex-hook-fixtures.sh` fixture 7b (`pretooluse-pinning-guard-claude-write-da-workspace-clean.json`)가 staged-snapshot wrapper + `TMPDIR=/tmp` 조합에서 fail. main base에서도 동일 회귀 — pinning-guard 정책 강화 후 fixture 미동기화로 보임. 별도 fix 필요. `TMPDIR=/private/tmp` 우회로 회피 가능 (이 PR 검증과 동일 우회).