### PR TITLE
fix(vscode): GitLens pre-release 만료로 git blame이 잠기던 회귀 수정

### DIFF
--- a/modules/darwin/programs/vscode/default.nix
+++ b/modules/darwin/programs/vscode/default.nix
@@ -140,7 +140,12 @@ in
           aaron-bond.better-comments
 
           # Git
-          eamodio.gitlens
+          # GitLens는 release(-release) variant로 고정한다. open-vsx/marketplace의 latest는
+          # 날짜 버전(예: 2026.5.171822) pre-release를 가리키는데, pre-release 빌드는 만료
+          # 기한이 내장되어 만료 시 current-line blame 등 전 기능이 잠기고 만료 팝업이
+          # VSCode 재시작마다 반복된다. -release는 pre-release를 제외한 정식 릴리스(17.x)를
+          # 받으므로 만료 회귀가 없다. (무료 범위: current line blame/hover/status bar blame.)
+          pkgs.open-vsx-release.eamodio.gitlens
           github.vscode-pull-request-github
 
           # 언어


### PR DESCRIPTION
## 1. Summary

- VSCode GitLens 확장을 `pkgs.open-vsx.eamodio.gitlens`(latest = pre-release) → `pkgs.open-vsx-release.eamodio.gitlens`(정식 릴리스 17.x)로 고정한다.
- pre-release 빌드에 내장된 만료 기한 때문에 inline git blame을 포함한 전 기능이 잠기고, "pre-release version has expired" 팝업이 VSCode 재시작마다 반복되던 회귀를 차단한다.
- 직접 추적 이슈 없음 (사용자가 사용 중 발견·보고한 회귀 버그).

## 2. 기존 문제 / 배경

`nix-vscode-extensions` overlay의 `open-vsx`/`vscode-marketplace` attribute는 해당 확장의 **latest** 버전을 가리킨다. GitLens(eamodio)는 정식 릴리스(semver `17.x`)와 별개로 날짜 형식 버전(예: `2026.5.171822`)의 **pre-release 빌드**를 publish하는데, 이 pre-release가 latest로 잡혀 설치됐다.

GitLens pre-release 빌드는 **만료 기한이 내장**되어 있어, 만료일이 지나면:

- inline git blame(current line blame) 등 확장 기능 전체가 잠긴다 — 본 환경에서 GitLens를 쓰는 유일한 목적이 line-by-line inline blame이라 사실상 확장이 무력화됐다.
- "This pre-release version (2026.5.171822) of GitLens has expired" 알림이 뜨고, Upgrade/Switch to Release 어떤 버튼을 눌러도 GUI 설치가 막혀 있어(`mutableExtensionsDir = false`) 변화가 없으며, VSCode 재시작마다 팝업이 다시 표시됐다.

## 3. CIR (Change Intent Record)

