### PR TITLE
feat(macos): 무인 에이전트 gh GH_TOKEN 우회 — c/codex 세션 GH_TOKEN 주입 (closes #848)

### DIFF
--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -3,6 +3,7 @@
   config,
   pkgs,
   lib,
+  constants,
   ...
 }:
 
@@ -88,5 +89,53 @@ in
       # sqlite3 등이 시스템 바이너리를 shadow한다. append로 우회.
       [ -d "$ANDROID_HOME/platform-tools" ] && export PATH="$PATH:$ANDROID_HOME/platform-tools"
     ''
+
+    # ════════════════════════════════════════════════════════════════
+    # #848: 무인 에이전트 gh Touch ID 우회 (Mac 전용, PRD #780 Phase 2b 후속)
+    # c/codex 런처가 세션 시작 시 op read로 GH_TOKEN을 1회 주입(Touch ID 1회) →
+    # 세션 내 gh는 무인 작동(화면잠금/sleep 무관). 대화형 직접 gh는 op plugin biometric 유지.
+    # graceful: op read 실패/빈 값 시 GH_TOKEN 미주입 → 기존 경로 fallback(work 맥북 무해).
+    # 토큰은 env(메모리)만 — 디스크 평문 0 (Phase 2b hosts.yml 평문 제거 이득 보존).
+    # mkOrder 1600: shared default.nix의 plugins.sh source(mkAfter=1500)와 shellAliases 이후 로드.
+    # ════════════════════════════════════════════════════════════════
+    (lib.mkOrder 1600 ''
+      # gh: GH_TOKEN 있으면 직접 사용, 없으면 op plugin biometric (plugins.sh alias override).
+      unalias gh 2>/dev/null || true
+      gh() {
+        if [ -n "''${GH_TOKEN:-}" ]; then
+          command gh "$@"
+        elif [ -f "$HOME/.config/op/plugins.sh" ]; then
+          op plugin run -- gh "$@"
+        else
+          command gh "$@"
+        fi
+      }
+
+      # 에이전트 런처용 GH_TOKEN 발급 (op read, Touch ID 1회). 실패 시 빈 문자열(graceful).
+      _agent_gh_token() {
+        command -v op >/dev/null 2>&1 || return 0
+        op read --no-newline --account "${constants.onePassword.account}" \
+          "op://${constants.onePassword.vaults.automation}/github-pat/token" 2>/dev/null || true
+      }
+
+      # c(Claude Code) / codex 런처: 세션 시작 시 GH_TOKEN 주입(성공 시에만), 프로세스 한정.
+      unalias c codex 2>/dev/null || true
+      c() {
+        local _tok; _tok="$(_agent_gh_token)"
+        if [ -n "$_tok" ]; then
+          GH_TOKEN="$_tok" command claude --dangerously-skip-permissions --mcp-config ~/.claude/mcp.json "$@"
+        else
+          command claude --dangerously-skip-permissions --mcp-config ~/.claude/mcp.json "$@"
+        fi
+      }
+      codex() {
+        local _tok; _tok="$(_agent_gh_token)"
+        if [ -n "$_tok" ]; then
+          GH_TOKEN="$_tok" command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen "$@"
+        else
+          command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen "$@"
+        fi
+      }
+    '')
   ];
 }


### PR DESCRIPTION
## Summary

- Mac 무인 에이전트(`c`=claude / `codex`) 런처가 세션 시작 시 `op read`로 **GH_TOKEN을 1회 주입**(Touch ID 1회) → 세션 내 `gh`는 화면잠금/sleep과 무관하게 무인 작동. 대화형 직접 `gh`는 op plugin biometric 유지.
- `gh`를 함수로 3분기(GH_TOKEN 있으면 `command gh` / `plugins.sh` 있으면 `op plugin run` / else `command gh`), graceful fallback, 토큰 env(메모리) 한정.
- **Closes #848.**

## 기존 문제 / 배경

