### PR TITLE
fix(wt): 비대화형 cd 경로 출력 계약 복구 — wrapper self-gate + tmux 단일 정책

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이
 
 ## Worktree (wt)
 
-`wt`로 git worktree를 생성/이동/정리한다 (`.claude/worktrees/<dir>`, 현재 HEAD 기준 분기). 비대화형 셸(LLM Bash tool 등)에서는 zsh 함수 래퍼가 없어 `~/.local/bin/wt` 바이너리가 직접 실행되고 자동으로 비대화형 모드가 된다 (fzf/번호 선택/tmux attach 비활성; `WT_NONINTERACTIVE=1`로 강제 가능). 비대화형 사용 규칙:
+`wt`로 git worktree를 생성/이동/정리한다 (`.claude/worktrees/<dir>`, 현재 HEAD 기준 분기). 비대화형 셸(LLM Bash tool 등)에서는 자동으로 비대화형 모드가 된다 (fzf/번호 선택/tmux attach/tmux 윈도우 전환 비활성; `WT_NONINTERACTIVE=1`로 강제 가능). LLM 하네스가 대화형 셸 snapshot을 주입해 zsh 래퍼 함수가 비대화형 셸에 존재할 수 있으나, 래퍼는 비대화형(WT_NONINTERACTIVE 또는 stdin 비TTY)을 감지하면 `~/.local/bin/wt` 바이너리로 passthrough하므로 아래 규칙은 동일하게 성립한다. 비대화형 사용 규칙:
 
 - 생성: `wt <branch>`. 기존 worktree/브랜치와 충돌하면 비대화형은 **안전하게 실패**하므로 의도를 `--if-exists=reuse|recreate|fail`로 명시한다.
 - 이동: 비대화형은 cd 불가 — 경로를 stdout으로 출력하므로 `cd "$(wt cd <name>)"`로 쓴다. 인자 없는 `wt cd`는 실패하니 이름을 지정한다.

--- a/modules/shared/programs/cheat/cheatsheets/wt/command
+++ b/modules/shared/programs/cheat/cheatsheets/wt/command
@@ -58,9 +58,9 @@ wt — Git worktree 관리 (fzf TUI, tmux 통합)
   wt cd <name>              해당 경로로 cd
   wt ls / wt cleanup        동일하게 동작
 
