### PR TITLE
perf(zsh): 셸 startup 최적화 — 이중 compinit + 사문 promptinit 제거

### DIFF
--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -128,7 +128,8 @@ in
   #   (1) 이중 compinit: 시스템 /etc/zshrc의 compinit + 사용자 ~/.zshrc(home-manager)의 compinit이
   #       셸당 둘 다 실행되어, 두 compinit이 같은 ~/.zcompdump를 두고 매 셸 콜드 재빌드(fpath 전수
   #       감사)를 반복했다. 이게 startup의 지배적 비용이었다.
-  #   (2) prompt suse: promptinit 테마는 Starship이 PROMPT/precmd를 전부 덮어써 100% 사문(dead work).
+  #   (2) prompt suse(= nix-darwin programs.zsh.promptInit 기본 테마): Starship이 PROMPT/precmd를
+  #       전부 덮어써 100% 사문(dead work).
   # enableGlobalCompInit=false: 시스템 compinit을 제거해 사용자 compinit(home-manager 기본 full
   #   compinit)을 단일 정본으로 만든다. 이중→단일로 콜드 재빌드 반복이 사라지고, 단일 compinit은
   #   ~/.zcompdump가 신선하면 로드만(재빌드 안 함)·fpath 변경 시 자동 재빌드하며 compaudit(보안감사)도
@@ -136,8 +137,11 @@ in
   #   (사용자 .zshrc가 fpath 구성 후 자체 compinit 실행).
   # promptInit="": Starship이 덮어쓰는 prompt suse 테마 로드를 제거(프롬프트 동작 불변).
   # Trade-off: 시스템 compinit 제거로, 사용자 ~/.zshrc를 source하지 않는 셸(sudo -i/su - root 등)은
-  #   completion이 미초기화된다(single-user macOS라 영향 낮음). enableBashCompletion(기본 true)은
-  #   유지 — nvm/bun completion의 bash `complete` 호환. 본 옵션은 darwin 전용(NixOS는 별도 호스트).
+  #   compinit이 0회 실행된다. 이때 유지된 시스템 bashcompinit(enableBashCompletion 기본 true)이
+  #   compinit 없이 남아, 그런 셸에서 시스템 레벨 `complete` 호출 시 compdef 미정의 에러가 날 수
+  #   있다(single-user macOS·root에 ~/.zshrc 부재라 실현 가능성은 낮음). enableBashCompletion을
+  #   유지하는 이유는 정상 사용자 세션의 nvm/bun completion(bash `complete`) 호환이다. 본 옵션은
+  #   darwin 전용(NixOS는 별도 호스트).
   programs.zsh.enableGlobalCompInit = false;
   programs.zsh.promptInit = "";
 

--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -122,6 +122,20 @@ in
   # zsh 활성화 (darwin-rebuild PATH 설정에 필수)
   programs.zsh.enable = true;
 
