### PR TITLE
feat(ssh): 1Password agent 다운 시 minipc SSH 회귀 예방

### DIFF
--- a/.claude/skills/managing-ssh/SKILL.md
+++ b/.claude/skills/managing-ssh/SKILL.md
@@ -20,9 +20,14 @@ sudo에서 SSH_AUTH_SOCK 유실
 - `sudo` 실행 시 환경변수가 초기화되어 SSH 키 인증 실패
 - 해결: `sudo -E` 또는 sudoers에서 `SSH_AUTH_SOCK` 유지 설정
 
-재부팅 후 SSH 키 미로드
+재부팅 후 SSH 키 미로드 (NixOS/GitHub 맥락)
 - launchd agent로 자동 로드 설정되어 있지만 실패할 수 있음
 - 수동 로드: `ssh-add $HOME/.ssh/id_ed25519`
+
+macOS에서 `ssh minipc` preflight 차단 (1Password agent)
+- Phase 2a 후 macOS SSH는 1Password agent(mac-ssh)로 인증 — 로컬 id_ed25519는 archive됨
+- 1Password 데스크탑 미실행/잠금 시 `ssh()` preflight가 안내·자동 기동·최대 15초 대기
+- 해결: 1Password 잠금 해제. 즉시 접속은 `ssh minipc-emergency` (passphrase). 상세: references/troubleshooting.md
 
 NixOS에서 SSH 키 자동 로드 방식 혼동
 - NixOS는 launchd가 아니라 `services.ssh-agent` + `programs.keychain`으로 키 로드

--- a/.claude/skills/managing-ssh/references/troubleshooting.md
+++ b/.claude/skills/managing-ssh/references/troubleshooting.md
@@ -6,6 +6,7 @@
 
 > 발생 시점: 2026-01-15
 > 해결: launchd agent + nrs 자동 로드
+> Phase 2a(#833) 이후 갱신: macOS SSH 인증은 1Password SSH agent(IdentityAgent)로 전환되었고, 아래의 `ssh-add-keys` launchd agent와 로컬 `~/.ssh/id_ed25519`는 제거(archive)되었다. 현재 SSH 키는 1Password가 제공하며, 로그인 시 자동 기동(`launchd.agents.onepassword-autostart`)으로 agent socket 생존을 보장한다. 아래 내용은 전환 전 이력으로 남겨둔다.
 
 증상: 재부팅 후 `nrs` 또는 `darwin-rebuild switch` 실행 시 GitHub SSH fetch 실패.
 
@@ -63,6 +64,42 @@ cat ~/Library/Logs/ssh-add-keys.log
 macOS의 `AddKeysToAgent yes` 설정은 SSH를 처음 사용할 때 키를 agent에 로드합니다. 재부팅 후 바로 SSH 작업을 하면 키가 로드되지 않은 상태일 수 있습니다.
 
 > 참고: SSH 키 자동 로드는 launchd agent에서 처리됩니다.
+
+---
+
+### Mac에서 `ssh minipc`가 1Password preflight로 차단됨
+
+> 발생 맥락: 1Password SSH agent 전환(Phase 2a) 후속
+
+증상: `ssh minipc` 실행 시 아래 안내가 뜨고 접속이 지연/차단됨.
+
+```text
+⚠️  ssh minipc 차단: 1Password SSH agent에 mac-ssh 키가 없습니다.
+   원인: 1Password 데스크탑이 미실행/잠금 상태 → mac-ssh 키 미제공.
+```
+
+원인: macOS의 minipc 인증은 1Password agent의 `mac-ssh` 키에 의존한다(구 로컬 `id_ed25519`는 서버 authorized_keys에서 제거됨). 1Password 데스크탑이 미실행/잠금이면 agent가 키를 제공하지 못해, ssh가 구 키로 폴백하다 `Permission denied (publickey)`로 차단된다.
+
+shell의 `ssh()` preflight 래퍼(`modules/shared/programs/shell/darwin.nix`)가 `ssh -G`의 effective IdentityAgent로 minipc를 식별해 원인·복구를 안내하고, 1Password를 자동 기동한 뒤 agent 복구를 최대 15초 대기한다.
+
+해결:
+
+1. 1Password 데스크탑을 Touch ID/마스터 비밀번호로 잠금 해제 (Settings → Developer → "Use the SSH agent" 확인)
+2. 평시엔 로그인 자동 기동(`launchd.agents.onepassword-autostart`)이 socket을 살려두므로, 이 상황은 1Password를 수동 종료(quit)했거나 크래시한 경우에만 발생한다.
+
+즉시 접속이 필요하면 1Password와 무관한 emergency 경로를 쓴다:
+
+```bash
+# IdentityAgent=none, ~/.ssh/emergency_ed25519 사용 (passphrase 직접 입력)
+ssh minipc-emergency
+```
+
+확인:
+
+```bash
+# 1Password agent에 mac-ssh 키가 보이는지
+SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" ssh-add -L | grep mac-ssh
+```
 
 ---
 

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -162,8 +162,8 @@
   };
 
   # ═══════════════════════════════════════════════════════════════
