### PR TITLE
fix(homebrew): tap trust 기본 강제로 깨진 brew bundle 복구

### DIFF
--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -9,6 +9,73 @@
   ...
 }:
 
+# ── Homebrew tap trust ──────────────────────────────────────
+# Homebrew는 third-party tap의 formula/cask 로드 시 명시적 trust를 기본 요구한다
+# (HOMEBREW_REQUIRE_TAP_TRUST default: true — env_config.rb). trust 미등록 tap의
+# formula가 brew bundle 대상이면 "Refusing to load formula ..."로 activation이 실패한다.
+# opt-out(HOMEBREW_NO_REQUIRE_TAP_TRUST)은 "will be removed in a later release"라 비채택.
+#
+# 선언된 taps를 brew bundle/cleanup보다 먼저 brew trust로 등록한다 — 이 목록에 tap을
+# 선언하는 행위 자체를 신뢰 의사 표명으로 간주한다. trust.json은 additive로만 관리한다:
+# 선언 해제된 tap을 untrust로 회수하지 않는다 (cleanup = "none"과 동일한 보수성.
+# 수동 trust한 tap을 activation이 임의 회수하지 않기 위함).
+#
+# 실행 형태는 nix-darwin의 brew bundle 호출과 동일하게 맞춘다 (sudo --user --set-home
+# + 동일 env): brew는 root 실행을 거부하고, trust.json 경로가 $HOME 기준
+# (~/.homebrew/trust.json, sudo env_reset으로 XDG_CONFIG_HOME 미전파)이므로 bundle이
+# 읽는 파일과 일치해야 한다. extraEnv가 HOMEBREW_USER_CONFIG_HOME처럼 trust store
+# 위치를 바꾸는 경우에도 두 단계가 같은 trust.json을 보도록 env 구성을 bundle과 맞춘다.
+# trust 서브커맨드가 없는 구버전 Homebrew에서는 감지 후 no-op (멱등: 재등록 시
+# "Already trusted" 출력, exit 0).
+let
+  cfg = config.homebrew;
+
+  # github.com 기본형 URL을 canonical "owner/repo" tap 이름으로 정규화한다
+  # (Homebrew Tap.remote_to_reference와 동일 의도 — scheme://, user@, SCP 콜론,
+  # .git, trailing slash 변형 흡수). GitHub 기본형(homebrew-* repo)이 아니면 null.
+  canonicalGitHubName =
+    url:
+    let
+      stripped = lib.removeSuffix ".git" (lib.removeSuffix "/" url);
+      m = builtins.match "([A-Za-z][A-Za-z0-9+.-]*://)?([^@/]+@)?github\\.com[:/]([^/]+)/homebrew-(.+)" stripped;
+    in
+    if m == null then null else "${builtins.elemAt m 2}/${builtins.elemAt m 3}";
+
+  # trust principal 결정 — 항상 remote URL 형태로 넘긴다:
+  # - clone_target tap: 그 URL 자체가 principal (Homebrew Tap#matches_reference?는
+  #   user/repo reference를 default GitHub remote에만 매칭).
+  # - 일반 tap: 선언이 의미하는 default GitHub remote URL을 명시적으로 trust한다.
+  #   이름으로 trust하면 brew trust가 설치된 tap의 "현재" remote를 principal로
+  #   저장하므로(Trust.trust_name → Tap#reference), 로컬에서 remote가 drift된 tap을
+  #   조용히 신뢰하게 된다. URL은 remote_to_reference가 canonical name으로 정규화해
+  #   선언 의도를 고정하고, drift된 tap은 bundle 단계에서 untrusted로 fail-loud한다.
+  defaultRemote =
+    name:
+    let
+      parts = lib.splitString "/" name;
+    in
+    "https://github.com/${lib.elemAt parts 0}/homebrew-${lib.elemAt parts 1}";
+  trustTargets = map (
+    tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
+  ) cfg.taps;
+
+  # bundle의 brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
+  trustEnv =
+    lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+    ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv;
+  brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " trustEnv} "${cfg.prefix}/bin/brew" trust'';
+
+  trustEnabled = cfg.enable && trustTargets != [ ];
+  trustScript = ''
+    # Homebrew tap trust — brew bundle/cleanup 이전에 선언 tap 신뢰 등록
+    if [ -f "${cfg.prefix}/bin/brew" ]; then
+      if ${brewTrust} --help >/dev/null 2>&1; then
+        echo >&2 "Trusting declared Homebrew taps..."
+        ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
+      fi
+    fi
+  '';
+in
 {
   homebrew = lib.mkMerge [
     # ── 공통: 모든 darwin 호스트 ─────────────────────────────────
@@ -112,61 +179,37 @@
     })
   ];
 
-  # ── Homebrew tap trust ──────────────────────────────────────
-  # Homebrew는 third-party tap의 formula/cask 로드 시 명시적 trust를 기본 요구한다
-  # (HOMEBREW_REQUIRE_TAP_TRUST default: true — env_config.rb). trust 미등록 tap의
-  # formula가 brew bundle 대상이면 "Refusing to load formula ..."로 activation이 실패한다.
-  # opt-out(HOMEBREW_NO_REQUIRE_TAP_TRUST)은 "will be removed in a later release"라 비채택.
-  #
+  # clone_target이 GitHub 기본형 URL인데 canonical name이 선언명과 다른 alias 구성은
+  # brew trust가 URL을 canonical name으로 정규화해 저장하므로 URL principal이 보존되지
+  # 않고, 설치된 custom remote tap은 name reference 매칭을 거부당해 trust 등록 후에도
+  # untrusted로 남는다. 런타임 silent 실패 대신 eval 시점에 거부한다.
+  assertions = map (tap: {
+    assertion =
+      tap.clone_target == null
+      || (
+        let
+          canonical = canonicalGitHubName tap.clone_target;
+        in
+        canonical == null || lib.toLower canonical == lib.toLower tap.name
+      );
+    message = ''
+      homebrew.taps: "${tap.name}"의 clone_target(${toString tap.clone_target})은
+      GitHub 기본형 URL이라 brew trust가 canonical name으로 정규화해 저장하는데,
+      선언된 tap 이름과 달라 설치된 tap에 trust가 매칭되지 않는다. tap 이름을
+      canonical name으로 선언하거나 GitHub 기본형이 아닌 remote를 사용하라.'';
+  }) cfg.taps;
+
   # nix-darwin의 homebrew activation slot(activationScripts.homebrew.text)에 mkBefore로
   # prepend하여, groups/users 이후라는 기존 brew 실행 순서 계약을 유지하면서 bundle보다
