### PR TITLE
feat(skills): managing-secrets에 1Password routing 매트릭스 + inventory 추가

### DIFF
--- a/.claude/prds/prd-1password-migration/phase-05-skill-refactor.md
+++ b/.claude/prds/prd-1password-migration/phase-05-skill-refactor.md
@@ -35,7 +35,7 @@ Last Updated: 2026-05-27
 - 통합 inventory 표 (SKILL.md inline 또는 `references/inventory.md`)
 - 1Password 운영 절차 추가: SA token rotation 5단계, Service Account 발급, vault 생성, item naming convention, `op_get` helper 사용법
 - SSH device key 운영 절차 추가(조건부): 아래 "Phase 2a Mobile SSH Integration Policy"를 따른다.
-- `evals/queries.json`은 **add-only**: 1Password 혼동 쌍을 신규 추가하고, 기존 vaultwarden 쌍 위에 `"comment": "DEPRECATED — Phase 6에서 삭제"` 표기만 추가. vaultwarden 쌍 자체의 삭제는 Phase 6 책임 (FR-17 분할 정책)
+- `evals/queries.json`: 1Password 혼동/포함 쌍을 신규 추가. vaultwarden negative 쌍은 **Phase 5에서 제거**(소유자 결정 — 1Password 마이그레이션 스킬의 초점 정리, hosting-vaultwarden 자체 evals가 positive 검증을 커버). 당초 add-only(Phase 6 삭제) 계획에서 변경됨 — Phase Change Log 2026-06-01 참조
 - SKILL.md frontmatter trigger 키워드 확장: `'1password', '1Password', 'op CLI', 'opnix', 'service account token', 'Automation vault', 'biometric unlock'`
 - `NOT for Vaultwarden 비밀번호 관리자 (use hosting-vaultwarden)` line은 Phase 6에서 hosting-vaultwarden 스킬 삭제와 동시 제거 (본 phase에서는 변경하지 않음)
 - Phase 2b에서 reserved한 확장 트리거 텍스트 박제: "추가 shell plugin 도입 조건 = (a) 해당 도구 secret을 .env로 export하는 패턴 ≥ 2건 발생 OR (b) agenix 평문 노출 위험 보고 1건"
@@ -45,7 +45,7 @@ Last Updated: 2026-05-27
 
 - 새 managing-1password 스킬 신설 (NG-3)
 - hosting-vaultwarden 스킬 삭제 (Phase 6)
-- managing-secrets/evals/queries.json의 vaultwarden 쌍 완전 삭제 (Phase 6에서 처리, 본 phase에서는 1Password 쌍 신규 추가만)
+- (변경됨) vaultwarden 쌍은 Phase 5에서 제거함 — Phase Change Log 2026-06-01 참조. Phase 6 잔여 작업은 hosting-vaultwarden 스킬 삭제 + 잔여 dead reference 정리
 
 ### Phase 2a Mobile SSH Integration Policy
 
@@ -96,7 +96,7 @@ Phase 5는 Phase 2a mobile SSH follow-up 정책을 새로 결정하지 않는다
 - [ ] SKILL.md frontmatter trigger 키워드 확장 (1Password 관련 추가)
 - [ ] `evals/queries.json` 작업 (add-only):
   - [ ] 1Password 혼동 쌍 신규 추가 (예: "Service Account 발급 절차" `should_trigger=true`, "1Password Master Password 분실 복구" `should_trigger=true`, "op CLI biometric prompt 안 뜸" `should_trigger=true`)
-  - [ ] 기존 vaultwarden 혼동 쌍 항목에 `"comment": "DEPRECATED — Phase 6 vaultwarden 삭제 시 함께 제거"` 필드 1개 추가 (삭제 X)
+  - [x] vaultwarden negative 쌍 제거 (소유자 결정 — 당초 comment marker 계획에서 변경, Phase Change Log 2026-06-01)
   - [ ] 신규 추가 후 eval harness 실행 (있다면) — 모든 항목 통과 확인
 - [ ] SKILL.md 줄수 재측정: 250줄 이하 확인. 초과 시 references/ 분할 트리거:
   - `references/agenix.md` 신규 (agenix-only 워크플로: re-encrypt, host 추가, secrets.nix 패턴)
@@ -129,28 +129,29 @@ Phase 5는 Phase 2a mobile SSH follow-up 정책을 새로 결정하지 않는다
 - [ ] NFR-3 (SKILL.md ≤ 250줄) 충족 또는 references/ 분할 완료
 - [ ] Phase 2b reserved 확장 트리거 텍스트 박제 완료
 - [ ] Phase 2a Mobile SSH Integration Policy 적용 결과 기록 완료
-- [ ] Phase 6 진행 시 vaultwarden 쌍 삭제만 남도록 정리됨
+- [x] vaultwarden negative 쌍 Phase 5에서 제거 (Phase 6 잔여 = hosting-vaultwarden 스킬/dead reference 정리)
 
 ## Phase-End Multi-Pass Review
 
 - [ ] 1. Intent/coverage — SC-7 달성
-- [ ] 2. Correctness — routing 매트릭스가 모든 case (system / user / mixed)를 cover. inventory 표가 23개 .age + 1Password 항목 모두 포함
+- [ ] 2. Correctness — routing 매트릭스가 모든 case (system / user / mixed)를 cover. inventory 표가 20개 .age(실측 — 당초 PRD의 23개는 STALE) + 1Password 항목 모두 포함
 - [ ] 3. Simplicity — SKILL.md 줄수 250 이하 유지. 분할 시 references/ 2개로 한정
 - [ ] 4. Code quality — markdown 표 형식 일관, trigger 키워드 sorted/dedup
 - [ ] 5. Duplication/cleanup — vaultwarden 관련 dead reference는 Phase 6에서 처리. 본 phase에서 reverse polarity 신규 쌍 우선 추가
 - [ ] 6. Security/privacy — inventory 표에 평문 token 누출 0. 1Password vault item 이름만 노출
 - [ ] 7. Performance — SKILL.md 줄수 측정 후 분할 필요성 결정
 - [ ] 8. Validation — eval harness 또는 manual LLM query 검증
