### PR TITLE
fix(darwin,tests): greedyCasks 비활성화·docker-desktop 제거 + codex-sync 테스트 macOS 회귀 수정

### DIFF
--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -53,10 +53,10 @@ darwinOnly = [ ... pkgs.패키지명 ];
 
 ```nix
 # cleanup = "none" — 선언되지 않은 앱을 삭제하지 않음 (수동 설치 cask 보호)
-# upgrade = true + greedyCasks = true — 자체 업데이터 앱의 버전 드리프트 방지
+# upgrade = true + greedyCasks = false — 자체 업데이터 cask는 brew upgrade 강제 대상에서 제외
 homebrew.casks = [
   "ghostty" "raycast" "rectangle"
-  "hammerspoon" "homerow" "docker-desktop"
+  "hammerspoon" "homerow"
   "fork" "monitorcontrol"
 ];
 homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, 오디오 처리

--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -66,7 +66,7 @@ homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, �
 # slack → Homebrew에서 제거 (수동 설치 선호, 자체 업데이터에 위임)
 ```
 
-새 Mac 세팅 시: 직접 설치된 앱은 `brew install --cask --adopt <앱>`으로 Homebrew 관리로 전환 필요.
+새 Mac 세팅 시: `nrs`가 cask 설치 때 자동으로 adopt를 시도하며, 번들 버전 충돌 등으로 실패할 때만 `brew install --cask --adopt <앱>`을 수동 실행.
 
 자세한 내용: [references/features.md](references/features.md#gui-앱-homebrew-casks)
 

--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -57,7 +57,7 @@ darwinOnly = [ ... pkgs.패키지명 ];
 homebrew.casks = [
   "ghostty" "raycast" "rectangle"
   "hammerspoon" "homerow"
-  "fork" "monitorcontrol"
+  "fork" "monitorcontrol" "1password" "1password-cli"
 ];
 homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, 오디오 처리
 # shottr → Nix 패키지로 관리 (libraries/packages.nix darwinOnly)

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -345,6 +345,8 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | Homerow        | 키보드 네비게이션          |
 | Fork           | Git GUI                    |
 | MonitorControl | 외부 모니터 밝기 조절      |
+| 1Password      | 비밀번호/SSH 키/PAT 관리   |
+| 1Password CLI  | `op` CLI (1password-cli cask) |
 
 ### Nix 패키지로 관리하는 GUI 앱
 
@@ -390,11 +392,11 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 
 ### 직접 설치 앱의 adopt 전환
 
-기존에 `/Applications`에 직접 설치된 앱을 Homebrew Cask 관리로 전환하려면 `--adopt` 플래그를 사용합니다.
+`nrs`(brew bundle)는 cask 설치 시 `--force`가 없으면 `--adopt`를 자동으로 추가하므로(`Homebrew bundle/cask.rb`), 직접 설치된 앱도 대개 자동으로 adopt됩니다. 아래는 자동 adopt가 실패하는 경우(번들 버전 충돌 등)나 동작을 이해할 때 참고용입니다.
 
-`--adopt`가 필요한 이유:
+`--adopt`가 하는 일:
 
-Homebrew Cask는 `/Applications`에 동일 앱이 이미 존재하면 `brew install`을 거부합니다:
+Homebrew Cask는 `/Applications`에 동일 앱이 이미 존재하면 `--adopt` 없는 `brew install`을 거부합니다:
 
 ```text
 Error: It seems there is already an App at '/Applications/Raycast.app'
@@ -413,7 +415,7 @@ Error: It seems there is already an App at '/Applications/Raycast.app'
 
 brew install --cask --adopt raycast:
   1. Raycast 다운로드
-  2. /Applications/Raycast.app 이미 있음 → 기존 앱을 Caskroom으로 이동(백업)
+  2. /Applications/Raycast.app 이미 있음 → 기존 앱은 그대로 두고 source와 번들 버전 비교(백업 안 함)
   3. Homebrew 메타데이터에 "raycast는 내가 관리 중"으로 등록
   4. 이후 brew upgrade raycast로 업데이트 가능
 ```
@@ -427,7 +429,7 @@ brew install --cask --adopt raycast:
 brew install --cask --adopt raycast
 
 # 여러 앱 일괄 adopt (Nix 패키지로 관리하는 shottr, vscode 제외)
-for cask in ghostty raycast rectangle hammerspoon homerow fork monitorcontrol; do
+for cask in ghostty raycast rectangle hammerspoon homerow fork monitorcontrol 1password 1password-cli; do
   brew install --cask --adopt "$cask" || echo "FAILED: $cask"
 done
 

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -415,7 +415,8 @@ Error: It seems there is already an App at '/Applications/Raycast.app'
 
 brew install --cask --adopt raycast:
   1. Raycast 다운로드
-  2. /Applications/Raycast.app 이미 있음 → 기존 앱은 그대로 두고 source와 번들 버전 비교(백업 안 함)
+  2. /Applications/Raycast.app 이미 있음 → 기존 앱을 그대로 채택, 백업 안 함
+     (Raycast는 auto_updates cask라 버전 비교 생략; auto_updates 아닌 cask만 source와 번들 버전 비교)
   3. Homebrew 메타데이터에 "raycast는 내가 관리 중"으로 등록
   4. 이후 brew upgrade raycast로 업데이트 가능
 ```

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -343,7 +343,6 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | Rectangle      | 창 관리                    |
 | Hammerspoon    | 키보드 리매핑/자동화       |
 | Homerow        | 키보드 네비게이션          |
-| Docker Desktop | 컨테이너                   |
 | Fork           | Git GUI                    |
 | MonitorControl | 외부 모니터 밝기 조절      |
 
@@ -361,22 +360,22 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | 앱      | 사유 |
 | ------- | ---- |
 | Ghostty | `pkgs.ghostty-bin`은 CLI 바이너리만 제공하고 macOS .app 번들을 포함하지 않음. Ghostty.app은 Homebrew Cask로만 설치 가능. |
-| Docker Desktop | nixpkgs에 macOS용 패키지 없음 (CLI만 존재) |
 | Fork    | 상용 Git GUI, nixpkgs에 없음 |
 
 ### 업그레이드 정책
 
-`onActivation.upgrade = true` + `greedyCasks = true` 조합으로 버전 드리프트를 방지합니다.
+`onActivation.upgrade = true` + `greedyCasks = false` 조합입니다.
 
-- upgrade = true: `nrs` 실행 시 `brew upgrade`를 자동 실행
-- greedyCasks = true: `auto_updates` 속성이 있는 cask도 `brew upgrade` 대상에 포함
+- upgrade = true: `nrs` 실행 시 자체 업데이터가 없는 cask와 formula를 `brew upgrade`
+- greedyCasks = false: `auto_updates` 속성이 있는 cask(1Password 등)는 `brew upgrade` 강제 대상에서 제외
 
-자체 업데이터가 있는 앱이 Homebrew와 독립적으로 버전을 변경해도, `nrs` 실행 시 Homebrew가 최신 버전으로 동기화합니다.
+자체 업데이터가 있는 앱은 그 업데이터가 최신을 유지하므로, `nrs` 실행마다 대용량 cask(.dmg)를 재다운로드하지 않습니다.
 
 ### Homebrew 관리에서 제외한 앱
 
 | 앱 | 사유 |
 | --- | --- |
+| Docker Desktop | 자체 업데이터가 강력하고 선언적 관리 이점이 없음. greedyCasks 시절 `nrs` activation마다 대용량 .dmg를 재다운로드하던 주원인. 수동 설치·자체 업데이트 위임. |
 | Figma | 자체 업데이터가 적극적으로 버전을 변경하여 Homebrew 관리 버전과 불일치. adopt 시 버전 차이로 설치 거부됨. 자체 업데이터에 위임. |
 | Slack | 수동 설치 선호. 자체 업데이터에 위임. |
 
@@ -398,7 +397,7 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 Homebrew Cask는 `/Applications`에 동일 앱이 이미 존재하면 `brew install`을 거부합니다:
 
 ```text
-Error: It seems there is already an App at '/Applications/Docker.app'
+Error: It seems there is already an App at '/Applications/Raycast.app'
 ```
 
 `--adopt` 없이는 두 가지 선택지뿐입니다:
@@ -408,15 +407,15 @@ Error: It seems there is already an App at '/Applications/Docker.app'
 `--adopt`는 세 번째 선택지를 제공합니다:
 
 ```text
-일반 brew install --cask docker-desktop:
-  1. Docker Desktop 다운로드
-  2. /Applications/Docker.app 이미 있음 → 에러, 중단
+일반 brew install --cask raycast:
+  1. Raycast 다운로드
+  2. /Applications/Raycast.app 이미 있음 → 에러, 중단
 
-brew install --cask --adopt docker-desktop:
-  1. Docker Desktop 다운로드
-  2. /Applications/Docker.app 이미 있음 → 기존 앱을 Caskroom으로 이동(백업)
-  3. Homebrew 메타데이터에 "docker-desktop은 내가 관리 중"으로 등록
-  4. 이후 brew upgrade docker-desktop으로 업데이트 가능
+brew install --cask --adopt raycast:
+  1. Raycast 다운로드
+  2. /Applications/Raycast.app 이미 있음 → 기존 앱을 Caskroom으로 이동(백업)
+  3. Homebrew 메타데이터에 "raycast는 내가 관리 중"으로 등록
+  4. 이후 brew upgrade raycast로 업데이트 가능
 ```
 
 기존 앱을 삭제하지 않으므로 설정/로그인 상태가 보존됩니다. adopt 후 `nrs`를 실행하면 homebrew.nix 선언과 실제 설치 상태가 일치합니다.
@@ -425,10 +424,10 @@ brew install --cask --adopt docker-desktop:
 
 ```bash
 # 개별 앱 adopt
-brew install --cask --adopt docker-desktop
+brew install --cask --adopt raycast
 
 # 여러 앱 일괄 adopt (Nix 패키지로 관리하는 shottr, vscode 제외)
-for cask in ghostty raycast rectangle hammerspoon homerow docker-desktop fork monitorcontrol; do
+for cask in ghostty raycast rectangle hammerspoon homerow fork monitorcontrol; do
   brew install --cask --adopt "$cask" || echo "FAILED: $cask"
 done
 

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -73,7 +73,7 @@
       # 따라서 nrs 실행 전에 직접 설치된 앱을 --adopt로 전환해야 한다:
       #   brew install --cask --adopt raycast 1password ...
       #
-      # adopt 후에는 nrs(darwin-rebuild)가 해당 cask를 정상적으로 인식하여 에러 없이 통과한다.
+      # adopt 후에는 nrs가 해당 cask를 정상적으로 인식하여 에러 없이 통과한다.
       # cleanup="none"이므로 미adopt 앱이 남아있어도 삭제되지는 않지만,
       # brew가 해당 앱의 존재를 모르므로 업데이트/관리가 불가능한 상태로 남는다.
       #

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -63,7 +63,9 @@
       # nix-darwin은 이 목록으로 `brew bundle`을 실행하고, brew bundle은 cask 설치 시
       # `--force`가 없으면 `--adopt`를 자동으로 붙인다 (Homebrew bundle/cask.rb).
       # 따라서 /Applications에 동일 앱이 이미 있어도 대개 자동 adopt되어 에러 없이 통과한다 —
-      # 기존 앱을 삭제·백업하지 않고 source(다운로드본)와 번들 버전을 비교한 뒤 Homebrew 관리로 등록한다.
+      # 기존 앱을 삭제·백업하지 않고 Homebrew 관리로 등록한다.
+      # (auto_updates cask[Raycast·1Password 등]는 버전 비교 없이 기존 앱을 채택하고,
+      #  그 외 cask만 source와 번들 버전을 비교한다 — Homebrew cask/artifact/moved.rb)
       #
       # 단 기존 앱과 source의 번들 버전이 다르면 adopt가 거부될 수 있다. 이때는:
       #   1) 기존 앱을 최신으로 맞춘 뒤 다시 nrs → 버전 일치로 자동 adopt

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -60,20 +60,16 @@
       #
       # [adopt 가이드] 새 Mac 또는 직접 설치된 앱이 있는 경우
       #
-      # nix-darwin은 이 목록을 기반으로 `brew install --cask <앱>`을 실행한다.
-      # 그런데 Homebrew Cask는 /Applications에 동일 앱이 이미 존재하면 설치를 거부한다:
-      #   Error: It seems there is already an App at '/Applications/Raycast.app'
+      # nix-darwin은 이 목록으로 `brew bundle`을 실행하고, brew bundle은 cask 설치 시
+      # `--force`가 없으면 `--adopt`를 자동으로 붙인다 (Homebrew bundle/cask.rb).
+      # 따라서 /Applications에 동일 앱이 이미 있어도 대개 자동 adopt되어 에러 없이 통과한다 —
+      # 기존 앱을 삭제·백업하지 않고 source(다운로드본)와 번들 버전을 비교한 뒤 Homebrew 관리로 등록한다.
       #
-      # 이때 선택지는 3가지:
-      #   1) 기존 앱 삭제 후 brew install → 앱 설정/로그인 상태 유실 위험
+      # 단 기존 앱과 source의 번들 버전이 다르면 adopt가 거부될 수 있다. 이때는:
+      #   1) 기존 앱을 최신으로 맞춘 뒤 다시 nrs → 버전 일치로 자동 adopt
       #   2) 이 목록에서 해당 cask 제거 → 선언적 관리 포기
-      #   3) brew install --cask --adopt → 기존 앱을 삭제하지 않고 Homebrew가
-      #      "내가 설치한 것"으로 인식하도록 등록만 수행. 이후 brew upgrade로 관리 가능.
+      #   3) 수동으로 먼저 전환: brew install --cask --adopt raycast 1password ...
       #
-      # 따라서 nrs 실행 전에 직접 설치된 앱을 --adopt로 전환해야 한다:
-      #   brew install --cask --adopt raycast 1password ...
-      #
-      # adopt 후에는 nrs가 해당 cask를 정상적으로 인식하여 에러 없이 통과한다.
       # cleanup="none"이므로 미adopt 앱이 남아있어도 삭제되지는 않지만,
       # brew가 해당 앱의 존재를 모르므로 업데이트/관리가 불가능한 상태로 남는다.
       #

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -38,12 +38,12 @@
       };
 
       # [업그레이드 정책]