-[.wt-parent]
-  부모 브랜치를 worktree 루트에 기록 (gitignore됨)
-  확인: cat .claude/worktrees/<name>/.wt-parent
+[.wt-last / wt cd -]
+  마지막 worktree 경로를 .claude/worktrees/.wt-last에 기록
+  wt cd -                   이전 worktree로 이동 (cd -, git checkout - 패턴)
 
 Tip
 - wt ls로 상태 확인 → wt cleanup으로 MERGED 일괄 정리가 기본 워크플로우

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -283,15 +283,18 @@ in
       #─────────────────────────────────────────────────────────────────────────
       ''
         wt() {
-          # 비대화형 셸에서는 wrapper를 우회하고 바이너리에 위임한다.
-          # Claude Code 같은 LLM 하네스는 대화형 셸의 snapshot을 비대화형 셸에
-          # 주입하므로 "비대화형엔 wrapper가 없다"는 가정이 성립하지 않는다.
-          # wrapper의 cd 분기는 경로를 stdout에 내지 않아(직접 cd가 목적)
-          # `cd "$(wt cd <name>)"` 비대화형 계약이 조용히 깨진다 — zsh에서
-          # `cd ""`는 no-op 성공이라 잘못된 디렉토리에서 후속 명령이 실행된다.
-          # 게이트 기준은 바이너리의 _wt_interactive와 동일 (WT_NONINTERACTIVE
-          # 또는 stdin 비TTY).
-          if [[ -n "''${WT_NONINTERACTIVE:-}" ]] || [[ ! -t 0 ]]; then
+          # 비대화형/캡처 컨텍스트에서는 wrapper를 우회하고 바이너리에 위임한다.
+          # (1) Claude Code 같은 LLM 하네스는 대화형 셸의 snapshot을 비대화형 셸에
+          #     주입하므로 "비대화형엔 wrapper가 없다"는 가정이 성립하지 않는다.
+          # (2) wrapper의 cd 분기는 경로를 stdout에 내지 않아(직접 cd가 목적)
+          #     `cd "$(wt cd <name>)"` 계약이 조용히 깨진다 — zsh에서 `cd ""`는
+          #     no-op 성공이라 잘못된 디렉토리에서 후속 명령이 실행된다.
+          # (3) stdout 비TTY 검사: 대화형 셸이라도 $(...)/파이프로 stdout이 캡처되면
+          #     호출자가 출력을 원하는 것이므로 wrapper의 직접-cd UX 대신 바이너리의
+          #     경로 출력 계약을 따른다.
+          # 게이트 기준 = 바이너리의 _wt_interactive(WT_NONINTERACTIVE 또는 stdin
+          # 비TTY) + stdout 비TTY.
+          if [[ -n "''${WT_NONINTERACTIVE:-}" ]] || [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
             command wt "$@"
             return $?
           fi

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -283,6 +283,19 @@ in
       #─────────────────────────────────────────────────────────────────────────
       ''
         wt() {
+          # 비대화형 셸에서는 wrapper를 우회하고 바이너리에 위임한다.
+          # Claude Code 같은 LLM 하네스는 대화형 셸의 snapshot을 비대화형 셸에
+          # 주입하므로 "비대화형엔 wrapper가 없다"는 가정이 성립하지 않는다.
+          # wrapper의 cd 분기는 경로를 stdout에 내지 않아(직접 cd가 목적)
+          # `cd "$(wt cd <name>)"` 비대화형 계약이 조용히 깨진다 — zsh에서
+          # `cd ""`는 no-op 성공이라 잘못된 디렉토리에서 후속 명령이 실행된다.
+          # 게이트 기준은 바이너리의 _wt_interactive와 동일 (WT_NONINTERACTIVE
+          # 또는 stdin 비TTY).
+          if [[ -n "''${WT_NONINTERACTIVE:-}" ]] || [[ ! -t 0 ]]; then
+            command wt "$@"
+            return $?
+          fi
+
           # --tmux: exec tmux를 위해 subshell 캡처 우회
           local _wt_has_tmux=false
           local _wt_arg

--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -105,11 +105,18 @@ _open_worktree() {
     fi
   else
     # tmux 밖 또는 비대화형: 경로 stdout 출력 (래퍼가 cd)
-    [[ "$run_claude" == "true" ]] && _info "경고: --claude는 tmux 세션 안에서만 동작합니다"
-    if [[ "$stay" == "true" ]]; then
-      # --stay: 현재 디렉토리 유지, 경로만 안내
+    if [[ "$run_claude" == "true" ]]; then
+      if [[ -n "${TMUX:-}" ]]; then
+        _info "경고: --claude는 비대화형에서 정책상 무시됩니다 (tmux UI 비활성)"
+      else
+        _info "경고: --claude는 tmux 세션 안에서만 동작합니다"
+      fi
+    fi
+    if [[ "$stay" == "true" ]] && _wt_interactive; then
+      # --stay (대화형): 현재 디렉토리 유지, 경로만 안내 — stdout에 내면 래퍼가 cd해버린다
       _info "worktree 경로: $wt_path"
     else
+      # 비대화형은 --stay여도 stdout 경로 출력 계약을 지킨다 (래퍼는 self-gate로 우회됨)
       echo "$wt_path"
     fi
   fi

--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -78,7 +78,9 @@ _open_worktree() {
     _warn "비대화형: --tmux 무시 (경로 출력으로 fallback)"
   fi
 
-  if [[ -n "${TMUX:-}" ]]; then
+  # tmux 윈도우 생성/전환은 대화형 한정 (정책: _wt_tmux_ui_allowed) — 비대화형
+  # create/reuse는 tmux 화면을 건드리지 않고 아래 else의 경로 stdout 출력을 따른다.
+  if _wt_tmux_ui_allowed; then
     local window_id open_rc=0
     window_id=$(_wt_tmux_open "$wt_path" "$window_name" "$stay") || open_rc=$?
 
@@ -102,7 +104,7 @@ _open_worktree() {
       fi
     fi
   else
-    # tmux 밖: 경로 stdout 출력 (래퍼가 cd)
+    # tmux 밖 또는 비대화형: 경로 stdout 출력 (래퍼가 cd)
     [[ "$run_claude" == "true" ]] && _info "경고: --claude는 tmux 세션 안에서만 동작합니다"
     if [[ "$stay" == "true" ]]; then
       # --stay: 현재 디렉토리 유지, 경로만 안내

--- a/modules/shared/scripts/lib/wt/navigate.sh
+++ b/modules/shared/scripts/lib/wt/navigate.sh
@@ -159,8 +159,11 @@ cmd_cd() {
     _warn "비대화형: --tmux 무시 (경로만 출력)"
   fi
 
-  # tmux 안이면 윈도우 전환 시도
-  if [[ -n "${TMUX:-}" ]]; then
+  # tmux 안이면 윈도우 전환 시도 (대화형 한정) — 비대화형 호출(LLM/스크립트)은
+  # "경로를 stdout으로 출력" 계약을 지켜야 하고, 사용자 tmux 화면을 임의로
+  # 전환하는 부수효과도 내면 안 된다. 전환 성공 시 경로 출력 없이 return 0이라
+  # `cd "$(wt cd <name>)"`가 빈 문자열을 받는다 (zsh의 `cd ""`는 no-op 성공).
+  if [[ -n "${TMUX:-}" ]] && _wt_interactive; then
     local window_id
     if window_id=$(_wt_find_tmux_window "$target_path"); then
       tmux select-window -t "$window_id"

--- a/modules/shared/scripts/lib/wt/navigate.sh
+++ b/modules/shared/scripts/lib/wt/navigate.sh
@@ -159,11 +159,12 @@ cmd_cd() {
     _warn "비대화형: --tmux 무시 (경로만 출력)"
   fi
 
-  # tmux 안이면 윈도우 전환 시도 (대화형 한정) — 비대화형 호출(LLM/스크립트)은
-  # "경로를 stdout으로 출력" 계약을 지켜야 하고, 사용자 tmux 화면을 임의로
-  # 전환하는 부수효과도 내면 안 된다. 전환 성공 시 경로 출력 없이 return 0이라
-  # `cd "$(wt cd <name>)"`가 빈 문자열을 받는다 (zsh의 `cd ""`는 no-op 성공).
-  if [[ -n "${TMUX:-}" ]] && _wt_interactive; then
+  # tmux 안이면 윈도우 전환 시도 (대화형 한정 — 정책은 _wt_tmux_ui_allowed가 소유).
+  # 비대화형 호출(LLM/스크립트)은 "경로를 stdout으로 출력" 계약을 지켜야 하고,
+  # 사용자 tmux 화면을 임의로 전환하는 부수효과도 내면 안 된다. 전환 성공 시 경로
+  # 출력 없이 return 0이라 `cd "$(wt cd <name>)"`가 빈 문자열을 받는다
+  # (zsh의 `cd ""`는 no-op 성공).
+  if _wt_tmux_ui_allowed; then
     local window_id
     if window_id=$(_wt_find_tmux_window "$target_path"); then
       tmux select-window -t "$window_id"

--- a/modules/shared/scripts/lib/wt/tmux.sh
+++ b/modules/shared/scripts/lib/wt/tmux.sh
@@ -1,4 +1,13 @@
 # shellcheck shell=bash
+# tmux UI 부수효과(윈도우 생성/전환) 허용 여부 — 단일 정책 경계.
+# 비대화형(LLM/스크립트) 호출은 사용자 tmux 화면을 임의로 바꾸지 않고
+# "경로를 stdout으로 출력" 계약을 지켜야 한다 (CLAUDE.md Worktree 섹션).
+# cd/create/reuse 등 tmux 윈도우 전환·생성이 가능한 모든 경로는 이 함수로
+# 게이트한다 — 호출자별 가드 복제로 정책 누락이 생기는 것을 막는다.
+_wt_tmux_ui_allowed() {
+  [[ -n "${TMUX:-}" ]] && _wt_interactive
+}
+
 # worktree 디렉토리에 해당하는 tmux 윈도우 찾기
 # tmux 안/밖 모두 동작 — 서버 실행 여부만 확인
 _wt_find_tmux_window() {

--- a/modules/shared/scripts/wt.sh
+++ b/modules/shared/scripts/wt.sh
@@ -34,6 +34,13 @@
 #           cleanup [name...] 위치 인자 + --yes, ls --json 구조화 출력.
 #    제거: .wt-parent (write-only dead data, 읽는 코드 0곳) / gum 의존 (wt ls 표시 전용 잔재,
 #         plain printf fallback이 동등; packages.nix에서도 제거).
+# v8: 비대화형 stdout 계약 강화 — "비대화형 셸은 래퍼 없이 직행"(v7 전제)이 깨짐을 확인.
+#    배경: LLM 하네스(Claude Code)가 대화형 셸 snapshot을 비대화형 셸에 주입해 zsh 래퍼가
+#          존재할 수 있다. 래퍼 cd 분기는 경로를 출력하지 않아 cd "$(wt cd <name>)"가 빈
+#          문자열을 받고, zsh의 `cd ""` no-op 성공으로 잘못된 디렉토리에서 후속 명령이 실행됐다.
+#    수정: 래퍼 self-gate(WT_NONINTERACTIVE/stdin 비TTY/stdout 비TTY → 바이너리 passthrough),
+#          tmux UI 부수효과(윈도우 생성/전환)는 _wt_tmux_ui_allowed 단일 정책으로 대화형 한정,
+#          --stay도 비대화형에서는 stdout 경로 출력.
 
 set -euo pipefail
 
@@ -121,8 +128,8 @@ Git worktree 관리 도구 (fzf TUI, tmux 통합; 비대화형/LLM 셸 호환)
 
 비대화형 (LLM/스크립트):
   stdin이 tty가 아니거나 WT_NONINTERACTIVE=1이면 비대화형 모드.
-  fzf/번호선택/tmux attach 대신 명시 플래그·인자가 필요하다.
-  생성/이동 경로는 stdout으로 출력되므로 cd "\$(wt cd <name>)" 형태로 사용.
+  fzf/번호선택/tmux attach/tmux 윈도우 생성·전환 대신 명시 플래그·인자가 필요하다.
+  생성/이동 경로는 stdout으로 출력되므로 cd "\$(wt cd <name>)" 형태로 사용 (--stay 포함).
 
 Codex:
   worktree 생성/재생성 bootstrap은 해당 worktree를 Codex 전역 config에 trust한다.

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1574,6 +1574,53 @@ STUB
   [[ ! -f "$marker" ]] || fail "noninteractive wt create/reuse must not touch tmux windows"
 }
 
+# 비대화형 --stay: 대화형에서는 경로를 stderr 안내만 하지만(stdout에 내면 래퍼가
+# cd해버림), 비대화형에서는 stdout 경로 출력 계약을 지켜야 한다.
+test_wt_create_stay_noninteractive_prints_path_to_stdout() {
+  local sandbox home_dir repo_root stdout_only expected_path stub_dir marker
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubbin"
+  marker="$sandbox/tmux-ui-called"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  expected_path="$repo_root/.claude/worktrees/feature_one"
+
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/tmux" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-sessions) exit 0 ;;
+  list-panes)    printf '@1 %s\n' "${TMUX_STUB_PANE_PATH:?}" ;;
+  select-window|new-window) touch "${TMUX_STUB_MARKER:?}" ;;
+  *)             exit 0 ;;
+esac
+STUB
+  chmod +x "$stub_dir/tmux"
+
+  # stdout만 캡처 (stderr 제외) — 경로가 "stdout"으로 나오는지가 검증 대상
+  stdout_only=$(
+    TMUX="$sandbox/fake-tmux-socket,1234,0" \
+    TMUX_STUB_PANE_PATH="$expected_path" \
+    TMUX_STUB_MARKER="$marker" \
+    HOME="$home_dir" \
+    PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
+    WT_NONINTERACTIVE=1 \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/wt"'" --stay --if-exists=reuse feature_one
+    ' 2>/dev/null
+  )
+
+  assert_contains "$stdout_only" "$expected_path"
+  [[ ! -f "$marker" ]] || fail "noninteractive --stay must not touch tmux windows"
+}
+
 test_shadow_paths_do_not_override_managed_helpers() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)
@@ -2647,6 +2694,7 @@ run_test "wt create if-exists=reuse returns path" test_wt_create_if_exists_reuse
 run_test "wt cd requires name when noninteractive" test_wt_cd_noninteractive_requires_name
 run_test "wt cd prints path in tmux when noninteractive" test_wt_cd_noninteractive_in_tmux_prints_path
 run_test "wt create/reuse prints path in tmux when noninteractive" test_wt_create_reuse_noninteractive_in_tmux_prints_path
+run_test "wt --stay prints path to stdout when noninteractive" test_wt_create_stay_noninteractive_prints_path_to_stdout
 run_test "shadow paths do not override managed helpers" test_shadow_paths_do_not_override_managed_helpers
 run_test "wt symlink alias does not load adjacent helpers" test_wt_symlink_alias_does_not_load_adjacent_helpers
 run_test "rebuild-common symlink alias does not load adjacent helpers" test_rebuild_common_symlink_alias_does_not_load_adjacent_helpers

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1526,6 +1526,54 @@ STUB
   [[ ! -f "$marker" ]] || fail "noninteractive wt cd must not call tmux select-window"
 }
 
+# 비대화형 + TMUX 환경: create/reuse 경로(_open_worktree)도 동일 정책
+# (_wt_tmux_ui_allowed)을 따라야 한다 — tmux 윈도우 생성/전환 없이 경로를
+# stdout으로 출력한다.
+test_wt_create_reuse_noninteractive_in_tmux_prints_path() {
+  local sandbox home_dir repo_root output expected_path stub_dir marker
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubbin"
+  marker="$sandbox/tmux-ui-called"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  expected_path="$repo_root/.claude/worktrees/feature_one"
+
+  # tmux stub: select-window/new-window 호출 시 marker를 남겨 미호출을 검증한다.
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/tmux" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-sessions) exit 0 ;;
+  list-panes)    printf '@1 %s\n' "${TMUX_STUB_PANE_PATH:?}" ;;
+  select-window|new-window) touch "${TMUX_STUB_MARKER:?}" ;;
+  *)             exit 0 ;;
+esac
+STUB
+  chmod +x "$stub_dir/tmux"
+
+  output=$(
+    TMUX="$sandbox/fake-tmux-socket,1234,0" \
+    TMUX_STUB_PANE_PATH="$expected_path" \
+    TMUX_STUB_MARKER="$marker" \
+    HOME="$home_dir" \
+    PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
+    WT_NONINTERACTIVE=1 \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/wt"'" --if-exists=reuse feature_one
+    ' 2>&1
+  )
+
+  assert_contains "$output" "$expected_path"
+  [[ ! -f "$marker" ]] || fail "noninteractive wt create/reuse must not touch tmux windows"
+}
+
 test_shadow_paths_do_not_override_managed_helpers() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)