-  # 1Password vault 이름 (단일 소스)
-  # GUI에서 동일 이름으로 vault를 생성해야 op CLI가 조회 가능
+  # 1Password 설정 (단일 소스): account, vault 이름, SSH agent socket, autostart 인자
+  # vault는 GUI에서 동일 이름으로 생성해야 op CLI가 조회 가능
   # ═══════════════════════════════════════════════════════════════
   onePassword = {
     # op CLI 멀티 계정(개인+회사) 환경에서 Automation vault가 속한 개인 account 고정.
@@ -175,6 +175,21 @@
       automation = "Automation"; # LLM·자동화·시스템 토큰 (SSH 키는 ssh vault로 분리)
       ssh = "SSH"; # 디바이스 SSH key(mac-ssh/emergency-ssh) 전용 — SA token blast radius에서 격리
     };
+    # 1Password macOS SSH agent socket — home 기준 상대 경로 (단일 소스).
+    # nix: "${homeDir}/${agentSocketRelPath}", shell: "$HOME/${agentSocketRelPath}".
+    # ~/.1password/agent.sock symlink는 자동생성되지 않아 group container 경로를 직접 쓴다.
+    # 사용처: ssh IdentityAgent(modules/darwin/programs/ssh) + ssh() preflight(shell/darwin.nix).
+    agentSocketRelPath = "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+    # 1Password 백그라운드 기동 인자 (단일 소스). -g 포커스 유지, -j hidden, --silent 메인창 억제.
+    # launchd 자동 기동은 [ "/usr/bin/open" ] ++ openArgs (절대경로), shell preflight 복구는
+    # `open ${escapeShellArgs openArgs}`로 공유한다 — flag 변경 시 한 곳만 고친다.
+    openArgs = [
+      "-gj"
+      "-a"
+      "1Password"
+      "--args"
+      "--silent"
+    ];
   };
 
   # ═══════════════════════════════════════════════════════════════

--- a/modules/darwin/programs/ssh/default.nix
+++ b/modules/darwin/programs/ssh/default.nix
@@ -7,8 +7,8 @@
 }:
 let
   homeDir = config.home.homeDirectory;
