### PR TITLE
fix(wt): cleanup이 손상 worktree에서 git fatal로 폭사하는 버그 수정 (#883)

### DIFF
--- a/modules/shared/scripts/lib/wt/cleanup.sh
+++ b/modules/shared/scripts/lib/wt/cleanup.sh
@@ -53,10 +53,24 @@ cmd_cleanup() {
   local item_dirty=()
   local item_unpushed=()
   local merged_indices=()
+  local broken_count=0
 
   local idx=0
   for wt in "${worktrees[@]}"; do
     [[ "$wt" == "$current_wt" ]] && continue
+
+    # 손상(stale) worktree 가드 (#883): gitdir이 무효하면(예: 사용자명 마이그레이션
+    # 잔재로 .git이 죽은 gitdir을 가리킴) 아래 _wt_last_commit_msg 등 무가드 git 호출이
+    # set -e/pipefail로 폭사한다. 정리 후보에서 제외하고 경고만 남긴다 (사용자 정책:
+    # 경고 + 정리 제외 — 자동 삭제 시 미커밋 작업물 손실 위험이라 보수적으로 건너뜀).
+    if _wt_is_broken "$wt"; then
+      # 경로에 작은따옴표/공백이 있어도 사용자가 그대로 복붙할 수 있도록 %q로 인용.
+      local _safe_wt
+      printf -v _safe_wt '%q' "$wt"
+      _warn "손상된 worktree 건너뜀: $(basename "$wt") (gitdir 무효 — 수동 정리: rm -rf ${_safe_wt} 후 git worktree prune)"
+      broken_count=$((broken_count + 1))
+      continue
+    fi
 
     local name branch ts age pr_status dirty_flag unpushed_flag last_msg
     name=$(basename "$wt")
@@ -104,7 +118,12 @@ cmd_cleanup() {
 
   if [[ "$auto" == "true" ]]; then
     if (( ${#merged_indices[@]} == 0 )); then
-      _info "자동 정리 대상 (MERGED)이 없습니다"
+      # 손상 카운트를 late-auto(아래)·name-filter 요약과 일관되게 노출 (#883 broken-only 경로).
+      if (( broken_count > 0 )); then
+        _info "자동 정리 대상 (MERGED)이 없습니다 (손상 ${broken_count}개 건너뜀)"
+      else
+        _info "자동 정리 대상 (MERGED)이 없습니다"
+      fi
       return 0
     fi
 
@@ -131,7 +150,11 @@ cmd_cleanup() {
     done
 
     git worktree prune 2>/dev/null || true
-    _info "자동 정리 완료"
+    if (( broken_count > 0 )); then
+      _info "자동 정리 완료 (손상 ${broken_count}개 건너뜀)"
+    else
+      _info "자동 정리 완료"
+    fi
     return 0
   fi
 
@@ -197,7 +220,12 @@ cmd_cleanup() {
         break
       fi
     done
-    (( found_idx < 0 )) && continue
+    if (( found_idx < 0 )); then
+      # items에 없음: 존재하지 않거나, 손상되어 제외됐거나(위 경고), 현재 worktree.
+      # 과거엔 silent continue라 "정리 완료: 0개"만 떠 진단이 어려웠다 (#883).
+      _warn "정리 대상 아님: $sel_name (존재하지 않거나, 손상되어 제외됐거나, 현재 worktree)"
+      continue
+    fi
 
     local wt_path="${item_paths[$found_idx]}"
     local branch="${item_branches[$found_idx]}"
@@ -219,5 +247,9 @@ cmd_cleanup() {
   done
 
   git worktree prune 2>/dev/null || true
-  _info "정리 완료: ${removed}개 삭제"
+  if (( broken_count > 0 )); then
+    _info "정리 완료: ${removed}개 삭제 (손상 ${broken_count}개 건너뜀)"
+  else
+    _info "정리 완료: ${removed}개 삭제"
+  fi
 }

--- a/modules/shared/scripts/lib/wt/git-state.sh
+++ b/modules/shared/scripts/lib/wt/git-state.sh
@@ -35,6 +35,15 @@ _collect_worktrees() {
   done < <(find "$wt_base" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
 }
 
+# worktree gitdir 유효성 — 손상(stale/orphaned)이면 0(true).
+# .git 파일이 존재하지 않는 gitdir을 가리키면(예: 사용자명 마이그레이션 잔재) 모든
+# `git -C "$wt"`가 fatal(exit 128)을 낸다. _collect_worktrees는 .git 파일 존재만
+# 검사하므로 이런 손상 worktree까지 수집하는데, 무가드 git 호출이 set -e/pipefail로
+# 폭사하기 전에(예: _wt_last_commit_msg) 이 헬퍼로 걸러낸다 (#883).
+_wt_is_broken() {
+  ! git -C "$1" rev-parse --git-dir >/dev/null 2>&1
+}
+
 # worktree의 브랜치명
 _wt_branch() {
   local b
@@ -112,8 +121,14 @@ _wt_pr_status() {
 }
 
 # 마지막 커밋 메시지 (한 줄)
+# 자매 함수 _wt_branch(|| true)·_wt_last_commit_ts(|| echo "0")와 일관되게 git 실패를
+# 흡수한다. git을 먼저 변수로 받아(|| msg="") 파이프라인 밖으로 빼므로, 손상/detached
+# worktree에서 git이 fatal(128)을 내도 pipefail이 그 128을 채택해 set -e로 폭사하는
+# 경로가 사라진다 (#883: bare assignment + pipefail + stale worktree 폭사).
 _wt_last_commit_msg() {
-  git -C "$1" log -1 --format='%s' 2>/dev/null | cut -c1-60
+  local msg
+  msg=$(git -C "$1" log -1 --format='%s' 2>/dev/null) || msg=""
+  printf '%s' "$msg" | cut -c1-60
 }
 
 # ── PR 상태 병렬 조회 ────────────────────────────────────────────────────────

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -633,6 +633,18 @@ create_git_fixture_repo() {
   )
 }
 
+add_stale_worktree() {
+  # 손상(stale) worktree fixture: .git이 존재하지 않는 gitdir을 가리킨다 (사용자명
+  # 마이그레이션 잔재 모사 — #883의 실제 트리거). 'aaa_broken'은 정렬상 feature_one보다
+  # 앞서므로 _collect_worktrees(find … | sort -z)가 먼저 수집 → items 빌드 루프가 정상
+  # worktree 전에 손상 worktree에 도달, 가드가 없다면 _wt_last_commit_msg 무가드
+  # 파이프라인이 set -e/pipefail로 폭사(exit 128)하는 회귀 조건을 만든다.
+  local repo_root="$1"
+  local broken_path="$repo_root/.claude/worktrees/aaa_broken"
+  mkdir -p "$broken_path"
+  printf 'gitdir: /nonexistent/green/Workspace/nixos-config/.git/worktrees/aaa_broken\n' > "$broken_path/.git"
+}
+
 run_test() {
   local name="$1"
   shift
@@ -1811,6 +1823,137 @@ EOF
   [[ -d "$target_path" ]] || fail "expected reused branch worktree to be kept: $target_path"
 }
 
+test_wt_cleanup_auto_survives_stale_worktree() {
+  # #883 회귀: 손상(stale) worktree가 섞여 있어도 wt cleanup --auto가 git fatal(exit 128)로
+  # silent 폭사하지 않고, 정상 MERGED worktree는 정리하며 손상 worktree는 경고 후 건너뛴다.
+  local sandbox home_dir repo_root gh_dir output target_path broken_path head_oid rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  gh_dir="$sandbox/gh-bin"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  git -C "$repo_root" remote add origin https://example.invalid/nixos-config.git
+  target_path="$repo_root/.claude/worktrees/feature_one"
+  broken_path="$repo_root/.claude/worktrees/aaa_broken"
+  head_oid="$(git -C "$target_path" rev-parse HEAD)"
+  add_stale_worktree "$repo_root"
+
+  mkdir -p "$gh_dir"
+  cat > "$gh_dir/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'MERGED %s\n' "$head_oid"
+EOF
+  chmod +x "$gh_dir/gh"
+
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    PATH="$gh_dir:$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/wt"'" cleanup --auto
+    ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" != "128" ]] || fail "cleanup --auto가 손상 worktree에서 git fatal(128)로 폭사: $output"
+  [[ "$rc" == "0" ]] || fail "cleanup --auto 비정상 종료 rc=$rc: $output"
+  assert_contains "$output" "자동 정리 완료"
+  assert_contains "$output" "손상된 worktree 건너뜀: aaa_broken"
+  assert_contains "$output" "손상 1개 건너뜀"  # 요약 suffix로 broken_count 노출·정확도 고정
+  [[ ! -d "$target_path" ]] || fail "정상 MERGED worktree가 제거되지 않음: $target_path"
+  [[ -d "$broken_path" ]] || fail "손상 worktree는 보존돼야 함(정리 제외): $broken_path"
+}
+
+test_wt_cleanup_name_filter_survives_stale_worktree() {
+  # #883 회귀: name-filter 경로(wt cleanup <name>)도 손상 worktree가 섞여 있어도 exit 128로
+  # silent 폭사하지 않고, 지정한 정상 worktree를 정리하며 손상 worktree는 경고 후 건너뛴다.
+  local sandbox home_dir repo_root gh_dir output target_path broken_path head_oid rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  gh_dir="$sandbox/gh-bin"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  git -C "$repo_root" remote add origin https://example.invalid/nixos-config.git
+  target_path="$repo_root/.claude/worktrees/feature_one"
+  broken_path="$repo_root/.claude/worktrees/aaa_broken"
+  head_oid="$(git -C "$target_path" rev-parse HEAD)"
+  add_stale_worktree "$repo_root"
+
+  mkdir -p "$gh_dir"
+  cat > "$gh_dir/gh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'MERGED %s\n' "$head_oid"
+EOF
+  chmod +x "$gh_dir/gh"
+
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    PATH="$gh_dir:$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/wt"'" cleanup feature_one --yes
+    ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" != "128" ]] || fail "cleanup <name>이 손상 worktree에서 git fatal(128)로 폭사: $output"
+  [[ "$rc" == "0" ]] || fail "cleanup <name> 비정상 종료 rc=$rc: $output"
+  assert_contains "$output" "정리 완료: 1개 삭제"
+  assert_contains "$output" "손상된 worktree 건너뜀: aaa_broken"
+  assert_contains "$output" "손상 1개 건너뜀"  # 요약 suffix로 broken_count 노출·정확도 고정
+  [[ ! -d "$target_path" ]] || fail "지정한 정상 worktree가 제거되지 않음: $target_path"
+  [[ -d "$broken_path" ]] || fail "손상 worktree는 보존돼야 함(정리 제외): $broken_path"
+}
+
+test_wt_cleanup_auto_broken_only_reports_skip_count() {
+  # #883 broken-only 시나리오: 손상 worktree만 있고 MERGED 정리 대상이 0인 경우
+  # (cleanup.sh의 merged_indices==0 early-return 분기 — PoC가 실제로 밟던 경로).
+  # gh mock·origin remote를 두지 않아 PR 상태가 NONE이 되어 merged_indices가 비고,
+  # cleanup이 폭사하지 않고 손상 카운트를 종합 요약에 일관 노출하며 둘 다 보존하는지 고정.
+  local sandbox home_dir repo_root output target_path broken_path rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  target_path="$repo_root/.claude/worktrees/feature_one"
+  broken_path="$repo_root/.claude/worktrees/aaa_broken"
+  add_stale_worktree "$repo_root"
+
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/wt"'" cleanup --auto
+    ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" != "128" ]] || fail "broken-only cleanup --auto가 git fatal(128)로 폭사: $output"
+  [[ "$rc" == "0" ]] || fail "broken-only cleanup --auto 비정상 종료 rc=$rc: $output"
+  assert_contains "$output" "손상된 worktree 건너뜀: aaa_broken"
+  assert_contains "$output" "자동 정리 대상 (MERGED)이 없습니다 (손상 1개 건너뜀)"
+  [[ -d "$broken_path" ]] || fail "손상 worktree는 보존돼야 함(정리 제외): $broken_path"
+  [[ -d "$target_path" ]] || fail "MERGED 아닌 정상 worktree는 보존돼야 함: $target_path"
+}
+
 test_missing_managed_helpers_fail_closed() {
   local sandbox home_dir repo_root output
   sandbox=$(new_sandbox)
@@ -2282,6 +2425,9 @@ run_test "wt cleanup auto removes merged worktree" test_wt_cleanup_auto_removes_
 run_test "wt cleanup auto skips dirty merged worktree" test_wt_cleanup_auto_skips_dirty_merged_worktree
 run_test "wt cleanup auto skips unpushed merged worktree" test_wt_cleanup_auto_skips_unpushed_with_upstream
 run_test "wt cleanup auto skips merged branch reuse" test_wt_cleanup_auto_skips_merged_branch_reuse
+run_test "wt cleanup auto survives stale worktree" test_wt_cleanup_auto_survives_stale_worktree
+run_test "wt cleanup name-filter survives stale worktree" test_wt_cleanup_name_filter_survives_stale_worktree
+run_test "wt cleanup auto broken-only reports skip count" test_wt_cleanup_auto_broken_only_reports_skip_count
 run_test "missing managed helpers fail closed" test_missing_managed_helpers_fail_closed
 run_test "fixture git setup ignores host global hooks" test_fixture_git_is_hermetic_against_global_hooks
 run_test "nixos nrs offline force smoke" test_nixos_nrs_offline_force_smoke


### PR DESCRIPTION
## Summary

- `wt cleanup`이 비대화형 셸에서 손상(stale) worktree를 만나면 `set -e`/`pipefail`로 silent하게 `exit 128`(또는 `exit 0` no-op)로 죽어 worktree/브랜치가 잔존하던 버그 수정
- 무가드 git 파이프라인(`_wt_last_commit_msg`)에 자매 함수와 일관된 가드를 추가하고, 손상 worktree를 감지해 정리 후보에서 제외 + 경고 출력
- squash-merge worktree/stale worktree 회귀 테스트 3개 추가

Closes #883

## 기존 문제 / 배경

비대화형 셸(LLM Bash tool 등)에서 PR을 머지한 뒤 `wt cleanup`으로 worktree를 정리하는 흐름이 흔하다. 그러나 `wt cleanup <name> --yes`는 "PR 상태 조회 중..." 직후 아무 출력 없이 `exit 0`으로, `WT_NONINTERACTIVE=1 wt cleanup --auto --yes`는 `exit 128`(git fatal)로 죽고 worktree/로컬 브랜치가 그대로 남았다. "정리 완료" / "삭제 실패" 문구가 둘 다 출력되지 않아 진단이 불가능했다.

## CIR (Change Intent Record)

**발견 경위**: PR 작업 마무리 중 worktree 정리 단계에서 발생. 재현 환경이 소실돼 이슈 등록 시점엔 root cause 미확정 상태였고, 이슈 본문은 원인을 "squash merge = not-fully-merged"로 추정했다.

**진단**: 격리 fixture에 손상 worktree를 섞어 `bash -x` trace로 재현한 결과, 실제 멈춤 지점은 auto/name-filter 분기 **이전의 공통 items 빌드 루프**에 있는 `last_msg=$(_wt_last_commit_msg "$wt")`였다. `_wt_last_commit_msg`만 자매 함수(`_wt_branch`의 `|| true`, `_wt_last_commit_ts`의 `|| echo "0"`)와 달리 무가드 파이프라인(`git log ... 2>/dev/null | cut`)이었다.

폭사 3중 조건(모두 bash 실측으로 확인):
1. 전역 `set -euo pipefail`
2. bare assignment — `local last_msg`가 별도 줄에 선언돼 명령치환이 set -e에 의해 마스킹되지 않음
3. 손상 worktree의 git fatal `exit 128` — `.git`이 사용자명 마이그레이션으로 더 이상 존재하지 않는 gitdir을 가리켜 모든 `git -C "$wt"`가 `fatal: not a git repository`. `2>/dev/null`은 stderr만 막고 exit code는 보존 → `pipefail`이 git의 128을 파이프라인 종료코드로 채택 → `set -e` 즉사.

items 루프가 분기보다 앞이라 두 경로 모두 같은 줄에서 죽는다. 이슈가 관찰한 `exit 0`(name-filter) vs `exit 128`(auto) 차이는 그 시점 손상 worktree의 정렬 위치/존재에 따른 비결정적 변형이며 메커니즘은 동일하다. **즉 트리거는 squash merge가 아니라 "set -euo pipefail + stale worktree git fatal" 조합이다** (이슈 본문 가설 반증).

**설계 의도**: 손상 worktree는 **경고 + 정리 제외**로 처리한다(자동 삭제 시 미커밋 작업물 손실 위험이라 보수적). 이슈의 "유지 대상" 안전 정책(auto의 dirty/unpushed 보수 스킵, name-filter 확인 후 삭제, 비대화형 안전 실패, branch-name-reuse 가드)은 보존하고, 공통 실패 처리(exit code 집계·에러 메시지)만 표준화했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `_wt_last_commit_msg` 가드만 | 파이프라인 실패만 흡수 | 최소 변경 | 손상 worktree가 여전히 items에 진입해 잔여 위험·사용자 인지 불가 | ❌ 부분 수정 |
| 손상 worktree 감지 + 경고 + 정리 제외 | `_wt_is_broken` 가드로 items 진입 전 차단 + 가드 심화로 헬퍼도 보강 | 근본 방어 + 사용자 인지 + 정책 부합 | 코드 소폭 증가 | ✅ 채택 |
| cleanup이 손상 worktree 자동 prune+삭제 | 잔재 자동 청소 | 환경 자동 정리 | 미커밋 작업물 손실 위험 (정책 위반) | ❌ |
| `_collect_worktrees`에서 완전 필터 | 손상 worktree를 목록에서 제거 | 단순 | `wt ls`에서도 사라져 사용자 인지 불가 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/scripts/lib/wt/git-state.sh` | `_wt_last_commit_msg`에 가드 추가(git을 파이프라인 밖 변수로 분리 + 실패 흡수), 손상 감지 헬퍼 `_wt_is_broken` 신설 |
| `modules/shared/scripts/lib/wt/cleanup.sh` | items 루프에 손상 worktree 가드(경고 + 정리 제외 + 카운트 집계), auto/name-filter 요약에 손상 건너뜀 노출, name-filter 미매칭 안내, 안내 경로 `%q` 안전 인용 |
| `tests/shell-script-tests.sh` | `add_stale_worktree` 헬퍼 + 회귀 테스트 3개(auto/name-filter survives stale, broken-only) |

핵심 코드:

```sh
# git-state.sh — 자매 함수와 일관된 가드 + 손상 감지
_wt_last_commit_msg() {
  local msg
  msg=$(git -C "$1" log -1 --format='%s' 2>/dev/null) || msg=""
  printf '%s' "$msg" | cut -c1-60
}
_wt_is_broken() { ! git -C "$1" rev-parse --git-dir >/dev/null 2>&1; }
```

```sh
# cleanup.sh — items 루프 진입 전 손상 worktree 제외(경고 + 정리 제외)
if _wt_is_broken "$wt"; then
  local _safe_wt; printf -v _safe_wt '%q' "$wt"
  _warn "손상된 worktree 건너뜀: $(basename "$wt") (gitdir 무효 — 수동 정리: rm -rf ${_safe_wt} 후 git worktree prune)"
  broken_count=$((broken_count + 1)); continue
fi
```

## 참고 레퍼런스

- Closes #883
- 관련 OPEN 이슈 #237 (`refactor(wt): wt cleanup 개선`) — 기능 개선이라 본 버그(fix)와 주제가 다름
- 원인 계열: 사용자명 마이그레이션 잔재 (이슈 #884 맥락의 동일 원인 계열)

## Human Test Plan

전제: 손상 worktree가 존재하는 환경(또는 fixture로 재현). 머지 후 `nrs`로 배포해야 실제 `~/.local/bin/wt`에 반영된다.

1. **손상 worktree가 섞인 `--auto` 정리**
   - 실행: `wt cleanup --auto`
   - 기대: 손상 worktree마다 `손상된 worktree 건너뜀: <name> (...)` 경고, MERGED 정상 worktree는 정리, `자동 정리 완료 (손상 N개 건너뜀)`, `exit 0`. 손상 worktree는 디스크에 보존.
   - 실패 시: `exit 128`이거나 silent 종료면 가드 미적용 — `git -C <broken_wt> log -1` 직접 실행해 fatal 여부 확인.

2. **name-filter 정리**
   - 실행: `wt cleanup <name> --yes`
   - 기대: 지정한 정상 worktree 정리, 손상 worktree 경고 + 건너뜀, `정리 완료: N개 삭제 (손상 M개 건너뜀)`, `exit 0`.

3. **손상 worktree만 있는 경우 (MERGED 0개)**
   - 실행: 정상 MERGED 없이 `wt cleanup --auto`
   - 기대: `자동 정리 대상 (MERGED)이 없습니다 (손상 N개 건너뜀)`, `exit 0`. 손상 worktree 보존.

4. **회귀 테스트**
   - 실행: `bash tests/run-shell-script-tests.sh` (또는 pre-push)
   - 기대: wt cleanup 회귀 3종 포함 전체 통과.

**한계 / 후속**
- `wt ls` / `wt ls --json`은 손상 worktree를 별도 표시하지 않고 정상처럼 나열한다(cleanup만 감지/제외). 필요 시 별도 후속.
- `bootstrap.sh`의 `git worktree remove --force || rm -rf`는 본 변경 이전부터 존재하는 선존 패턴으로, 정적 손상 worktree에서는 100% 안전 건너뜀이라 본 PR 스코프 밖.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crash when cleanup encounters broken or stale worktrees.
  * Improved error handling for inaccessible Git directories.

* **New Features**
  * Added detection of broken worktrees with skip warnings and manual removal hints.
  * Enhanced cleanup reporting to display skipped broken worktrees in summary output.

* **Tests**
  * Added regression tests for broken worktree cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->