@@ -2598,6 +2646,7 @@ run_test "wt create conflict requires if-exists when noninteractive" test_wt_cre
 run_test "wt create if-exists=reuse returns path" test_wt_create_if_exists_reuse_returns_path
 run_test "wt cd requires name when noninteractive" test_wt_cd_noninteractive_requires_name
 run_test "wt cd prints path in tmux when noninteractive" test_wt_cd_noninteractive_in_tmux_prints_path
+run_test "wt create/reuse prints path in tmux when noninteractive" test_wt_create_reuse_noninteractive_in_tmux_prints_path
 run_test "shadow paths do not override managed helpers" test_shadow_paths_do_not_override_managed_helpers
 run_test "wt symlink alias does not load adjacent helpers" test_wt_symlink_alias_does_not_load_adjacent_helpers
 run_test "rebuild-common symlink alias does not load adjacent helpers" test_rebuild_common_symlink_alias_does_not_load_adjacent_helpers

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1476,6 +1476,56 @@ test_wt_cd_noninteractive_requires_name() {
   assert_contains "$output" "이름을 인자로"
 }
 
+# 비대화형 + TMUX 환경: tmux 윈도우 전환 분기는 대화형 한정이어야 한다.
+# 가드 없으면 매칭 윈도우 존재 시 select-window 후 경로 출력 없이 return 0 —
+# `cd "$(wt cd <name>)"`가 빈 문자열을 받고(zsh `cd ""`는 no-op 성공) 사용자
+# tmux 화면이 임의 전환된다.
+test_wt_cd_noninteractive_in_tmux_prints_path() {
+  local sandbox home_dir repo_root output expected_path stub_dir marker
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubbin"
+  marker="$sandbox/select-window-called"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+
+  expected_path="$repo_root/.claude/worktrees/feature_one"
+
+  # tmux stub: 대상 worktree에 매칭되는 pane이 존재하는 상황을 재현한다.
+  # select-window 호출 시 marker 파일을 남겨 "호출되지 않았음"을 검증한다.
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/tmux" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+  list-sessions) exit 0 ;;
+  list-panes)    printf '@1 %s\n' "${TMUX_STUB_PANE_PATH:?}" ;;
+  select-window) touch "${TMUX_STUB_MARKER:?}" ;;
+  *)             exit 0 ;;
+esac
+STUB
+  chmod +x "$stub_dir/tmux"
+
+  output=$(
+    TMUX="$sandbox/fake-tmux-socket,1234,0" \
+    TMUX_STUB_PANE_PATH="$expected_path" \
+    TMUX_STUB_MARKER="$marker" \
+    HOME="$home_dir" \
+    PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
+    WT_NONINTERACTIVE=1 \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/wt"'" cd feature_one
+    ' 2>&1
+  )
+
+  assert_contains "$output" "$expected_path"
+  [[ ! -f "$marker" ]] || fail "noninteractive wt cd must not call tmux select-window"
+}
+
 test_shadow_paths_do_not_override_managed_helpers() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)