-  # 먼저 선언된 taps를 brew trust로 등록한다 — 이 목록에 tap을 선언하는 행위 자체를
-  # 신뢰 의사 표명으로 간주한다. trust.json은 additive로만 관리한다: 선언 해제된
-  # tap을 untrust로 회수하지 않는다 (cleanup = "none"과 동일한 보수성. 수동 trust한
-  # tap을 activation이 임의 회수하지 않기 위함).
-  #
-  # 실행 형태는 nix-darwin의 brew bundle 호출과 동일하게 맞춘다 (sudo --user --set-home
-  # + 동일 env): brew는 root 실행을 거부하고, trust.json 경로가 $HOME 기준
-  # (~/.homebrew/trust.json, sudo env_reset으로 XDG_CONFIG_HOME 미전파)이므로 bundle이
-  # 읽는 파일과 일치해야 한다. extraEnv가 HOMEBREW_USER_CONFIG_HOME처럼 trust store
-  # 위치를 바꾸는 경우에도 두 단계가 같은 trust.json을 보도록 env 구성을 bundle과 맞춘다.
-  # trust 서브커맨드가 없는 구버전 Homebrew에서는 감지 후 no-op (멱등: 재등록 시
-  # "Already trusted" 출력, exit 0).
-  system.activationScripts.homebrew.text =
-    let
-      cfg = config.homebrew;
-      # trust principal 결정 — 항상 remote URL 형태로 넘긴다:
-      # - clone_target tap: 그 URL 자체가 principal (Homebrew Tap#matches_reference?는
-      #   user/repo reference를 default GitHub remote에만 매칭).
-      # - 일반 tap: 선언이 의미하는 default GitHub remote URL을 명시적으로 trust한다.
-      #   이름으로 trust하면 brew trust가 설치된 tap의 "현재" remote를 principal로
-      #   저장하므로(Trust.trust_name → Tap#reference), 로컬에서 remote가 drift된 tap을
-      #   조용히 신뢰하게 된다. URL은 remote_to_reference가 canonical name으로 정규화해
-      #   선언 의도를 고정하고, drift된 tap은 bundle 단계에서 untrusted로 fail-loud한다.
-      defaultRemote =
-        name:
-        let
-          parts = lib.splitString "/" name;
-        in
-        "https://github.com/${lib.elemAt parts 0}/homebrew-${lib.elemAt parts 1}";
-      trustTargets = map (
-        tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
-      ) cfg.taps;
-      # bundle의 brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
-      trustEnv =
-        lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
-        ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv;
-      brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " trustEnv} "${cfg.prefix}/bin/brew" trust'';
-    in
-    lib.mkIf (cfg.enable && trustTargets != [ ]) (
-      lib.mkBefore ''
-        # Homebrew tap trust — brew bundle 이전에 선언 tap 신뢰 등록
-        if [ -f "${cfg.prefix}/bin/brew" ]; then
-          if ${brewTrust} --help >/dev/null 2>&1; then
-            echo >&2 "Trusting declared Homebrew taps..."
-            ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
-          fi
-        fi
-      ''
-    );
+  # 먼저 trust를 등록한다.
+  system.activationScripts.homebrew.text = lib.mkIf trustEnabled (lib.mkBefore trustScript);
+
+  # cleanup = "check"는 checks 단계(activation 순서상 homebrew slot보다 앞)에서
+  # brew bundle cleanup을 실행해 formula를 로드하므로(nix-darwin homebrew 모듈이
+  # system.checks.text에 등록), 같은 trust prelude를 checks에도 mkBefore로 prepend한다.
+  # darwin-rebuild check 모드에서도 trust 등록이 수행되는 부수효과가 있으나,
+  # 멱등·additive·선언 의도 범위 내 쓰기라 수용한다.
+  system.checks.text = lib.mkIf (trustEnabled && cfg.onActivation.cleanup == "check") (
+    lib.mkBefore trustScript
+  );
 }

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -41,9 +41,27 @@ let
       lowered = lib.toLower (lib.trim url);
       noSlash = builtins.match "(.*[^/])/*" lowered;
       stripped = lib.removeSuffix ".git" (if noSlash == null then lowered else builtins.elemAt noSlash 0);
+      # 캡처 순서: [ scheme userinfo owner repo ]
       m = builtins.match "([a-z][a-z0-9+.-]*://)?([^@/]+@)?github\\.com[:/]([^/]+)/homebrew-(.+)" stripped;
+      owner = builtins.elemAt m 2;
+      repo = builtins.elemAt m 3;
     in
-    if m == null then null else "${builtins.elemAt m 2}/${builtins.elemAt m 3}";
+    if m == null then null else "${owner}/${repo}";
+
+  # 선언된 tap 이름을 Homebrew Bundle sanitize_tap_name(dsl.rb의
+  # HOMEBREW_TAP_ARGS_REGEX)과 동일하게 canonical name으로 정규화한다:
+  # downcase 후 repo 부분의 선택적 leading "homebrew-" 제거.
+  # bundle은 "user/homebrew-repo" 선언을 "user/repo" tap으로 처리하므로,
+  # trust 측 계산도 같은 identity를 기준으로 해야 한다. 반환값은 lowercase다.
+  sanitizeTapName =
+    name:
+    let
+      # 캡처 순서: [ owner homebrew-접두(optional) repo ]
+      m = builtins.match "([a-z0-9_-]+)/(homebrew-)?([a-z0-9_-]+)" (lib.toLower name);
+      owner = builtins.elemAt m 0;
+      repo = builtins.elemAt m 2;
+    in
+    if m == null then lib.toLower name else "${owner}/${repo}";
 
   # trust principal 결정 — 항상 remote URL 형태로 넘긴다:
   # - clone_target tap: 그 URL 자체가 principal (Homebrew Tap#matches_reference?는
@@ -56,9 +74,11 @@ let
   defaultRemote =
     name:
     let
