### PR TITLE
docs(configuring-codex): #886 머지 후 발견된 문서-코드 인용 불일치 정정

### DIFF
--- a/.claude/skills/configuring-codex/SKILL.md
+++ b/.claude/skills/configuring-codex/SKILL.md
@@ -69,9 +69,9 @@ SKILL.md는 이 둘 위의 운영 절차를 서술한다.
 
 `installCodexCli`는 멱등 가드가 있어 최초 설치만 하고 버전은 자동 갱신하지 않는다.
 가드는 `mise ls -g --current --json npm:@openai/codex`에서
-`installed == true`인 엔트리가 존재하면 `mise use -g npm:@openai/codex`를 skip한다
-(default.nix:203-210). `length > 0` 단독이 아니라 `select(.installed == true)`로 거르는 것은
-config 등록 후 설치 실패한 `[{installed:false}]` 상태에 속지 않기 위함이다(default.nix:201-202 주석).
+`installed == true`인 엔트리가 존재하면 `mise use -g npm:@openai/codex`를 skip한다.
+`length > 0` 단독이 아니라 `select(.installed == true)`로 거르는 것은
+config 등록 후 설치 실패한 `[{installed:false}]` 상태에 속지 않기 위함이다(`installCodexCli` 가드 주석 참조).
 즉 `nrs` 후 검증만으로 버전이 올라가리라 기대하면 안 된다 — 자동 업데이트 없음이 의도다.
 
 정식 업데이트(수동 절차):
@@ -86,8 +86,8 @@ hash -r && codex --version
 
 `npm install -g @openai/codex` 금지:
 node 글로벌(`~/.local/share/mise/installs/node/<ver>/bin`)에 깔리면 PATH상 mise backend bin보다
-우선이라 backend shim을 가린다. 다음 `nrs`의 `cleanupManualNodeCodex`(default.nix:221-237)가
-각 node 버전 prefix의 npm으로 `env PATH="$node_prefix/bin:mise/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`를
+우선이라 backend shim을 가린다. 다음 `nrs`의 `cleanupManualNodeCodex`가
+각 node 버전 prefix의 npm으로 `env PATH="$node_prefix/bin:${pkgs.mise}/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`를
 반복 호출해 수동 글로벌을 제거하므로, 구버전으로 롤백된 것처럼 보인다.
 (`lts`/`24`/`latest` 같은 symlink 별칭 디렉토리는 `[ ! -L ]` 가드로 제외해 중복 uninstall을 막는다.)
 
@@ -109,7 +109,7 @@ Codex CLI는 디렉토리 심링크를 따라가지만 파일 심링크는 무�
 
 ## 실행 정책 / Trust 메모
 
-`codex-cli 0.122.0` 기준으로 `codex trust` 독립 서브커맨드는 확인되지 않았다.  
+`codex-cli 0.137.0` 기준으로 `codex trust` 독립 서브커맨드는 확인되지 않았다.  
 권한 프롬프트 동작은 전역 실행 정책으로 제어한다.
 
 ```toml

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -104,7 +104,7 @@ codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' 
 5. `configuring-codex` 스킬 문서와 실제 구현(`default.nix`, verify script) 간 불일치 여부 점검
 6. pre-commit `ai-skills-consistency` 훅 확인 (관련 staged 변경 시 fail, 긴급 우회: `SKIP_AI_SKILL_CHECK=1`)
 7. `installCodexCli` 멱등 가드(`mise ls -g --current --json npm:@openai/codex`의 `installed == true` 판정)가 살아있어 `nrs`가 codex 버전을 자동 업데이트하지 않는지 확인
-8. `cleanupManualNodeCodex`(default.nix:221-237)가 수동 `npm install -g @openai/codex` 잔재를 제거하는지 확인 — 수동 글로벌이 PATH상 mise shim을 가려 "codex 업데이트가 안 되는 것처럼" 보이는 회귀의 근원
+8. `cleanupManualNodeCodex`가 수동 `npm install -g @openai/codex` 잔재를 제거하는지 확인 — 수동 글로벌이 PATH상 mise shim을 가려 "codex 업데이트가 안 되는 것처럼" 보이는 회귀의 근원
 
 ## 2026-05-02 업데이트: SKILL.md 도구-중립성 lint
 
@@ -169,9 +169,9 @@ Codex CLI가 디렉토리 심링크는 공식 지원함을 확인했다.
 
 - SoT는 `~/.config/mise/config.toml`의 `[tools]` 항목: `"npm:@openai/codex" = "latest"`, `node = "lts"`.
 - 멱등 가드: `installCodexCli`는 `mise ls -g --current --json npm:@openai/codex`에서 `installed == true`인
-  엔트리가 있으면 `mise use -g npm:@openai/codex`를 skip한다(default.nix:203-210).
+  엔트리가 있으면 `mise use -g npm:@openai/codex`를 skip한다.
   `length > 0` 단독이 아니라 `select(.installed == true)`로 거르는 것은 config 등록 후 설치 실패한
-  `[{installed:false}]` 상태에 속지 않기 위함이다(default.nix:201-202 주석).
+  `[{installed:false}]` 상태에 속지 않기 위함이다(`installCodexCli` 가드 주석).
 - 따라서 `nrs`는 codex 버전을 자동 업데이트하지 않는다. 정식 업데이트는 수동 절차다:
 
 ```bash