@@ -2547,6 +2597,7 @@ run_test "wt ls --json outputs parseable array" test_wt_ls_json_outputs_parseabl
 run_test "wt create conflict requires if-exists when noninteractive" test_wt_create_conflict_noninteractive_requires_if_exists
 run_test "wt create if-exists=reuse returns path" test_wt_create_if_exists_reuse_returns_path
 run_test "wt cd requires name when noninteractive" test_wt_cd_noninteractive_requires_name
+run_test "wt cd prints path in tmux when noninteractive" test_wt_cd_noninteractive_in_tmux_prints_path
 run_test "shadow paths do not override managed helpers" test_shadow_paths_do_not_override_managed_helpers
 run_test "wt symlink alias does not load adjacent helpers" test_wt_symlink_alias_does_not_load_adjacent_helpers
 run_test "rebuild-common symlink alias does not load adjacent helpers" test_rebuild_common_symlink_alias_does_not_load_adjacent_helpers


### PR DESCRIPTION
## Summary

- 비대화형 셸(LLM Bash tool, 스크립트)에서 `cd "$(wt cd <name>)"`가 **빈 문자열을 받아 잘못된 디렉토리에서 후속 명령이 조용히 실행되던** 사고를 복구한다.
- 근본 원인 두 가지를 모두 제거한다: ① LLM 하네스의 셸 snapshot 주입으로 zsh wrapper가 비대화형 셸에 존재 → wrapper에 비대화형/캡처 self-gate 추가, ② 바이너리의 tmux 윈도우 전환 분기가 경로 출력 없이 종료 → tmux UI 부수효과를 `_wt_tmux_ui_allowed` 단일 정책으로 대화형 한정.
- `--stay` 비대화형 stdout 계약, 도움말/CIR/cheat sheet 문서 정합, 회귀 테스트 3건을 함께 반영한다.