+  # 셸 startup 최적화 — nix-darwin /etc/zshrc가 매 인터랙티브 셸에 emit하는 중복/사문 작업 제거.
+  # === Change Intent Record ===
+  # 측정(고부하 darwin 호스트, min 지표)으로 다음 두 비용을 확인:
+  #   (1) 이중 compinit: /etc/zshrc의 시스템 compinit + 사용자 ~/.zshrc(home-manager)의 compinit이
+  #       셸당 각각 실행되어 compinit이 2회 돌고, 매 셸 zcompdump를 콜드 재빌드(fpath 전수 감사)했다.
+  #   (2) prompt suse: promptinit 테마(~32ms)는 Starship이 PROMPT/precmd를 전부 덮어써 100% 사문.
+  # enableGlobalCompInit=false: 시스템 compinit을 제거해 사용자 compinit을 단일 정본으로 만든다.
+  #   nix-darwin 옵션 doc이 "custom fpath + custom compinit을 두면 끄라"고 명시한 바로 그 케이스
+  #   (사용자 .zshrc가 fpath 구성 후 자체 compinit 실행). completion 동작은 사용자 compinit이 보존.
+  # promptInit="": Starship이 덮어쓰는 prompt suse 테마 로드를 제거(프롬프트 동작 불변).
+  # 사용자 compinit의 -C 캐싱 + nrs 시 zcompdump 무효화는 modules/shared/programs/shell/default.nix.
+  programs.zsh.enableGlobalCompInit = false;
+  programs.zsh.promptInit = "";
+
   # macOS 시스템 기본값
   system.defaults = {
     # Dock 설정

--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -124,15 +124,20 @@ in
 
   # 셸 startup 최적화 — nix-darwin /etc/zshrc가 매 인터랙티브 셸에 emit하는 중복/사문 작업 제거.
   # === Change Intent Record ===
-  # 측정(고부하 darwin 호스트, min 지표)으로 다음 두 비용을 확인:
-  #   (1) 이중 compinit: /etc/zshrc의 시스템 compinit + 사용자 ~/.zshrc(home-manager)의 compinit이
-  #       셸당 각각 실행되어 compinit이 2회 돌고, 매 셸 zcompdump를 콜드 재빌드(fpath 전수 감사)했다.
-  #   (2) prompt suse: promptinit 테마(~32ms)는 Starship이 PROMPT/precmd를 전부 덮어써 100% 사문.
-  # enableGlobalCompInit=false: 시스템 compinit을 제거해 사용자 compinit을 단일 정본으로 만든다.
-  #   nix-darwin 옵션 doc이 "custom fpath + custom compinit을 두면 끄라"고 명시한 바로 그 케이스
-  #   (사용자 .zshrc가 fpath 구성 후 자체 compinit 실행). completion 동작은 사용자 compinit이 보존.
+  # 측정(darwin 호스트)으로 두 비용을 확인:
+  #   (1) 이중 compinit: 시스템 /etc/zshrc의 compinit + 사용자 ~/.zshrc(home-manager)의 compinit이
+  #       셸당 둘 다 실행되어, 두 compinit이 같은 ~/.zcompdump를 두고 매 셸 콜드 재빌드(fpath 전수
+  #       감사)를 반복했다. 이게 startup의 지배적 비용이었다.
+  #   (2) prompt suse: promptinit 테마는 Starship이 PROMPT/precmd를 전부 덮어써 100% 사문(dead work).
+  # enableGlobalCompInit=false: 시스템 compinit을 제거해 사용자 compinit(home-manager 기본 full
+  #   compinit)을 단일 정본으로 만든다. 이중→단일로 콜드 재빌드 반복이 사라지고, 단일 compinit은
+  #   ~/.zcompdump가 신선하면 로드만(재빌드 안 함)·fpath 변경 시 자동 재빌드하며 compaudit(보안감사)도
+  #   유지한다. nix-darwin 옵션 doc이 "custom fpath + custom compinit을 두면 끄라"고 명시한 케이스
+  #   (사용자 .zshrc가 fpath 구성 후 자체 compinit 실행).
   # promptInit="": Starship이 덮어쓰는 prompt suse 테마 로드를 제거(프롬프트 동작 불변).
-  # 사용자 compinit의 -C 캐싱 + nrs 시 zcompdump 무효화는 modules/shared/programs/shell/default.nix.
+  # Trade-off: 시스템 compinit 제거로, 사용자 ~/.zshrc를 source하지 않는 셸(sudo -i/su - root 등)은
+  #   completion이 미초기화된다(single-user macOS라 영향 낮음). enableBashCompletion(기본 true)은
+  #   유지 — nvm/bun completion의 bash `complete` 호환. 본 옵션은 darwin 전용(NixOS는 별도 호스트).
   programs.zsh.enableGlobalCompInit = false;
   programs.zsh.promptInit = "";
 

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -150,6 +150,22 @@ in
   # Zsh 설정 (공통)
   programs.zsh = {
     enable = true;
+
+    # compinit 캐싱 — nix-darwin enableGlobalCompInit=false(시스템 compinit 제거, modules/darwin/
+    # configuration.nix)로 사용자 compinit이 단일 정본이 된 뒤, 매 인터랙티브 셸의 zcompdump 콜드
+    # 재빌드(fpath 전수 감사)를 -C(보안감사 skip + 덤프 재사용)로 대체한다. fpath가 전부 nix
+    # store(root 소유·immutable)라 compaudit은 순수 오버헤드 → -C 안전. 덤프 부재 시(nrs 직후
+    # 첫 셸)에만 full 빌드하며, 새 도구 completion 정확성은 home.activation.invalidateZcompdump
+    # (nrs마다 1회 재빌드)가 보장한다.
+    completionInit = ''
+      autoload -Uz compinit
+      if [[ -s ''${ZDOTDIR:-$HOME}/.zcompdump ]]; then
+        compinit -C
+      else
+        compinit
+      fi
+    '';
+
     autosuggestion = {
       enable = true;
       highlight = "fg=#808080";
@@ -401,6 +417,15 @@ in
       #─────────────────────────────────────────────────────────────────────────
     ];
   };
+
+  # nrs(home-manager activation)마다 zcompdump를 무효화 → 위 completionInit의 -C 캐시가 항상
+  # 최신 completion으로 1회 재빌드된다. 이 repo는 도구를 nrs로만 추가하므로, nrs 후 첫 인터랙티브
+  # 셸이 zcompdump를 재빌드하고 이후 셸은 -C로 캐시 로드한다. 함께 정리: 과거 중단된 빌드가 남긴
+  # host-specific 임시 덤프(.zcompdump.<host>.<pid>)와 zwc 컴파일 캐시. 이로써 새 도구 completion
+  # 정확성과 startup 속도를 양립시킨다.
+  home.activation.invalidateZcompdump = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD rm -f "$HOME/.zcompdump" "$HOME"/.zcompdump.*
+  '';
 
   # Starship 프롬프트
   programs.starship = {

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -150,22 +150,6 @@ in
   # Zsh 설정 (공통)
   programs.zsh = {
     enable = true;
-
-    # compinit 캐싱 — nix-darwin enableGlobalCompInit=false(시스템 compinit 제거, modules/darwin/
-    # configuration.nix)로 사용자 compinit이 단일 정본이 된 뒤, 매 인터랙티브 셸의 zcompdump 콜드
-    # 재빌드(fpath 전수 감사)를 -C(보안감사 skip + 덤프 재사용)로 대체한다. fpath가 전부 nix
-    # store(root 소유·immutable)라 compaudit은 순수 오버헤드 → -C 안전. 덤프 부재 시(nrs 직후
-    # 첫 셸)에만 full 빌드하며, 새 도구 completion 정확성은 home.activation.invalidateZcompdump
-    # (nrs마다 1회 재빌드)가 보장한다.
-    completionInit = ''
-      autoload -Uz compinit
-      if [[ -s ''${ZDOTDIR:-$HOME}/.zcompdump ]]; then
-        compinit -C
-      else
-        compinit
-      fi
-    '';
-
     autosuggestion = {
       enable = true;
       highlight = "fg=#808080";
@@ -417,15 +401,6 @@ in
       #─────────────────────────────────────────────────────────────────────────
     ];
   };
-
-  # nrs(home-manager activation)마다 zcompdump를 무효화 → 위 completionInit의 -C 캐시가 항상
-  # 최신 completion으로 1회 재빌드된다. 이 repo는 도구를 nrs로만 추가하므로, nrs 후 첫 인터랙티브
-  # 셸이 zcompdump를 재빌드하고 이후 셸은 -C로 캐시 로드한다. 함께 정리: 과거 중단된 빌드가 남긴
-  # host-specific 임시 덤프(.zcompdump.<host>.<pid>)와 zwc 컴파일 캐시. 이로써 새 도구 completion
-  # 정확성과 startup 속도를 양립시킨다.
-  home.activation.invalidateZcompdump = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD rm -f "$HOME/.zcompdump" "$HOME"/.zcompdump.*
-  '';
 
   # Starship 프롬프트
   programs.starship = {

--- a/tests/bench-shell-startup.sh
+++ b/tests/bench-shell-startup.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # 셸 startup 측정 — opt-in 재현용(repro) 벤치. 회귀 게이트가 아니다 (lefthook/CI 미배선).
 #
-# 레퍼런스 "Life is too short for a slow terminal"의 핵심 처방(측정)을 재현하는 도구.
+# 레퍼런스 "Life is too short for a slow terminal"
+# (https://mijndertstuij.nl/posts/life-is-too-short-for-a-slow-terminal/)의 핵심 처방(측정)을 재현한다.
 # 절대 ms가 시스템 부하(관찰자 효과)로 크게 흔들려 hard-gate(pre-push/CI 차단)에는
 # 부적합하다 — min/구조적 비교 위주로 해석한다. 회귀의 결정론적 lock은
-# tests/eval-tests.nix의 구조 불변식(Test D10~D11)이 담당하며, 이 스크립트는 게이트 책임을 지지 않는다.
+# tests/eval-tests.nix의 구조 불변식(Test D10~D12)이 담당하며, 이 스크립트는 게이트 책임을 지지 않는다.
 #
 # 사용: bash tests/bench-shell-startup.sh
 #
@@ -18,8 +19,8 @@ cat <<'EOF'
 == 인터랙티브 zsh startup 측정 (zsh -i -c exit) ==
 주의:
   - 이 측정은 rc-sourcing(.zshenv + .zshrc)만 잰다. 사용자가 체감하는 first-prompt /
-    input latency와는 다르다(레퍼런스 댓글 지적). precmd 훅·zle 위젯·direnv devShell
-    평가는 'zsh -i -c exit'에서 발화하지 않아 미포함이다.
+    input latency와는 다르다 — precmd 훅·zle 위젯·direnv devShell 평가는
+    'zsh -i -c exit'에서 발화하지 않아 미포함이다.
   - 절대 ms는 시스템 부하에 민감하다. 동일 부하에서의 전후(nrs 적용 전/후) 비교,
     또는 min을 구조 지표로 본다.
 

--- a/tests/bench-shell-startup.sh
+++ b/tests/bench-shell-startup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# 셸 startup 측정 — opt-in 수동 벤치 (lefthook/CI 미배선).
+#
+# 레퍼런스 "Life is too short for a slow terminal"의 핵심 처방(측정)을 위한 도구.
+# 절대 ms가 시스템 부하(관찰자 효과)로 크게 흔들려 hard-gate(pre-push/CI 차단)에는
+# 부적합하다 — min/구조적 비교 위주로 해석한다. 회귀의 결정론적 lock은
+# tests/eval-tests.nix의 구조 불변식(Test D10~D12)이 담당한다.
+#
+# 사용: bash tests/bench-shell-startup.sh
+#
+# hyperfine은 프로젝트 flake.lock의 nixpkgs pin에서 주입한다(레지스트리 fetch·pin 우회 없음;
+# pre-push statusline-bats의 `nix shell --inputs-from .` 패턴과 동일).
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+cat <<'EOF'
+== 인터랙티브 zsh startup 측정 (zsh -i -c exit) ==
+주의:
+  - 이 측정은 rc-sourcing(.zshenv + .zshrc)만 잰다. 사용자가 체감하는 first-prompt /
+    input latency와는 다르다(레퍼런스 댓글 지적). precmd 훅·zle 위젯·direnv devShell
+    평가는 'zsh -i -c exit'에서 발화하지 않아 미포함이다.
+  - 절대 ms는 시스템 부하에 민감하다. 동일 부하에서의 전후(nrs 적용 전/후) 비교,
+    또는 min을 구조 지표로 본다.
+
+EOF
+
+exec nix shell --inputs-from . nixpkgs#hyperfine --command \
+  hyperfine --warmup 3 --runs 20 'zsh -i -c exit'

--- a/tests/bench-shell-startup.sh
+++ b/tests/bench-shell-startup.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# 셸 startup 측정 — opt-in 수동 벤치 (lefthook/CI 미배선).
+# 셸 startup 측정 — opt-in 재현용(repro) 벤치. 회귀 게이트가 아니다 (lefthook/CI 미배선).
 #
-# 레퍼런스 "Life is too short for a slow terminal"의 핵심 처방(측정)을 위한 도구.
+# 레퍼런스 "Life is too short for a slow terminal"의 핵심 처방(측정)을 재현하는 도구.
 # 절대 ms가 시스템 부하(관찰자 효과)로 크게 흔들려 hard-gate(pre-push/CI 차단)에는
 # 부적합하다 — min/구조적 비교 위주로 해석한다. 회귀의 결정론적 lock은
-# tests/eval-tests.nix의 구조 불변식(Test D10~D12)이 담당한다.
+# tests/eval-tests.nix의 구조 불변식(Test D10~D11)이 담당하며, 이 스크립트는 게이트 책임을 지지 않는다.
 #
 # 사용: bash tests/bench-shell-startup.sh
 #

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -411,7 +411,8 @@ let
         }
         # 셸 startup 최적화 회귀 lock — modules/darwin/configuration.nix.
         # 타이밍이 아닌 config-level 불변식만 검증(결정론적, 부하 무관).
-        # (D9는 루프 밖 글로벌 테스트라 여기서는 D8 다음 D10부터 이어진다.)
+        # D-넘버는 per-host 루프와 글로벌 리스트가 공유하는 단일 시퀀스다. 글로벌 불변식(D9
+        # unexpected-host)은 메인 tests 리스트에 있으므로, per-host 루프는 D8 다음 D10부터 이어진다.
         {
           name = "Test D10 ${hostName}: 시스템 compinit 중복 제거 — enableGlobalCompInit이 false여야 함";
           cond = hasHost && cfg.programs.zsh.enableGlobalCompInit == false;
@@ -419,6 +420,25 @@ let
         {
           name = "Test D11 ${hostName}: 사문 promptinit 제거 — promptInit이 빈 문자열이어야 함 (Starship이 프롬프트를 덮어씀)";
           cond = hasHost && cfg.programs.zsh.promptInit == "";
+        }
+        {
+          # D10이 시스템 compinit을 제거하므로 사용자 compinit이 유일 정본이 되어야 한다.
+          # 부정 불변식(D10)과 긍정 불변식(이 테스트)을 한 쌍으로 잠가, 향후 home-manager 쪽
+          # 변경(enableCompletion=false 등)이 단일-정본 추상화를 침묵으로 깨는 것을 방지한다.
+          name = "Test D12 ${hostName}: 시스템 compinit 제거의 짝 — 사용자(home-manager) compinit이 단일 정본으로 존재해야 함";
+          cond =
+            hasHost
+            && (
+              let
+                hmZsh = cfg.home-manager.users.${cfg.system.primaryUser}.programs.zsh;
+              in
+              # enableCompletion이 켜져 있고 completionInit에 compinit 호출이 있는지 함께 검증한다.
+              # (builtins.match는 전체-문자열 앵커라 .* 래핑 필요; 멀티라인 대비 newline 평탄화)
+              hmZsh.enableCompletion
+              &&
+                builtins.match ".*compinit.*" (builtins.replaceStrings [ "\n" ] [ " " ] hmZsh.completionInit)
+                != null
+            );
         }
       ]
     ) expectedDarwinHosts

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -409,8 +409,9 @@ let
           name = "Test D8 ${hostName}: 자연 스크롤이 비활성화되어야 함";
           cond = hasHost && cfg.system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" == false;
         }
