### PR TITLE
docs(configuring-codex): codex 업데이트 경로를 mise backend 기준으로 문서화

### DIFF
--- a/.claude/skills/configuring-codex/SKILL.md
+++ b/.claude/skills/configuring-codex/SKILL.md
@@ -14,8 +14,8 @@ Codex CLI 호환 레이어와 프로젝트 스킬 발견 문제를 다룹니다.
 
 ## 작성 기준
 
-- 확인 날짜: 2026-04-21
-- 확인 버전: codex-cli 0.122.0
+- 확인 날짜: 2026-06-05
+- 확인 버전: codex-cli 0.137.0
 - 재검증: `codex --version && ./scripts/ai/verify-ai-compat.sh`
 
 ## 목적과 범위
@@ -60,9 +60,46 @@ codex 0.106+에서 default (code) collaboration mode에서도 `request_user_inpu
 
 ## 설치/업데이트 경로
 
-Codex CLI 바이너리 설치/업데이트는 `modules/shared/programs/codex/default.nix`의
-`home.activation.installCodexCli`에서 관리한다. 운영 절차는 `nrs` 적용 후
-`codex --version`과 `./scripts/ai/verify-ai-compat.sh`로 검증한다.
+Codex CLI 바이너리는 mise npm backend(`npm:@openai/codex`)로 설치한다.
+SoT는 레이어별로 갈린다 — 버전 핀의 SoT는 `~/.config/mise/config.toml`의 `[tools]`
+(`"npm:@openai/codex" = "latest"`, `node = "lts"`)이고, 설치/정리 코드 동작의 SoT는
+`modules/shared/programs/codex/default.nix`의 activation 3종
+(`cleanupLegacyCodexCli`, `installCodexCli`, `cleanupManualNodeCodex`)이다.
+SKILL.md는 이 둘 위의 운영 절차를 서술한다.
+
+`installCodexCli`는 멱등 가드가 있어 최초 설치만 하고 버전은 자동 갱신하지 않는다.
+가드는 `mise ls -g --current --json npm:@openai/codex`에서
+`installed == true`인 엔트리가 존재하면 `mise use -g npm:@openai/codex`를 skip한다
+(default.nix:203-210). `length > 0` 단독이 아니라 `select(.installed == true)`로 거르는 것은
+config 등록 후 설치 실패한 `[{installed:false}]` 상태에 속지 않기 위함이다(default.nix:201-202 주석).
+즉 `nrs` 후 검증만으로 버전이 올라가리라 기대하면 안 된다 — 자동 업데이트 없음이 의도다.
+
+정식 업데이트(수동 절차):
+
+```bash
+mise use -g npm:@openai/codex@latest
+hash -r && codex --version
+```
+
+`@latest`를 명시한 호출은 사용자 수동 절차이며 default.nix 코드에 그대로 존재하는 호출은 아니다
+(코드의 설치 호출은 버전 무지정 `mise use -g npm:@openai/codex`).
+
+`npm install -g @openai/codex` 금지:
+node 글로벌(`~/.local/share/mise/installs/node/<ver>/bin`)에 깔리면 PATH상 mise backend bin보다
+우선이라 backend shim을 가린다. 다음 `nrs`의 `cleanupManualNodeCodex`(default.nix:221-237)가
+각 node 버전 prefix의 npm으로 `env PATH="$node_prefix/bin:mise/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`를
+반복 호출해 수동 글로벌을 제거하므로, 구버전으로 롤백된 것처럼 보인다.
+(`lts`/`24`/`latest` 같은 symlink 별칭 디렉토리는 `[ ! -L ]` 가드로 제외해 중복 uninstall을 막는다.)
+
+진단 — 두 codex 공존이 의심되면 PATH 첫 매치를 확인한다:
+
+```bash
+whence -p codex   # PATH 첫 매치 경로
+type -a codex     # 모든 후보 (node/<ver>/bin이 mise backend bin보다 앞이면 수동 글로벌 잔재)
+```
+
+검증: `hash -r && codex --version`, `./scripts/ai/verify-ai-compat.sh`.
+비대화형 셸에서 codex shim 미노출 문제는 `managing-mise`의 셸 활성화 구조를 참조한다.
 
 ## 진단 우선순위 (중요)
 
@@ -88,6 +125,7 @@ sandbox_mode = "danger-full-access"
 - 권한 프롬프트 반복: `~/.codex/config.toml`의 `approval_policy`, `sandbox_mode`를 확인한다.
 - AGENTS 불일치: 프로젝트 루트 `AGENTS.md -> CLAUDE.md` 심링크를 복구한다.
 - 활성화 누락: `nrs` 실행 후 `./scripts/ai/verify-ai-compat.sh`로 재검증한다.