-- [ ] 9. Future-phase — Phase 6에서 vaultwarden 쌍 + hosting-vaultwarden 삭제 작업이 본 phase 산출물에 의존 (deprecation marker)
+- [ ] 9. Future-phase — Phase 6 hosting-vaultwarden 스킬 삭제 (vaultwarden eval 쌍은 Phase 5에서 제거 완료 — deprecation marker 미사용)
 - [ ] 10. PRD sync — master PRD Status, Current Phase, Change Log 갱신
 
 ## Discoveries / Decisions
 
-- SKILL.md baseline 줄수: (측정 후 박제)
-- 분할 트리거 발동 여부 (250줄 초과 시 references/ 분할 결정)
-- 신규 trigger 키워드 충돌 조사 결과
+- SKILL.md 줄수: baseline 125줄 → 최종 166줄 (≤250 충족)
+- 분할: 250줄 미만이라 routing matrix + inventory는 SKILL.md inline 유지. 운영 절차만 `references/1password.md`로 분리 (`references/agenix.md`는 기존 troubleshooting.md/workflows.md가 커버하므로 신설하지 않음)
+- 신규 trigger 키워드 충돌 조사: `rg -l "trigger.*1[Pp]assword" .claude/skills/ --glob '!**/managing-secrets/**'` → 0건
 
 ## Phase Change Log
 
 - 2026-05-17: Phase file created.
 - 2026-05-26: Phase 2a mobile SSH follow-up을 Phase 5 조건부 scope로 반영. Follow-up 결정이 닫혔으면 확정 Termius 운영 절차를 문서화하고, 열려 있으면 Phase 2a Post-Merge Remediation 링크와 master PRD Open Questions의 Phase 2a mobile SSH follow-up 항목만 Phase 5 exit gate로 요구한다.
