### PR TITLE
docs(claude/statusline): bats 주석의 제거된 CACHE_TTL_DIR 참조 정리

### DIFF
--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -320,11 +320,11 @@ EOF
 )
   # HOME override 로 lib 의 SESSION_STATE_DIR (=\$HOME/.claude/status-icons) 와
   # statusline.sh 의 transcript canonical 경계(\$HOME/.claude/projects) 를 fake HOME
-  # 으로 redirect. statusline.sh 는 HEAVY_CACHE_DIR 와 CACHE_TTL_DIR 에서 XDG_*
-  # 변수를 직접 참조하므로(`${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-\$HOME/.local/state}/...}`,
-  # `${XDG_DATA_HOME:-\$HOME/.local/share}/...`), 부모 shell 의 XDG_* 가 set 이면
-  # 실제 시스템 경로로 leak 되어 테스트 부산물이 host 에 남고 다음 run 의 cached
-  # vars 가 오염될 수 있다. 4 개 모두 fake_home 하위로 pin.
+  # 으로 redirect. statusline.sh 는 HEAVY_CACHE_DIR 에서 XDG_* 변수를 직접
+  # 참조하므로(`${XDG_RUNTIME_DIR:-${XDG_STATE_HOME:-\$HOME/.local/state}/...}`),
+  # 부모 shell 의 XDG_* 가 set 이면 실제 시스템 경로로 leak 되어 테스트 부산물이
+  # host 에 남고 다음 run 의 cached vars 가 오염될 수 있다. 관련 XDG_* 를 모두
+  # fake_home 하위로 pin.
   run run_statusline_with_input "$stdin_json" \
     HOME="$fake_home" \
     XDG_CONFIG_HOME="$fake_home/.config" \
@@ -558,7 +558,7 @@ EOF
 }
 
 # plan fixture 실행 helper: HOME + XDG_* 를 모두 PLAN_HOME 하위로 pin 한다.
-# statusline.sh 는 HEAVY_CACHE_DIR/CACHE_TTL_DIR 에서 XDG_* 를 직접 참조하므로
+# statusline.sh 는 HEAVY_CACHE_DIR 에서 XDG_* 를 직접 참조하므로
 # (sidecar test 와 동일 사유), HOME 만 override 하면 부모 shell 의 XDG_* 가 set 일 때
 # heavy/cache 파일이 실제 시스템 경로로 leak 되어 호스트를 오염시키고 다음 run 의
 # cached vars 가 stale 해져 비결정적이 된다. PLAN_HOME 은 BATS_TEST_TMPDIR 하위라


### PR DESCRIPTION
## Summary
- Cache TTL 기능 제거(#891) 후 `statusline.bats` 의 XDG 격리 주석 2곳이 참조하던, 더 이상 존재하지 않는 `CACHE_TTL_DIR` 를 `HEAVY_CACHE_DIR` 기준으로 정정. 주석만 변경(동작 영향 없음).

## 배경
#891 에서 Cache TTL/캐시 히트율 기능과 관련 hook 이 제거되며 `CACHE_TTL_DIR`(`XDG_DATA_HOME` 기반 last-stop) 경로가 사라졌으나, 테스트의 XDG 격리 설명 주석은 이를 계속 참조하고 있었다.

## CIR / ADR
해당 없음 — 단순 주석 정정.

## Human Test
- `bats statusline.bats` 25/25 통과(주석만 변경이라 동작 영향 없음).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated inline test comments to clarify environment variable handling in test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->