@@ -182,8 +182,8 @@ hash -r && codex --version
 ### `npm install -g @openai/codex` 금지
 
 수동 글로벌은 `~/.local/share/mise/installs/node/<ver>/bin`에 깔려 PATH상 mise backend bin보다 우선이라
-backend shim을 가린다. 다음 `nrs`의 `cleanupManualNodeCodex`(default.nix:221-237)가 각 node 버전
-prefix의 npm으로 `env PATH="$node_prefix/bin:mise/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`를
+backend shim을 가린다. 다음 `nrs`의 `cleanupManualNodeCodex`가 각 node 버전
+prefix의 npm으로 `env PATH="$node_prefix/bin:${pkgs.mise}/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`를
 반복 호출해 수동 글로벌을 제거하므로, 사용자가 "codex가 구버전으로 롤백됐다"고 느끼는 회귀가 발생한다.
 `lts`/`24`/`latest` 같은 symlink 별칭 디렉토리는 `[ ! -L ]` 가드로 제외해 중복 uninstall을 막는다.
 

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -194,8 +194,9 @@ whence -p codex   # PATH 첫 매치 경로 (node/<ver>/bin이면 수동 글로�
 type -a codex     # 모든 후보
 ```
 
-`codex`는 `command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen` 셸 alias로 래핑되어
-있으므로, 바이너리 자체 경로는 `whence -p codex`로 확인한다.
+`codex`는 셸 alias로 래핑되어 있다 — Linux는 안내 `echo`를 `>&2`로 먼저 출력한 뒤
+`command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen`를 실행하고, macOS는 선행 echo 없이
+같은 `command codex …`를 실행한다. 따라서 바이너리 자체 경로는 `whence -p codex`로 확인한다.
 
 ## 참고 문서
 


### PR DESCRIPTION
## 1. Summary

- PR #886이 정정 전 첫 커밋만 squash 머지되어, 후속 코드 리뷰로 확인된 **문서–코드 인용 불일치 4건**이 main에 반영되지 못했다. 본 PR이 정정분만 분리 반영한다.
- 정정: `cleanupManualNodeCodex` PATH 인용, `default.nix` 라인 번호 참조, Trust 메모 버전, `codex` alias 인용.

## 2. 기존 문제 / 배경

PR #886(머지됨)은 codex 업데이트 경로를 mise npm backend 기준으로 문서화했다. 머지 후 독립 리뷰어/auditor로 검토하던 중 문서가 인용한 `default.nix` 명령/조건/버전이 실제 코드와 어긋나는 지점을 발견했으나, #886이 그 전에 머지되어 정정이 main에 들어가지 못했다. 정정 내용은 브랜치에 보존돼 있었고 본 PR로 분리 반영한다.

## 3. CIR (Change Intent Record)

- **발견 경위**: #886 머지 후 다단계 코드 리뷰에서 다수 관점이 동일하게 PATH 인용 오류로 수렴했고, 코드와 직접 대조해 확정했다. 무해로 판정한 2건(SKILL.md↔runbook의 의도적 다층 중복, PATH 우선순위 표현)은 제외했다.
- **설계 의도**: 문서가 코드를 백틱으로 인용할 때 실제 소스와 정확히 일치시키고, 코드 이동에 취약한 라인 번호 대신 안정 식별자(activation 이름)로 참조한다.

## 4. ADR (Architecture Decision Record)

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 정정분만 분리한 새 PR | 리뷰 가능, diff 최소 | PR 하나 추가 | ✅ 채택 |
| #886 재오픈/수정 | 단일 PR | 이미 squash 머지됨 — 불가 | ❌ |
| main에 직접 push | 빠름 | 브랜치 보호/리뷰 우회 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `SKILL.md` | PATH 인용 `mise/bin`→`${pkgs.mise}/bin`; `default.nix:NNN` 라인번호 제거 → `installCodexCli`/`cleanupManualNodeCodex` 이름 참조; Trust 메모 확인 버전 0.122.0→0.137.0 |
| `references/runbook-codex-compat.md` | 동일 PATH 인용 정정 + 라인번호 제거; `codex` alias 인용을 플랫폼별로 정정(Linux 선행 안내 `echo` 포함, macOS 미포함) |

핵심 정정(SKILL.md):

```
# 실제 default.nix와 일치
`env PATH="$node_prefix/bin:${pkgs.mise}/bin:$PATH" "$npm_bin" uninstall -g @openai/codex`
```

> 참고: runbook의 "codex trust 관련 메모" 절(`0.122.0` 표기)은 본 PR 범위 밖의 기존 dated 기록이라 보존했다. 현재 운영 문서인 `SKILL.md`의 Trust 메모만 작성 기준(0.137.0)과 일치시켰다.

## 6. 참고 레퍼런스

- PR #886 — 정정 대상이 된 원 문서화(codex 업데이트 경로 mise backend)

## 7. Human Test Plan

1. 정정 완전성: `grep -rn "bin:mise/bin\|default\.nix:[0-9]" .claude/skills/configuring-codex/` 결과 0건.
2. PATH 인용 일치: `SKILL.md`/`runbook`의 uninstall 명령이 `modules/shared/programs/codex/default.nix`의 `cleanupManualNodeCodex` 실제 명령과 동일.
3. alias 정확성: runbook의 `codex` alias 설명이 `modules/shared/programs/shell/default.nix`의 Linux/macOS 분기와 일치.
4. Trust 버전: `SKILL.md`의 확인 버전(작성 기준)과 Trust 메모가 0.137.0으로 정합. `codex help trust`가 `unrecognized subcommand`임을 재확인.