- 발견 경위: 사용자가 (1) marketplace 검색에서 GitLens가 2개로 중복 표시, (2) pre-release 만료 팝업 반복, (3) inline git blame 미동작 세 증상을 보고. 가장 심각한 것은 blame 미동작이었다.
- 진단: 설치된 버전 `2026.5.171822`가 날짜 기반 = pre-release임을 확인. `nix-vscode-extensions`의 소스별 버전을 평가한 결과 `open-vsx`/`vscode-marketplace`(latest)는 pre-release를, `open-vsx-release`/`vscode-marketplace-release`는 정식 릴리스 `17.12.2`를 가리켰다.
- 무료 범위 확인: 사용자는 GitLens 유료 기능을 쓰지 않고 inline blame만 사용한다. current line blame / hover / status bar blame은 GitLens 정식 릴리스에서 무료 제공되므로, release 고정으로 요구 기능을 그대로 충족한다.
- 중복 표시(cosmetic)는 별도 원인으로 확인 — 이번 PR 범위 밖. 아래 별도 섹션에 기록.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `open-vsx` latest 유지 | 현행 | 변경 없음 | pre-release 만료 회귀 재발 | ❌ |
| `open-vsx-release` 고정 | open-vsx의 정식 릴리스만 | pre-release 제외 → 만료 없음, 프로젝트 "open-vsx 우선" 정책 일치 | latest 대비 한 단계 보수적 버전 | ✅ |
| `vscode-marketplace-release` 고정 | marketplace 정식 릴리스 | 동일하게 만료 없음 | 빌드 결과가 `open-vsx-release`와 동일 store path로 귀결(검증함) → open-vsx 우선 정책상 불필요 | ❌ |
| 다른 blame 확장으로 교체 | GitLens 제거 | 만료 이슈 원천 차단 | 사용자가 이미 GitLens에 익숙, 학습 비용 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/darwin/programs/vscode/default.nix` | `open-vsx` 블록의 `eamodio.gitlens` 한 줄을 `pkgs.open-vsx-release.eamodio.gitlens`로 교체 + 이유 주석 |

```nix
# Git
# GitLens는 release(-release) variant로 고정한다. open-vsx/marketplace의 latest는
# 날짜 버전(예: 2026.5.171822) pre-release를 가리키는데, pre-release 빌드는 만료
# 기한이 내장되어 만료 시 current-line blame 등 전 기능이 잠기고 만료 팝업이
# VSCode 재시작마다 반복된다. -release는 pre-release를 제외한 정식 릴리스(17.x)를
# 받으므로 만료 회귀가 없다. (무료 범위: current line blame/hover/status bar blame.)
pkgs.open-vsx-release.eamodio.gitlens
```

### 부수 확인: marketplace 검색 중복 표시 (이번 PR 범위 밖, cosmetic)

설치된 GitLens의 `identifier.uuid`/`metadata.id`/`publisherId`가 모두 빈 값이라, VSCode 갤러리(Microsoft marketplace) 검색 결과의 GitLens(진짜 UUID 보유)와 설치본을 동일 항목으로 합치지 못해 검색에서 2개로 표시된다. `nix-vscode-extensions`가 만든 확장에 marketplace UUID 메타데이터가 포함되지 않는 구조적 한계로, 소스 variant 변경으로는 해결되지 않음(두 release variant가 동일 store path로 빌드됨을 확인). 기능에는 영향 없으며 `@installed gitlens` 필터 시 1개로 표시된다. 근본 해결은 갤러리를 open-vsx로 바꾸는 product.json override가 필요하나 marketplace 전용 확장 검색을 막는 트레이드오프가 커 채택하지 않음.

## 6. 참고 레퍼런스

- VSCode 마이그레이션(Cursor → VSCode): PR #181 (GitLens 확장 최초 도입)
- `nix-vscode-extensions`: https://github.com/nix-community/nix-vscode-extensions — `*-release` attribute가 pre-release를 제외함
- GitLens: current line blame은 무료(Community) 기능

## 7. Human Test Plan

1. `nrs` 실행 후 VSCode를 완전 종료(`Cmd+Q`)하고 재시작한다.
   - 기대: 확장 GitLens 버전이 `17.x`(정식 릴리스)로 설치됨. `ls -la ~/.vscode/extensions/eamodio.gitlens`가 `...gitlens-17.x.x` store path를 가리킴.
2. 임의의 git 추적 파일을 열고 한 줄에 커서를 둔다.
   - 기대: 줄 끝에 inline git blame(작성자·시간·커밋 메시지)이 표시된다.
   - 실패 시: `gitlens.currentLine.enabled`가 false로 꺼져 있지 않은지 settings.json 확인.
3. VSCode를 재시작한다.
   - 기대: "pre-release version has expired" 팝업이 더 이상 표시되지 않는다.
   - 실패 시: 설치 버전이 여전히 날짜 형식(pre-release)인지 확인 — `extensions.json`의 GitLens version 필드 점검.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GitLens extension configuration to use the stable release version instead of pre-release, preventing potential feature lockouts and version expiry issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->