-      parts = lib.splitString "/" name;
+      parts = lib.splitString "/" (sanitizeTapName name);
+      owner = lib.elemAt parts 0;
+      repo = lib.elemAt parts 1;
     in
-    "https://github.com/${lib.elemAt parts 0}/homebrew-${lib.elemAt parts 1}";
+    "https://github.com/${owner}/homebrew-${repo}";
   trustTargets = map (
     tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
   ) cfg.taps;
@@ -205,7 +225,8 @@ in
         let
           canonical = canonicalGitHubName tap.clone_target;
         in
-        canonical == null || lib.toLower canonical == lib.toLower tap.name
+        # canonicalGitHubName과 sanitizeTapName 모두 lowercase를 반환한다
+        canonical == null || canonical == sanitizeTapName tap.name
       );
     message = ''
       homebrew.taps: "${tap.name}"의 clone_target(${toString tap.clone_target})은

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -111,4 +111,37 @@
       # };
     })
   ];
+
+  # ── Homebrew tap trust ──────────────────────────────────────
+  # Homebrew는 third-party tap의 formula/cask 로드 시 명시적 trust를 기본 요구한다
+  # (HOMEBREW_REQUIRE_TAP_TRUST default: true — env_config.rb). trust 미등록 tap의
+  # formula가 brew bundle 대상이면 "Refusing to load formula ..."로 activation이 실패한다.
+  # opt-out(HOMEBREW_NO_REQUIRE_TAP_TRUST)은 "will be removed in a later release"라 비채택.
+  #
+  # brew bundle(activationScripts.homebrew)보다 먼저 실행되는 extraActivation에서
+  # 선언된 taps를 brew trust로 등록한다 — 이 목록에 tap을 선언하는 행위 자체를
+  # 신뢰 의사 표명으로 간주한다. trust.json은 additive로만 관리한다: 선언 해제된
+  # tap을 untrust로 회수하지 않는다 (cleanup = "none"과 동일한 보수성. 수동 trust한
+  # tap을 activation이 임의 회수하지 않기 위함).
+  #
+  # 실행 형태는 nix-darwin의 brew bundle 호출과 동일하게 맞춘다 (sudo --user --set-home):
+  # brew는 root 실행을 거부하고, trust.json 경로가 $HOME 기준(~/.homebrew/trust.json,
+  # sudo env_reset으로 XDG_CONFIG_HOME 미전파)이므로 bundle이 읽는 파일과 일치해야 한다.
+  # trust 서브커맨드가 없는 구버전 Homebrew에서는 감지 후 no-op (멱등: 재등록 시
+  # "Already trusted" 출력, exit 0).
+  system.activationScripts.extraActivation.text =
+    let
+      cfg = config.homebrew;
+      tapNames = map (tap: tap.name) cfg.taps;
+      brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home "${cfg.prefix}/bin/brew" trust'';
+    in
+    lib.mkIf (cfg.enable && tapNames != [ ]) ''
+      # Homebrew tap trust — brew bundle 이전에 선언 tap 신뢰 등록
+      if [ -f "${cfg.prefix}/bin/brew" ]; then
+        if ${brewTrust} --help >/dev/null 2>&1; then
+          echo >&2 "Trusting declared Homebrew taps..."
+          ${brewTrust} --tap ${lib.escapeShellArgs tapNames}
+        fi
+      fi
+    '';
 }

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -48,20 +48,24 @@ let
     in
     if m == null then null else "${owner}/${repo}";
 
+  # Homebrew Bundle dsl.rb의 HOMEBREW_TAP_ARGS_REGEX와 동일한 tap name 형식.
+  # 캡처 순서: [ owner homebrew-접두(optional) repo ]. downcase된 입력에 적용한다.
+  tapNameRegex = "([a-z0-9_-]+)/(homebrew-)?([a-z0-9_-]+)";
+
   # 선언된 tap 이름을 Homebrew Bundle sanitize_tap_name(dsl.rb의
   # HOMEBREW_TAP_ARGS_REGEX)과 동일하게 canonical name으로 정규화한다:
   # downcase 후 repo 부분의 선택적 leading "homebrew-" 제거.
   # bundle은 "user/homebrew-repo" 선언을 "user/repo" tap으로 처리하므로,
   # trust 측 계산도 같은 identity를 기준으로 해야 한다. 반환값은 lowercase다.
+  # 형식 불일치 name은 null — 아래 assertions가 eval 시점에 거부한다.
   sanitizeTapName =
     name:
     let
-      # 캡처 순서: [ owner homebrew-접두(optional) repo ]
-      m = builtins.match "([a-z0-9_-]+)/(homebrew-)?([a-z0-9_-]+)" (lib.toLower name);
+      m = builtins.match tapNameRegex (lib.toLower name);
       owner = builtins.elemAt m 0;
       repo = builtins.elemAt m 2;
     in
-    if m == null then lib.toLower name else "${owner}/${repo}";
+    if m == null then null else "${owner}/${repo}";
 
   # trust principal 결정 — 항상 remote URL 형태로 넘긴다:
   # - clone_target tap: 그 URL 자체가 principal (Homebrew Tap#matches_reference?는
@@ -71,45 +75,70 @@ let
   #   저장하므로(Trust.trust_name → Tap#reference), 로컬에서 remote가 drift된 tap을
   #   조용히 신뢰하게 된다. URL은 remote_to_reference가 canonical name으로 정규화해
   #   선언 의도를 고정하고, drift된 tap은 bundle 단계에서 untrusted로 fail-loud한다.
+  # 형식 불일치 name은 null 전파 (assertions가 거부) — elemAt 범위 오류 같은
+  # 불친절한 eval 에러 대신 명확한 assertion 메시지가 먼저 도달하도록 total 함수로 둔다.
   defaultRemote =
     name:
     let
-      parts = lib.splitString "/" (sanitizeTapName name);
+      sanitized = sanitizeTapName name;
+      parts = lib.splitString "/" sanitized;
       owner = lib.elemAt parts 0;
       repo = lib.elemAt parts 1;
     in