## 기존 문제/배경

다른 작업 세션에서 `cd "$(wt cd <워크트리명>)" && nix eval ...`이 **main repo에서 실행되어 잘못된 결과**를 내는 사고가 실제 발생했다. 증상이 간헐적이라 추적이 어려웠는데, 원인 사슬은 다음과 같았다:

1. Claude Code 같은 LLM 하네스는 세션 시작 시 **대화형 zsh의 snapshot**(함수 포함)을 떠서 비대화형 Bash tool 셸에 주입한다. 기존 전제("비대화형 셸에는 zsh 래퍼가 없어 `~/.local/bin/wt` 바이너리가 직행")가 깨진다.
2. wrapper의 `wt cd` 분기는 바이너리의 stdout(경로)을 캡처해 **직접 `cd`하고 아무것도 출력하지 않는다** — `$()` 안에서는 subshell cd라 무의미하고, 캡처 결과는 빈 문자열이 된다.
3. zsh에서 `cd ""`는 **에러가 아니라 no-op 성공**(exit 0, 현재 디렉토리 유지)이다. 따라서 셸의 기존 cwd가 우연히 목표 워크트리였던 동안은 정상처럼 보이다가, cwd가 리셋되는 순간부터 main repo에서 조용히 실행됐다 — 간헐 증상의 정체.
4. 별개로, 바이너리 자체도 `$TMUX` 설정 + 대상 워크트리에 매칭되는 tmux 윈도우 존재 시 `select-window` 후 **경로 출력 없이 return 0** 하는 분기를 갖고 있었다 (비대화형 호출이 사용자 tmux 화면을 임의 전환하는 부수효과 포함). create/reuse가 공유하는 `_open_worktree`에도 같은 무가드 분기가 있었다.

