### PR TITLE
fix(shell): gh 무인 인증 non-interactive 셸 갭 수정 — PATH wrapper (#872 후속)

### DIFF
--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -10,6 +10,49 @@
 let
   darwinScriptsDir = ../../../darwin/scripts;
   sharedScriptsDir = ../../../shared/scripts;
+
+  # #872 후속(run-da 반영): gh 무인 인증을 PATH 실행 파일로 제공한다.
+  # gh wrapper가 interactive .zshrc(initContent) 함수로만 정의되면 non-interactive 셸
+  # (Claude Code Bash tool의 shell snapshot 등)에 적용되지 않아 gh가 biometric/미인증으로 빠졌다.
+  # gh-auth는 PATH 실행 파일이지만 `gh` 라우팅은 shellAliases gh="gh-auth"에 의존한다 — 이는
+  # Claude Code Bash tool의 shell snapshot이 캡처하는 셸(주 사용 환경, LLM 자동화)을 커버한다.
+  # rc를 읽지 않는 셸(CI의 bash -c 등)은 범위 밖이며(F4), homebrew gh가 PATH 최우선이라
+  # ~/.local/bin shim도 비효과 + 현재 CI 무인 gh 수요 없음(YAGNI) — 필요 시 별도 follow-up.
+  #
+  # gh-pat-mac: SA token → github-pat을 per-user temp 캐시(0700/0600, 12h TTL, prefix 검증)에
+  # 무인 발급해 stdout으로 출력. 캐시/SA/op 부재 시 빈 출력(graceful). c/codex 런처와 공유.
+  ghPatMac = pkgs.writeShellScriptBin "gh-pat-mac" ''
+    # F1: getconf 실패 시 빈 prefix→상대경로(gh-pat-NNN) 붕괴로 PAT가 cwd에 평문 기록될 수 있다.
+    # absolute 경로인지 검증하고, 아니면 fail-closed(발급 안 함)한다.
+    _tmp="$(/usr/bin/getconf DARWIN_USER_TEMP_DIR 2>/dev/null)"
+    case "$_tmp" in /*) ;; *) exit 0 ;; esac
+    _cache="''${_tmp%/}/gh-pat-$(id -u)"
+    if [ -f "$_cache" ] && [ -z "$(/usr/bin/find "$_cache" -mmin +720 2>/dev/null)" ]; then
+      _c="$(cat "$_cache" 2>/dev/null)"
+      case "$_c" in ghp_*|github_pat_*) printf '%s' "$_c"; exit 0 ;; esac
+    fi
+    rm -f "$_cache" 2>/dev/null
+    _sa="$HOME/.config/op/sa-token-mac"
+    [ -r "$_sa" ] || exit 0
+    command -v op >/dev/null 2>&1 || exit 0
+    _tok=$(OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline \
+           "op://${constants.onePassword.vaults.automation}/github-pat/token" 2>/dev/null || true)
+    case "$_tok" in ghp_*|github_pat_*) ;; *) exit 0 ;; esac
+    ( umask 077; printf '%s' "$_tok" > "$_cache.tmp.$$" && mv -f "$_cache.tmp.$$" "$_cache" )
+    printf '%s' "$_tok"
+  '';
+
+  # gh-auth: GH_TOKEN 미설정 시 gh-pat-mac으로 발급해 주입한 뒤 실제 gh를 exec한다.
+  # F3: op plugin biometric fallback은 제거했다 — [ -t 0 ]는 PTY를 받은 non-interactive
+  # automation도 true라 무인 환경에서 biometric 팝업으로 빠질 수 있고, plugins.sh source도
+  # 제거(default.nix)되어 도달 불가다. 발급 실패 시 GH_TOKEN 없이 실제 gh로 exec(gh 자체 인증).
+  ghAuth = pkgs.writeShellScriptBin "gh-auth" ''
+    if [ -z "''${GH_TOKEN:-}" ]; then
+      _tok="$(${ghPatMac}/bin/gh-pat-mac)"
+      [ -n "$_tok" ] && export GH_TOKEN="$_tok"
+    fi
+    exec ${pkgs.gh}/bin/gh "$@"
+  '';
 in
 {
   # macOS용 스크립트 설치
@@ -54,7 +97,17 @@ in
     # Hammerspoon CLI
     hs = "/Applications/Hammerspoon.app/Contents/Frameworks/hs/hs";
     hsr = ''hs -c "hs.reload()"'';
+    # #872 후속: gh를 무인 wrapper(gh-auth)로 라우팅. shellAliases는 Claude Code Bash tool의 shell
+    # snapshot이 캡처하므로, interactive .zshrc 함수와 달리 LLM 자동화 셸에서도 gh가 무인 동작한다.
+    # rc를 읽지 않는 CI류 셸은 범위 밖(F4) — let 블록 주석 참조.
+    gh = "gh-auth";
   };
+
+  # #872 후속: gh 무인 wrapper 실행 파일 (interactive/non-interactive/snapshot 공통)
+  home.packages = [
+    ghPatMac
+    ghAuth
+  ];
 
   # macOS 전용 Zsh 초기화
   programs.zsh.initContent = lib.mkMerge [
@@ -91,62 +144,24 @@ in
     ''
 
     # ════════════════════════════════════════════════════════════════
-    # #872: 무인 에이전트 gh 인증 (Mac 전용, 방식 B — SA token → github-pat 캐시)
+    # #872(+후속): 무인 에이전트 gh 인증 (Mac 전용, 방식 B — SA token → github-pat 캐시)
     # PRD #780 Phase 2b. per-session op read(#848/#871, Touch ID 1회) 대체.
-    # SA token(agenix 배포 ~/.config/op/sa-token-mac)으로 github-pat을 무인 발급(Touch ID 0회) →
-    # per-user temp 캐시(getconf DARWIN_USER_TEMP_DIR, 0700 디렉토리/0600 파일, 재부팅 휘발)에
-    # 저장 후 세션/프로세스 간 재사용. 무인 다중 에이전트 지원.
+    # gh 자체는 gh-auth wrapper(let 블록 + shellAliases gh="gh-auth")가 처리한다(snapshot 캡처 셸 커버).
+    # 셸 함수는 interactive .zshrc 전용이라 non-interactive(Claude Code Bash tool snapshot)에 미적용이라
+    # gh가 biometric/미인증으로 빠졌다 → shellAliases 라우팅으로 LLM 자동화 셸을 커버. 아래는 c/codex 런처.
+    # gh-pat-mac이 SA token(agenix 배포 ~/.config/op/sa-token-mac)으로 github-pat을 per-user temp
+    # 캐시(getconf DARWIN_USER_TEMP_DIR, 0700/0600, 12h TTL, 재부팅 휘발)에 무인 발급(Touch ID 0회).
     # SA token은 op 프로세스 env로만 전달(셸 env 미상주), 캐시엔 github-pat만(디스크 평문은 휘발 tmp 한정).
-    # graceful: sa-token 미배포(work role)·op 부재·발급 실패 시 GH_TOKEN 미주입 → biometric/기존 경로.
-    # 셸 lazy(launchd 비의존): op는 셸 PATH 사용, agenix 복호화 완료 후 로그인 셸에서 실행.
-    # mkOrder 1600: shared default.nix의 plugins.sh source(mkAfter=1500)와 shellAliases 이후 로드.
+    # graceful: sa-token 미배포(work role)·op 부재·발급 실패 시 GH_TOKEN 미주입 → 실제 gh로 exec.
+    # 아래 mkOrder 1600 블록은 interactive 전용 c/codex 런처다(gh-pat-mac 공유).
     # ════════════════════════════════════════════════════════════════
     (lib.mkOrder 1600 ''
-      # github-pat 캐시 발급/조회 (방식 B):
-      #  - 캐시 경로는 per-user temp(getconf DARWIN_USER_TEMP_DIR, 0700 디렉토리)로 고정. world-writable
-      #    /tmp 폴백을 쓰지 않아, 타 로컬 사용자가 캐시 파일을 선점해 GH_TOKEN을 치환하는 표면을 제거한다.
-      #  - 유효 캐시(존재 + 12h 이내 + github-pat 형식)만 재사용. 만료(TTL)·부분쓰기·형식 불일치 캐시는
-      #    폐기 후 SA로 재발급 → stale/truncated 토큰을 silent하게 GH_TOKEN으로 주입하지 않는다.
-      #  - 동시 다중 에이전트 첫 호출 중복 발급은 무인 무해(atomic mv, 마지막 write win).
-      _gh_pat() {
-        local _cache; _cache="$(/usr/bin/getconf DARWIN_USER_TEMP_DIR)gh-pat-$(id -u)"
-        if [ -f "$_cache" ] && [ -z "$(/usr/bin/find "$_cache" -mmin +720 2>/dev/null)" ]; then
-          local _c; _c="$(cat "$_cache" 2>/dev/null)"
-          case "$_c" in (ghp_*|github_pat_*) printf '%s' "$_c"; return 0 ;; esac
-        fi
-        rm -f "$_cache" 2>/dev/null
-        local _sa="$HOME/.config/op/sa-token-mac"
-        [ -r "$_sa" ] || return 0
-        command -v op >/dev/null 2>&1 || return 0
-        local _tok
-        _tok=$(OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline \
-               "op://${constants.onePassword.vaults.automation}/github-pat/token" 2>/dev/null || true)
-        case "$_tok" in (ghp_*|github_pat_*) ;; (*) return 0 ;; esac
-        ( umask 077; printf '%s' "$_tok" > "$_cache.tmp.$$" && mv -f "$_cache.tmp.$$" "$_cache" )
-        printf '%s' "$_tok"
-      }
-
-      # gh: GH_TOKEN 있으면 직접, 없으면 캐시 PAT 주입, 그래도 없으면 op plugin biometric → command gh.
-      unalias gh 2>/dev/null || true
-      gh() {
-        if [ -n "''${GH_TOKEN:-}" ]; then
-          command gh "$@"
-        else
-          local _tok; _tok="$(_gh_pat)"
-          if [ -n "$_tok" ]; then
-            GH_TOKEN="$_tok" command gh "$@"
-          elif [ -f "$HOME/.config/op/plugins.sh" ]; then
-            op plugin run -- gh "$@"
-          else
-            command gh "$@"
-          fi
-        fi
-      }
-
-      # c(Claude Code) / codex 런처: 세션 시작 시 캐시 PAT을 GH_TOKEN으로 주입(성공 시에만), 프로세스 한정.
+      # c(Claude Code) / codex 런처: 세션 시작 시 gh-pat-mac(PATH bin)으로 github-pat을 발급해
+      # GH_TOKEN으로 주입(성공 시에만), 프로세스 한정. graceful: 발급 실패 시 미주입.
+      # gh 자체는 gh-auth wrapper(PATH 실행 파일, let 블록)가 처리 — shellAliases gh = "gh-auth".
       unalias c codex 2>/dev/null || true
       c() {
-        local _tok; _tok="$(_gh_pat)"
+        local _tok; _tok="$(gh-pat-mac)"
         if [ -n "$_tok" ]; then
           GH_TOKEN="$_tok" command claude --dangerously-skip-permissions --mcp-config ~/.claude/mcp.json "$@"
         else
@@ -154,7 +169,7 @@ in
         fi
       }
       codex() {
-        local _tok; _tok="$(_gh_pat)"
+        local _tok; _tok="$(gh-pat-mac)"
         if [ -n "$_tok" ]; then
           GH_TOKEN="$_tok" command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen "$@"
         else

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -377,15 +377,11 @@ in
       ''
 
       #─────────────────────────────────────────────────────────────────────────
-      # 1Password Shell Plugins (op plugin init gh → ~/.config/op/plugins.sh)
-      # gh = "op plugin run -- gh" alias로 wrapping — github-pat을 호출 시점에 주입 (PRD #780 Phase 2b)
-      # guard: plugins.sh 부재 시 silent skip (op plugin init 전·CI·MiniPC 등 — Mac 전용 자산)
+      # 1Password Shell Plugins(op plugin init gh)의 gh alias source는 제거됨 (#872 후속, run-da F2).
+      # op plugin alias("op plugin run -- gh")는 gh-auth wrapper를 덮어 non-interactive 셸에서
+      # biometric 팝업을 유발했고(F2 회귀), plugins.sh 재생성 시 다시 회귀하므로 의존을 끊는다.
+      # gh 무인 인증은 modules/shared/programs/shell/darwin.nix의 gh-auth wrapper가 담당한다.
       #─────────────────────────────────────────────────────────────────────────
-      (lib.mkAfter ''
-        if [ -f "$HOME/.config/op/plugins.sh" ]; then
-          source "$HOME/.config/op/plugins.sh"
-        fi
-      '')
     ];
   };
 


### PR DESCRIPTION
## Summary

- Mac의 무인 `gh` 인증을 **PATH 실행 파일**(`gh-pat-mac`/`gh-auth`) + `shellAliases`로 재구성해, **non-interactive 셸**(Claude Code Bash tool의 shell snapshot 등)에서도 `gh`가 Touch ID 0회로 동작하게 한다.
- 기존 #872 방식 B는 gh wrapper를 interactive `.zshrc` 함수로만 정의해 LLM 자동화 셸에서 1Password biometric 팝업이 떴다 — 그 갭을 닫는다.

Refs #780 (#872 후속)

## 기존 문제 / 배경

#872(방식 B)로 Mac `gh`를 SA token→github-pat 캐시로 무인화했으나, gh wrapper가 **interactive `.zshrc`(initContent) 함수**로만 정의됐다. non-interactive 셸은 이 함수를 로드하지 않는다:

- Claude Code Bash tool은 `~/.claude/shell-snapshots`의 스냅샷을 source하는데, 스냅샷은 **shellAliases(zshrc 초반)는 캡처하지만 initContent 함수(후반)는 미캡처**한다(실측). 그 결과 `gh`가 1Password Shell Plugin alias(`op plugin run -- gh`)로 빠져 **biometric 팝업**이 떴다.
- 즉 "무인 자동화"가 목표인데 정작 **LLM이 gh를 쓰는 환경에서 팝업**이 발생하는 갭이었다. (`op plugin run -- gh` 경로에서 팝업이 뜨는 것을 경로별 실측으로 확정.)

## CIR (Change Intent Record)

- 세션 중 반복된 1Password 팝업을 경로별로 실측해 원인을 좁혔다: 정상 캐시 경로는 팝업이 없고, gh가 op plugin alias로 빠지는 경로에서만 팝업이 떴다.
- 근본 원인은 gh 무인 로직이 **interactive 셸 전용**이라 non-interactive 셸에 적용되지 않는 것이었다. 셸 함수 대신 **PATH 실행 파일**로 만들면 셸 종류와 무관하게 동작한다는 방향을 잡았다.
- `~/.local/bin/gh` 형태의 직접 shim도 검토했으나, 현재 PATH에서 homebrew `gh`(`/opt/homebrew/bin`)가 최우선이라 가려져 효과가 없음을 PATH 실측으로 확인하고 기각했다. 대신 `gh-auth` 실행 파일을 두고 `shellAliases.gh = "gh-auth"`로 라우팅 — 이는 Claude Code 스냅샷이 캡처하는 영역이라 주 사용 환경(LLM 자동화)을 커버한다.
- 코드 리뷰에서 ① getconf 실패 시 토큰이 상대경로(cwd)에 평문 기록될 위험, ② op plugin alias source가 재생성되면 회귀, ③ TTY 판정만으로는 PTY를 받은 자동화도 biometric에 빠질 수 있음을 확인해 모두 반영했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| interactive 함수(기존 #872) | initContent에 gh 함수 정의 | interactive 셸 무인 | non-interactive(snapshot/CI) 미적용 → 팝업 | ❌ |
| 직접 `gh` shim(`~/.local/bin/gh`) | gh 이름 PATH 파일 | 셸 종류 무관 | homebrew gh가 PATH 최우선이라 가려져 비효과 | ❌ |
| `gh-auth` 실행 파일 + `shellAliases.gh` | wrapper bin + alias 라우팅 | 스냅샷 캡처 영역 활용, 주 환경 커버 | rc를 읽지 않는 CI류 셸은 범위 밖 | ✅ |

> 알려진 범위 한계: rc를 읽지 않는 셸(CI의 `bash -c` 등)은 shellAliases 미적용이라 무인 범위 밖이다. Claude Code 주 환경은 스냅샷으로 커버되고, CI 무인 gh 수요가 없어 추가 shim은 보류한다(YAGNI).

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/shell/darwin.nix` | `gh-pat-mac`/`gh-auth`를 `writeShellScriptBin`으로 정의(let), `home.shellAliases.gh = "gh-auth"`, `home.packages` 등록. `c`/`codex` 런처는 `gh-pat-mac` bin 공유. 기존 gh/`_gh_pat` 함수 제거 |
| `modules/shared/programs/shell/default.nix` | op plugin `plugins.sh` source 블록 제거(alias 의존 차단) |

핵심 wrapper:

```sh
# gh-pat-mac: SA token → github-pat 무인 발급 (per-user temp 캐시, 12h TTL, prefix 검증)
_tmp="$(/usr/bin/getconf DARWIN_USER_TEMP_DIR 2>/dev/null)"
case "$_tmp" in /*) ;; *) exit 0 ;; esac          # absolute 검증 — 실패 시 fail-closed
_cache="${_tmp%/}/gh-pat-$(id -u)"
# ... 캐시 hit(12h·prefix) → 출력 / 미스 → SA로 op read 후 0600 atomic write

# gh-auth: GH_TOKEN 미설정 시 발급 주입 후 실제 gh exec (op plugin fallback 없음)
if [ -z "${GH_TOKEN:-}" ]; then
  _tok="$(gh-pat-mac)"; [ -n "$_tok" ] && export GH_TOKEN="$_tok"
fi
exec ${pkgs.gh}/bin/gh "$@"
```

`gh-auth`는 `gh` 이름을 설치하지 않으므로 `programs.gh`(nix gh)와 충돌하지 않고, `${pkgs.gh}/bin/gh`를 절대경로로 exec해 재귀가 없다. NixOS는 별도 경로(`shell/nixos.nix`의 `/run/opnix/.../github-pat` GH_TOKEN wrapper)를 쓰므로 `default.nix` 변경의 영향을 받지 않는다.

## 참고 레퍼런스

- epic #780 — 1Password 마이그레이션
- #872 — Mac 무인 gh(방식 B), 본 PR의 직접 선행
- #848 (CLOSED) / #871 — per-session op read(방식 B 이전 단계)
- `modules/shared/programs/shell/nixos.nix` — MiniPC gh GH_TOKEN wrapper(영향 없음 확인)

## Human Test Plan

`nrs` 적용 후 새 셸/세션에서:

1. `gh-auth api user --jq .login` → `greenheadHQ`, **Touch ID 0회**(직접 bin 경로).
2. `gh api user --jq .login`(shellAliases 경유) → 무인.
3. `ls -la "$(/usr/bin/getconf DARWIN_USER_TEMP_DIR)gh-pat-$(id -u)"` → `0600`, 부모 디렉토리 `0700`(per-user).
4. `env | grep -i op_service` → **0건**(SA token 셸 env 미상주).
5. (회귀) `c`/`codex` 런처가 `gh-pat-mac` 공유로 GH_TOKEN 주입 정상.

**실패 시 진단**: `ls ~/.config/op/sa-token-mac`(0400 배포 확인), `command -v gh-auth`(PATH 등록 확인), `which -a gh`. work role 호스트는 SA 미배포라 `gh-auth`가 GH_TOKEN 없이 실제 gh로 exec(graceful).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured GitHub authentication flow in macOS shell environments for improved token management and caching with automatic expiration.

* **Chores**
  * Updated shell integration to streamline GitHub CLI operations in non-interactive contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->