### PR TITLE
chore: macOS username green→greenhead 마이그레이션

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# green/nixos-config
+# greenheadHQ/nixos-config
 
 macOS와 NixOS 개발 환경을 **nix-darwin/NixOS + Home Manager**로 선언적으로 관리하는 프로젝트입니다.
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "green/nixos-config - macOS & NixOS Development Environment";
+  description = "greenheadHQ/nixos-config - macOS & NixOS Development Environment";
 
   inputs = {
     # === Change Intent Record ===
@@ -108,7 +108,7 @@
             };
         in
         {
-          "greenhead-MacBookPro" = mkDarwinHost "green" "personal";
+          "greenhead-MacBookPro" = mkDarwinHost "greenhead" "personal";
           "work-MacBookPro" = mkDarwinHost "glen" "work";
         };
 

--- a/modules/darwin/programs/folder-actions/default.nix
+++ b/modules/darwin/programs/folder-actions/default.nix
@@ -63,7 +63,7 @@ in
     folder-action-compress-rar = {
       enable = true;
       config = {
-        Label = "com.green.folder-action.compress-rar";
+        Label = "com.greenhead.folder-action.compress-rar";
         ProgramArguments = [ "${homeDir}/.local/bin/compress-rar.sh" ];
         WatchPaths = [ "${folderActionsDir}/compress-rar" ];
         StandardOutPath = "${logsDir}/compress-rar.log";
@@ -78,7 +78,7 @@ in
     folder-action-compress-video = {
       enable = true;
       config = {
-        Label = "com.green.folder-action.compress-video";
+        Label = "com.greenhead.folder-action.compress-video";
         ProgramArguments = [ "${homeDir}/.local/bin/compress-video.sh" ];
         WatchPaths = [ "${folderActionsDir}/compress-video" ];
         StandardOutPath = "${logsDir}/compress-video.log";
@@ -93,7 +93,7 @@ in
     folder-action-rename-asset = {
       enable = true;
       config = {
-        Label = "com.green.folder-action.rename-asset";
+        Label = "com.greenhead.folder-action.rename-asset";
         ProgramArguments = [ "${homeDir}/.local/bin/rename-asset.sh" ];
         WatchPaths = [ "${folderActionsDir}/rename-asset" ];
         StandardOutPath = "${logsDir}/rename-asset.log";
@@ -105,7 +105,7 @@ in
     folder-action-convert-video-to-gif = {
       enable = true;
       config = {
-        Label = "com.green.folder-action.convert-video-to-gif";
+        Label = "com.greenhead.folder-action.convert-video-to-gif";
         ProgramArguments = [ "${homeDir}/.local/bin/convert-video-to-gif.sh" ];
         WatchPaths = [ "${folderActionsDir}/convert-video-to-gif" ];
         StandardOutPath = "${logsDir}/convert-video-to-gif.log";
@@ -120,7 +120,7 @@ in
     folder-action-upload-immich = {
       enable = true;
       config = {
-        Label = "com.green.folder-action.upload-immich";
+        Label = "com.greenhead.folder-action.upload-immich";
         ProgramArguments = [ "${homeDir}/.local/bin/upload-immich.sh" ];
         WatchPaths = [ shottrDefaultDir ];
         StandardOutPath = "${logsDir}/upload-immich.log";

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -69,7 +69,7 @@ cleanup_launchd_agents() {
     local uid cleaned=0 failed=0 exit_code
     uid=$(id -u)
 
-    # 동적으로 com.green.* 에이전트 찾아서 정리
+    # 동적으로 com.green.*/com.greenhead.* 에이전트 찾아서 정리 (username 마이그레이션 전환기: dual-namespace)
     # 주의: ((++var)) 사용 필수. ((var++))는 var=0일 때 exit code 1 반환 → set -e로 스크립트 종료됨
     while IFS= read -r agent; do
         [[ -z "$agent" ]] && continue
@@ -84,14 +84,14 @@ cleanup_launchd_agents() {
                 ((++failed))
             fi
         fi
-    done < <(launchctl list 2>/dev/null | awk '/com\.green\./ {print $3}')
+    done < <(launchctl list 2>/dev/null | awk '/com\.(green|greenhead)\./ {print $3}')
 
     # plist 파일 삭제
     local plist_count
-    plist_count=$(find ~/Library/LaunchAgents -name 'com.green.*.plist' 2>/dev/null | wc -l | tr -d ' ')
+    plist_count=$(find ~/Library/LaunchAgents -name 'com.green*.plist' 2>/dev/null | wc -l | tr -d ' ')
 
     if [[ "$plist_count" -gt 0 ]]; then
-        rm -f ~/Library/LaunchAgents/com.green.*.plist
+        rm -f ~/Library/LaunchAgents/com.green*.plist
         log_info "  ✓ Removed $plist_count plist file(s)"
     fi
 

--- a/modules/nixos/programs/ssh-client/default.nix
+++ b/modules/nixos/programs/ssh-client/default.nix
@@ -18,7 +18,7 @@ in
       };
       "mac" = {
         hostname = constants.network.macbookTailscaleIP;
-        user = "green";
+        user = "greenhead";
         identityFile = sshKeyPath;
         extraOptions = {
           ControlMaster = "auto";

--- a/modules/shared/programs/cheat/cheatsheets/process/lsof
+++ b/modules/shared/programs/cheat/cheatsheets/process/lsof
@@ -7,7 +7,7 @@ lsof — 열린 파일/소켓/포트를 누가 잡고 있는지 조회. "이 포
   lsof -i :PORT              특정 포트를 점유한 프로세스
                              $ lsof -i :3000
                              COMMAND  PID USER ... NAME
-                             node    8923 green ... TCP *:3000 (LISTEN)
+                             node    8923 greenhead ... TCP *:3000 (LISTEN)
 
   lsof -i tcp:PORT           TCP 한정
                              $ lsof -i tcp:80
@@ -33,8 +33,8 @@ lsof — 열린 파일/소켓/포트를 누가 잡고 있는지 조회. "이 포
   lsof +D DIR                디렉토리 하위 전체 (느릴 수 있음)
 
 [사용자/조합]
-  lsof -u green              특정 사용자 소유
-  lsof -u green -i :3000     green이 잡은 3000 포트만
+  lsof -u greenhead              특정 사용자 소유
+  lsof -u greenhead -i :3000     greenhead이 잡은 3000 포트만
 
 [삭제됐지만 열린 파일] (디스크 차지 누수)
   lsof | grep '(deleted)'    rm 됐지만 process가 fd 잡고 있어 공간 점유

--- a/modules/shared/programs/cheat/cheatsheets/process/pgrep
+++ b/modules/shared/programs/cheat/cheatsheets/process/pgrep
@@ -29,7 +29,7 @@ pgrep — 이름/속성으로 PID 검색. 출력은 PID(들). top/htop의 시각
 
 [속성 필터]
   pgrep -U UID|user          소유 UID/사용자
-                             $ pgrep -U green -l
+                             $ pgrep -U greenhead -l
                              8923 ssh
 
   pgrep -P PPID              부모 PID
@@ -40,7 +40,7 @@ pgrep — 이름/속성으로 PID 검색. 출력은 PID(들). top/htop의 시각
   pgrep -g PGID              프로세스 그룹 ID
 
 [조합]
-  pgrep -fU green "Chrome"   green 소유 + Chrome 풀 커맨드라인 매칭
+  pgrep -fU greenhead "Chrome"   greenhead 소유 + Chrome 풀 커맨드라인 매칭
 
 [매칭 함정 — "활성 상태 보기에는 보이는데 pgrep은 안 잡을 때"]
   $ pgrep -l chrome

--- a/modules/shared/programs/cheat/cheatsheets/process/pkill
+++ b/modules/shared/programs/cheat/cheatsheets/process/pkill
@@ -21,7 +21,7 @@ pkill — 이름/속성 매칭으로 시그널 전송. pgrep과 동일 매처 + 
   pkill -USR1 PATTERN        SIGUSR1 — 앱 정의 시그널
 
 [속성 필터] (pgrep과 동일)
-  pkill -U green PATTERN     특정 사용자 소유만
+  pkill -U greenhead PATTERN     특정 사용자 소유만
   pkill -P 1234 PATTERN      특정 PPID 자식만
   pkill -g 5678 PATTERN      특정 PGID 그룹만
 

--- a/modules/shared/programs/cheat/cheatsheets/process/ps
+++ b/modules/shared/programs/cheat/cheatsheets/process/ps
@@ -30,7 +30,7 @@ ps — 프로세스 스냅샷. top/htop과 달리 정적 출력이라 순서 안
   ps -m                      메모리(RSS) 내림차순 정렬
                              $ ps -Ao pid,%mem,command -m | head -10
 
-  ps -U green                특정 사용자 소유만
+  ps -U greenhead                특정 사용자 소유만
   ps -t ttys001              특정 tty만
 
 [Linux procps-ng]
@@ -42,7 +42,7 @@ ps — 프로세스 스냅샷. top/htop과 달리 정적 출력이라 순서 안
 
   ps --sort -size            VSZ 기준 (rss vs size 의미 다름)
 
-  ps -U green                특정 사용자 (양 플랫폼 동일)
+  ps -U greenhead                특정 사용자 (양 플랫폼 동일)
   ps -t tty1                 특정 tty (양 플랫폼 동일)
 
 [자주 쓰는 조합]

--- a/modules/shared/programs/cheat/cheatsheets/process/scenarios
+++ b/modules/shared/programs/cheat/cheatsheets/process/scenarios
@@ -6,7 +6,7 @@ process 운영 시나리오 — "지금 이 상황에서 뭘 치지?" 모음.
 [1. 특정 포트 점유 프로세스 찾아 종료]
   $ lsof -i :3000                            # 누가 쓰는지 확인
   COMMAND  PID USER ... NAME
-  node    8923 green ... TCP *:3000 (LISTEN)
+  node    8923 greenhead ... TCP *:3000 (LISTEN)
   $ kill 8923                                # 정상 종료 (SIGTERM)
   $ lsof -i :3000                            # 확인 — 비었으면 OK
   # 안 죽으면:
@@ -17,9 +17,9 @@ process 운영 시나리오 — "지금 이 상황에서 뭘 치지?" 모음.
   # macOS (-r = CPU 내림차순):
   $ ps -Ao pid,user,%cpu,command -r | head -5
     PID USER  %CPU COMMAND
-  82342 green 95.3 chrome --type=renderer --enable-...
-  47829 green 42.1 node /Users/green/proj/webpack-dev-server
-  47820 green 18.7 node /Users/green/proj/jest --watch
+  82342 greenhead 95.3 chrome --type=renderer --enable-...
+  47829 greenhead 42.1 node /Users/greenhead/proj/webpack-dev-server
+  47820 greenhead 18.7 node /Users/greenhead/proj/jest --watch
    1023 root   8.2 /usr/sbin/spindump
 
   # Linux (--sort -%cpu = CPU 내림차순):
@@ -37,10 +37,10 @@ process 운영 시나리오 — "지금 이 상황에서 뭘 치지?" 모음.
   # macOS (-m = RSS 내림차순):
   $ ps -Ao pid,user,%mem,rss,command -m | head -5
     PID USER  %MEM     RSS COMMAND
-  41023 green 12.4 2031234 Discord Helper (Renderer)
-  82342 green  8.1 1326541 chrome --type=renderer ...
-  31002 green  5.2  852416 /Applications/Slack.app/Contents/...
-   1234 green  3.8  621304 node /Users/green/proj/server.js
+  41023 greenhead 12.4 2031234 Discord Helper (Renderer)
+  82342 greenhead  8.1 1326541 chrome --type=renderer ...
+  31002 greenhead  5.2  852416 /Applications/Slack.app/Contents/...
+   1234 greenhead  3.8  621304 node /Users/greenhead/proj/server.js
 
   # Linux (--sort -rss = RSS 내림차순):
   $ ps -Ao pid,user,%mem,rss,command --sort -rss | head -5
@@ -70,9 +70,9 @@ process 운영 시나리오 — "지금 이 상황에서 뭘 치지?" 모음.
   $ pkill -f "Slay the Spire"                # 풀 이름으로 종료
 
 [7. 특정 사용자 소유 프로세스 전부 정리 (logout 전)]
-  $ pgrep -U green -l                        # 확인 먼저
-  $ pkill -U green                           # 정상 종료
-  $ pkill -U green -9                        # 안 죽는 것만 강제
+  $ pgrep -U greenhead -l                        # 확인 먼저
+  $ pkill -U greenhead                           # 정상 종료
+  $ pkill -U greenhead -9                        # 안 죽는 것만 강제
 
 [8. 데몬 설정 reload (재시작 없이)]
   $ pkill -HUP nginx                         # nginx config reload

--- a/modules/shared/programs/cheat/cheatsheets/process/top
+++ b/modules/shared/programs/cheat/cheatsheets/process/top
@@ -23,8 +23,8 @@ top — 시스템 표준 프로세스 모니터. macOS BSD와 Linux procps-ng는
   top -pid PID               특정 PID만 추적
                              $ top -pid 1234
 
-  top -user green            특정 사용자 소유만
-  top -U green               동의어
+  top -user greenhead            특정 사용자 소유만
+  top -U greenhead               동의어
 
 [Linux procps-ng]                  # NixOS / 대부분 Linux 배포판
   top                        대화형 모드 (q로 종료)

--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -3,7 +3,7 @@
 # Thariq(Anthropic) gist 기반 — session_id, repo context 추가
 #
 # Log format (TSV): timestamp user session_id repo skill args
-# 예: 1742302800	green	abc123	nixos-config	managing-minipc	""
+# 예: 1742302800	greenhead	abc123	nixos-config	managing-minipc	""
 
 command -v jq >/dev/null 2>&1 || exit 0
 

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/data-sources.md
@@ -4,7 +4,7 @@
 
 | 호스트 | Claude Code | Codex |
 |--------|-------------|-------|
-| Mac (`/Users/green`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
+| Mac (`/Users/greenhead`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
 | MiniPC (`/home/greenhead`) | `~/.claude/projects/**/*.jsonl` | `~/.codex/sessions/**/rollout-*.jsonl` |
 
 원격 호스트는 `subprocess.run(["ssh", alias, "find", "~/.claude/projects", "-name", "*.jsonl", ...])` 고정 argv로 path 목록만 수집한 뒤, 실제 파일 내용은 `subprocess.run(["ssh", alias, "cat", path])`로 가져온다. 호스트당 SSH cat 호출은 ControlMaster 다중화 + `concurrent.futures.ThreadPoolExecutor(max_workers=SSH_FETCH_WORKERS)`로 병렬 처리한다 (host 순차 진행, host당 K=8 fetch 병렬). ControlMaster가 비활성인 호스트는 K=1 직렬 fallback이 5분 budget 안에 끝나지 않으므로 fetch 자체를 skip하고 명시적 warning을 누적한다 (사용자가 ControlMaster 활성화 누락을 즉시 인지).
@@ -53,7 +53,7 @@ INTENSITY_DIR_MARKER = re.compile(
   "snapshot_id": "pr-670-baseline",
   "captured_at": "2026-05-04T15:00:00Z",
   "files": [
-    "/Users/green/.claude/projects/.../<sessionId>.jsonl",
+    "/Users/greenhead/.claude/projects/.../<sessionId>.jsonl",
     "/home/greenhead/.codex/sessions/.../rollout-<id>.jsonl",
     "..."
   ],

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/references/host-handling.md
@@ -42,7 +42,7 @@ shell string 금지. 항상 list argv 형태로 subprocess.run 호출. 단 ssh r
 - 확장자 `.jsonl`로 종결.
 - `posixpath.normpath`로 traversal(`../`) 정규화.
 - `posixpath.isabs`로 relative path 폐기 (find stdout이 비정상으로 relative line을 내보낸 경우).
-- `posixpath.commonpath([base_norm, path_norm]) == base_norm and path_norm != base_norm` boundary 비교 — sibling-prefix(`/Users/green/.claude/projects-evil/x.jsonl`) 거부, absolute/relative mix는 ValueError로 폐기.
+- `posixpath.commonpath([base_norm, path_norm]) == base_norm and path_norm != base_norm` boundary 비교 — sibling-prefix(`/Users/greenhead/.claude/projects-evil/x.jsonl`) 거부, absolute/relative mix는 ValueError로 폐기.
 - 비교 대상 base는 `HOST_PATH_MAP[host]["claude"]` 또는 `HOST_PATH_MAP[host]["codex"]` absolute prefix.
 
 검증 실패 시 `ValueError` 또는 (find stdout 처리에서는) silently 폐기.
@@ -88,11 +88,11 @@ remote `find` stdout의 path line은 비신뢰 입력으로 간주. 각 line을 
 
 ## Command path vs validation/corpus path 역할 분리
 
-`HOST_PATH_MAP`의 absolute home prefix (`/Users/green/...`, `/home/greenhead/...`)는 SSH 명령 인자에 직접 들어가지 않는다. 명령 인자에는 host-neutral relative tilde 표현 (`~/.claude/projects`, `~/.codex/sessions`)을 사용해 host별 home directory hardcoded를 명령 구성에서 제거한다. 원격 shell이 `~`를 해당 user의 home으로 expansion한다.
+`HOST_PATH_MAP`의 absolute home prefix (`/Users/greenhead/...`, `/home/greenhead/...`)는 SSH 명령 인자에 직접 들어가지 않는다. 명령 인자에는 host-neutral relative tilde 표현 (`~/.claude/projects`, `~/.codex/sessions`)을 사용해 host별 home directory hardcoded를 명령 구성에서 제거한다. 원격 shell이 `~`를 해당 user의 home으로 expansion한다.
 
 absolute prefix는 다음 두 용도로만 사용한다:
 
-1. Validation path: `_allowed_remote_path`가 SSH find stdout (비신뢰 입력) 각 line을 검증할 때 boundary 비교 기준으로 사용한다. `posixpath.normpath` + `posixpath.commonpath([base_norm, path_norm]) == base_norm` 비교로 sibling-prefix (`/Users/green/.claude/projects-evil/...`), traversal (`../../etc/shadow`), relative path (find stdout이 비정상으로 relative line을 내보낸 경우)를 모두 거부한다.
+1. Validation path: `_allowed_remote_path`가 SSH find stdout (비신뢰 입력) 각 line을 검증할 때 boundary 비교 기준으로 사용한다. `posixpath.normpath` + `posixpath.commonpath([base_norm, path_norm]) == base_norm` 비교로 sibling-prefix (`/Users/greenhead/.claude/projects-evil/...`), traversal (`../../etc/shadow`), relative path (find stdout이 비정상으로 relative line을 내보낸 경우)를 모두 거부한다.
 2. Corpus path: `--corpus manifest.json` 모드에서 host 분류 prefix로도 사용한다 (`HOST_PATH_MAP` base prefix 순회). 미매칭 path는 silent host 배정 대신 warning만 누적한다 — 새 host 지원은 `HOST_PATH_MAP`에 명시 추가가 정답이다.
 
 이 역할 분리는 PR review thread의 `HOST_PATH_MAP` fragility 질문에 답한다 — 명령 구성에서는 hardcoded prefix를 제거하지만, 보안 경계와 corpus host inference에는 absolute prefix가 SSOT로 남는다 (host model 중앙화는 별도 PR로 분리, 본 reference의 NG-3 참조).
@@ -130,7 +130,7 @@ JSON sidecar의 `warnings` 배열에도 같은 메시지가 들어간다.
 
 | 호스트 | Claude Code base | Codex base |
 |--------|-----------------|------------|
-| mac | `/Users/green/.claude/projects/` | `/Users/green/.codex/sessions/` |
+| mac | `/Users/greenhead/.claude/projects/` | `/Users/greenhead/.codex/sessions/` |
 | minipc | `/home/greenhead/.claude/projects/` | `/home/greenhead/.codex/sessions/` |
 
 `--corpus manifest.json` 사용 시 위 표의 `HOST_PATH_MAP` base prefix를 우선 순회하여 host를 분류한다. 미매칭 path는 `warnings` 누적 후 처리에서 제외 — 새 host 지원은 `HOST_PATH_MAP` 추가가 정답이다 (silent host 배정 회피).

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/scripts/analyze.py
@@ -117,8 +117,8 @@ SELECTIVE_LINE = re.compile(
 #   corpus path:     `--corpus manifest.json` 모드에서 host 분류 prefix로도 사용한다 (D-6).
 HOST_PATH_MAP = {
     "mac": {
-        "claude": "/Users/green/.claude/projects",
-        "codex": "/Users/green/.codex/sessions",
+        "claude": "/Users/greenhead/.claude/projects",
+        "codex": "/Users/greenhead/.codex/sessions",
     },
     "minipc": {
         "claude": "/home/greenhead/.claude/projects",
@@ -744,7 +744,7 @@ def _allowed_remote_path(host: str, path: str) -> bool:
     3. `posixpath.normpath`로 traversal(`../`) 정규화.
     4. `posixpath.isabs`로 relative path 폐기 (find stdout 비신뢰).
     5. `posixpath.commonpath([base_norm, path_norm]) == base_norm` boundary 비교 —
-       sibling-prefix(`/Users/green/.claude/projects-evil/...`)는 commonpath가
+       sibling-prefix(`/Users/greenhead/.claude/projects-evil/...`)는 commonpath가
        base_norm와 다르므로 거부. absolute/relative mix는 ValueError → 폐기.
     6. `path_norm != base_norm`로 base 자체 통과를 차단 (`.jsonl` 확장자 검사가
        이미 거부하지만 방어적 명시).

--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/tests/test_analyze.py
@@ -101,19 +101,19 @@ def test_hostile_path_rejection(analyze_module):
     """`_allowed_remote_path` boundary check가 다음 4 시나리오를 모두 거부함을 검증.
 
     1. 외부 절대 경로 (`/etc/passwd`).
-    2. traversal (`/Users/green/.claude/projects/../../../etc/shadow`).
-    3. sibling-prefix (`/Users/green/.claude/projects-evil/x.jsonl`).
+    2. traversal (`/Users/greenhead/.claude/projects/../../../etc/shadow`).
+    3. sibling-prefix (`/Users/greenhead/.claude/projects-evil/x.jsonl`).
     4. relative path (find stdout이 비정상으로 relative line을 내보낸 경우).
     """
     cases = [
         ("mac", "/etc/passwd"),
-        ("mac", "/Users/green/.claude/projects/../../../etc/shadow"),
-        ("mac", "/Users/green/.claude/projects-evil/x.jsonl"),
-        ("mac", "Users/green/.claude/projects/a.jsonl"),
+        ("mac", "/Users/greenhead/.claude/projects/../../../etc/shadow"),
+        ("mac", "/Users/greenhead/.claude/projects-evil/x.jsonl"),
+        ("mac", "Users/greenhead/.claude/projects/a.jsonl"),
         # 추가 시나리오: shell metacharacter 거부 (기존 계약 회귀 가드)
-        ("mac", "/Users/green/.claude/projects/a.jsonl;rm -rf /"),
+        ("mac", "/Users/greenhead/.claude/projects/a.jsonl;rm -rf /"),
         # 추가 시나리오: .jsonl 확장자 부재 거부
-        ("mac", "/Users/green/.claude/projects/notes.txt"),
+        ("mac", "/Users/greenhead/.claude/projects/notes.txt"),
     ]
     for host, path in cases:
         assert analyze_module._allowed_remote_path(host, path) is False, (
@@ -129,25 +129,25 @@ def test_allowed_remote_path_boundary_check(analyze_module):
     """
     # 정상 child path는 통과
     assert analyze_module._allowed_remote_path(
-        "mac", "/Users/green/.claude/projects/abc/sess.jsonl"
+        "mac", "/Users/greenhead/.claude/projects/abc/sess.jsonl"
     ) is True
     assert analyze_module._allowed_remote_path(
-        "mac", "/Users/green/.codex/sessions/2026/05/10/rollout-x.jsonl"
+        "mac", "/Users/greenhead/.codex/sessions/2026/05/10/rollout-x.jsonl"
     ) is True
     assert analyze_module._allowed_remote_path(
         "minipc", "/home/greenhead/.claude/projects/x/y.jsonl"
     ) is True
     # sibling-prefix는 startswith로는 통과하지만 commonpath로는 거부
     assert analyze_module._allowed_remote_path(
-        "mac", "/Users/green/.claude/projects-evil/x.jsonl"
+        "mac", "/Users/greenhead/.claude/projects-evil/x.jsonl"
     ) is False
     # base 자체는 .jsonl이 아니므로 거부 + commonpath path_norm != base_norm 가드
     assert analyze_module._allowed_remote_path(
-        "mac", "/Users/green/.claude/projects"
+        "mac", "/Users/greenhead/.claude/projects"
     ) is False
     # mac path를 minipc host로 검증 시 거부 (host별 base 분리)
     assert analyze_module._allowed_remote_path(
-        "minipc", "/Users/green/.claude/projects/x.jsonl"
+        "minipc", "/Users/greenhead/.claude/projects/x.jsonl"
     ) is False
 
 
@@ -163,8 +163,8 @@ def test_analyze_remote_session_partial_fetch_result(analyze_module, monkeypatch
     않는다. dispatch 경로 자체는 V-1 live 측정과 코드 review로 검증한다.
     """
     warnings: list[str] = []
-    fail_path = "/Users/green/.claude/projects/fail.jsonl"
-    ok_path = "/Users/green/.claude/projects/ok.jsonl"
+    fail_path = "/Users/greenhead/.claude/projects/fail.jsonl"
+    ok_path = "/Users/greenhead/.claude/projects/ok.jsonl"
 
     def fake_fetch(host, path, w):
         if path == fail_path:

--- a/scripts/add-host.sh
+++ b/scripts/add-host.sh
@@ -27,7 +27,7 @@ esac
 read -rp "2. 호스트명 (예: greenhead-MacBookPro): " hostname
 
 # 3. 사용자명
-read -rp "3. 사용자명 (예: green): " username
+read -rp "3. 사용자명 (예: greenhead): " username
 
 # 4. 호스트 유형
 echo "4. 호스트 유형을 선택하세요:"

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -2101,7 +2101,7 @@ EOF
 set -euo pipefail
 case "${1:-}" in
   list)
-    printf '%s\n' '-\t0\tcom.green.test-agent'
+    printf '%s\n' '-\t0\tcom.greenhead.test-agent'
     exit 0
     ;;
   bootout) exit 0 ;;


### PR DESCRIPTION
## Summary

- macOS 로컬 username을 `green`→`greenhead`로 변경한 계정 rename에 맞춰, Nix 선언과 username 종속 참조를 동기화한다.
- `flake.nix`의 darwin host username 한 줄이 single source of truth이며, launchd 라벨·SSH alias·DA 분석 경로·문서 예시를 함께 정합화한다.
- Closes #31

## 기존 문제 / 배경

MiniPC(NixOS)는 이미 `greenhead`인데 macOS만 `green`이라 SSH alias·문서·자동화 곳곳에 정체성 불일치가 누적됐다. 사용자가 계정 short name + home dir을 `greenhead`/`/Users/greenhead`로 in-place rename(UID 501 보존)한 뒤, `flake.nix`가 여전히 `green`을 가리켜 home-manager가 삭제된 `/Users/green`을 참조하는 drift가 발생했다 (`HISTFILE` 등 `Permission denied` 재발). 이 PR은 그 drift를 해소한다.

## CIR (Change Intent Record)

- 계정 rename은 GUI/재로그인이 필요해 수동 수행했고, 이후 `nrs`가 빌드 시 박힌 옛 `FLAKE_PATH=/Users/green`으로 `cd` 실패해 자가 갱신이 막혔다. `darwin-rebuild`를 1회 직접 호출해 부트스트랩, 새 `nrs`(greenhead 경로)를 재생성한 뒤 정상 흐름으로 복귀했다.
- username은 `mkDarwinHost` 첫 인자가 `specialArgs.username`으로 전 darwin 모듈에 전파되는 single source of truth다. 따라서 `configuration.nix`/`home.nix` 등의 `${username}`/`/Users/${username}` 파생값은 직접 수정하지 않는다(자동 전파). 실제로 변경 필수는 `flake.nix` 한 줄.
- launchd 라벨(`com.green.*`)은 username 변수가 아니라 하드코딩 reverse-DNS라 자동 전파되지 않아 명시 변경했다.
- `analyze.py`의 `HOST_PATH_MAP` mac base는 username 종속 절대경로라 변경 대상이며, boundary 검증 테스트와 lockstep으로 갱신했다.
- 색상 토큰(`%C(green)` 등), historical 박제 기록(`TRIAL_AND_ERROR.md`), 실제 username과 무관한 참조는 선별 보존했다.

## ADR (Architecture Decision Record)

| 결정 | 대안 | 장점 | 단점 | 채택 |
|------|------|------|------|------|
| launchd 라벨 | 유지 `com.green.*` | bootout 불필요 | 명명 불일치 영구화 | ❌ |
| | 마이그레이션 `com.greenhead.*` | 명명 일관성 | 구 라벨 정리 필요 | ✅ |
| 구 라벨 정리 | 단순 치환(신 라벨만) | 간단 | 구 라벨 orphan 잔존 → 이중 트리거 | ❌ |
| | 전환기 dual-namespace | 구·신 모두 cleanup | 1회성 임시 패턴 | ✅ |
| owner 표기 | 유지 `green` / `greenhead` | - | 실제 remote owner와 불일치 | ❌ |
| | `greenheadHQ` | 실제 GitHub owner(org) 일치 | - | ✅ |

> 실제 적용 시 home-manager generation diff가 launchd 라벨 전환(구 bootout + plist 삭제 + 신 등록)을 자동 처리함을 확인. dual-namespace `nrs.sh` cleanup은 안전망으로 남긴다.

## 구현 상세

| 파일 | 변경 |
|------|------|
| `flake.nix` | darwin host username `green`→`greenhead`; description owner `green`→`greenheadHQ` |
| `modules/darwin/programs/folder-actions/default.nix` | launchd Label 5개 `com.green.*`→`com.greenhead.*` |
| `modules/darwin/scripts/nrs.sh` | cleanup awk/glob을 dual-namespace로 (`com.(green\|greenhead)`, `com.green*`) |
| `modules/nixos/programs/ssh-client/default.nix` | `mac` alias `user` `green`→`greenhead` (MiniPC측, MiniPC에서 활성화) |
| `.../analyzing-da-sessions/scripts/analyze.py` | `HOST_PATH_MAP` mac base `/Users/green`→`/Users/greenhead` |
| `.../analyzing-da-sessions/tests/test_analyze.py` | boundary 검증 fixture lockstep |
| `tests/shell-script-tests.sh` | nrs cleanup stub fixture `com.greenhead.test-agent` |
| cheat 치트시트(6) · DA 문서(2) · `add-host.sh` · `log-skill.sh` · `README.md` | username 예시·문서 동기화 |

## 참고 레퍼런스

- Closes #31 — 이슈 본문에 방법 비교·예상 사이드이펙트 매트릭스·상세 테스트 절차
- MiniPC↔macOS 양방향 SSH 설정 및 IdeaProjects→Workspace 경로 마이그레이션 이력(이슈 #31 Related Commits 참조)

## Human Test Plan

1. `whoami; id -u greenhead; echo $HOME` → `greenhead` / `501` / `/Users/greenhead`
2. `launchctl list | grep com.greenhead` → folder-action 5개 등록 · `launchctl list | grep com.green | rg -v greenhead` → 0건
3. `nix eval '.#darwinConfigurations."greenhead-MacBookPro".config.system.primaryUser'` → `"greenhead"`
4. 새 `nrs` 1회 실행 → `cd` 에러 없이 정상 완료 (FLAKE_PATH가 greenhead 경로로 갱신됨)
5. (MiniPC 세션) `nrs` 후 `ssh -o BatchMode=yes mac whoami` → `greenhead`
6. DA 분석: `_allowed_remote_path("mac", "/Users/greenhead/.claude/projects/x.jsonl")` → True (mac base 정합)
7. 실패 시: `flake.nix` username과 `system.primaryUser` 일치 확인, `~/Library/LaunchAgents/com.green*.plist` 잔존(구 라벨 orphan) 점검

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project repository name from `green/nixos-config` to `greenheadHQ/nixos-config`.
  * Updated macOS host configuration, SSH client settings, and system service identifiers from `green` to `greenhead`.

* **Documentation**
  * Updated cheatsheets, reference guides, and example documentation with new username references and file paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/greenheadHQ/nixos-config/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->