### PR TITLE
fix(pinning): DA scratch whitelist에 중첩 prefix 허용 (closes #852)

### DIFF
--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -180,6 +180,10 @@ pinning_should_check_path() {
     # macOS는 /tmp가 /private/tmp의 symlink, /var가 /private/var의 symlink.
     # realpath -m 등으로 canonicalize되면 /private/* 형태가 되므로 둘 다 매치 필요.
     /tmp/da-*/* | /private/tmp/da-*/*) return 1 ;;
+    # 한 단계 중첩 prefix 허용: nix develop의 /tmp/nix-shell.XXX, Claude Code Bash tool의
+    # /tmp/claude-501 등 TMPDIR이 임의 prefix를 두고 그 안에 da-* scratch를 만드는 케이스
+    # (issue #852). depth-unbounded이지만 attacker 모델이 아니라 host trust 범위라 안전.
+    /tmp/*/da-*/* | /private/tmp/*/da-*/*) return 1 ;;
     /var/folders/*/T/da-*/* | /private/var/folders/*/T/da-*/*) return 1 ;;
   esac
 

--- a/modules/shared/programs/claude/files/lib/pinning-patterns.sh
+++ b/modules/shared/programs/claude/files/lib/pinning-patterns.sh
@@ -177,13 +177,19 @@ pinning_should_check_path() {
     */skills/parallel-audit/*) return 1 ;;
     tests/fixtures/* | */tests/fixtures/*) return 1 ;;
     eval-workspace/* | */eval-workspace/*) return 1 ;;
+    # DA scratch dynamic TMPDIR shapes — host trust model. extend with caution:
+    # 새 TMPDIR scheme 추가는 정책 표면 영구 확장이라 PR review 시 명시 신호로 만든다.
     # macOS는 /tmp가 /private/tmp의 symlink, /var가 /private/var의 symlink.
     # realpath -m 등으로 canonicalize되면 /private/* 형태가 되므로 둘 다 매치 필요.
     /tmp/da-*/* | /private/tmp/da-*/*) return 1 ;;
-    # 한 단계 중첩 prefix 허용: nix develop의 /tmp/nix-shell.XXX, Claude Code Bash tool의
-    # /tmp/claude-501 등 TMPDIR이 임의 prefix를 두고 그 안에 da-* scratch를 만드는 케이스
-    # (issue #852). depth-unbounded이지만 attacker 모델이 아니라 host trust 범위라 안전.
+    # TMPDIR이 임의 prefix를 두고 그 안에 da-* scratch를 만드는 케이스 (issue #852):
+    # nix develop의 /tmp/nix-shell.<random>, Claude Code Bash tool의 /tmp/claude-<uid> 등.
+    # case glob의 `*`는 `/`를 포함하므로 본 패턴은 실제로는 depth-unbounded 매칭이다
+    # (예: /tmp/a/b/da-x/y.md도 매치). 그러나 attacker 모델이 아니라 host trust 범위
+    # (개발자 host + lefthook 단일 user)라 안전. 향후 multi-tenant CI에서 호출되면 재검토 필요.
     /tmp/*/da-*/* | /private/tmp/*/da-*/*) return 1 ;;
+    # macOS user-isolated TMPDIR (confstr _CS_DARWIN_USER_TEMP_DIR). /var/folders/<2>/<32>/T/는
+    # 표준 고정 구조라 그 안에 추가 prefix가 끼는 케이스는 미관측. 발생 시 별도 arm 추가.
     /var/folders/*/T/da-*/* | /private/var/folders/*/T/da-*/*) return 1 ;;
   esac
 

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -777,6 +777,8 @@ STUB
     "[7/lib] should_check fallback must preserve self-exclude paths without GNU realpath/readlink"
   assert_eq "$(PATH="$sandbox/bin-stubs:${PATH:-/usr/bin:/bin}"; if pinning_should_check_path "/tmp/da-test-abc/scratch.md"; then printf check; else printf skip; fi)" "skip" \
     "[7/lib] should_check fallback must preserve DA scratch whitelist without GNU realpath/readlink"
+  assert_eq "$(if pinning_should_check_path "/tmp/nix-shell.test/da-foo/bar.md"; then printf check; else printf skip; fi)" "skip" \
+    "[7/lib] nested TMPDIR da-* scratch must hit whitelist (issue #852)"
   mkdir -p "$sandbox/.claude/plans"
   : > "$sandbox/.claude/plans/existing.md"
   assert_eq "$(PATH="$sandbox/bin-stubs:${PATH:-/usr/bin:/bin}" PINNING_PROJECT_ROOT="$sandbox" pinning_match_count_for_path "$scan_file" "$sandbox/.claude/plans/existing.md")" "2" \


### PR DESCRIPTION
## Summary

- pinning-guard 정책 lib의 DA scratch whitelist에 중첩 TMPDIR prefix 패턴 추가.
- `nix develop`(TMPDIR=`/tmp/nix-shell.*`), Claude Code Bash tool(TMPDIR=`/tmp/claude-<uid>`) 등 호스트 TMPDIR이 임의 prefix를 두고 그 안에 `da-*` scratch를 만드는 케이스에서 fixture가 false negative로 deny되던 회귀 해소.
- Closes #852.

## 기존 문제/배경

`modules/shared/programs/claude/files/lib/pinning-patterns.sh`의 DA scratch whitelist는 직속 자식만 면제했다.

- `/tmp/da-*/*`, `/private/tmp/da-*/*`
- `/var/folders/*/T/da-*/*`, `/private/var/folders/*/T/da-*/*`

그러나 다음 호스트 환경에서는 TMPDIR이 임의 prefix를 두고 그 안에 `da-*` scratch를 만들기 때문에 위 패턴이 매치되지 않는다.

- `nix develop --command`: TMPDIR=`/tmp/nix-shell.<random>` → 임시 경로 `/tmp/nix-shell.<random>/da-codex-hook-fixture.<random>/finding.md`
- Claude Code Bash tool: TMPDIR=`/tmp/claude-<uid>` → 임시 경로 `/tmp/claude-<uid>/da-codex-hook-fixture.<random>/finding.md`
- lefthook 의 staged-snapshot wrapper 경유 fixture 실행도 동일

결과적으로 `tests/test-codex-hook-fixtures.sh`의 `[7b] pretooluse-pinning-guard-claude-write-da-workspace-clean.json` fixture가 clean pass 기대 케이스를 deny로 오탐했고, pre-push hook이 이 환경에서 차단되어 모든 PR이 `TMPDIR=/private/tmp git push` 우회에 의존했다 (issue #852 보강 코멘트 참조).

## CIR

- 발견 경위: 별도 환경 디버그 흐름(PR #858, #859)에서 push가 `TMPDIR=/private/tmp` 우회 없이 통과되지 않는 회귀를 추적하다가 `codex-hook-fixtures` fixture 7b가 wrapper 경유에서만 fail함을 확인. 동일 패턴이 이미 #852에 등록되어 있어 새 발견(staged-snapshot wrapper + Bash tool TMPDIR=`/tmp/claude-<uid>`에서도 같은 회귀)을 코멘트로 보강 후 작업 시작.
- 설계 의도: 정책 lib의 whitelist case glob에 nested prefix arm 1개 추가. 이 lib은 macOS/NixOS 양 호스트의 PreToolUse pinning-guard가 source하는 hot path라 모든 host edit 흐름에 영향이 가는 trade-off.
- 구현 코드 리뷰 반영: case glob의 `*`가 `/`를 포함하므로 본 패턴은 실제로는 depth-unbounded 매칭이라는 표준 동작을 주석에 정직하게 명시. "DA scratch dynamic TMPDIR shapes — host trust model. extend with caution" 카테고리 헤더로 정적 whitelist와 동적 host TMPDIR 그룹을 분리해 미래 prefix 추가 요청 시 review 신호 강화. `/var/folders` 그룹은 macOS confstr `_CS_DARWIN_USER_TEMP_DIR` 표준 고정 구조라 중간 prefix 케이스 미관측이라는 사실을 한 줄로 명시. 인용 예시 `claude-501`은 macOS 첫 사용자 UID 501에 의존한 stale 인용이라 `claude-<uid>` 자리표시자로 일반화.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 정책 lib 완화 | `pinning-patterns.sh`의 `pinning_should_check_path` case에 `/tmp/*/da-*/*`, `/private/tmp/*/da-*/*` arm 추가 | 모든 host workflow(`nix develop`, Bash tool, lefthook wrapper)에서 일관 통과. 단일 SoT. | hook이 PreToolUse마다 호출하는 hot path 정책 표면이 영구 확장됨 | ✅ |
| fixture runner-side 정규화 | `tests/test-codex-hook-fixtures.sh`의 `mktemp -d "${TMPDIR:-/tmp}/da-codex-hook-fixture.XXX"` 한 줄을 host TMPDIR로 고정하거나 `/tmp/da-*` 직접 사용으로 변경 | 정책 표면 무영향, fixture only 한정 minimal fix | test 환경만 통과시킴. 일반 사용자가 `nix develop` 안에서 실제 DA scratch를 만드는 host workflow의 false negative는 잔존. 동일 회귀가 다른 표면에서 재발 | ❌ |
| `path: input` symlink 거부 회피만 시도 | lefthook staged-snapshot 환경 버그 단독 fix (PR #859와 통합) | 환경 버그 일괄 처리 | issue #852가 명시한 fixture-pinning 정합성 문제는 미해결 | ❌ |

채택한 정책 lib 완화의 host trust 가정: 단일 user local lefthook 환경 + 개발자 host. multi-tenant CI에 노출되면 이 가정이 깨지므로 주석에 재검토 트리거를 명시했다.

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claude/files/lib/pinning-patterns.sh` | `pinning_should_check_path` case 블록에 nested DA scratch arm 추가 + 카테고리 헤더 주석 + macOS confstr 라쇼날 한 줄 |

핵심 변경 (반영 후 최종 형태):

```bash
    # DA scratch dynamic TMPDIR shapes — host trust model. extend with caution:
    # 새 TMPDIR scheme 추가는 정책 표면 영구 확장이라 PR review 시 명시 신호로 만든다.
    # macOS는 /tmp가 /private/tmp의 symlink, /var가 /private/var의 symlink.
    # realpath -m 등으로 canonicalize되면 /private/* 형태가 되므로 둘 다 매치 필요.
    /tmp/da-*/* | /private/tmp/da-*/*) return 1 ;;
    # TMPDIR이 임의 prefix를 두고 그 안에 da-* scratch를 만드는 케이스 (issue #852):
    # nix develop의 /tmp/nix-shell.<random>, Claude Code Bash tool의 /tmp/claude-<uid> 등.
    # case glob의 `*`는 `/`를 포함하므로 본 패턴은 실제로는 depth-unbounded 매칭이다
    # (예: /tmp/a/b/da-x/y.md도 매치). 그러나 attacker 모델이 아니라 host trust 범위
    # (개발자 host + lefthook 단일 user)라 안전. 향후 multi-tenant CI에서 호출되면 재검토 필요.
    /tmp/*/da-*/* | /private/tmp/*/da-*/*) return 1 ;;
    # macOS user-isolated TMPDIR (confstr _CS_DARWIN_USER_TEMP_DIR). /var/folders/<2>/<32>/T/는
    # 표준 고정 구조라 그 안에 추가 prefix가 끼는 케이스는 미관측. 발생 시 별도 arm 추가.
    /var/folders/*/T/da-*/* | /private/var/folders/*/T/da-*/*) return 1 ;;
```

호출자 (인터페이스 호환 검증됨, 무변경): `modules/shared/programs/claude/files/hooks/pinning-{guard,alert}.sh`, `modules/shared/programs/codex/files/hooks/pinning-{guard,alert}.sh`, `scripts/ai/commit-msg-pinning.sh`(텍스트 스캔만, path-aware API 미사용).

## 참고 레퍼런스

- Closes #852 — 본 회귀의 root cause 등록 이슈. 본 PR과 #852 코멘트로 보강된 추가 표면(staged-snapshot wrapper, Bash tool TMPDIR) 모두 해소.
- 연관: PR #858 (이 우회 의존), PR #859 (lefthook staged-snapshot tmp symlink 환경 버그 — 본 PR 머지 후에도 별도 환경 버그라 #859 머지 필요).
- 코드: `modules/shared/programs/claude/files/lib/pinning-patterns.sh` 본문 (`pinning_should_check_path`).
- 정책 본체: 사용자 글로벌 CLAUDE.md "Durable output pinning policy" (lib whitelist 카테고리는 lib-level 운영 디테일로 의도적 비공개 유지).
- fnmatch 표준: bash/zsh `case` glob의 `*`가 `/`를 포함한다는 표준 동작.

## Human Test Plan

### 사전 조건

- main에 본 PR 머지 + `nrs` (활성 hook 갱신).
- pinning-guard hook이 활성 상태인지 확인: `cat ~/.claude/hooks/pinning-guard.sh | head -3`.

### 단계별 기대 동작

1. **fixture 직접 실행 통과 확인** (회귀가 fix됐는지 검증):
   ```bash
   bash ./tests/test-codex-hook-fixtures.sh --no-live
   # 기대: All codex hook fixture tests passed.
   ```

2. **staged-snapshot wrapper 경유 통과 확인** (회귀 시나리오 재현):
   ```bash
   bash ./scripts/ai/run-staged-snapshot.sh -- bash ./tests/test-codex-hook-fixtures.sh --no-live
   # 기대: All codex hook fixture tests passed.
   # 이전: FAIL: [7b] pretooluse-pinning-guard-claude-write-da-workspace-clean.json
   ```

3. **nix develop 경유 통과 확인**:
   ```bash
   nix develop --command bash tests/test-codex-hook-fixtures.sh --no-live
   # 기대: All codex hook fixture tests passed.
   ```

4. **TMPDIR 우회 없이 push 가능한지 확인** (선택 사항 — PR #859 머지된 환경에서):
   ```bash
   # 새 branch에 trivial 변경 + push
   git push
   # 기대: pre-push hook 통과 (TMPDIR=/private/tmp 우회 불필요)
   ```

### 실패 시 진단

- fixture가 여전히 deny로 오탐되면: `nrs`가 적용 안 된 상태. 활성 lib 경로 확인: `readlink -f ~/.claude/hooks/pinning-guard.sh` → nix store path → 그 lib이 새 arm을 포함하는지 grep.
- nix develop 안에서만 fail하면: nix devShell의 TMPDIR scheme 확인 (`echo $TMPDIR`). 본 PR이 다루는 `/tmp/*/da-*/*` shape이 아니면 별도 arm 추가 필요 (예: `/run/user/*/da-*/*`).
- 의도된 deny 케이스(예: tests/fixtures/codex-hooks/stdin/pretooluse-pinning-guard-claude-write-da-traversal-deny)가 통과해버리면: `_pinning_raw_path_has_traversal` 가드(case 평가 전에 raw path의 `..`을 fail-closed로 처리)가 정상 동작하는지 확인.

### Rollback 경로

회귀가 발생하면:

1. 본 PR 단순 revert — 정책 표면이 원복되지만 fixture false negative와 PR push 차단도 재발.
2. fixture-side fix로 대체 (ADR 기각안 채택): `tests/test-codex-hook-fixtures.sh`의 `mktemp -d "${TMPDIR:-/tmp}/da-codex-hook-fixture.XXX"`를 호스트 TMPDIR 고정 또는 `/tmp/da-...` 직접 사용으로 변경. test는 통과하나 일반 host workflow의 false negative는 잔존.
3. 검증 evidence (`grep -r '/tmp/.*/da-' tests/fixtures` → 매치 fixture 없음 확인) — 다른 fixture가 nested DA scratch shape을 deny 케이스로 의존하지 않음.

### 검증 결과 요약 (머지 전)

- `shellcheck modules/shared/programs/claude/files/lib/pinning-patterns.sh` → 무경고
- `bash ./tests/test-codex-hook-fixtures.sh --no-live` → 통과
- `bash ./scripts/ai/run-staged-snapshot.sh -- bash ./tests/test-codex-hook-fixtures.sh --no-live` → 통과
- 코드 리뷰 (Opus 8 reviewer + Arbiter): CRITICAL 없음, 모든 신뢰도 finding 반영 완료
- 사이드이펙트 전수조사 (Opus 6 bundle): 전 SAFE, baseline delta 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security validation for temporary directory paths to properly handle additional path variations across different systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->