-        # 셸 startup 최적화 회귀 lock — modules/darwin/configuration.nix + shell/default.nix.
+        # 셸 startup 최적화 회귀 lock — modules/darwin/configuration.nix.
         # 타이밍이 아닌 config-level 불변식만 검증(결정론적, 부하 무관).
+        # (D9는 루프 밖 글로벌 테스트라 여기서는 D8 다음 D10부터 이어진다.)
         {
           name = "Test D10 ${hostName}: 시스템 compinit 중복 제거 — enableGlobalCompInit이 false여야 함";
           cond = hasHost && cfg.programs.zsh.enableGlobalCompInit == false;
@@ -418,18 +419,6 @@ let
         {
           name = "Test D11 ${hostName}: 사문 promptinit 제거 — promptInit이 빈 문자열이어야 함 (Starship이 프롬프트를 덮어씀)";
           cond = hasHost && cfg.programs.zsh.promptInit == "";
-        }
-        {
-          name = "Test D12 ${hostName}: 사용자 compinit이 -C 캐싱 fast-path를 써야 함 (콜드 재빌드 회피)";
-          cond =
-            hasHost
-            && (
-              let
-                hmUser = builtins.head (builtins.attrNames cfg.home-manager.users);
-                completionInit = cfg.home-manager.users.${hmUser}.programs.zsh.completionInit;
-              in
-              builtins.match ".*compinit -C.*" (builtins.replaceStrings [ "\n" ] [ " " ] completionInit) != null
-            );
         }
       ]
     ) expectedDarwinHosts

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -409,6 +409,28 @@ let
           name = "Test D8 ${hostName}: 자연 스크롤이 비활성화되어야 함";
           cond = hasHost && cfg.system.defaults.NSGlobalDomain."com.apple.swipescrolldirection" == false;
         }