Phase 2b(#827)에서 Mac `gh`를 1Password Shell Plugin alias(`op plugin run -- gh`)로 전환한 결과, 비대화형 도구(Claude Code Bash tool 등)는 명령마다 독립 `zsh -c` 프로세스라 op biometric 세션 캐시가 공유되지 않아 **매 `gh` 호출마다 Touch ID**가 필요했다. 특히 잠자는 동안 무인 에이전트 장기 실행 시 사람이 Touch ID를 누를 수 없어 `gh`가 완전히 막혔다. (이번 작업 세션에서도 `gh pr create`가 op biometric에서 두 번 dismiss되는 마찰을 실제로 겪음.)

## CIR (Change Intent Record)

설계는 #848에서 7개 분기로 사용자 확정됨 — biometric의 본질 한계(무인 불가)를 "에이전트 런처 세션 시작 1회 인증 + GH_TOKEN env 캐시"로 우회(MiniPC GH_TOKEN wrapper의 Mac 세션 버전). 적용 범위는 에이전트 세션만(대화형 직접 gh는 biometric 유지 — 빈도 낮아 수용), 캐시는 env 한정(디스크 평문 0, Phase 2b hosts.yml 평문 제거 이득 보존), auto-lock은 보안 기본값 유지.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 결정 |
|---|---|---|
| op 데스크탑 biometric 캐시 연장 | auto-lock 12h 등 연장 | ❌ 12h hard limit 미해결 + 노트북 열린 동안 금고 노출 |
| **에이전트 런처 GH_TOKEN env 주입** | c/codex 세션 시작 시 op read → GH_TOKEN | ✅ MiniPC 패턴 일관, env 한정 |
| 토큰 파일 캐시 | ~/.config 등에 토큰 파일 | ❌ 디스크 평문 노출 |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/shell/darwin.nix` | 함수 시그니처에 `constants` 추가 + `lib.mkOrder 1600` 블록: `unalias` 후 `gh`/`c`/`codex` 함수 정의, `_agent_gh_token`(op read, graceful) |

핵심: `c`/`codex`는 `op read` 성공 시에만 `GH_TOKEN="$_tok" command claude/codex …`로 **프로세스 한정** 주입(호출 셸 env 미오염), 실패 시 기존 경로. `gh`는 GH_TOKEN 유무로 분기. `mkOrder 1600`으로 plugins.sh source(`mkAfter`=1500)·shellAliases 이후 로드되어 alias를 override.

## 참고 레퍼런스

- epic #780, Phase 2b #827(Shell Plugin gh), Phase 3 #842(MiniPC GH_TOKEN wrapper 대조 패턴)
- 대조 구현: `modules/shared/programs/shell/nixos.nix` (MiniPC headless gh wrapper)

## Human Test Plan

이미 로컬에서 검증 완료(이 PR 작업 중, worktree `nrs` 적용 후):

1. `nix eval` — `darwinConfigurations.greenhead-MacBookPro` initContent에 #848 블록 + constants 보간 정상.
2. `nrs`(darwin-rebuild switch) 적용 후 새 셸:
   - `whence -w gh c codex _agent_gh_token` → 전부 **function** (alias override 성공).
   - `_agent_gh_token` → token 40자 `ghp_…` 발급, 비대화형 `gh api user` = **greenheadHQ** (GH_TOKEN env 무인 인증).
   - `~/.config/gh/hosts.yml` 평문 `oauth_token` **0건**.
3. 머지 후: `main` pull + `nrs`로 main 기준 재적용(현 worktree config와 동일 내용). work-MacBookPro는 개인 1Password 미로그인 시 `op read` 실패 → graceful fallback(무해).

> 후속: 대화형 `gh`의 op plugin biometric 경로는 GH_TOKEN 미주입 시 그대로 유지됨(본문 확인).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS shell configuration to enhance GitHub authentication handling for command-line tools, enabling more flexible token management across shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->