-  # 1Password macOS SSH agent socket (group container 경로 — ~/.1password/agent.sock symlink는 자동생성 안 됨)
-  onePasswordAgentSock = "${homeDir}/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+  # 1Password macOS SSH agent socket (단일 소스: constants.onePassword.agentSocketRelPath)
+  onePasswordAgentSock = "${homeDir}/${constants.onePassword.agentSocketRelPath}";
 in
 {
   # Mac SSH는 1Password SSH agent로 인증 (PRD #780 Phase 2a).
@@ -31,7 +31,11 @@ in
       "minipc" = {
         hostname = constants.network.minipcTailscaleIP;
         user = "greenhead";
+        # mac-ssh 공개키로 고정 + IdentitiesOnly — agent의 mac-ssh 키만 제시한다.
+        # 구 id_rsa/id_ecdsa 등 무차별 키 시도(서버 로그 오염·MaxAuthTries lockout 위험)를 차단한다.
+        identityFile = "${homeDir}/.ssh/mac-ssh.pub";
         extraOptions = {
+          IdentitiesOnly = "yes";
           ControlMaster = "auto";
           ControlPath = "~/.ssh/cm-%h-%p-%r";
           # ControlPersist 600 유지 — #710 analyzing-da-sessions의 ControlMaster 다중화(K=8 worker pool)가 의존.
@@ -46,6 +50,7 @@ in
         identityFile = "${homeDir}/.ssh/emergency_ed25519";
         extraOptions = {
           IdentityAgent = "none"; # 1Password agent 우회 — emergency key 직접 사용
+          IdentitiesOnly = "yes"; # emergency_ed25519만 제시
         };
       };
     };
@@ -60,4 +65,27 @@ in
     [[ssh-keys]]
     vault = "${constants.onePassword.vaults.ssh}"
   '';
+
+  # minipc IdentityFile 고정용 mac-ssh 공개키 (개인키는 1Password agent 보관).
+  # IdentitiesOnly=yes와 함께 agent의 mac-ssh 키만 제시하게 한다(무차별 키 시도 차단).
+  home.file.".ssh/mac-ssh.pub".text = "${constants.sshDeviceKeys.macSsh}\n";
+
+  # 1Password 로그인 자동 기동 (minipc SSH 회귀 예방, PRD #780 Phase 2a 후속)
+  # 근본 원인: Mac SSH 인증을 1Password agent(mac-ssh)로 이관(FR-8)한 뒤, 1Password 데스크탑이
+  # 미실행/quit이면 agent socket이 죽어 mac-ssh 키를 제공하지 못한다. 그러면 ssh가 구 로컬 키로
+  # 폴백 → 서버에서 퇴출된 키라 "Permission denied (publickey)"로 전면 차단된다.
+  # 로그인 시 1Password를 백그라운드(-g 포커스 유지, -j hidden, --silent 메인창 억제)로 기동해
+  # agent socket 생존을 보장한다(잠금은 ssh 시 Touch ID 프롬프트로 해제). open은 멱등이라 이미
+  # 실행 중이면 무해. 미설치/실패는 non-fatal(로그만). 수동 quit 등 잔여 케이스는 shell의 ssh
+  # preflight 래퍼(modules/shared/programs/shell/darwin.nix)가 안전망으로 처리한다.
+  launchd.agents.onepassword-autostart = lib.mkIf (hostType == "personal") {
+    enable = true;
+    config = {
+      # 절대경로 open + 공유 기동 인자 (단일 소스: constants.onePassword.openArgs)
+      ProgramArguments = [ "/usr/bin/open" ] ++ constants.onePassword.openArgs;
+      RunAtLoad = true; # 로그인(agent 로드) 시 1회 — KeepAlive 불필요(open은 즉시 종료)
+      StandardOutPath = "${homeDir}/Library/Logs/onepassword-autostart.log";
+      StandardErrorPath = "${homeDir}/Library/Logs/onepassword-autostart.log";
+    };
+  };
 }

--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -4,6 +4,7 @@
   pkgs,
   lib,
   constants,
+  hostType,
   ...
 }:
 
@@ -53,6 +54,12 @@ let
     fi
     exec ${pkgs.gh}/bin/gh "$@"
   '';