+- codex 업데이트가 안 됨 / `npm install -g`가 안 먹힘: `installCodexCli` 멱등 가드로 `nrs`는 최초 설치만 하므로 정식 업데이트는 `mise use -g npm:@openai/codex@latest` 후 `hash -r`로 한다. `npm install -g @openai/codex`는 `cleanupManualNodeCodex`가 제거하므로 사용하지 않는다 (`whence -p codex`로 PATH 잔재 확인).
 
 ## 투영 아키텍처
 

--- a/.claude/skills/configuring-codex/evals/queries.json
+++ b/.claude/skills/configuring-codex/evals/queries.json
@@ -8,5 +8,9 @@
   {"query": "sandbox_mode를 danger-full-access로 바꾸기", "should_trigger": true, "why": "경계선: sandbox_mode는 codex config 범위"},
   {"query": "Codex 권한 프롬프트가 계속 떠", "should_trigger": true, "why": "저항적: 권한 프롬프트 = approval_policy 설정"},
   {"query": "AI 도구 호환 설정 확인", "should_trigger": true, "why": "저항적: AI 도구 호환 = codex 호환 레이어"},
-  {"query": "codex 바이너리 업데이트하기", "should_trigger": true, "why": "저항적: 설치/업데이트 경로는 codex 스킬"}
+  {"query": "codex 바이너리 업데이트하기", "should_trigger": true, "why": "저항적: 설치/업데이트 경로는 codex 스킬"},
+  {"query": "codex 버전이 nrs 해도 안 올라가", "should_trigger": true, "why": "저항적: nrs는 최초 설치만 하고 멱등 가드로 업데이트를 건너뛴다 — installCodexCli 동작 지식이 필요"},
+  {"query": "codex를 최신 버전으로 업데이트하려면", "should_trigger": true, "why": "명시적: codex 업데이트는 트리거 키워드, 정식 경로는 mise use -g npm:@openai/codex@latest"},
+  {"query": "npm install -g @openai/codex 했더니 codex가 꼬였어", "should_trigger": true, "why": "경계선: 수동 npm 글로벌이 mise shim을 가리는 PATH 충돌 — cleanupManualNodeCodex가 다루는 영역"},
+  {"query": "whence -p codex 결과가 mise shim이 아니야", "should_trigger": true, "why": "저항적: PATH 진단으로 수동 글로벌 잔재 식별 — codex 설치 소유권 범위"}
 ]

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -103,6 +103,8 @@ codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' 
 4. `codex exec`로 project-scope 스킬 1개 이상 런타임 확인
 5. `configuring-codex` 스킬 문서와 실제 구현(`default.nix`, verify script) 간 불일치 여부 점검
 6. pre-commit `ai-skills-consistency` 훅 확인 (관련 staged 변경 시 fail, 긴급 우회: `SKIP_AI_SKILL_CHECK=1`)
+7. `installCodexCli` 멱등 가드(`mise ls -g --current --json npm:@openai/codex`의 `installed == true` 판정)가 살아있어 `nrs`가 codex 버전을 자동 업데이트하지 않는지 확인
+8. `cleanupManualNodeCodex`(default.nix:221-237)가 수동 `npm install -g @openai/codex` 잔재를 제거하는지 확인 — 수동 글로벌이 PATH상 mise shim을 가려 "codex 업데이트가 안 되는 것처럼" 보이는 회귀의 근원
 
 ## 2026-05-02 업데이트: SKILL.md 도구-중립성 lint
 
@@ -152,6 +154,48 @@ Codex CLI가 디렉토리 심링크는 공식 지원함을 확인했다.
 
 - `.agents/skills/<name>` → `../../.claude/skills/<name>` 디렉토리 심링크
 - `verify-ai-compat.sh`, `warn-skill-consistency.sh`에서 디렉토리 심링크 기준 검증