## CIR (Change Intent Record)

- **v1** (이번 변경): 사고 재현·추적으로 snapshot 주입 + wrapper cd 분기 무출력 + zsh `cd ""` no-op의 3중 결합을 확인. wrapper 최상단에 바이너리 `_wt_interactive`와 동일 기준(WT_NONINTERACTIVE 또는 stdin 비TTY)의 self-gate를 추가하고, 바이너리 `wt cd`의 tmux 윈도우 전환 분기에 대화형 가드를 추가.
- **v2** (이번 변경): 코드 리뷰에서 같은 무가드 tmux 분기가 create/reuse 공유 경계(`_open_worktree`)에도 있음을 확인 — 호출자별 가드 복제는 새 호출자 추가 시 정책 누락을 낳으므로, tmux UI 부수효과 허용 여부를 `_wt_tmux_ui_allowed` 단일 정책 함수로 통일.
- **v3** (이번 변경): 전수조사에서 잔여 경로 발견 — 대화형 셸에서 stdout만 파이프인 `cd "$(wt cd <name>)"` 조합은 게이트가 안 걸림(stdout 비TTY 조건 추가), `--stay`는 경로를 stderr로만 안내해 비대화형 stdout 계약 위반(비대화형은 stdout 출력으로 통일), 문서(CIR 주석/도움말/cheat sheet)의 구계약 서술 정리.