+
+  # ssh() preflight 단일 소스 주입 (constants 기반 — socket/키/기동인자 중복 제거)
+  opAgentSock = "$HOME/${constants.onePassword.agentSocketRelPath}"; # zsh가 런타임에 $HOME 확장
+  macSshKeyB64 = lib.elemAt (lib.splitString " " constants.sshDeviceKeys.macSsh) 1; # 공개키 가운데 base64 (nix가 split)
+  opLaunchCmd = "/usr/bin/open ${lib.escapeShellArgs constants.onePassword.openArgs}"; # 1Password 백그라운드 기동(절대경로)
+  minipcHostIP = constants.network.minipcTailscaleIP; # ssh -G effective hostname 판정 기준
 in
 {
   # macOS용 스크립트 설치
@@ -142,6 +149,59 @@ in
       # sqlite3 등이 시스템 바이너리를 shadow한다. append로 우회.
       [ -d "$ANDROID_HOME/platform-tools" ] && export PATH="$PATH:$ANDROID_HOME/platform-tools"
     ''
+
+    # ════════════════════════════════════════════════════════════════
+    # ssh minipc preflight (1Password agent 안전망, PRD #780 Phase 2a 후속)
+    # minipc 인증은 1Password agent의 mac-ssh 키에 의존한다(구 로컬 id_ed25519는 서버에서 퇴출).
+    # 1Password가 미실행/잠금이면 agent가 mac-ssh를 못 줘 ssh가 구 키로 폴백→Permission denied가
+    # 난다. 그 순간 원인·복구를 안내하고 1Password를 자동 기동한 뒤 agent 복구를 짧게 대기한다.
+    # 평시엔 launchd 자동 기동(modules/darwin/programs/ssh)이 socket을 살려두므로 이 경로는
+    # 수동 quit/크래시 등 잔여 케이스 전용이다. interactive 셸 전용(non-interactive 자동화는
+    # 이 맥락을 아는 호출자가 쓰고, GUI open 팝업이 부적절하므로 raw ssh로 통과).
+    # personal 전용 — minipc matchBlock/launchd와 스코프 일치(work Mac은 Tailnet 미소속이라 무관).
+    # 대상 판정은 전부 `ssh -G "$@"`에 위임한다 — 수동 옵션 파싱은 ssh의 방대한 옵션 공간(메타모드·
+    # user@host·-W·포트·alias·remote command)을 못 따라가 미탐·오탐이 난다. ssh -G는 -O/-W/-G 등과도
+    # 충돌 없이 effective config를 출력한다(실측). preflight는 effective IdentityAgent가 1Password
+    # socket과 정확히 일치할 때만 — none(emergency)·빈값·다른 agent 명시·타호스트는 raw ssh로 통과한다.
+    # 활성 ControlMaster면 통과(multiplex/worker pool 재사용 보존)하되, "$@"를 -O check에 직접 넘기면
+    # -W/-O와 충돌하므로 effective ControlPath만 -S로 쓴다. 키 매칭은 macSsh base64(단일 소스, nix split).
+    # ════════════════════════════════════════════════════════════════
+    (lib.optionalString (hostType == "personal") ''
+      ssh() {
+        local _cfg _host _ident _cpath
+        _cfg=$(command ssh -G "$@" 2>/dev/null)
+        _host=$(print -r -- "$_cfg" | awk 'tolower($1)=="hostname"{print $2; exit}')
+        # IdentityAgent 전체 값(공백 포함 경로)을 추출해 1Password socket과 정확 비교한다.
+        _ident=$(print -r -- "$_cfg" | awk 'tolower($1)=="identityagent"{sub(/^[^ ]+[ ]+/, ""); print; exit}')
+        if [[ "$_host" == "${minipcHostIP}" && "$_ident" == "${opAgentSock}" ]]; then
+          # 현재 호출의 effective ControlPath에 활성 master가 있으면 새 인증 불필요 → 통과.
+          # 사용자 "$@"를 -O check에 직접 넘기면 -W/-O와 충돌하므로 effective ControlPath만 -S로 쓴다.
+          _cpath=$(print -r -- "$_cfg" | awk 'tolower($1)=="controlpath"{sub(/^[^ ]+[ ]+/, ""); print; exit}')
+          local _sock="${opAgentSock}" _b64="${macSshKeyB64}"
+          if { [[ -z "$_cpath" || "$_cpath" == none ]] || ! command ssh -O check -S "$_cpath" "${minipcHostIP}" 2>/dev/null; } \
+            && ! SSH_AUTH_SOCK="$_sock" ssh-add -L 2>/dev/null | grep -qF "$_b64"; then
+            # Touch ID 잠금 해제 대기 상한(초) — interactive shell을 오래 막지 않도록. tries = timeout / interval.
+            local _poll_interval=0.5 _timeout_seconds=15
+            local _max_tries=$(( _timeout_seconds / _poll_interval ))
+            print -u2 "⚠️  ssh minipc 차단: 1Password SSH agent에 mac-ssh 키가 없습니다."
+            print -u2 "   원인: 1Password 데스크탑이 미실행/잠금 상태 → mac-ssh 키 미제공."
+            print -u2 "   조치: 1Password를 기동합니다 — Touch ID로 잠금 해제하세요."
+            print -u2 "   대안: 즉시 접속이 필요하면  ssh minipc-emergency  (passphrase 직접 입력)."
+            ${opLaunchCmd} 2>/dev/null
+            local _i=0
+            while ! SSH_AUTH_SOCK="$_sock" ssh-add -L 2>/dev/null | grep -qF "$_b64"; do
+              if (( ++_i > _max_tries )); then
+                print -u2 "   ✗ agent 복구 대기 초과(''${_timeout_seconds}s). 잠금 해제 후 재시도하거나 ssh minipc-emergency 사용."
+                return 1
+              fi
+              sleep $_poll_interval
+            done
+            print -u2 "   ✓ agent 복구됨 — 접속합니다."
+          fi
+        fi
+        command ssh "$@"
+      }
+    '')
 
     # ════════════════════════════════════════════════════════════════
     # #872(+후속): 무인 에이전트 gh 인증 (Mac 전용, 방식 B — SA token → github-pat 캐시)


### PR DESCRIPTION
## Summary

- macOS에서 1Password SSH agent가 미실행/잠금일 때 `ssh minipc`가 `Permission denied (publickey)`로 차단되던 회귀를 예방한다.
- 로그인 시 1Password를 백그라운드 자동 기동(launchd)해 agent socket 생존을 보장하고, `ssh()` preflight 래퍼가 agent 부재 시 원인·복구를 안내한 뒤 자동 기동·복구 대기한다.
- minipc/emergency 인증 키를 고정(`IdentitiesOnly`)하고 1Password 설정 상수를 단일 소스화한다.

## 기존 문제 / 배경

Phase 2a에서 macOS SSH 인증을 로컬 `~/.ssh/id_ed25519` 파일에서 1Password SSH agent의 `mac-ssh` 키로 이관하고, 구 키를 MiniPC `authorized_keys`에서 제거했다. 이후 `ssh minipc`는 1Password 데스크탑이 실행 중일 때만 동작한다.

1Password가 종료(재부팅·수동 quit·크래시)되면 agent socket이 죽어 `mac-ssh` 키를 제공하지 못한다. 그러면 ssh가 남아 있는 구 로컬 키로 폴백하는데, 그 키는 서버에서 이미 퇴출됐으므로 인증이 전면 차단된다. 실제로 이 증상이 발생했고, 원인이 키 손상이 아니라 **단일 의존(1Password 데스크탑) 실패**임이 진단됐다. Phase 2a가 이 위험을 대비해 도입한 emergency 키 경로가 정확히 이 상황을 위한 fallback이다.

## CIR (Change Intent Record)

- **발견 경위**: `ssh minipc` 접속 실패를 진단하던 중, 클라이언트가 제시하는 키가 서버에서 퇴출된 구 키이고, 1Password 데스크탑 미실행으로 agent socket이 죽어 `mac-ssh`를 제공하지 못한 것이 근본 원인임을 확인했다.
- **설계 의도(이중 방어)**: (a) 예방 — 로그인 시 1Password를 백그라운드 자동 기동해 socket을 항상 살려둔다. (b) 안전망 — 그럼에도 수동 quit/크래시로 죽으면 `ssh()` preflight가 원인·복구를 안내하고 1Password를 자동 기동한 뒤 agent 복구를 짧게 대기한다.
- **대상 판정의 진화**: 처음엔 수동으로 ssh 옵션을 파싱해 minipc를 식별하려 했으나, ssh의 방대한 옵션 공간(메타모드·`user@host`·`-W`·포트·config alias·remote command)을 추적하지 못해 미탐/오탐이 반복됐다. 최종적으로 `ssh -G "$@"`의 effective hostname/IdentityAgent에 판정을 전부 위임해 정확성과 단순성을 동시에 얻었다.
- **안전 경계**: 같은 Tailscale IP를 쓰는 emergency 경로(`IdentityAgent=none`)는 1Password 우회 fallback이므로 preflight에서 제외하고, effective IdentityAgent가 1Password socket과 정확히 일치할 때만 개입한다. 활성 ControlMaster가 있으면 새 인증 없이 통과해 multiplex/worker pool 재사용을 막지 않는다.
- **스코프**: minipc 접속은 personal Mac 전용이므로 launchd 자동 기동과 `ssh()` 래퍼 모두 `personal` hostType에 한정했다.

이 변경은 단일 의존 실패에 대한 진단·예방·안전망·문서화를 함께 다루며, 외부 에이전트 기반의 설계 리뷰와 병렬 전수 회귀 조사를 거쳐 다듬어졌다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 수동 ssh 옵션 파싱 | argv를 순회해 값 소비 옵션을 건너뛰고 destination을 추출 | 외부 호출 없음 | OpenSSH 옵션 전체를 추적 불가 → 미탐/오탐, 유지보수 부담 | ❌ |
| `ssh -G` effective 판정 | `ssh -G "$@"`로 effective hostname/identityagent에 판정 위임 | ssh 자신이 모든 옵션을 해석 → 정확·단순 | 매 호출 `ssh -G` 1회 오버헤드(경미) | ✅ |
| IdentityAgent `!= none` 체크 | identityagent가 none이 아니면 1Password로 간주 | 간단 | 빈값·다른 agent 명시를 오판 | ❌ |
| IdentityAgent 정확 매칭 | effective IdentityAgent가 1Password socket과 정확히 일치할 때만 | 다른 agent/빈값/emergency를 정확히 제외 | — | ✅ |
| `-O check "$@"` | 현재 호출 인자 그대로 master를 확인 | 호출별 설정 반영 | 사용자 `-O`/`-W`와 충돌 | ❌ |
| `-O check -S <effective ControlPath>` | effective ControlPath만 `-S`로 지정 | 충돌 없이 호출별 master 확인 | — | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `libraries/constants.nix` | `onePassword`에 `agentSocketRelPath`/`openArgs` 단일 소스 추가, 섹션 헤더를 실제 범위로 확장 |
| `modules/darwin/programs/ssh/default.nix` | `launchd.agents.onepassword-autostart` 자동 기동, minipc/emergency `IdentitiesOnly` + `mac-ssh.pub` 고정, socket/open 인자를 constants 참조 |
| `modules/shared/programs/shell/darwin.nix` | `ssh()` preflight 래퍼(`ssh -G` 판정 + IdentityAgent 정확 매칭 + ControlPath sanitize, personal 전용) |
| `.claude/skills/managing-ssh/*` | 1Password agent 전환·preflight·emergency 경로 문서화 |

핵심 판정 로직:

```zsh
_cfg=$(command ssh -G "$@" 2>/dev/null)
_host=$(... hostname ...);  _ident=$(... identityagent ...)
if [[ "$_host" == "<minipc Tailscale IP>" && "$_ident" == "<1Password agent socket>" ]]; then
  # effective ControlPath의 master가 없고, agent에 mac-ssh 키도 없으면 안내·자동기동·복구대기
fi
command ssh "$@"
```

## 참고 레퍼런스

- PRD #780 / PR #833 — Phase 2a Mac SSH (1Password agent 이관, emergency fallback, 디바이스 키 등록)
- PR #874 — SSH 전용 vault 분리

## Human Test Plan

1. **적용**: `nrs`로 빌드·적용한다. 기대: 빌드 성공, `~/.ssh/config`의 `minipc`에 `IdentitiesOnly yes` + `IdentityFile ~/.ssh/mac-ssh.pub`, `~/.ssh/mac-ssh.pub` 생성, `launchd.agents.onepassword-autostart` 등록.
2. **자동 기동**: 재로그인(또는 `launchctl kickstart`로 onepassword-autostart 실행). 기대: 1Password가 백그라운드(메뉴바)로 기동, agent socket 생존.
3. **정상 경로**: 1Password 잠금 해제 상태에서 `ssh minipc`. 기대: 바로 접속.
4. **회귀 시나리오**: 1Password를 완전 종료(Quit) → `ssh minipc`. 기대: preflight 안내가 뜨고 1Password가 자동 기동, 잠금 해제 시 접속. 잠금을 안 하면 약 15초 후 emergency 안내 출력.
5. **emergency 경로**: `ssh minipc-emergency`. 기대: passphrase 입력 후 접속(1Password 무관).
6. **특수 호출 비간섭**: `ssh -G minipc`(config dump), `ssh github.com`, `ssh -W localhost:22 minipc`, `ssh minipc-emergency`가 불필요한 preflight 없이 정상 동작.

실패 시 진단:

```bash
# agent에 mac-ssh 키가 보이는지
SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" ssh-add -L | grep mac-ssh
# ssh가 해석한 effective IdentityAgent / hostname 확인
ssh -G minipc | grep -E '^(hostname|identityagent) '
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded SSH troubleshooting guides for macOS, including detailed recovery procedures for authentication issues and emergency access options.

* **New Features**
  * Added automatic SSH authentication recovery mechanism that restarts SSH services when they become unavailable on macOS systems.

* **Improvements**
  * Enhanced SSH agent configuration for better reliability and security on macOS personal systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->