-      # upgrade=true + greedyCasks=true 조합:
-      # - upgrade=true: nrs 실행 시 brew upgrade를 자동 실행
-      # - greedyCasks=true: auto_updates가 있는 cask도 brew upgrade 대상에 포함
-      # 자체 업데이터가 있는 앱이 Homebrew와 독립적으로 버전을 변경해도
-      # nrs 실행 시 Homebrew가 최신 버전으로 동기화하여 버전 드리프트를 방지한다.
-      greedyCasks = true;
+      # upgrade=true: nrs 실행 시 자체 업데이터가 없는 cask와 formula를 brew upgrade.
+      # greedyCasks=false: auto_updates가 있는 cask(1Password 등)는 brew upgrade 대상에서 제외한다.
+      #   해당 앱은 자체 업데이터가 최신을 유지하므로, nrs activation마다 대용량 .dmg를
+      #   재다운로드할 이유가 없다 (greedyCasks=true 시절 Docker Desktop 등 수백 MB를 매번 재다운로드했다).
+      #   cask 목록 등재 = 설치 보장은 그대로이며, 강제 동기화만 끈다.
+      greedyCasks = false;
 
       # Homebrew Tap (서드파티 저장소)
       taps = [
@@ -71,7 +71,7 @@
       #      "내가 설치한 것"으로 인식하도록 등록만 수행. 이후 brew upgrade로 관리 가능.
       #
       # 따라서 nrs 실행 전에 직접 설치된 앱을 --adopt로 전환해야 한다:
-      #   brew install --cask --adopt docker-desktop raycast ...
+      #   brew install --cask --adopt raycast 1password ...
       #
       # adopt 후에는 nrs(darwin-rebuild)가 해당 cask를 정상적으로 인식하여 에러 없이 통과한다.
       # cleanup="none"이므로 미adopt 앱이 남아있어도 삭제되지는 않지만,
@@ -81,9 +81,11 @@
       # shottr → libraries/packages.nix darwinOnly로 이동 (pkgs.shottr가 macOS .app 번들 포함)
       #
       # [Nix 전환이 불가능한 앱]
-      # docker-desktop: Docker Desktop은 nixpkgs에 macOS용 패키지 없음 (CLI만 존재)
       # fork: 상용 Git GUI, nixpkgs에 없음
       # [Homebrew에서 제거한 앱]
+      # docker-desktop: 자체 업데이터가 강력하고 이 프로젝트에서 선언적 관리 이점이 없음.
+      #        greedyCasks 시절 nrs activation마다 Docker.dmg(수백 MB)를 재다운로드하던 주원인.
+      #        기존 /Applications/Docker.app은 cleanup="none"이라 유지되며 자체 업데이트에 위임.
       # figma: 자체 업데이터가 적극적으로 버전을 변경하여 Homebrew가 관리하는 버전과 불일치 발생.
       #        adopt 시 버전 불일치로 설치 거부됨. 자체 업데이터에 위임.
       # slack: 수동 설치 선호. 자체 업데이터에 위임.
@@ -96,7 +98,6 @@
         "rectangle"
         "hammerspoon"
         "homerow"
-        "docker-desktop"
         "fork"
         "monitorcontrol"
         # 1Password 비밀번호/SSH 키/PAT 통합 (PRD #780 Phase 1)

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -33,7 +33,7 @@
       # 선언되지 않은 앱 정리
       onActivation = {
         autoUpdate = true;
-        upgrade = true; # 선언된 모든 패키지를 최신 버전으로 업그레이드
+        upgrade = true; # brew upgrade 활성화 — auto_updates cask 포함 여부는 아래 greedyCasks 정책을 따름
         cleanup = "none"; # 선언되지 않은 앱을 자동 삭제하지 않음
       };
 

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -62,7 +62,7 @@
       #
       # nix-darwin은 이 목록을 기반으로 `brew install --cask <앱>`을 실행한다.
       # 그런데 Homebrew Cask는 /Applications에 동일 앱이 이미 존재하면 설치를 거부한다:
-      #   Error: It seems there is already an App at '/Applications/Docker.app'
+      #   Error: It seems there is already an App at '/Applications/Raycast.app'
       #
       # 이때 선택지는 3가지:
       #   1) 기존 앱 삭제 후 brew install → 앱 설정/로그인 상태 유실 위험

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1701,6 +1701,10 @@ test_codex_sync_wrapper_opt_in_flags() {
     "$home_dir/.claude/skills/syncing-codex-harness/references" \
     "$project_root" \
     "$(dirname "$custom_mcp")"
+  # codex-sync.sh는 project-root를 _canonical_project_root()의 (cd && pwd -P)로 정규화한다.
+  # macOS의 $TMPDIR(/var/folders → /private/var)·/tmp(→ /private/tmp) 심링크 때문에
+  # 정규화 전/후 경로가 어긋나므로, 기대값도 동일하게 정규화해 플랫폼 간 일치시킨다.
+  project_root="$(cd "$project_root" && pwd -P)"
 
   cat > "$home_dir/.claude/skills/syncing-codex-harness/references/sync.sh" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1690,7 +1690,7 @@ EOF
 }
 
 test_codex_sync_wrapper_opt_in_flags() {
-  local sandbox home_dir project_root marker_file output custom_mcp python_shim rc
+  local sandbox home_dir project_root expected_root marker_file output custom_mcp python_shim rc
   sandbox=$(new_sandbox)
   home_dir="$sandbox/home"
   project_root="$sandbox/project"
@@ -1701,10 +1701,10 @@ test_codex_sync_wrapper_opt_in_flags() {
     "$home_dir/.claude/skills/syncing-codex-harness/references" \
     "$project_root" \
     "$(dirname "$custom_mcp")"
-  # codex-sync.sh는 project-root를 _canonical_project_root()의 (cd && pwd -P)로 정규화한다.
-  # macOS의 $TMPDIR(/var/folders → /private/var)·/tmp(→ /private/tmp) 심링크 때문에
-  # 정규화 전/후 경로가 어긋나므로, 기대값도 동일하게 정규화해 플랫폼 간 일치시킨다.
-  project_root="$(cd "$project_root" && pwd -P)"
+  # codex-sync.sh는 project-root 입력을 _canonical_project_root()의 (cd && pwd -P)로 정규화한다.
+  # 입력(project_root)은 비정규화 그대로 두어 macOS $TMPDIR(/var/folders → /private/var)·
+  # /tmp(→ /private/tmp) 심링크 입력 정규화 동작 자체를 회귀 검증하고, 기대값만 정규화해 비교한다.
+  expected_root="$(cd "$project_root" && pwd -P)"
 
   cat > "$home_dir/.claude/skills/syncing-codex-harness/references/sync.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -1727,7 +1727,7 @@ EOF
   output="$(cat "$marker_file")"
   assert_contains "$output" "<python>"
   assert_contains "$output" "<all>"
-  assert_contains "$output" "<$project_root>"
+  assert_contains "$output" "<$expected_root>"
   assert_not_contains "$output" "--user-mcp"
   assert_not_contains "$output" "--trust-project"
 
@@ -1737,7 +1737,7 @@ EOF
   output="$(cat "$marker_file")"
   assert_contains "$output" "<--trust-project>"
   assert_contains "$output" "<--user-mcp=$home_dir/.claude/mcp.json>"
-  assert_contains "$output" "<$project_root>"
+  assert_contains "$output" "<$expected_root>"
 
   : > "$marker_file"
   HOME="$home_dir" CODEX_SYNC_MARKER="$marker_file" CODEX_SYNC_PYTHON="$python_shim" \


### PR DESCRIPTION
## Summary

이 PR은 두 개의 독립적인 darwin/tests 변경을 함께 담는다.

**(1) Homebrew 업그레이드 정책 정리** (`modules/darwin/programs/homebrew.nix`)
- `greedyCasks = true → false` — 자체 업데이터가 있는 cask(1Password 등)를 `brew upgrade` 강제 동기화 대상에서 제외.
- `docker-desktop` cask 제거 — 자체 업데이터에 위임.
- adopt 가이드 주석을 `nrs`-only 표현으로 정리.

**(2) codex-sync 테스트 macOS 경로 회귀 수정** (`tests/shell-script-tests.sh`)
- `test_codex_sync_wrapper_opt_in_flags`의 sandbox project-root를 `pwd -P`로 정규화하여, macOS에서만 실패하던 pre-push `shell-script-tests`를 수정.

(연관 이슈 없음)

## 기존 문제/배경

**(1) Homebrew**: `nrs` 실행이 비정상적으로 오래 걸리는 현상을 진단한 결과, nix 평가·빌드는 이미 끝났고 activation의 Homebrew bundle 단계가 대용량 cask(.dmg)를 매번 재다운로드하고 있었다. `Fetching docker-desktop, 1password`에서 멈춘 듯 보였으나 실제로는 `Docker.dmg`(~700MB)를 받는 중이었고, 병목은 디스크 IO·네트워크뿐이었다(CPU·메모리 여유).

**(2) codex-sync 테스트**: 위 Homebrew PR을 push할 때 pre-push hook의 `shell-script-tests` 중 `codex-sync wrapper opt-in flags` 케이스가 실패했다. 조사 결과 이는 **이 PR과 무관한 pre-existing 회귀**로, main HEAD에서도 동일하게 실패했다. PR #850이 도입한 테스트가 sandbox project-root를 정규화 없이 기대값으로 써서, macOS의 `$TMPDIR`(`/var/folders` → `/private/var`)·`/tmp`(→ `/private/tmp`) 심링크 때문에 `codex-sync.sh`의 `_canonical_project_root`(`pwd -P`) 출력과 어긋났다. Linux CI는 해당 경로가 심링크가 아니라 통과하여 미검출되었다.

## CIR (Change Intent Record)

**(1) Homebrew**: `onActivation.upgrade = true`와 `greedyCasks = true`의 조합이 근본 원인. `greedyCasks`가 `auto_updates`를 가진 cask까지 매 nrs마다 `brew upgrade` 대상에 포함시켜 대용량 .dmg를 반복 재다운로드한다. `greedyCasks`/`upgrade`를 도입한 PR #91의 명분(Figma·Cursor·Slack의 버전 드리프트 방지)은 그 앱들이 현재 cask 목록에 전부 부재하여 근거가 사라지고 비용만 남은 상태였다. greedyCasks를 끄되 cask 목록 등재는 유지하여 "설치 보장"은 보존하고 "강제 동기화"만 제거한다. `docker-desktop`은 선언적 관리 이점이 없어 제거하고 자체 업데이터에 위임한다(`1password`/`1password-cli`는 선언적 관리 의존부가 많아 유지).

**(2) codex-sync 테스트**: `codex-sync.sh`의 `pwd -P` 정규화는 정상 동작이며 처음부터 일관됐다. 결함은 PR #850이 추가한 테스트가 sandbox 경로를 그 규칙에 맞춰 정규화하지 않은 것. 따라서 `codex-sync.sh`를 건드리지 않고 테스트 기대값만 동일하게 `(cd && pwd -P)`로 정규화한다. mise 우회 격리 재현(system python)으로 모든 project-root assert 통과를 확인했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| greedyCasks=false + docker 제거 | 자체 업데이터 cask 강제 동기화 해제 + Docker 위임 | 대용량 재다운로드 근본 제거 | 자체 업데이터 없는 cask는 여전히 upgrade 대상(비용 미미) | ✅ |
| docker만 제거 | Docker만 목록에서 제거 | 변경 최소 | 1Password 등 greedy 대상 잔존 → 증상 반복 | ❌ |
| upgrade=false | 업그레이드 전면 비활성화 | nrs 항상 가벼움 | 선언적 최신화 철학과 충돌 | ❌ |
| (테스트) 기대값을 pwd -P 정규화 | 테스트 project-root만 정규화 | codex-sync.sh 무변경, 국소 수정 | — | ✅ |
| (테스트) codex-sync.sh가 비정규화 경로 전달 | 대상 코드를 바꿔 정규화 제거 | — | 정상 동작을 훼손, 영향 범위 큼 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/darwin/programs/homebrew.nix` | `greedyCasks = false`, `docker-desktop` 제거, 업그레이드 정책·adopt 주석 현행화 |
| `tests/shell-script-tests.sh` | `test_codex_sync_wrapper_opt_in_flags`에서 `project_root="$(cd "$project_root" && pwd -P)"` 정규화 + 이유 주석 |

```nix
# greedyCasks=false: auto_updates가 있는 cask(1Password 등)는 brew upgrade 대상에서 제외한다.
greedyCasks = false;
```

```bash
# codex-sync.sh는 project-root를 _canonical_project_root()의 (cd && pwd -P)로 정규화한다.
# macOS의 $TMPDIR·/tmp 심링크 때문에 정규화 전/후 경로가 어긋나므로 기대값도 동일하게 정규화한다.
project_root="$(cd "$project_root" && pwd -P)"
```

## 참고 레퍼런스

- PR #91 — `greedyCasks`/`upgrade` 정책 도입 및 Figma cask 제거 (본 변경이 되돌리는 정책의 출처)
- PR #850 — codex-sync `--user-mcp`/`--trust-project` opt-in 전환 + `test_codex_sync_wrapper_opt_in_flags` 도입 (macOS 경로 회귀의 출처)
- PRD #780 — 1Password 통합 (`1password`/`1password-cli` cask 유지 근거)

## Human Test Plan

1. **Homebrew — 대용량 cask 재다운로드 소멸**
   - 본 브랜치 적용 후 `nrs` 실행.
   - 기대: `Homebrew bundle` 단계에서 `Fetching docker-desktop, 1password` 같은 대용량 fetch가 사라지고 빠르게 통과.
   - 실패 시: activation 로그의 `Fetching ...` 라인과 `brew bundle --file=<store Brewfile>` 출력으로 greedy 대상 점검.

2. **Homebrew — Docker.app 보존**
   - nrs 완료 후 `/Applications/Docker.app` 존재 확인.
   - 기대: `cleanup = "none"`이므로 삭제되지 않고 유지.

3. **codex-sync 테스트 — macOS 통과**
   - macOS에서 `bash tests/shell-script-tests.sh`의 `codex-sync wrapper opt-in flags` 케이스 확인.
   - 기대: `<project_root>` 경로 assert 통과 (이전: `/private` 접두 불일치로 실패).
   - 주의: 이 머신은 현재 `python3`가 mise shim이라 mise 환경이 불안정하면 테스트가 mise 에러로 중단될 수 있다(테스트 수정과 무관한 환경 이슈).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Homebrew cask management documentation with clarified upgrade policies for casks featuring auto-update support.
  * Revised configuration examples and removed Docker Desktop from the managed casks list.

* **Chores**
  * Updated Homebrew cask configuration and test reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->