+- 2026-06-01: Phase 5 구현 완료 (PR #878). routing 매트릭스 + 통합 inventory(.age 20개 + 1Password 항목) + `references/1password.md` 운영 절차 + frontmatter trigger 확장 + Shell Plugin 확장 정책 박제. 결정 변경: vaultwarden negative 쌍을 당초 add-only(Phase 6 삭제) 대신 Phase 5에서 제거 — 1Password 마이그레이션 스킬의 초점 정리, hosting-vaultwarden 자체 evals/queries.json이 positive 검증을 커버. 독립 검증(설계·코드 비판적 리뷰 + 전수 감사)으로 STALE 교정 반영: mobile-ssh=Termius keychain(1Password 미보관), shottr-license=Darwin-only HM 배포, SA token material=agenix `.age`(vault item은 github-pat), emergency 1Password item 이름=emergency-ssh(ssh key comment는 emergency-fallback). PRD 당초 예시의 `.age 23개`는 실측 20개로 정정.

--- a/.claude/skills/managing-secrets/SKILL.md
+++ b/.claude/skills/managing-secrets/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: managing-secrets
 description: |
-  Manage encrypted secrets with agenix: .age files, re-encryption, decryption failures.
+  Manage encrypted secrets with agenix (.age) and 1Password (op CLI, Service Account token, SSH/Automation vault).
+  Covers .age re-encryption, decryption failures, github-pat 무인 gh 인증, SA token 90일 rotation, SSH device key.
   Trigger: '시크릿', '암호화', '복호화', 'agenix', 'secrets.nix', 'age key', '.age', '토큰 추가',
-  're-encrypt', '/run/agenix'.
+  're-encrypt', '/run/agenix', '1Password', '1password', 'op CLI', 'op_get', 'opnix', 'service account token', 'SA token',
+  'Automation vault', 'SSH vault', 'github-pat', 'gh 무인 인증', '90일 rotation', 'op read', 'biometric unlock',
+  'SSH device key', 'mobile-ssh', 'Termius'.
   NOT for Vaultwarden 비밀번호 관리자 (use hosting-vaultwarden).
 ---
 
@@ -41,31 +44,64 @@ Claude Code에서 `agenix -e` 실패 (`/dev/stdin` 에러)
 서비스 모듈에서는 하드코딩 대신 `config.age.secrets.<name>.path`를 참조해 실제 경로를 사용한다.
 
 Secret 형식은 shell 변수 (`KEY=value`)로, 사용처에서 `source`로 로드한다.
-배포 권한은 `0400` mode이며, agenix가 복호화하여 지정 경로에 배치한다.
+배포 권한은 기본 `0400` mode이며, agenix가 복호화하여 지정 경로에 배치한다 (예외: opnix SA token `.age`는 `root:onepassword-secrets` `0640` — inventory 참조).
 
-### 현재 등록된 Secret 목록
+### Routing Matrix (사용주체 × Storage × Vault × Tag)
 
-| Secret | 배포 경로 | 용도 |
-|--------|----------|------|
-| `pushover-share.age` | `~/.config/pushover/share` | sharing-text 스킬 텍스트 공유 (수동 push 함수) |
-| `pushover-immich.age` | `~/.config/pushover/immich` | Immich FolderAction 업로드 알림 |
-| `pane-note-links.age` | `~/.config/pane-note/links.txt` | Pane Notepad 링크 |
-| `immich-api-key.age` | `~/.config/immich/api-key` | Immich CLI 업로드 인증 |
-| `immich-db-password.age` | `/run/agenix/immich-db-password` | Immich PostgreSQL 비밀번호 |
-| `pushover-system-monitor.age` | `/run/agenix/pushover-system-monitor` | 시스템 하드웨어 모니터링 Pushover (smartd + temp-monitor) |
-| `pushover-uptime-kuma.age` | `/run/agenix/pushover-uptime-kuma` | Uptime Kuma 업데이트 알림 |
-| `pushover-copyparty.age` | `/run/agenix/pushover-copyparty` | Copyparty 업데이트 알림 |
-| `pushover-vaultwarden.age` | `/run/agenix/pushover-vaultwarden` | Vaultwarden 업데이트 알림 |
-| `copyparty-password.age` | `/run/agenix/copyparty-password` | Copyparty 파일 서버 비밀번호 |
-| `vaultwarden-admin-token.age` | `/run/agenix/vaultwarden-admin-token` | Vaultwarden 관리자 패널 토큰 |
-| `shottr-license.age` | `~/.config/shottr/license` | Shottr 라이센스 pre-fill (`KC_LICENSE` + `KC_VAULT`) |
-| `cloudflare-dns-api-token.age` | `/run/agenix/cloudflare-dns-api-token` | Caddy HTTPS 인증서 발급용 |
-| `karakeep-nextauth-secret.age` | `/run/agenix/karakeep-nextauth-secret` | Karakeep NextAuth 세션 시크릿 |
-| `karakeep-meili-master-key.age` | `/run/agenix/karakeep-meili-master-key` | Karakeep Meilisearch 마스터 키 |
-| `karakeep-openai-key.age` | `/run/agenix/karakeep-openai-key` | Karakeep OpenAI API 키 |
-| `pushover-karakeep.age` | `/run/agenix/pushover-karakeep` | Karakeep 서비스 알림 (업데이트/백업/모니터) |
+agenix(.age 정적)와 1Password(동적 github-pat / SSH device key / SA token)가 공존한다. 사용주체별 라우팅:
 
-상세는 `secrets/secrets.nix` 참조.
+| 사용주체 | Storage | Vault | Tag / 식별자 |
+|----------|---------|-------|--------------|
+| Mac 무인 gh 인증 (gh-pat-mac → github-pat 캐시) | 1Password | Automation | `github-pat` (`op://Automation/github-pat/token`) |
+| Mac SA token (gh-pat-mac이 `OP_SERVICE_ACCOUNT_TOKEN`으로 사용) | agenix → 1Password SA | Automation (read-only SA) | service account token (mac) |
+| MiniPC opnix (부팅 oneshot → `/run/opnix/<user>/github-pat` materialize) | 1Password | Automation | `github-pat` (`op://Automation/github-pat/token`) |
+| MiniPC SA token (opnix tokenFile, host key 복호화) | agenix → 1Password SA | Automation (read-only SA) | service account token (minipc) |
+| Mac SSH agent + MiniPC authorized_keys 등록 (`mac-ssh`) | 1Password | SSH | ssh device key — #874 격리 |
+| Emergency fallback SSH (`~/.ssh/emergency_ed25519` + backup copy) | 1Password | SSH | ssh device key (`emergency-ssh`) — #874 격리 |
+| iPhone/iPad (Termius 공유 단일 키) | Termius keychain | — | ssh device key (`mobile-ssh`) — #866 단일 공유 키, 1Password 미보관 |
+| agenix .age 시크릿 (Mac+MiniPC home / MiniPC service) | agenix | — | recipient group (allHosts / minipcOnly / minipcHostOnly / macbook) |
+
+핵심 원칙:
+- SA token = Automation read-only → SSH vault 접근 불가. blast radius를 github-pat 한정으로 축소(#874).
+- agenix는 recipient group으로 호스트 노출을 통제: `allHosts` / `minipcOnly`(서비스) / `minipcHostOnly`(host key 전용 부팅 의존) / `macbook`(Mac user 키 단독).
+- 1Password 운영 절차 본문(SA 발급 / rotation / op CLI / gh 무인 / SSH device key)은 [references/1password.md](references/1password.md) 참조.
+
+### 통합 Secret Inventory
+
+agenix `.age` 20개(디스크 실측) + 1Password 항목(github-pat, SSH device key) + 1Password Service Account(token material은 agenix `.age` 보관)를 단일 표로 통합. 이 표는 빠른 참조용 스냅샷이며 SSOT가 아니다 — 값이 충돌하면 코드(`secrets/secrets.nix` recipient, `libraries/constants.nix` vault/sshDeviceKeys, HM home 경로는 `modules/shared/programs/secrets/default.nix` · NixOS `/run/agenix` 서비스 시크릿은 `modules/nixos/programs/` 하위 service module)을 우선한다. secret 추가/변경 시 코드를 먼저 갱신한 뒤 이 표를 동기화한다. recipient(복호화 가능 호스트)와 실제 배포 호스트는 다를 수 있다.
+
+| Name | Storage | Vault | 배포경로·위치 | 소비처 | recipient |
+|------|---------|-------|---------------|--------|-----------|
+| `pushover-share.age` | agenix | — | `~/.config/pushover/share` (Mac+MiniPC home) | sharing-text 수동 push; opnix-rotate-mac 만료 알림 `PUSHOVER_FILE` source | allHosts |
+| `pane-note-links.age` | agenix | — | `~/.config/pane-note/links.txt` (Mac+MiniPC home) | pane-note.sh 새 노트 Links 섹션 | allHosts |
+| `immich-db-password.age` | agenix | — | `/run/agenix/immich-db-password` (MiniPC) | immich.nix dbPasswordPath → PostgreSQL | minipcOnly |
+| `immich-api-key.age` | agenix | — | Mac `~/.config/immich/api-key` / MiniPC `/run/agenix/immich-api-key` | immich-update·immich-cleanup FolderAction upload | allHosts |
+| `pushover-immich.age` | agenix | — | Mac `~/.config/pushover/immich` / MiniPC `/run/agenix/pushover-immich` | immich-update·cleanup·backup 알림 | allHosts |
+| `pushover-folder-actions.age` | agenix | — | `~/.config/pushover/folder-actions` (Mac 전용) | macOS FolderActions (compress-video / convert-video-to-gif / rename-asset / compress-rar) 실패 알림 | macbook 단독(인라인) |
+| `shottr-license.age` | agenix | — | `~/.config/shottr/license` (Mac home, Darwin-only HM 배포) | Shottr 라이센스 (kc-license + kc-vault pre-fill) | allHosts (복호화 recipient — 배포는 Mac만) |
+| `copyparty-password.age` | agenix | — | `/run/agenix/copyparty-password` (MiniPC) | copyparty.nix passwordPath → 파일서버 비밀번호 | minipcOnly |
+| `vaultwarden-admin-token.age` | agenix | — | `/run/agenix/vaultwarden-admin-token` (MiniPC) | vaultwarden.nix adminTokenPath → 관리자 패널 토큰 | minipcOnly |
+| `cloudflare-dns-api-token.age` | agenix | — | `/run/agenix/cloudflare-dns-api-token` (MiniPC) | caddy.nix → Caddy HTTPS(DNS-01) 인증서 발급 | minipcOnly |
+| `pushover-uptime-kuma.age` | agenix | — | `/run/agenix/pushover-uptime-kuma` (MiniPC) | uptime-kuma-update 알림 | minipcOnly |
+| `pushover-copyparty.age` | agenix | — | `/run/agenix/pushover-copyparty` (MiniPC) | copyparty-update 알림 | minipcOnly |
+| `pushover-vaultwarden.age` | agenix | — | `/run/agenix/pushover-vaultwarden` (MiniPC) | vaultwarden-update + vaultwarden-backup pushoverCredPath | minipcOnly |
+| `karakeep-nextauth-secret.age` | agenix | — | `/run/agenix/karakeep-nextauth-secret` (MiniPC) | karakeep.nix nextauthSecretPath → NextAuth secret | minipcOnly |
+| `karakeep-meili-master-key.age` | agenix | — | `/run/agenix/karakeep-meili-master-key` (MiniPC) | karakeep.nix meiliMasterKeyPath → Meilisearch master key | minipcOnly |
+| `karakeep-openai-key.age` | agenix | — | `/run/agenix/karakeep-openai-key` (MiniPC) | karakeep.nix openaiKeyPath → AI 태깅 OpenAI 키 | allHosts |
+| `pushover-karakeep.age` | agenix | — | `/run/agenix/pushover-karakeep` (MiniPC) | karakeep-update·notify·singlefile-bridge·backup·fallback-sync·log-monitor (다중 모듈 merge) | allHosts |
+| `pushover-system-monitor.age` | agenix | — | `/run/agenix/pushover-system-monitor` (MiniPC) | smartd·temp-monitor·smoke-test·opnix-rotate(MiniPC) 하드웨어/SMART/온도/SA rotation 알림 (다중 모듈 merge) | minipcOnly |
+| `opnix-service-account-token.age` | agenix → 1Password SA | Automation (SA 접근 vault) | `/run/agenix/opnix-service-account-token` (`root:onepassword-secrets`, 0640, MiniPC) | opnix tokenFile → 부팅 oneshot이 `op://Automation/github-pat/token`을 `/run/opnix/<user>/github-pat` tmpfs로 materialize → nixos.nix gh wrapper가 GH_TOKEN 소비 | minipcHostOnly (host key 복호화) |
+| `opnix-service-account-token-mac.age` | agenix → 1Password SA | Automation (SA 접근 vault) | `~/.config/op/sa-token-mac` (agenix home-manager, 0400, `isDarwin && hostType==personal`) | darwin.nix gh-pat-mac이 `OP_SERVICE_ACCOUNT_TOKEN`으로 `op read op://Automation/github-pat/token` → temp 캐시 → gh-auth/c/codex 런처가 GH_TOKEN 주입. MiniPC host-key SA와 별개 격리 SA(#872) | macbook (Mac user 로그인 키 단독, work role 미배포) |
+| `github-pat` (1Password 항목) | 1Password | Automation | `op://Automation/github-pat/token` | Mac: gh-pat-mac이 SA token으로 `op read` → temp 캐시. MiniPC: opnix가 tmpfs로 materialize. SA token이 읽는 실제 PAT 항목 | — |
+| `mac-ssh` (1Password 항목) | 1Password | SSH | SSH vault item (comment `mac-ssh`, `constants.sshDeviceKeys.macSsh`) | Mac SSH agent(agent.toml이 SSH vault 노출) + MiniPC authorized_keys 등록. #874로 Automation→SSH vault 격리 | — |
+| `mobile-ssh` (디바이스 키) | Termius keychain | — | Termius keychain 보관 (iPhone·iPad 동기화 공유); 공개키만 `constants.sshDeviceKeys.mobile` | iPhone/iPad Termius 공유 단일 키(#866, 디바이스별 격리 불성립). MiniPC authorized_keys 등록용. 1Password 미보관 | — |
+| `emergency-ssh` (1Password 항목) | 1Password | SSH | SSH vault item (backup copy; ssh key comment `emergency-fallback`); 운영 키는 `~/.ssh/emergency_ed25519` (`IdentityAgent=none` 독립 fallback) | 긴급 fallback SSH 접속. 1Password backup copy가 SSH vault 보관. #874로 Automation→SSH vault 격리 | — |
+| SA token (mac) | 1Password | Automation (read-only) | 1Password Service Account; token은 `opnix-service-account-token-mac.age`로 암호화되어 `~/.config/op/sa-token-mac` 배포 | Mac gh-pat-mac이 github-pat 발급 시 사용. blast radius=Automation read-only(SSH vault 접근 불가). 90일 cadence rotation (만료 record†) | — |
+| SA token (minipc) | 1Password | Automation (read-only) | 1Password Service Account; token은 `opnix-service-account-token.age`로 암호화되어 `/run/agenix/opnix-service-account-token` 배포 | MiniPC opnix가 github-pat materialize 시 사용. blast radius=Automation read-only. 90일 cadence rotation (만료 record†). Mac SA와 별개 발급 격리 SA | — |
+
+† `secrets/opnix-service-account-expiry.txt`(MiniPC) / `secrets/opnix-service-account-expiry-mac.txt`(Mac)는 평문 ISO date record(.age 아님). 1Password Individual SA 자동 만료 미지원 + op CLI 만료 조회 미지원 대체. rotation 운영은 [references/1password.md](references/1password.md) 참조.
+
+상세는 `secrets/secrets.nix`(.age) + `libraries/constants.nix`(1Password) 참조.
 
 ### Secret 추가/수정
 
@@ -73,7 +109,7 @@ Secret 형식은 shell 변수 (`KEY=value`)로, 사용처에서 `source`로 로�
 
 1. `secrets/secrets.nix`에 선언 추가
 2. `.age` 파일 생성 (암호화 방법은 [references/workflows.md](references/workflows.md) 참조)
-3. `modules/shared/programs/secrets/default.nix`에 배포 경로 + 권한 설정
+3. 배포 경로 + 권한 설정 (HM home secret은 `modules/shared/programs/secrets/default.nix`, NixOS 서비스 secret은 해당 service module, opnix SA token은 opnix module)
 
 수정 워크플로:
 
@@ -119,7 +155,12 @@ HM activation이 `~/.config/shottr/license`에서 값을 읽어 `defaults write 
 
 상세는 [references/troubleshooting.md](references/troubleshooting.md) 참조.
 
+## Shell Plugin 확장 정책
+
+추가 shell plugin 도입 조건 = (a) 도구 secret을 `.env`로 export하는 패턴이 2건 이상 OR (b) agenix 평문 노출 위험 보고 1건. 둘 중 하나를 충족할 때만 새 shell plugin을 도입한다 (SSOT: epic #780 Phase 2b 확장 트리거 기준).
+
 ## 레퍼런스
 
+- 1Password 운영 (SA 발급 / 90일 rotation / op CLI / gh 무인 / SSH device key): [references/1password.md](references/1password.md)
 - 워크플로 상세 (암호화/복호화/호스트 추가): [references/workflows.md](references/workflows.md)
 - 트러블슈팅: [references/troubleshooting.md](references/troubleshooting.md)

--- a/.claude/skills/managing-secrets/evals/queries.json
+++ b/.claude/skills/managing-secrets/evals/queries.json
@@ -9,14 +9,12 @@
   {"query": "시크릿 관리 어떻게 하는 거야", "should_trigger": true, "why": "저항적: 시크릿 관리 = managing-secrets 스킬"},
   {"query": "Pushover 토큰 추가하려면", "should_trigger": true, "why": "저항적: Pushover 시크릿은 agenix로 관리"},
   {"query": "암호화된 값 확인하고 싶어", "should_trigger": true, "why": "저항적: 복호화 워크플로는 시크릿 스킬"},
-  {"query": "Vaultwarden 비밀번호 관리자 백업 상태 확인해줘", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "Bitwarden 클라이언트에서 로그인이 안 돼", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "vaultwarden 관리자 패널 접속 방법", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "비밀번호 관리자 서버 상태 확인", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "vaultwarden 컨테이너가 재시작됐어", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "Master Password 분실했을 때 복구 방법", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "vaultwarden 백업이 실패했다는 알림 받았어", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "iPhone에서 Bitwarden 앱 설정하기", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "ADMIN_TOKEN을 Argon2id로 변경하기", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"},
-  {"query": "vaultwarden-update 명령 실행해줘", "should_trigger": false, "why": "혼동 쌍: hosting-vaultwarden"}
+  {"query": "1Password Service Account token 발급하고 agenix에 추가하는 방법", "should_trigger": true, "why": "#872 Mac/MiniPC 격리 SA token 발급 + agenix 재암호화 절차 — managing-secrets Phase 5 신규 1Password 운영 절차 범위"},
+  {"query": "op read가 biometric prompt를 안 띄우고 무인으로 동작 안 해", "should_trigger": true, "why": "#876 Mac 무인 gh 인증(gh-pat-mac/gh-auth PATH wrapper) biometric 팝업 회귀 트러블슈팅 — Phase 5 1Password 영역"},
+  {"query": "SA token 90일 rotation 만료 알림이 안 와", "should_trigger": true, "why": "#875 opnix-rotate-mac launchd / opnix-rotate-check systemd 만료 record + warnDays=14 알림 운영 — Phase 5 1Password 운영 절차"},
+  {"query": "github-pat 캐시가 만료됐는데 gh 인증이 안 돼", "should_trigger": true, "why": "#872/#876 방식 B per-user temp 캐시(12h TTL) → SA token으로 op read 무인 발급 흐름 — managing-secrets 1Password 영역"},
+  {"query": "SSH 키를 어느 1Password vault에 넣어야 해 Automation 아니면 SSH", "should_trigger": true, "why": "#874 SSH 키 전용 SSH vault 격리(SA blast radius 축소) — Phase 5 routing matrix/vault 라우팅 범위"},
+  {"query": "opnix-service-account-token-mac.age를 재암호화하려면", "should_trigger": true, "why": "Mac 전용 SA token .age 재암호화(recipient=macbook user key) — agenix re-encrypt + 1Password SA 교차 범위, managing-secrets 핵심"},
+  {"query": "op CLI Automation vault에서 토큰 읽는 명령어", "should_trigger": true, "why": "op://Automation/github-pat/token op read 사용법 — Phase 5 op_get/op CLI 운영 절차 트리거 확장 범위"},
+  {"query": "iPhone Termius에 넣을 mobile-ssh 공유 키 rotate 방법", "should_trigger": true, "why": "#866 mobile-ssh 단일 공유 키 rotate + Termius 디바이스 해제 모델 — Phase 2a Mobile SSH Integration Policy(닫힘) 운영 절차"}
 ]

--- a/.claude/skills/managing-secrets/references/1password.md
+++ b/.claude/skills/managing-secrets/references/1password.md
@@ -1,0 +1,81 @@
+# 1Password 운영 (SA 발급 / rotation / op CLI / gh 무인 / SSH device key)
+
+agenix(.age 정적 시크릿)와 별개로, 1Password를 동적 시크릿(github-pat) / SSH device key / Service Account(SA) token의 저장소로 사용한다. 본 문서는 1Password 운영 절차 본문을 담당하며, routing matrix와 통합 inventory는 SKILL.md에 있다.
+
+평문 금지: SA token / PAT(`ghp_`, `github_pat_`) / SSH private key / 공개키 본체는 이 문서에 포함하지 않는다. item 이름·vault·경로·comment 식별자만 기록한다.
+
+## Vault 접근 경계
+
+vault 라우팅(Automation / SSH / Personal)의 정본은 SKILL.md의 Routing Matrix다. 여기서는 1Password에 실제 보관되는 항목과 SA 접근 경계만 정리한다.
+
+- `Automation` vault item: `github-pat`. (1Password Service Account는 Automation read-only로 `github-pat`을 읽는 주체이며, SA token material 자체는 agenix `.age`에 보관된다 — vault item 아님.)
+- `SSH` vault(#874로 Automation에서 격리): `mac-ssh`(SSH agent), `emergency-ssh` backup copy(ssh key comment는 `emergency-fallback`). `mobile-ssh`는 1Password가 아니라 Termius keychain에 보관되므로 SSH vault에 없다.
+- SA token(Automation read-only)은 SSH vault 접근 불가 → blast radius가 github-pat 한정으로 축소된다(#874).
+
+SSOT: `libraries/constants.nix`의 `onePassword.vaults` / `onePassword.account` / `sshDeviceKeys`.
+
+## Service Account(SA) 발급 — Mac / MiniPC 격리 SA 2개
+
+호스트별로 별개 SA를 발급해 blast radius를 분리한다 (둘 다 Automation read-only).
+
+- MiniPC SA token → `opnix-service-account-token.age`로 agenix 재암호화 (recipient=`minipcHostOnly`, host key `/etc/ssh/ssh_host_ed25519_key`) → `/run/agenix/opnix-service-account-token` (`root:onepassword-secrets`, `0640`).
+- Mac SA token → `opnix-service-account-token-mac.age`로 재암호화 (recipient=`[constants.sshKeys.macbook]`, Mac user 키 단독, work role 미배포) → `~/.config/op/sa-token-mac` (`0400`, `isDarwin && hostType==personal` 한정).
+- SA는 SSH vault 접근 불가 → SA `op read` 대상은 `op://Automation/github-pat/token` 한정.
+
+host key recipient(`minipcHostOnly`) .age의 rekey는 host private key가 없는 Mac에서 실패하므로, MiniPC/root에서 user key와 host key를 둘 다 `-i`로 넘겨 rekey한다 (secrets.nix 헤더 주석 참조).
+
+SSOT: `secrets/secrets.nix`(L67-78), `modules/shared/programs/secrets/default.nix`, `modules/nixos/programs/opnix/default.nix`.
+
+## SA token 90일 rotation 만료 알림 — Mac launchd + MiniPC systemd 양쪽
+
+1Password Individual은 SA 자동 만료를 미지원하므로, 평문 ISO date expiry record(.txt)를 SSOT로 운용한다 (op CLI 만료 조회 미지원 대체). SA 재발급 시 해당 `.txt`를 갱신한다.
+
+| 호스트 | 메커니즘 | expiry record (SSOT) |
+|--------|----------|----------------------|
+| MiniPC (NixOS) | `systemd.services.opnix-rotate-check` (oneshot) + timer (`OnCalendar=weekly`, `Persistent=true`, `RandomizedDelaySec=1h`), `homeserver.opnix.enable` 게이팅 | `/etc/opnix-service-account-expiry` = `secrets/opnix-service-account-expiry.txt` |
+| Mac | `launchd.agents.opnix-rotate-mac` (user agent, `StartCalendarInterval` Weekday=1 10:00, `RunAtLoad=false`, Persistent 미지원), `hostType==personal` 한정 | `~/.config/op/sa-expiry-mac` = `secrets/opnix-service-account-expiry-mac.txt` |
+
+공통 동작: `warnDays=14` (남은 일수 ≤14면 알림, <0이면 priority=1). ISO-8601 `YYYY-MM-DD` 정규식 검증 후 GNU `date -d`로 epoch 변환 (BSD date 회피 — Mac은 `runtimeInputs`에 coreutils). MiniPC는 `pushover-system-monitor` cred + service-lib `send_notification_strict`, Mac은 `pushover/share` cred로 `curl api.pushover.net` 직접 호출.
+
+관련 PR: 90일 rotation 도입 #875.
+
+SSOT: `modules/darwin/programs/opnix-rotate.nix`, `modules/nixos/programs/opnix-rotate.nix`, `secrets/opnix-service-account-expiry{,-mac}.txt`.
+
+## Mac 무인 gh 인증 (방식 B: SA token → github-pat per-user temp 캐시)
+
+`gh-pat-mac` (`pkgs.writeShellScriptBin`, PATH 실행 파일):
+
+1. `getconf DARWIN_USER_TEMP_DIR`로 temp dir 획득 (absolute `/` 검증, 아니면 fail-closed `exit 0`).
+2. 캐시 경로 `$_tmp/gh-pat-$(id -u)`.
+3. 캐시 존재 & 720분(12h) 이내 & `ghp_`/`github_pat_` prefix면 캐시 반환.
+4. 아니면 `~/.config/op/sa-token-mac`을 읽어 `OP_SERVICE_ACCOUNT_TOKEN` env로만 전달해 `op read --no-newline op://Automation/github-pat/token` (SA token은 셸 env에 상주시키지 않음).
+5. prefix 검증 통과 시 `umask 077`로 atomic `mv` (디렉토리 `0700` / 파일 `0600`, 재부팅 시 휘발).
+6. stdout 출력.
+
+`gh-auth` (`writeShellScriptBin`): `GH_TOKEN` 미설정 시 `gh-pat-mac`으로 발급·export 후 실제 `gh` exec (발급 실패해도 graceful). `home.shellAliases.gh="gh-auth"`로 라우팅 — shell snapshot이 캡처해 LLM 자동화 셸까지 커버한다(#876).
+
+범위 한계 (F4): rc를 읽지 않는 CI류 `bash -c`는 범위 밖이고, homebrew `gh`가 PATH 최우선이면 shim이 무효가 될 수 있다. op plugin의 gh alias source는 회귀 차단을 위해 제거됨.
+
+SSOT: `modules/shared/programs/shell/darwin.nix`.
+
+### c/codex 런처 — interactive 세션 GH_TOKEN 주입
+
+`mkOrder 1600` 블록의 `c()`/`codex()` 함수(interactive `.zshrc` 전용)는 세션 시작 시 `gh-pat-mac`으로 github-pat을 발급해 성공 시에만 `GH_TOKEN`을 프로세스 한정으로 export한 뒤 런처를 실행한다. `gh` 자체 라우팅은 `gh-auth` wrapper가 별도 담당한다.
+
+## op CLI / op read — vault·item 라우팅
+
+- Mac: `onePassword.account` = 개인 sign-in 도메인이 biometric unlock 경로 전용 account로 고정 (멀티 계정 환경).
+- MiniPC: op CLI를 직접 쓰지 않고 opnix(Go SDK)가 `op://Automation/github-pat`을 `/run/opnix/<user>/github-pat`으로 materialize한다(`OP_SERVICE_ACCOUNT_TOKEN`이 account 결정). 아래 라우팅은 Mac/수동 op CLI 경로 기준.
+- 라우팅: 자동화/시스템 토큰 = `Automation` vault(`github-pat` 등), 디바이스 SSH 키 = `SSH` vault(`mac-ssh`/`emergency-ssh`; `mobile-ssh`는 Termius keychain이라 제외), 개인 항목 = `Personal` vault. SA(Automation read-only)는 SSH vault `op read` 차단.
+
+SSOT: `libraries/constants.nix`(onePassword), `modules/shared/programs/shell/darwin.nix`.
+
+## SSH device key 운영 (#866 닫힘 — mobile-ssh 단일 공유 키)
+
+`constants.sshDeviceKeys` 3종 — `macSsh`(comment `mac-ssh`), `mobile`(comment `mobile-ssh`), `emergency`(comment `emergency-fallback`) — 은 MiniPC `authorized_keys` 등록용 공개키이며(`mac-ssh`만 추가로 Mac SSH agent에 노출), agenix 복호화 recipient(`sshKeys`)와는 분리된 개념이다.
+
+- iPhone/iPad는 Termius keychain 동기화로 디바이스별 격리가 불성립 → `iphone-ssh`/`ipad-ssh` 분리 키를 폐기하고 단일 `mobile-ssh` 공유 키로 통합(#866 닫힘). 운영 모델: `mobile-ssh` 공유 키 rotate + Termius 디바이스 해제.
+- `mac-ssh` private key는 1Password SSH vault에 보관(#874로 Automation에서 격리), `agent.toml`이 SSH vault에 바인딩되어 SA token blast radius가 축소된다(SA는 SSH vault `op read` 차단). `mobile-ssh`는 1Password가 아니라 Termius keychain에만 보관된다(공개키만 agenix `sshDeviceKeys`로 MiniPC authorized_keys 등록).
+- Emergency fallback 운영 키는 `~/.ssh/emergency_ed25519` (`IdentityAgent=none` 독립 fallback), 1Password backup copy는 SSH vault에 보관.
+
+SSOT: `libraries/constants.nix`(sshDeviceKeys), `modules/darwin/programs/ssh/default.nix`, `secrets/secrets.nix`.

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -77,7 +77,7 @@
 
   # ═══════════════════════════════════════════════════════════════
   # 디바이스별 SSH 공개키 — MiniPC authorized_keys 등록용 (PRD #780 Phase 2a)
-  # 1Password Automation vault `ssh` tag inventory와 일관. agenix recipient(sshKeys)와는 분리.
+  # 1Password SSH vault inventory(#874로 Automation에서 분리)와 일관. agenix recipient(sshKeys)와는 분리.
   # private 보관: macSsh = 1Password vault(SSH agent), emergency = ~/.ssh + 1Password backup,
   #   mobile = Termius keychain (iPhone·iPad 공유). Termius 계정 동기화가 host의 key 지정과
   #   표준 키 private 본체를 기기 간 복제하므로 디바이스별 격리가 성립하지 않는다 → iPhone/iPad는

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -72,7 +72,7 @@ in
   "opnix-service-account-token.age".publicKeys = minipcHostOnly;
 
   # Mac 전용 1Password Service Account token (#872, epic #780 Phase 2b)
-  # 로그인 셸 _gh_pat()이 이 SA token으로 github-pat을 per-user temp 캐시에 무인 발급 (방식 B, launchd 비의존).
+  # 로그인 셸의 gh-pat-mac이 이 SA token으로 github-pat을 per-user temp 캐시에 무인 발급 (방식 B, launchd 비의존).
   # 개인 Mac user 로그인 키 전용 recipient — work role 호스트는 복호화 불가하여 graceful 분리.
   # MiniPC host-key SA(위 minipcHostOnly)와 별개로 발급된 격리 SA (blast radius 분리, Automation read-only).
   "opnix-service-account-token-mac.age".publicKeys = [ constants.sshKeys.macbook ];


### PR DESCRIPTION
## Summary

- `managing-secrets` 스킬을 agenix 단일 backend 가정에서 **agenix + 1Password 듀얼 backend**로 확장 — routing 매트릭스 + 통합 inventory + 1Password 운영 절차를 박제.
- `references/1password.md`(신규)에 SA 발급 / 90일 rotation / 무인 gh 인증 / op CLI / SSH device key 운영을 분리.
- `evals/queries.json`에 1Password 혼동/포함 쌍 8개 추가, frontmatter trigger를 1Password 키워드로 확장.
- (후속) PRD phase-05의 vaultwarden 결정 변경 반영 + 1Password 마이그레이션 후속 stale 주석(nix) 정합.

Closes #877
Refs #780

## 기존 문제 / 배경

epic #780(1Password 마이그레이션) Phase 1~3 + 후속(#866/#872/#874/#875/#876)이 머지되며 1Password 운영 패턴이 안정됐으나, `managing-secrets` 스킬은 여전히 agenix 단일 backend를 가정해 작성돼 있었다. 그 결과:

- "새 secret을 agenix vs 1Password 어디에 둘지" 라우팅 안내가 없었다.
- SA token / op CLI / vault / SSH device key 운영 절차가 스킬에 없어, 1Password 영역 질의가 스킬로 라우팅되지 않았다.
- inventory 표가 17개만 등재해 `secrets.nix` 실측(20개)과 어긋났고, SA token 2개가 누락돼 있었다.

## CIR (Change Intent Record)

Phase 5의 핵심 제약은 **"PRD 예시는 STALE(2026-05-27 작성)하니 베끼지 말고 코드 SSOT 실측값으로 작성"** 이었다. PRD가 가정한 값과 실제 코드는 5개 지점에서 달랐고, 모두 코드 기준으로 교정했다:

- SSH 키는 `Automation`/tag가 아니라 **전용 `SSH` vault**(`constants.onePassword.vaults.ssh="SSH"`, #874).
- iphone-ssh/ipad-ssh 분리 키가 아니라 **단일 `mobile-ssh` 공유 키**(Termius keychain, #866).
- SA token은 전역 1개가 아니라 **Mac/MiniPC 격리 SA 2개**(#872).
- rotation은 MiniPC systemd 단일이 아니라 **Mac launchd + MiniPC systemd 양쪽**(#875).
- 무인 gh 인증은 per-session op read가 아니라 **SA token → github-pat per-user temp 캐시 PATH wrapper**(#876).

작성 후 독립 검증으로 사실 정확성을 보강했다: `mobile-ssh`의 보관처는 1Password SSH vault가 아니라 **Termius keychain**(공개키만 agenix로 authorized_keys 등록), `shottr-license`는 Mac+MiniPC가 아니라 **Darwin-only HM 배포**(recipient `allHosts`와 배포 호스트는 별개), SA token material은 **1Password vault item이 아니라 agenix `.age`**(vault item은 `github-pat`), emergency 키의 1Password item 이름은 **`emergency-ssh`**(ssh key comment는 `emergency-fallback`)임을 코드 대조로 교정했다.

## ADR (Architecture Decision Record)

| 결정 | 대안 | 장점 | 단점 | 채택 |
|------|------|------|------|------|
| inventory 위치 | SKILL.md inline | routing과 cross-cutting하게 한눈에, ≤250줄 충족 | SSOT 복제 부담 | ✅ ("이 표는 SSOT 아님 — 코드 우선" 경고로 완화) |
| | references로 분리 | SKILL.md 최소화 | 라우팅↔inventory 참조 분산 | ❌ |
| 운영 절차 위치 | references/1password.md 분리 | SKILL.md 간결 유지(166줄) | 파일 1개 증가 | ✅ |
| | SKILL.md inline | 단일 파일 | 250줄 초과 확실 | ❌ |
| vaultwarden negative eval | 제거 | 1Password 마이그레이션 스킬의 초점 명확화 | managing-secrets 회귀 가드 일부 소실 | ✅ (hosting-vaultwarden 자체 eval이 positive 커버) |
| | Phase 6까지 유지 | PRD 원안 준수 | EOL 대상을 negative 10개로 부각해 초점 흐림 | ❌ |

vaultwarden 제거는 PRD 원안(add-only, Phase 6 삭제)에서 벗어나므로, `phase-05-skill-refactor.md`의 In/Out Scope·Checklist·Exit Criteria·Change Log를 결정 변경에 맞춰 함께 갱신했다.

## 구현 상세

| 파일 | 변경 |
|------|------|
| `.claude/skills/managing-secrets/SKILL.md` | Routing Matrix(사용주체×Storage×Vault×Tag, 8행) + 통합 Secret Inventory(`.age` 20개 + 1Password 항목 + SA, 평문 0) + frontmatter trigger 1Password 키워드 확장 + Shell Plugin 확장 정책. 166줄(≤250) |
| `.claude/skills/managing-secrets/references/1password.md` | 신규 — Vault 접근 경계 / SA 발급(Mac·MiniPC 격리 2개) / 90일 rotation(launchd+systemd) / 무인 gh 인증(방식 B 캐시) / op CLI / SSH device key 운영 |
| `.claude/skills/managing-secrets/evals/queries.json` | 1Password 혼동/포함 쌍 8개 add-only(전부 `should_trigger=true`), vaultwarden negative 쌍 제거 |
| `.claude/prds/prd-1password-migration/phase-05-skill-refactor.md` | (후속) vaultwarden 결정 변경 반영 + Discoveries 실측 박제(125→166줄, 분할/충돌 결과) + `.age` 23→20 정정 + Change Log 2026-06-01 |
| `secrets/secrets.nix`, `libraries/constants.nix` | (후속) stale 주석 정합 — `_gh_pat()`→`gh-pat-mac`(#876), "Automation vault ssh tag"→"SSH vault"(#874). 주석만, 동작 무관 |

inventory·routing의 모든 값은 `libraries/constants.nix`(onePassword.vaults, sshDeviceKeys), `secrets/secrets.nix`(.age recipient), `modules/{darwin,nixos,shared}/programs/...`를 직접 실측해 작성했고, 평문 토큰/PAT/SSH private key는 0건이다(item 이름·경로·vault만).

## 참고 레퍼런스

- epic #780 — 1Password 마이그레이션
- #866(mobile SSH 통합), #872(Mac 전용 SA), #874(SSH 전용 vault 분리), #875(Mac SA rotation), #876(gh non-interactive PATH wrapper)
- PRD `.claude/prds/prd-1password-migration/phase-05-skill-refactor.md`

## Human Test Plan

1. **라우팅 회귀**: "새 GitHub PAT를 1Password에 저장하려면?" / "SA token 90일 rotation 알림이 안 와" 질의 → `managing-secrets`로 라우팅되고 답변에 박제된 절차(Automation vault / opnix-rotate)가 등장하는지.
   - 실패 시: frontmatter trigger에 해당 키워드가 있는지(`1Password`/`op CLI`/`90일 rotation`) 확인.
2. **inventory 정확성**: `grep -c '.age".publicKeys' secrets/secrets.nix`(=20)의 모든 `.age`가 SKILL.md inventory 표에 등재됐는지 1:1 대조.
3. **SSOT 일치**: `mobile-ssh`가 inventory에서 `Termius keychain`(1Password 아님)으로, `shottr-license`가 `Darwin-only HM`으로, emergency 1Password item이 `emergency-ssh`로 표기됐는지 — `libraries/constants.nix:81-89`, `modules/shared/programs/secrets/default.nix:54` 대조.
4. **분량**: `wc -l .claude/skills/managing-secrets/SKILL.md` ≤ 250 (현재 166).
5. **eval 유효성**: `python3 -m json.tool < .claude/skills/managing-secrets/evals/queries.json` 통과, 18개 항목.
6. **주석 정합**: `rg '_gh_pat\(\)' secrets/secrets.nix` → 0건, `rg 'Automation vault .ssh. tag' libraries/constants.nix` → 0건.