-    "https://github.com/${owner}/homebrew-${repo}";
-  trustTargets = map (
-    tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
-  ) cfg.taps;
+    if sanitized == null then null else "https://github.com/${owner}/homebrew-${repo}";
+  trustTargets = lib.filter (t: t != null) (
+    map (tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name) cfg.taps
+  );
 
   # trust 명령의 env는 "그 직후 trust.json을 읽는 소비자"와 정확히 일치해야 한다 —
   # XDG_CONFIG_HOME류 변수가 trust store 위치 자체를 바꾸기 때문이다. nix-darwin은
   # bundle에는 extraEnv를 적용하지만 cleanup check에는 HOMEBREW_NO_AUTO_UPDATE=1만
   # 하드코딩하므로, prelude도 소비자별로 env를 달리 구성한다.
+  #
+  # trust 서브커맨드 존재는 프로세스 기동(--help probe, ruby ~1초) 대신 cmd 파일로
+  # 감지한다. Homebrew repository layout이 두 가지다: Apple Silicon은 prefix가 곧
+  # repo(/opt/homebrew/Library/...), Intel은 prefix/Homebrew가 repo
+  # (/usr/local/Homebrew/Library/...).
+  #
+  # updateBeforeTrust: trust를 모르는 구버전 brew + autoUpdate 구성에서는 직후
+  # bundle이 auto-update로 brew를 갱신한 뒤 trust 강제가 켜져 거부된다 (이번 회귀의
+  # 원인 경로와 동일 구조). 그 경우 trust 등록 전에 먼저 update해 1회성 실패를
+  # 제거한다. cleanup check prelude는 구버전 brew가 trust를 강제하지 않아 불필요.
   mkTrustScript =
-    env:
+    {
+      env,
+      updateBeforeTrust ? false,
+    }:
     let
-      brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " env} "${cfg.prefix}/bin/brew" trust'';
+      runBrew = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " env} "${cfg.prefix}/bin/brew"'';
+      trustCmdExists = ''{ [ -f "${cfg.prefix}/Library/Homebrew/cmd/trust.rb" ] || [ -f "${cfg.prefix}/Homebrew/Library/Homebrew/cmd/trust.rb" ]; }'';
     in
     ''
       # Homebrew tap trust — brew bundle/cleanup 이전에 선언 tap 신뢰 등록
       if [ -f "${cfg.prefix}/bin/brew" ]; then
-        if ${brewTrust} --help >/dev/null 2>&1; then
+        ${lib.optionalString updateBeforeTrust ''
+          if ! ${trustCmdExists}; then
+            echo >&2 "brew trust unavailable — updating Homebrew first..."
+            ${runBrew} update || true
+          fi
+        ''}
+        if ${trustCmdExists}; then
           echo >&2 "Trusting declared Homebrew taps..."
-          ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
+          ${runBrew} trust --tap ${lib.escapeShellArgs trustTargets}
         fi
       fi
     '';
 
   trustEnabled = cfg.enable && trustTargets != [ ];
   # bundle용: brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
-  bundleTrustScript = mkTrustScript (
-    lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
-    ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv
-  );
+  bundleTrustScript = mkTrustScript {
+    env =
+      lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+      ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv;
+    updateBeforeTrust = cfg.onActivation.autoUpdate;
+  };
   # cleanup check용: nix-darwin cleanup check의 hardcoded env와 동일하게 구성
-  checkTrustScript = mkTrustScript [ "HOMEBREW_NO_AUTO_UPDATE=1" ];
+  checkTrustScript = mkTrustScript { env = [ "HOMEBREW_NO_AUTO_UPDATE=1" ]; };
 in
 {
   homebrew = lib.mkMerge [
@@ -214,26 +243,43 @@ in
     })
   ];
 
-  # clone_target이 GitHub 기본형 URL인데 canonical name이 선언명과 다른 alias 구성은
-  # brew trust가 URL을 canonical name으로 정규화해 저장하므로 URL principal이 보존되지
-  # 않고, 설치된 custom remote tap은 name reference 매칭을 거부당해 trust 등록 후에도
-  # untrusted로 남는다. 런타임 silent 실패 대신 eval 시점에 거부한다.
-  assertions = map (tap: {
-    assertion =
-      tap.clone_target == null
-      || (
-        let
-          canonical = canonicalGitHubName tap.clone_target;
-        in
-        # canonicalGitHubName과 sanitizeTapName 모두 lowercase를 반환한다
-        canonical == null || canonical == sanitizeTapName tap.name
-      );
-    message = ''
-      homebrew.taps: "${tap.name}"의 clone_target(${toString tap.clone_target})은
-      GitHub 기본형 URL이라 brew trust가 canonical name으로 정규화해 저장하는데,
-      선언된 tap 이름과 달라 설치된 tap에 trust가 매칭되지 않는다. tap 이름을
-      canonical name으로 선언하거나 GitHub 기본형이 아닌 remote를 사용하라.'';
-  }) cfg.taps;
+  # tap 선언 형식/조합을 eval 시점에 거부한다 (런타임 silent 실패 방지).
+  # homebrew.enable=false인 host는 trust hook이 비활성이므로 검사하지 않는다
+  # (nix-darwin homebrew activation 자체도 mkIf cfg.enable로 게이트됨).
+  #
+  # 1) name 형식: Bundle HOMEBREW_TAP_ARGS_REGEX 불일치 name(슬래시 없음, 3개
+  #    세그먼트 등)은 trust principal 계산이 불가능하고, 묵인하면 의도하지 않은
+  #    principal을 조용히 trust하거나 불친절한 eval 에러가 난다.
+  # 2) clone_target alias: GitHub 기본형 URL인데 canonical name이 선언명과 다르면
+  #    brew trust가 URL을 canonical name으로 정규화해 저장하므로 URL principal이
+  #    보존되지 않고, 설치된 custom remote tap은 name reference 매칭을 거부당해
+  #    trust 등록 후에도 untrusted로 남는다.
+  assertions = lib.concatMap (tap: [
+    {
+      assertion = !cfg.enable || builtins.match tapNameRegex (lib.toLower tap.name) != null;
+      message = ''
+        homebrew.taps: "${tap.name}"은 Homebrew Bundle의 tap name 형식
+        (user/repo 또는 user/homebrew-repo)이 아니라 trust principal을
+        계산할 수 없다. user/repo 형식으로 선언하라.'';
+    }
+    {
+      assertion =
+        !cfg.enable
+        || tap.clone_target == null
+        || (
+          let
+            canonical = canonicalGitHubName tap.clone_target;
+          in
+          # canonicalGitHubName과 sanitizeTapName 모두 lowercase를 반환한다
+          canonical == null || canonical == sanitizeTapName tap.name
+        );
+      message = ''
+        homebrew.taps: "${tap.name}"의 clone_target(${toString tap.clone_target})은
+        GitHub 기본형 URL이라 brew trust가 canonical name으로 정규화해 저장하는데,
+        선언된 tap 이름과 달라 설치된 tap에 trust가 매칭되지 않는다. tap 이름을
+        canonical name으로 선언하거나 GitHub 기본형이 아닌 remote를 사용하라.'';
+    }
+  ]) cfg.taps;
 
   # nix-darwin의 homebrew activation slot(activationScripts.homebrew.text)에 mkBefore로
   # prepend하여, groups/users 이후라는 기존 brew 실행 순서 계약을 유지하면서 bundle보다

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -124,23 +124,32 @@
   # tap을 untrust로 회수하지 않는다 (cleanup = "none"과 동일한 보수성. 수동 trust한
   # tap을 activation이 임의 회수하지 않기 위함).
   #
