### PR TITLE
fix(folder-actions): upload-immich bunx → bun x — 사용자명 마이그레이션 후 깨진 심링크 우회

### DIFF
--- a/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh
@@ -692,7 +692,7 @@ fi
 
 log "업로드 시작: ${media_count}개 (${readable_size})"
 
-upload_output=$(bunx @immich/cli upload \
+upload_output=$(bun x @immich/cli upload \
     --album-name "Desktop Upload" \
     --delete \
     --concurrency 2 \


### PR DESCRIPTION
## Summary

- upload-immich Folder Action 스크립트가 `bunx @immich/cli` 대신 `bun x @immich/cli`를 호출하도록 변경
- `green→greenhead` 사용자명 마이그레이션 이후 깨진 `~/.bun/bin/bunx` 심링크에 더 이상 의존하지 않음 → 업로드 실패 영구 해결

## 기존 문제/배경

Shottr 스크린샷 폴더에 이미지가 떨어지면 launchd WatchPaths가 upload-immich Folder Action을 실행하는데, 다음 오류로 업로드가 실패했다:

```
/Users/greenhead/.local/bin/upload-immich.sh: line 699: bunx: command not found
```

원인은 `~/.bun/bin/bunx`가 옛 절대경로 `/Users/green/.bun/bin/bun`을 가리키는 **깨진 심링크**가 된 것이다. bun 설치 스크립트가 만든 이 심링크는 사용자명 마이그레이션(#865)으로 홈 경로가 `/Users/greenhead`로 바뀌면서 dangling 상태가 됐다.

- Folder Action launchd PATH는 `~/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`로, `~/.bun/bin`만 포함하고 mise shims는 없다 → 깨진 `bunx`만 만나 `command not found`.
- 인터랙티브 셸은 PATH상 mise shims(`~/.local/share/mise/shims/bunx`)가 `~/.bun/bin`보다 앞이라 우회되어 증상이 드러나지 않았다.
- `~/.bun/bin/bun` 본체는 정상 동작한다(실제 바이너리, `bun --version` → 1.1.37).

## CIR (Change Intent Record)

- 발견 경위: 실제 이미지 업로드 시도 중 Pushover로 `CLI 오류: ... bunx: command not found` 알림을 받아 진단 시작.
- 진단: Folder Action과 동일한 PATH 환경을 재현해 `bunx`는 not found, `bun`/`bun x`는 정상임을 확인. 심링크 타겟(`/Users/green/...`)과 마이그레이션 커밋(#865)을 대조해 회귀 원인을 특정.
- 설계 의도: `bunx`는 `bun x`의 별칭 심링크일 뿐이므로, bun 서브커맨드 `bun x`를 직접 호출하면 깨질 수 있는 외부 심링크 의존을 제거할 수 있다. PATH에 `bun` 본체만 있으면 동작한다.
- 범위 제한: 깨진 `~/.bun/bin/bunx` 심링크 자체와 PATH의 `/Users/green/.deno/bin` 같은 Nix 관리 밖 stale 경로는 본 PR 범위 밖. immich-upload는 이 변경으로 그것들과 무관하게 동작한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `bun x` 호출 | 스크립트에서 `bunx` → `bun x` | Nix 선언 관리로 영구 해결, 깨진 심링크 비의존, 1줄 변경 | 없음 (`bunx`와 동등) | ✅ 채택 |
| `~/.bun/bin/bunx` 심링크 수동 재생성 | `ln -sf bun ~/.bun/bin/bunx` | 즉시 복구, 스크립트 무변경 | Nix 관리 밖 비선언적, 다음 마이그레이션/재설치 시 재발 | ❌ 기각 |
| launchd PATH에 mise shims 추가 | PATH에 `~/.local/share/mise/shims` 포함 | bunx 그대로 사용 | mise 컨텍스트(.tool-versions/activate) 의존으로 더 취약 | ❌ 기각 |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh` | 업로드 호출을 `bunx` → `bun x`로 변경 (1줄) |

```diff
-upload_output=$(bunx @immich/cli upload \
+upload_output=$(bun x @immich/cli upload \
     --album-name "Desktop Upload" \
     --delete \
     --concurrency 2 \
     "$WATCH_DIR" 2>&1) && upload_exit=0 || upload_exit=$?
```

## 참고 레퍼런스

- #865 — `green→greenhead` 사용자명 마이그레이션 (깨진 심링크의 근본 원인)
- Folder Action 정의: `modules/darwin/programs/folder-actions/default.nix` (launchd PATH 포함)

## Human Test Plan

1. `nrs`로 적용 (이미 적용 완료, launchd 재등록 포함).
2. Shottr 스크린샷 폴더에 이미지를 한 장 떨어뜨린다.
   - 기대: 잠시 후 Pushover로 `📸 N개 파일 (...) → Desktop Upload` 성공 알림. 원본 파일은 업로드 후 삭제됨.
3. Immich 웹에서 `Desktop Upload` 앨범에 해당 이미지가 들어왔는지 확인.
4. 실패 시 진단:
   - `~/Library/Logs/folder-actions/upload-immich.log` / `upload-immich.error.log` 확인.
   - PATH 재현 검증: `env -i PATH="$HOME/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" HOME="$HOME" bash -c 'bun x @immich/cli --version'` → 버전이 출력되면 정상.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media upload process reliability by updating the underlying CLI invocation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->