+        # 셸 startup 최적화 회귀 lock — modules/darwin/configuration.nix + shell/default.nix.
+        # 타이밍이 아닌 config-level 불변식만 검증(결정론적, 부하 무관).
+        {
+          name = "Test D10 ${hostName}: 시스템 compinit 중복 제거 — enableGlobalCompInit이 false여야 함";
+          cond = hasHost && cfg.programs.zsh.enableGlobalCompInit == false;
+        }
+        {
+          name = "Test D11 ${hostName}: 사문 promptinit 제거 — promptInit이 빈 문자열이어야 함 (Starship이 프롬프트를 덮어씀)";
+          cond = hasHost && cfg.programs.zsh.promptInit == "";
+        }
+        {
+          name = "Test D12 ${hostName}: 사용자 compinit이 -C 캐싱 fast-path를 써야 함 (콜드 재빌드 회피)";
+          cond =
+            hasHost
+            && (
+              let
+                hmUser = builtins.head (builtins.attrNames cfg.home-manager.users);
+                completionInit = cfg.home-manager.users.${hmUser}.programs.zsh.completionInit;
+              in
+              builtins.match ".*compinit -C.*" (builtins.replaceStrings [ "\n" ] [ " " ] completionInit) != null
+            );
+        }
       ]
     ) expectedDarwinHosts
   );

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -423,8 +423,13 @@ let
         }
         {
           # D10이 시스템 compinit을 제거하므로 사용자 compinit이 유일 정본이 되어야 한다.
-          # 부정 불변식(D10)과 긍정 불변식(이 테스트)을 한 쌍으로 잠가, 향후 home-manager 쪽
-          # 변경(enableCompletion=false 등)이 단일-정본 추상화를 침묵으로 깨는 것을 방지한다.
+          # 부정 불변식(D10)과 긍정 불변식(이 테스트)을 한 쌍으로 잠가 단일-정본 추상화를 보호한다.
+          # 검증 대상 enableCompletion/completionInit은 이 repo가 명시 설정하지 않고 home-manager
+          # 업스트림 기본값(enableCompletion=true, completionInit="autoload -U compinit && compinit")에
+          # 의존한다 — repo를 grep해도 설정이 안 나오는 이유다. enableGlobalCompInit=false로 시스템
+          # compinit을 제거했기에 이 기본값이 유일 compinit이 되며, 깨지면(enableCompletion=false /
+          # oh-my-zsh·prezto 도입 / 업스트림 변경) darwin 전 셸 completion이 전면 사망한다 → 그 회귀를
+          # 조기 감지하려고 framework 기본값을 의도적으로 잠근다.
           name = "Test D12 ${hostName}: 시스템 compinit 제거의 짝 — 사용자(home-manager) compinit이 단일 정본으로 존재해야 함";
           cond =
             hasHost
@@ -433,7 +438,9 @@ let
                 hmZsh = cfg.home-manager.users.${cfg.system.primaryUser}.programs.zsh;
               in
               # enableCompletion이 켜져 있고 completionInit에 compinit 호출이 있는지 함께 검증한다.
-              # (builtins.match는 전체-문자열 앵커라 .* 래핑 필요; 멀티라인 대비 newline 평탄화)
+              # builtins.match는 전체-문자열 앵커(부분 매치 아님)라 .* 래핑이 필요하고, POSIX ERE의 `.`은
+              # newline을 매치하지 않아 completionInit이 멀티라인이면 전체 매치가 실패하므로 newline을
+              # 공백으로 평탄화한다(현 HM 기본값은 단일 라인이라 평탄화는 방어적 no-op).
               hmZsh.enableCompletion
               &&
                 builtins.match ".*compinit.*" (builtins.replaceStrings [ "\n" ] [ " " ] hmZsh.completionInit)


### PR DESCRIPTION
## Summary

- nix-darwin `programs.zsh.enableGlobalCompInit = false`로 시스템 `/etc/zshrc`의 중복 `compinit`을 제거해, 매 인터랙티브 셸이 `~/.zcompdump`를 콜드 재빌드하던 병리를 없앴다.
- `programs.zsh.promptInit = ""`로 Starship이 덮어써 사문이던 `prompt suse` 테마 로드를 제거했다.
- `tests/eval-tests.nix`에 회귀 lock(D10·D11·D12)과 opt-in 재현용 벤치 스크립트를 추가했다.

## 기존 문제 / 배경

"Life is too short for a slow terminal" 레퍼런스의 셸 startup 최적화 인사이트를 이 저장소에 전수조사한 결과, 다음 두 비용이 확인됐다:

1. **이중 compinit**: nix-darwin이 생성하는 시스템 `/etc/zshrc`의 `compinit`과 사용자 `~/.zshrc`(home-manager)의 `compinit`이 셸당 둘 다 실행된다. 두 호출이 같은 `~/.zcompdump`를 두고 매 인터랙티브 셸에서 콜드 재빌드(fpath 전수 감사)를 반복해, 셸 startup의 지배적 비용이 됐다(연속 셸 호출마다 덤프 mtime 갱신으로 실측 확인).
2. **사문 promptinit**: nix-darwin `promptInit` 기본값(`...prompt suse...`)이 매 셸 테마를 로드하지만, Starship이 `PROMPT`/`precmd`를 전부 덮어써 100% 사문(dead work)이다.

## CIR (Change Intent Record)

- 발견 경위: 레퍼런스 인사이트(프레임워크 없는 zsh, compinit 캐싱, 측정 우선)를 저장소에 매핑하던 중, 이미 정렬된 항목(Ghostty, no-framework zsh, 플러그인 최소주의) 외에 이중 compinit 병리와 사문 promptinit이 실질 갭으로 드러났다.
- 초기에는 사용자 `compinit`에 `-C`(compaudit skip + 덤프 재사용) 캐싱과 nrs 시 zcompdump 무효화를 적용하는 방향을 검토했다. 그러나 (1) `-C`의 `compaudit`(완성 함수 fpath 감사) skip을 정당화하던 "fpath가 전부 nix store(root 소유)"라는 전제가 실측과 다르고(`/opt/homebrew/share/zsh/site-functions` 등 사용자 소유 디렉터리 포함), (2) `-C`는 새 fpath 함수 감지를 건너뛰어 수동 `brew install`/`mise use` 후 completion이 다음 nrs까지 누락되는 동작 회귀가 있어, `-C`를 제거하고 **단일 full compinit**으로 전환했다.
- 핵심 통찰: 콜드 재빌드 병리의 원인은 `-C` 부재가 아니라 **이중 compinit**이었다. `enableGlobalCompInit = false`로 시스템 compinit을 제거하면, 사용자 `compinit`(home-manager 기본 full)이 단일 정본이 되어 신선 덤프는 로드만(재빌드 안 함)·fpath 변경 시 자동 재빌드하며 compaudit도 유지한다. nix-darwin 옵션 문서가 "custom fpath + custom compinit을 두면 끄라"고 안내하는 바로 그 케이스다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 현상 유지 | 시스템 + 사용자 이중 compinit | 변경 없음 | 매 셸 콜드 재빌드, 사문 promptinit | ❌ |
| `-C` 캐싱 + nrs 무효화 | 사용자 compinit을 `-C`로, nrs마다 덤프 무효화 | 최저 startup | compaudit skip(근거가 실측과 불일치), 수동 도구 completion 누락 회귀 | ❌ |
| 24h fast-path | `-C` + 24h마다 full 감사 | 절충 | 새 completion 최대 24h 지연, 분기 복잡 | ❌ |
| **`enableGlobalCompInit=false` + 단일 full compinit** | 시스템 compinit 제거, 사용자 full이 정본 | 콜드 병리 해소 + compaudit 유지 + completion 자동 반영 | 시스템 compinit 부재로 root/`sudo -i` 셸의 completion 미초기화(문서화된 latent trade-off) | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/darwin/configuration.nix` | `programs.zsh.enableGlobalCompInit = false` + `promptInit = ""` + CIR 주석(trade-off·darwin 스코프 명시) |
| `tests/eval-tests.nix` | darwin intent 회귀 lock D10(`enableGlobalCompInit==false`) / D11(`promptInit==""`) / D12(사용자 home-manager compinit 긍정 검증) |
| `tests/bench-shell-startup.sh` | opt-in 재현용 hyperfine 벤치(회귀 게이트 아님; lefthook/CI 미배선) |

```nix
# modules/darwin/configuration.nix
programs.zsh.enableGlobalCompInit = false;  # 시스템 compinit 제거 → 사용자 compinit 단일 정본
programs.zsh.promptInit = "";               # Starship이 덮는 prompt suse 테마 로드 제거
```

`enableBashCompletion`(기본 `true`)은 정상 사용자 세션의 nvm/bun completion(bash `complete`) 호환을 위해 유지한다. 시스템 compinit 제거로 `~/.zshrc`를 source하지 않는 셸(root/`sudo -i`)에서 `bashcompinit`이 `compinit` 없이 남아 시스템 레벨 `complete` 호출 시 `compdef` 미정의 에러가 날 수 있으나(single-user macOS·root에 `~/.zshrc` 부재라 latent), 이 trade-off는 코드 주석에 명시했다.

## 참고 레퍼런스

- "Life is too short for a slow terminal" — https://mijndertstuij.nl/posts/life-is-too-short-for-a-slow-terminal/
- 한글 요약 — https://news.hada.io/topic?id=30236
- NixOS(MiniPC)의 동일 최적화는 별도 follow-up 이슈로 추적한다(nix-darwin `enableGlobalCompInit`은 darwin 전용이며, NixOS는 시스템 compinit 경로가 달라 별도 점검 필요).

## Human Test Plan

1. **적용**: 워크트리/메인에서 `nrs` 실행. → 빌드·switch 성공, `etc-zshrc` derivation 재빌드.
2. **시스템 rc 확인**: `grep -nE 'compinit|prompt suse' /etc/zshrc`. → 시스템 `compinit`/`promptinit` 라인 없음(`bashcompinit`만 잔존 = 의도). 실패 시: `enableGlobalCompInit`/`promptInit`이 emit에 반영됐는지 `nix eval`로 확인.
3. **completion 동작**: 새 셸에서 `git <Tab>`, `ssh <Tab>`. → 정상 보강. `zsh -ic 'autoload -Uz compaudit; compaudit; echo $?'` → `0`(compaudit 수행·clean).
4. **콜드 병리 해소**: `for i in 1 2 3; do zsh -ic exit; stat -f %m ~/.zcompdump; done`(BSD stat). → mtime 불변(단일 compinit이 신선 덤프 로드만, 재빌드 안 함). 매번 갱신되면 회귀.
5. **프롬프트**: 새 셸에서 Starship 프롬프트 정상 렌더(promptInit 제거가 프롬프트에 영향 없음).
6. **회귀 lock**: `nix eval --impure --file tests/eval-tests.nix` → `true`(D10/D11/D12 포함 전체 통과).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell startup performance benchmark script for measuring interactive zsh session startup times

* **Tests**
  * Enhanced validation tests for zsh configuration initialization settings on Darwin hosts
  * Verifies proper system vs. user shell configuration separation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->