-  # 실행 형태는 nix-darwin의 brew bundle 호출과 동일하게 맞춘다 (sudo --user --set-home):
-  # brew는 root 실행을 거부하고, trust.json 경로가 $HOME 기준(~/.homebrew/trust.json,
-  # sudo env_reset으로 XDG_CONFIG_HOME 미전파)이므로 bundle이 읽는 파일과 일치해야 한다.
+  # 실행 형태는 nix-darwin의 brew bundle 호출과 동일하게 맞춘다 (sudo --user --set-home
+  # + 동일 env): brew는 root 실행을 거부하고, trust.json 경로가 $HOME 기준
+  # (~/.homebrew/trust.json, sudo env_reset으로 XDG_CONFIG_HOME 미전파)이므로 bundle이
+  # 읽는 파일과 일치해야 한다. extraEnv가 HOMEBREW_USER_CONFIG_HOME처럼 trust store
+  # 위치를 바꾸는 경우에도 두 단계가 같은 trust.json을 보도록 env 구성을 bundle과 맞춘다.
   # trust 서브커맨드가 없는 구버전 Homebrew에서는 감지 후 no-op (멱등: 재등록 시
   # "Already trusted" 출력, exit 0).
   system.activationScripts.extraActivation.text =
     let
       cfg = config.homebrew;
-      tapNames = map (tap: tap.name) cfg.taps;
-      brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home "${cfg.prefix}/bin/brew" trust'';
+      # custom remote tap(clone_target)의 trust principal은 이름이 아니라 remote URL이다 —
+      # Homebrew Tap#matches_reference?는 user/repo reference를 default GitHub remote에만
+      # 매칭하므로, 이름으로 trust하면 custom remote tap은 trusted로 매칭되지 않는다.
+      trustTargets = map (tap: if tap.clone_target != null then tap.clone_target else tap.name) cfg.taps;
+      # bundle의 brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
+      trustEnv =
+        lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+        ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv;
+      brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " trustEnv} "${cfg.prefix}/bin/brew" trust'';
     in
-    lib.mkIf (cfg.enable && tapNames != [ ]) ''
+    lib.mkIf (cfg.enable && trustTargets != [ ]) ''
       # Homebrew tap trust — brew bundle 이전에 선언 tap 신뢰 등록
       if [ -f "${cfg.prefix}/bin/brew" ]; then
         if ${brewTrust} --help >/dev/null 2>&1; then
           echo >&2 "Trusting declared Homebrew taps..."
-          ${brewTrust} --tap ${lib.escapeShellArgs tapNames}
+          ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
         fi
       fi
     '';

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -118,8 +118,9 @@
   # formula가 brew bundle 대상이면 "Refusing to load formula ..."로 activation이 실패한다.
   # opt-out(HOMEBREW_NO_REQUIRE_TAP_TRUST)은 "will be removed in a later release"라 비채택.
   #
-  # brew bundle(activationScripts.homebrew)보다 먼저 실행되는 extraActivation에서
-  # 선언된 taps를 brew trust로 등록한다 — 이 목록에 tap을 선언하는 행위 자체를
+  # nix-darwin의 homebrew activation slot(activationScripts.homebrew.text)에 mkBefore로
+  # prepend하여, groups/users 이후라는 기존 brew 실행 순서 계약을 유지하면서 bundle보다
+  # 먼저 선언된 taps를 brew trust로 등록한다 — 이 목록에 tap을 선언하는 행위 자체를
   # 신뢰 의사 표명으로 간주한다. trust.json은 additive로만 관리한다: 선언 해제된
   # tap을 untrust로 회수하지 않는다 (cleanup = "none"과 동일한 보수성. 수동 trust한
   # tap을 activation이 임의 회수하지 않기 위함).
@@ -131,26 +132,41 @@
   # 위치를 바꾸는 경우에도 두 단계가 같은 trust.json을 보도록 env 구성을 bundle과 맞춘다.
   # trust 서브커맨드가 없는 구버전 Homebrew에서는 감지 후 no-op (멱등: 재등록 시
   # "Already trusted" 출력, exit 0).
-  system.activationScripts.extraActivation.text =
+  system.activationScripts.homebrew.text =
     let
       cfg = config.homebrew;
-      # custom remote tap(clone_target)의 trust principal은 이름이 아니라 remote URL이다 —
-      # Homebrew Tap#matches_reference?는 user/repo reference를 default GitHub remote에만
-      # 매칭하므로, 이름으로 trust하면 custom remote tap은 trusted로 매칭되지 않는다.
-      trustTargets = map (tap: if tap.clone_target != null then tap.clone_target else tap.name) cfg.taps;
+      # trust principal 결정 — 항상 remote URL 형태로 넘긴다:
+      # - clone_target tap: 그 URL 자체가 principal (Homebrew Tap#matches_reference?는
+      #   user/repo reference를 default GitHub remote에만 매칭).
+      # - 일반 tap: 선언이 의미하는 default GitHub remote URL을 명시적으로 trust한다.
+      #   이름으로 trust하면 brew trust가 설치된 tap의 "현재" remote를 principal로
+      #   저장하므로(Trust.trust_name → Tap#reference), 로컬에서 remote가 drift된 tap을
+      #   조용히 신뢰하게 된다. URL은 remote_to_reference가 canonical name으로 정규화해
+      #   선언 의도를 고정하고, drift된 tap은 bundle 단계에서 untrusted로 fail-loud한다.
+      defaultRemote =
+        name:
+        let
+          parts = lib.splitString "/" name;
+        in
+        "https://github.com/${lib.elemAt parts 0}/homebrew-${lib.elemAt parts 1}";
+      trustTargets = map (
+        tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
+      ) cfg.taps;
       # bundle의 brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
       trustEnv =
         lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
         ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv;
       brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " trustEnv} "${cfg.prefix}/bin/brew" trust'';
     in