**trade-off**: 대화형 셸에서 stdout을 캡처하면(`$()`/파이프) wrapper의 직접-cd UX 대신 바이너리 passthrough가 된다 — 캡처 호출자는 출력을 원한다는 해석이며, 일반 대화형 `wt cd <name>` UX는 그대로다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| wrapper self-gate (비대화형/캡처 → 바이너리 passthrough) | wrapper 최상단에서 WT_NONINTERACTIVE/stdin 비TTY/stdout 비TTY 감지 시 `command wt` 위임 | snapshot 주입 등 wrapper가 어디에 복제되든 구조적으로 안전, 대화형 UX 보존 | wrapper에 분기 1개 추가 | ✅ |
| 하네스 쪽 우회 (LLM이 바이너리 절대경로만 사용) | CLAUDE.md에 "~/.local/bin/wt를 직접 호출" 규칙 추가 | 코드 무변경 | 규칙 기억에 의존(구조적 보장 없음), 다른 스크립트/하네스에는 무효 | ❌ |
| wrapper cd 분기가 cd 후 경로도 echo | cd하면서 stdout에도 경로 출력 | `$()` 캡처가 값을 받음 | 대화형 직접 호출 시 불필요한 출력, snapshot의 옛 wrapper에는 무효, 근본 원인(잘못된 컨텍스트에서 wrapper 활성) 미해결 | ❌ |
| tmux 분기 가드를 호출자별 복제 | cd와 _open_worktree에 각각 `[[ -n $TMUX ]] && _wt_interactive` | 단순 | 새 호출자 추가 시 정책 누락 재발 구조 | ❌ |
| tmux UI 단일 정책 함수 (`_wt_tmux_ui_allowed`) | 윈도우 생성/전환 가능 여부를 한 함수가 소유, 모든 경로가 공유 | 정책 누락 구조적 방지, 의도가 이름에 드러남 | 함수 1개 추가 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/shell/default.nix` | 수정 | zsh wrapper 최상단 self-gate (WT_NONINTERACTIVE / stdin 비TTY / stdout 비TTY → `command wt` passthrough) |
| `modules/shared/scripts/lib/wt/tmux.sh` | 수정 | `_wt_tmux_ui_allowed` 단일 정책 함수 추가 |
| `modules/shared/scripts/lib/wt/navigate.sh` | 수정 | `wt cd`의 tmux 윈도우 전환 분기를 정책 함수로 게이트 |
| `modules/shared/scripts/lib/wt/bootstrap.sh` | 수정 | `_open_worktree` tmux 분기 게이트, 비대화형 `--stay` stdout 출력, `--claude` 경고 원인별 분기 |
| `modules/shared/scripts/wt.sh` | 수정 | CIR 새 버전 배경 추가, 도움말에 tmux 윈도우 생성·전환 비활성 명시 |
| `modules/shared/programs/cheat/cheatsheets/wt/command` | 수정 | 제거된 `.wt-parent` 섹션 → `.wt-last`/`wt cd -` 설명 (기존 문서 부채) |
| `CLAUDE.md` | 수정 | Worktree 섹션의 "비대화형엔 래퍼 없음" 전제 서술 갱신 |
| `tests/shell-script-tests.sh` | 수정 | 회귀 테스트 3건 (비대화형+TMUX에서 cd/create·reuse/--stay 경로 stdout 출력 + tmux 윈도우 미접촉) |

### 핵심 코드

```zsh
# zsh wrapper self-gate (렌더링 결과)
wt() {
  if [[ -n "${WT_NONINTERACTIVE:-}" ]] || [[ ! -t 0 ]] || [[ ! -t 1 ]]; then
    command wt "$@"    # 비대화형/캡처: 바이너리의 "경로 stdout 출력" 계약
    return $?
  fi
  ...                  # 대화형: 기존 직접-cd UX
}
```

```bash
# tmux UI 부수효과 단일 정책 (lib/wt/tmux.sh)
_wt_tmux_ui_allowed() {
  [[ -n "${TMUX:-}" ]] && _wt_interactive
}
# cd(navigate.sh)와 create/reuse(_open_worktree, bootstrap.sh)가 공유
```

## 참고 레퍼런스

- PR #895 — 셸 startup 최적화 (zsh initContent 인접 변경 맥락)
- 셸 snapshot 주입 동작: Claude Code가 세션 시작 시 대화형 셸 함수를 `~/.claude/shell-snapshots/`로 캡처해 Bash tool 셸에 주입 (실측 확인: `type wt` → "shell function from .../shell-snapshots/...")
- zsh `cd ""` no-op 성공 동작 (실측: exit 0, 현재 디렉토리 유지)

## Human Test Plan

### 정상 동작 검증 (비대화형 계약)

1. 새 터미널(새 셸 세션)에서: `echo 'cd "$(wt cd <기존 워크트리명>)" && pwd' | zsh -i`
   - **기대**: 해당 워크트리 경로가 pwd로 출력된다.
   - **실패 시**: `awk '/^wt\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' ~/.zshrc`로 렌더링된 wrapper에 `! -t 1` 게이트가 있는지 확인.

2. tmux 안에서 비대화형 호출: 대상 워크트리에 pane이 열려 있는 상태로 `WT_NONINTERACTIVE=1 wt cd <name>` 실행.
   - **기대**: tmux 윈도우가 전환되지 않고 경로가 stdout으로 출력된다.
   - **실패 시**: `lib/wt/navigate.sh`의 `_wt_tmux_ui_allowed` 게이트와 `lib/wt/tmux.sh`의 정책 함수를 확인.

3. `WT_NONINTERACTIVE=1 wt --stay --if-exists=reuse <name> 2>/dev/null`
   - **기대**: stderr를 버려도 stdout에 경로가 출력된다.

### 대화형 UX 회귀 (Negative)

4. 터미널에서 직접 `wt cd <name>` 입력.
   - **기대**: 기존처럼 현재 셸이 해당 워크트리로 cd된다 (경로 echo 없음).
5. tmux 안 터미널에서 직접 `wt cd <name>` (대상 윈도우 존재 시).
   - **기대**: 기존처럼 해당 tmux 윈도우로 전환된다.
6. 터미널에서 직접 `wt --stay <branch>`.
   - **기대**: cd되지 않고 경로 안내만 출력된다 (stdout 경로 echo로 인한 의도치 않은 cd 없음).

### Regression

7. `bash tests/shell-script-tests.sh`
   - **기대**: 전체 테스트(56건) 통과 — wt cd/create/cleanup/ls 기존 동작 포함.
8. `wt ls --json | jq .`
   - **기대**: 기존과 동일한 JSON 배열 출력 (wrapper passthrough 경유).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-interactive mode to prevent tmux window switching and properly output paths to stdout for script integration.

* **Documentation**
  * Updated documentation and help text to clarify non-interactive behavior and proper `cd` usage patterns.

* **Tests**
  * Added test coverage for non-interactive operations to ensure tmux UI calls are not invoked and stdout output is correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->