+
+## 2026-06-05 업데이트: codex 바이너리 mise npm backend 운영
+
+### activation DAG (3단계)
+
+`modules/shared/programs/codex/default.nix`의 home.activation 3종이 codex 바이너리 lifecycle을 관리한다.
+
+1. `cleanupLegacyCodexCli` — 과거 설치 방식(GitHub ELF/brew cask) 잔재 정리
+2. `installCodexCli` — 멱등 가드 후 `mise use -g npm:@openai/codex` (최초 1회, 버전 무지정)
+3. `cleanupManualNodeCodex` — 수동 `npm install -g @openai/codex` 잔재 제거
+
+### SoT와 정식 업데이트
+
+- SoT는 `~/.config/mise/config.toml`의 `[tools]` 항목: `"npm:@openai/codex" = "latest"`, `node = "lts"`.
+- 멱등 가드: `installCodexCli`는 `mise ls -g --current --json npm:@openai/codex`에서 `installed == true`인
+  엔트리가 있으면 `mise use -g npm:@openai/codex`를 skip한다(default.nix:203-210).
+  `length > 0` 단독이 아니라 `select(.installed == true)`로 거르는 것은 config 등록 후 설치 실패한
+  `[{installed:false}]` 상태에 속지 않기 위함이다(default.nix:201-202 주석).
+- 따라서 `nrs`는 codex 버전을 자동 업데이트하지 않는다. 정식 업데이트는 수동 절차다:
+
+```bash
+mise use -g npm:@openai/codex@latest
+hash -r && codex --version
+```
+
+### `npm install -g @openai/codex` 금지
+
+수동 글로벌은 `~/.local/share/mise/installs/node/<ver>/bin`에 깔려 PATH상 mise backend bin보다 우선이라
+backend shim을 가린다. 다음 `nrs`의 `cleanupManualNodeCodex`(default.nix:221-237)가 각 node 버전
+prefix의 npm으로 `env PATH="$node_prefix/bin:mise/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`를
+반복 호출해 수동 글로벌을 제거하므로, 사용자가 "codex가 구버전으로 롤백됐다"고 느끼는 회귀가 발생한다.
+`lts`/`24`/`latest` 같은 symlink 별칭 디렉토리는 `[ ! -L ]` 가드로 제외해 중복 uninstall을 막는다.
+
+### 진단
+
+```bash
+whence -p codex   # PATH 첫 매치 경로 (node/<ver>/bin이면 수동 글로벌 잔재)
+type -a codex     # 모든 후보
+```
+
+`codex`는 `command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen` 셸 alias로 래핑되어
+있으므로, 바이너리 자체 경로는 `whence -p codex`로 확인한다.
 
 ## 참고 문서
 


### PR DESCRIPTION
## 1. Summary

- `configuring-codex` 스킬 문서에 codex 바이너리의 **mise npm backend 관리 모델**과 정식 업데이트 경로(`mise use -g npm:@openai/codex@latest`)를 명문화한다.
- `npm install -g @openai/codex`가 "업데이트되지 않는 것처럼" 보이는 회귀의 원인(`installCodexCli` 멱등 가드 + `cleanupManualNodeCodex` 제거 + PATH 충돌)과 진단 절차를 문서화한다.
- `SKILL.md` / `references/runbook-codex-compat.md` / `evals/queries.json` 3개 파일 보강. (직접 Close할 이슈 없음 — 운영 중 발견)

## 2. 기존 문제 / 배경

codex 바이너리는 `modules/shared/programs/codex/default.nix`의 activation으로 **mise npm backend**(`npm:@openai/codex`)를 통해 설치된다. 그러나 `SKILL.md`의 「설치/업데이트 경로」 절은 *"`installCodexCli`에서 관리, `nrs` 후 `codex --version`으로 검증"*까지만 적혀 있어, **실제로 버전을 올리는 방법이 누락**돼 있었다.

이 공백 때문에 다음 함정이 발생했다:

- 사용자가 `npm install -g @openai/codex`로 업데이트를 시도 → node 글로벌(`~/.local/share/mise/installs/node/<ver>/bin`)에 설치되지만, mise backend가 관리하는 codex와 **PATH상 공존·충돌**한다.
- `installCodexCli`는 멱등 가드(`installed == true` 판정)로 **이미 설치돼 있으면 skip** — 즉 `nrs`로는 버전이 자동으로 올라가지 않는다(의도된 설계).
- 다음 `nrs`의 `cleanupManualNodeCodex`가 수동 npm 글로벌을 `npm uninstall -g`로 제거 → 사용자는 "업데이트가 안 되고 구버전으로 롤백된다"고 느낀다.

문서에 정식 경로가 없으니 이 회귀를 추적하기 어려웠다.

## 3. CIR (Change Intent Record)