-    lib.mkIf (cfg.enable && trustTargets != [ ]) ''
-      # Homebrew tap trust — brew bundle 이전에 선언 tap 신뢰 등록
-      if [ -f "${cfg.prefix}/bin/brew" ]; then
-        if ${brewTrust} --help >/dev/null 2>&1; then
-          echo >&2 "Trusting declared Homebrew taps..."
-          ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
+    lib.mkIf (cfg.enable && trustTargets != [ ]) (
+      lib.mkBefore ''
+        # Homebrew tap trust — brew bundle 이전에 선언 tap 신뢰 등록
+        if [ -f "${cfg.prefix}/bin/brew" ]; then
+          if ${brewTrust} --help >/dev/null 2>&1; then
+            echo >&2 "Trusting declared Homebrew taps..."
+            ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
+          fi
         fi
-      fi
-    '';
+      ''
+    );
 }

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -33,11 +33,15 @@ let
   # github.com 기본형 URL을 canonical "owner/repo" tap 이름으로 정규화한다
   # (Homebrew Tap.remote_to_reference와 동일 의도 — scheme://, user@, SCP 콜론,
   # .git, trailing slash 변형 흡수). GitHub 기본형(homebrew-* repo)이 아니면 null.
+  # 정규화 순서는 Homebrew Tap.normalize_remote와 동일: strip → downcase →
+  # trailing slash 전체 제거 → .git 제거. 반환값은 lowercase다.
   canonicalGitHubName =
     url:
     let
-      stripped = lib.removeSuffix ".git" (lib.removeSuffix "/" url);
-      m = builtins.match "([A-Za-z][A-Za-z0-9+.-]*://)?([^@/]+@)?github\\.com[:/]([^/]+)/homebrew-(.+)" stripped;
+      lowered = lib.toLower (lib.trim url);
+      noSlash = builtins.match "(.*[^/])/*" lowered;
+      stripped = lib.removeSuffix ".git" (if noSlash == null then lowered else builtins.elemAt noSlash 0);
+      m = builtins.match "([a-z][a-z0-9+.-]*://)?([^@/]+@)?github\\.com[:/]([^/]+)/homebrew-(.+)" stripped;
     in
     if m == null then null else "${builtins.elemAt m 2}/${builtins.elemAt m 3}";
 
@@ -59,22 +63,33 @@ let
     tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
   ) cfg.taps;
 
-  # bundle의 brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
-  trustEnv =
-    lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
-    ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv;
-  brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " trustEnv} "${cfg.prefix}/bin/brew" trust'';
+  # trust 명령의 env는 "그 직후 trust.json을 읽는 소비자"와 정확히 일치해야 한다 —
+  # XDG_CONFIG_HOME류 변수가 trust store 위치 자체를 바꾸기 때문이다. nix-darwin은
+  # bundle에는 extraEnv를 적용하지만 cleanup check에는 HOMEBREW_NO_AUTO_UPDATE=1만
+  # 하드코딩하므로, prelude도 소비자별로 env를 달리 구성한다.
+  mkTrustScript =
+    env:
+    let
+      brewTrust = ''PATH="${cfg.prefix}/bin:$PATH" sudo --preserve-env=PATH --user=${lib.escapeShellArg cfg.user} --set-home env ${lib.concatStringsSep " " env} "${cfg.prefix}/bin/brew" trust'';
+    in
+    ''
+      # Homebrew tap trust — brew bundle/cleanup 이전에 선언 tap 신뢰 등록
+      if [ -f "${cfg.prefix}/bin/brew" ]; then
+        if ${brewTrust} --help >/dev/null 2>&1; then
+          echo >&2 "Trusting declared Homebrew taps..."
+          ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
+        fi
+      fi
+    '';
 
   trustEnabled = cfg.enable && trustTargets != [ ];
-  trustScript = ''
-    # Homebrew tap trust — brew bundle/cleanup 이전에 선언 tap 신뢰 등록
-    if [ -f "${cfg.prefix}/bin/brew" ]; then
-      if ${brewTrust} --help >/dev/null 2>&1; then
-        echo >&2 "Trusting declared Homebrew taps..."
-        ${brewTrust} --tap ${lib.escapeShellArgs trustTargets}
-      fi
-    fi
-  '';
+  # bundle용: brewBundleCmd와 동일한 env 구성 (HOMEBREW_NO_AUTO_UPDATE + extraEnv)
+  bundleTrustScript = mkTrustScript (
+    lib.optional (!cfg.onActivation.autoUpdate) "HOMEBREW_NO_AUTO_UPDATE=1"
+    ++ lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") cfg.onActivation.extraEnv
+  );
+  # cleanup check용: nix-darwin cleanup check의 hardcoded env와 동일하게 구성
+  checkTrustScript = mkTrustScript [ "HOMEBREW_NO_AUTO_UPDATE=1" ];
 in
 {
   homebrew = lib.mkMerge [
@@ -202,7 +217,7 @@ in
   # nix-darwin의 homebrew activation slot(activationScripts.homebrew.text)에 mkBefore로
   # prepend하여, groups/users 이후라는 기존 brew 실행 순서 계약을 유지하면서 bundle보다
   # 먼저 trust를 등록한다.
-  system.activationScripts.homebrew.text = lib.mkIf trustEnabled (lib.mkBefore trustScript);
+  system.activationScripts.homebrew.text = lib.mkIf trustEnabled (lib.mkBefore bundleTrustScript);
 
   # cleanup = "check"는 checks 단계(activation 순서상 homebrew slot보다 앞)에서
   # brew bundle cleanup을 실행해 formula를 로드하므로(nix-darwin homebrew 모듈이
@@ -210,6 +225,6 @@ in
   # darwin-rebuild check 모드에서도 trust 등록이 수행되는 부수효과가 있으나,
   # 멱등·additive·선언 의도 범위 내 쓰기라 수용한다.
   system.checks.text = lib.mkIf (trustEnabled && cfg.onActivation.cleanup == "check") (
-    lib.mkBefore trustScript
+    lib.mkBefore checkTrustScript
   );
 }


### PR DESCRIPTION
## Summary

- Homebrew가 tap trust 검사를 기본 활성화(`HOMEBREW_REQUIRE_TAP_TRUST` default true)하면서 third-party tap formula(`laishulu/homebrew/macism`) 로드가 거부되어 `darwin-rebuild switch`가 실패하던 것을 복구한다.
- 선언된 `homebrew.taps`를 brew bundle/cleanup보다 먼저 `brew trust`로 자동 등록하는 activation hook을 추가한다 — tap을 선언하는 행위 자체를 신뢰 의사 표명으로 간주하는 선언적 해법.
- trust principal은 항상 remote URL 형태로 고정하고, 비정형 tap 선언은 eval 시점 assertion으로 거부한다.

## 기존 문제/배경

`nrs` 실행 중 Homebrew auto-update가 새 버전을 받으면서 tap trust 정책이 기본 활성화됐다 (`env_config.rb`의 `HOMEBREW_REQUIRE_TAP_TRUST`가 `default: true`, opt-out 변수는 "will be removed in a later release"로 deprecated 예정).

```
Error: Refusing to load formula laishulu/homebrew/macism from untrusted tap laishulu/homebrew.
Run `brew trust --formula laishulu/homebrew/macism` or `brew trust laishulu/homebrew` to trust it.
❌ darwin-rebuild switch failed (exit code: 1)
```

trust 등록은 `~/.homebrew/trust.json`(또는 `HOMEBREW_USER_CONFIG_HOME` 기준)에 저장되는 가변 상태라, 수동 `brew trust` 1회로 풀면 새 머신/재설정 시마다 같은 실패가 재발한다. 이 저장소의 선언적 관리 철학과 맞지 않는다.

## CIR (Change Intent Record)

모든 버전이 이번 변경 내 설계 진화다.

- **v1** (이번 변경): `extraActivation`에서 tap "이름"으로 `brew trust` 등록. nrs 실측으로 복구 확인.
- **v2** (이번 변경): 코드 리뷰에서 두 계약 불일치 발견 — custom remote(`clone_target`) tap의 trust principal은 이름이 아니라 remote URL이고(`Tap#matches_reference?`는 이름 reference를 default GitHub remote에만 매칭), trust 단계 env가 bundle의 `extraEnv`와 갈라지면 두 단계가 다른 trust store를 본다. → clone_target 우선 + env 정합.
- **v3** (이번 변경): `extraActivation`은 `groups`/`users`보다 먼저 실행되어 "사용자 생성 후 brew 실행" 계약을 깨고, 이름 trust는 로컬에서 remote가 drift된 tap을 조용히 신뢰한다. → hook을 `activationScripts.homebrew.text`에 `mkBefore`로 이동, 일반 tap도 default GitHub remote URL로 principal 고정.
- **v4** (이번 변경): `cleanup = "check"` 구성은 checks 단계(homebrew slot보다 앞)에서 formula를 로드하고, GitHub 기본형 URL인데 canonical name이 선언명과 다른 alias clone_target은 CLI 정규화로 URL principal이 보존되지 않는다. → checks에도 trust prelude prepend + alias 조합 eval assertion 거부.
- **v5** (이번 변경): trust env는 "직후 trust.json을 읽는 소비자"와 정확히 일치해야 함 — upstream cleanup check는 `HOMEBREW_NO_AUTO_UPDATE=1`만 하드코딩. → env를 소비자별로 분리. URL/이름 정규화도 Homebrew `normalize_remote`·`sanitize_tap_name`과 동일 순서/기준으로 정합.
- **v6** (이번 변경): 전수조사에서 전환기 실패 경로(trust를 모르는 구버전 brew → bundle이 auto-update → 새 brew가 거부 — 이번 사건과 동일 구조)와 비정형 tap name의 불친절한 eval 에러/silent 오등록 발견. → 감지를 파일 기반으로 전환 + 필요 시 선행 update + name 형식 assertion.

**trade-off**: 선언 해제된 tap을 untrust로 회수하지 않는다(additive 관리 — `cleanup = "none"`과 동일한 보수성, 수동 trust 보호). 완전한 상태 수렴 대신 안전한 단방향 등록을 택했다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| opt-out 환경변수 | `HOMEBREW_NO_REQUIRE_TAP_TRUST`를 extraEnv로 설정 | 한 줄 변경 | upstream이 "will be removed in a later release" 명시 — 시한부 + 보안 검사 전면 무력화 | ❌ |
| 수동 `brew trust` 1회 | 즉시 해결 | 가장 빠름 | git 밖 가변 상태 — 새 머신/재설정마다 재발, 비선언적 | ❌ |
| tap 제거 (macism 대체) | third-party tap 의존 자체를 제거 | 근본 해결 | macism이 nixpkgs에 없고 Neovim 한영 전환 자동화가 의존 | ❌ |
| trust.json 파일을 직접 선언 관리 | home-manager로 trust.json 생성 | brew 호출 불필요 | 스키마가 Homebrew 소유(변경 추적 부담), 수동 trust 항목을 덮어쓸 위험 | ❌ |
| activation hook으로 선언 tap 자동 trust | bundle/cleanup 전에 `brew trust` 실행 | 선언적, 새 머신 자동 적용, additive(수동 trust 보존), 멱등 | activation에 brew 프로세스 1회 추가 (감지는 파일 기반이라 비용 0) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/programs/homebrew.nix` | 수정 (+137) | tap trust hook + 정규화 헬퍼 + assertions 추가 |

### 핵심 구조

```nix
# trust principal — 항상 remote URL 형태 (이름 trust는 drift된 local remote를 신뢰할 수 있음)
trustTargets = map (
  tap: if tap.clone_target != null then tap.clone_target else defaultRemote tap.name
) cfg.taps;  # 형식 불일치 name은 null 전파 → assertion이 거부

# env는 직후 trust.json을 읽는 소비자와 일치 (XDG_CONFIG_HOME류가 store 위치를 바꿈)
bundleTrustScript = mkTrustScript { env = <bundle과 동일: NO_AUTO_UPDATE? + extraEnv>; updateBeforeTrust = autoUpdate; };
checkTrustScript  = mkTrustScript { env = [ "HOMEBREW_NO_AUTO_UPDATE=1" ]; };  # upstream cleanup check와 동일

# groups/users 이후라는 기존 brew 실행 순서 계약을 유지하면서 bundle보다 앞에 배치
system.activationScripts.homebrew.text = lib.mkIf trustEnabled (lib.mkBefore bundleTrustScript);
# cleanup = "check"는 checks 단계에서 formula를 로드하므로 동일 prelude를 prepend
system.checks.text = lib.mkIf (trustEnabled && cfg.onActivation.cleanup == "check") (lib.mkBefore checkTrustScript);
```

생성되는 activation 스크립트 (이 호스트 기준):

```bash
# Homebrew tap trust — brew bundle/cleanup 이전에 선언 tap 신뢰 등록
if [ -f "/opt/homebrew/bin/brew" ]; then
  if { [ -f "/opt/homebrew/Library/Homebrew/cmd/trust.rb" ] || ...; }; then
    echo >&2 "Trusting declared Homebrew taps..."
    ... brew trust --tap https://github.com/laishulu/homebrew-homebrew
  fi
fi
# (직후 upstream의 brew bundle 실행)
```

### 설계 결정 요약

- **URL principal 고정**: `brew trust --tap <default GitHub URL>`은 `remote_to_reference`가 canonical name으로 정규화해 저장 — 선언 의도를 고정하고, drift된 tap은 bundle 단계에서 untrusted로 fail-loud (실측: `Already trusted tap: laishulu/homebrew`).
- **파일 기반 감지**: `--help` probe(ruby 기동 ~1초) 대신 `cmd/trust.rb` 존재 검사 (Apple Silicon `prefix`=repo, Intel `prefix/Homebrew` 두 layout). 구버전 brew + autoUpdate 구성은 trust 등록 전에 먼저 update해 "bundle이 brew를 갱신한 뒤 거부"라는 1회성 전환기 실패를 제거.
- **eval 시점 assertion**: tap name 형식(Bundle `HOMEBREW_TAP_ARGS_REGEX` 동일 기준)과 GitHub alias clone_target 조합을 빌드 전에 명확한 메시지로 거부. `homebrew.enable = false` host는 검사 제외.
- **정규화 정합**: `sanitize_tap_name`(downcase + 선택적 `homebrew-` 접두 제거), `normalize_remote`(strip → downcase → trailing slash 전체 제거 → `.git` 제거)와 동일 순서 — 단위 검증 케이스로 확인.

## 참고 레퍼런스

- Homebrew upstream 소스 — `Library/Homebrew/env_config.rb` (`HOMEBREW_REQUIRE_TAP_TRUST` default true), `Library/Homebrew/trust.rb` (trust store/principal 저장), `Library/Homebrew/tap.rb` (`matches_reference?`/`remote_to_reference`/`normalize_remote`), `Library/Homebrew/bundle/dsl.rb` (`sanitize_tap_name`)
- nix-darwin upstream — `modules/homebrew.nix` (bundle 호출 형태·`extraEnv`·cleanup check), `modules/system/activation-scripts.nix` (activation 순서)
- PR #890 — codex를 declarative nix overlay로 전환 (같은 파일의 최근 구조 변경 맥락)

## Human Test Plan

### 정상 동작 검증

1. trust를 회수한 뒤 빌드한다: `brew untrust --tap laishulu/homebrew && nrs`
   - **기대**: activation 로그에 `Trusting declared Homebrew taps...` 출력 후 Homebrew bundle이 `Refusing to load formula` 없이 통과. `~/.homebrew/trust.json`에 `"laishulu/homebrew"` 생성.
   - **실패 시**: `/opt/homebrew/Library/Homebrew/cmd/trust.rb` 존재 여부(구버전 brew면 감지 skip), `brew trust --tap https://github.com/laishulu/homebrew-homebrew`를 수동 실행해 sudo/env 문제를 분리 진단.

2. 멱등성: `nrs`를 한 번 더 실행한다.
   - **기대**: trust 단계가 `Already trusted` 경로로 조용히 통과 (exit 0), bundle 정상.
   - **실패 시**: trust.json 내용이 canonical name(`laishulu/homebrew`)인지 확인.

### 엣지 케이스 (eval 검증)

3. `homebrew.taps`에 `"foo"`(슬래시 없음)를 임시 추가 후 `nix eval .#darwinConfigurations.<host>.config.assertions`를 평가한다.
   - **기대**: "tap name 형식이 아니라 trust principal을 계산할 수 없다" assertion 실패 (elemAt 범위 오류 같은 불친절한 에러가 아님).
   - **실패 시**: `tapNameRegex`와 `sanitizeTapName`의 null 전파를 확인.

4. `{ name = "alias/repo"; clone_target = "https://github.com/real/homebrew-repo"; }`를 임시 추가 후 eval한다.
   - **기대**: alias clone_target assertion 실패 (canonical name 불일치 메시지).

### Regression

5. 기존 bundle 동작: `nrs` 후 `brew bundle check --file=<Brewfile store 경로>` 또는 nrs 로그에서 기존 13개 의존성이 그대로 설치 상태인지 확인한다.
   - **기대**: 기존 brews/casks 목록 변화 없음 (이번 변경은 trust 단계만 추가).

6. checks 단계 비오염: `nix eval --raw .#darwinConfigurations.<host>.config.system.checks.text | grep Trusting`
   - **기대**: 현 구성(`cleanup = "none"`)에서는 매치 없음 — trust prelude는 `cleanup = "check"`일 때만 checks에 포함.
   - **실패 시**: `system.checks.text`의 mkIf 조건을 확인.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Homebrew tap trust verification during system activation
  * Added validation checks for Homebrew tap configurations to prevent misconfiguration

* **Improvements**
  * Enhanced detection of improperly configured taps and mismatched repository identities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->