- **발견 경위**: codex npm 업데이트가 안 된다는 문제를 진단하던 중, 실측으로 두 개의 codex(mise backend가 관리하는 것 / 수동 `npm install -g`로 깔린 node 글로벌)가 PATH상 공존하며 서로를 가리는 상태를 확인했다. `default.nix`의 3단계 activation DAG와 대조해 멱등 가드·정리 동작을 검증했고, 모든 기술 주장을 코드 라인과 일치시켰다.
- **설계 의도**: 같은 함정을 반복하지 않도록 (1) 코드 동작의 SoT(`default.nix` activation)와 운영 절차(SKILL.md)를 명확히 분리하고, (2) 정식 업데이트 경로·금지 사유·진단 명령을 문서에 고정한다.
- **대안 검토**: 코드 주석만 보강하는 방안도 있었으나, 스킬 문서는 LLM/사용자의 진입점이므로 문서 보강을 택했다. `SKILL.md`만 고치는 대신 회귀 방지 체크리스트(runbook)와 트리거 평가(evals)까지 동반 갱신해 드리프트를 줄였다.
- **검증**: `verify-ai-compat.sh` 통과, skill-noise lint PASS, 사실/일관성/정책 관점의 교차 검토에서 blocking 없음(용어 명확화 1건만 반영).

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 스킬 문서 3종 보강 | SKILL.md + runbook + evals 동반 갱신 | LLM/사용자 진입점 일치, 회귀 체크·트리거까지 정합 | 변경 범위 다소 넓음 | ✅ 채택 |
| SKILL.md만 보강 | 본문 절만 수정 | 최소 변경 | runbook/evals 드리프트 잔존 | ❌ |
| default.nix 주석만 보강 | 코드 주석에 절차 추가 | 코드 근처 | 사용자/LLM이 잘 안 봄, 진입점 아님 | ❌ |
| "SoT" 단일 표기 유지 | 한 단어로 통칭 | 짧음 | 버전핀/코드동작 두 대상이 혼동됨 | ❌ 레이어 구분으로 대체 |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `.claude/skills/configuring-codex/SKILL.md` | 「설치/업데이트 경로」 절 재작성(SoT 레이어 구분, 멱등 가드, `mise use -g` 정식 경로, `npm install -g` 금지 사유, 진단 명령), FAQ 1줄, 작성 기준 메타 갱신(0.137.0) |
| `.claude/skills/configuring-codex/references/runbook-codex-compat.md` | 회귀 방지 체크리스트 항목 2건 + 「2026-06-05 업데이트」 운영 절 신규 |
| `.claude/skills/configuring-codex/evals/queries.json` | codex 업데이트 관련 트리거 쿼리 4건 추가 |

핵심 서술 (SKILL.md):

```
SoT는 레이어별로 갈린다 — 버전 핀의 SoT는 ~/.config/mise/config.toml의 [tools]
("npm:@openai/codex" = "latest", node = "lts")이고, 설치/정리 코드 동작의 SoT는
modules/shared/programs/codex/default.nix의 activation 3종
(cleanupLegacyCodexCli, installCodexCli, cleanupManualNodeCodex)이다.
```

```bash
# 정식 업데이트 (수동 절차)
mise use -g npm:@openai/codex@latest
hash -r && codex --version
```

## 6. 참고 레퍼런스

- 이슈 #822 — `installCodexCli` node_bin 빈 출력 시 PATH 삽입 가드 (멱등 가드/PATH 보강 로직의 직접 선행)
- 이슈 #861 — `using-codex-exec` 활성 codex-cli 버전/surface drift 갱신 (codex 버전 추적 인접 작업)
- 코드 SoT: `modules/shared/programs/codex/default.nix`의 `installCodexCli`(멱등 가드), `cleanupManualNodeCodex`(수동 글로벌 정리)

## 7. Human Test Plan

1. **문서 정합 검증**: `./scripts/ai/verify-ai-compat.sh` 실행 → "검증 통과" (커밋 후엔 WARN 없이).
   - 실패 시: `.agents/skills/` 디렉토리 심링크 상태부터 점검.
2. **업데이트 경로 재현**: `mise use -g npm:@openai/codex@latest` 후 `hash -r && codex --version`으로 최신 버전 확인.
   - 기대: backend 버전이 갱신되고 `whence -p codex`가 `.../installs/npm-openai-codex/latest/bin/codex`를 가리킨다.
3. **회귀 진단 절차 확인**: `type -a codex` 출력에 `node/<ver>/bin/codex`가 mise backend bin보다 앞서면 수동 글로벌 잔재 → `npm uninstall -g @openai/codex`로 제거.
   - 실패 시: SKILL.md 「설치/업데이트 경로」 절의 진단 블록을 따라 PATH 첫 매치를 확인.
4. **트리거 평가**: `evals/queries.json`의 신규 4개 쿼리가 `configuring-codex`로 라우팅되는지 평가 하니스로 확인.
