### PR TITLE
fix: migrate SSH settings

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778958912,
-        "narHash": "sha256-6pvS9rIF9mZRj1ENwu9fDLHeG1JFDTCpRyy6vJhXkTA=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "6e8dc7aa0e65fce67c76e18227a13a7d529f2cdf",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779113444,
-        "narHash": "sha256-/L61sT1PIKmGWIQpIh0uJGH/ANvcsf6y4alxtb9kelg=",
+        "lastModified": 1781837860,
+        "narHash": "sha256-oxAvnVo7JI7YNH9xaBt3n7dPTTcToUy5hlzVqTnA0sw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74f170c62d57f90e656841f1f699e6bdf40f0a24",
+        "rev": "3abeedcf409ecd8fca201646074bfb31797e8cc2",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779077424,
-        "narHash": "sha256-2nuxPFMR1R3IlV/OlF65qjs2gGjHhASa7U0+8QX0bJg=",
+        "lastModified": 1781756886,
+        "narHash": "sha256-O19FRVtXC+2fNkbIlwssYVay284ynwEK9QAvHAVTLFA=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "b7bde1772cdb20e77381516fbbb5306a621d0965",
+        "rev": "092eb7e14b6950afb62ad4b0bc2532a122d206e0",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -207,11 +207,11 @@
     "yazi-flavors": {
       "flake": false,
       "locked": {
-        "lastModified": 1778937272,
-        "narHash": "sha256-46x4K4dx4rlU108SXhctJOeGlO/W57Pnofb914Sa4vA=",
+        "lastModified": 1780204176,
+        "narHash": "sha256-qWNArjWuxWL+rOjLzyIniW5hJgWiAWTCgXmMXJpaWZE=",
         "owner": "yazi-rs",
         "repo": "flavors",
-        "rev": "54ab389e4deb3d1bc1d8de18d99e825962a55da1",
+        "rev": "0f9204bc948c8313963f5c9d571a82edc201f8aa",
         "type": "github"
       },
       "original": {

--- a/modules/darwin/programs/ssh/default.nix
+++ b/modules/darwin/programs/ssh/default.nix
@@ -15,43 +15,37 @@ in
   # 구 id_ed25519는 1Password mac-ssh로 대체되어 archive됨 (FR-8) → identityFile/ssh-add launchd 제거.
   programs.ssh = {
     enable = true;
-    # home-manager의 기본 SSH 설정 비활성화 (deprecated 경고 방지)
+    # home-manager의 기본 SSH 설정 비활성화
     enableDefaultConfig = false;
-    matchBlocks = {
+    settings = {
       "*" = {
-        extraOptions = {
-          AddKeysToAgent = "yes";
-          # 1Password SSH agent (group container socket — 공백 포함 경로라 quote 필요)
-          IdentityAgent = "\"${onePasswordAgentSock}\"";
-        };
+        AddKeysToAgent = "yes";
+        # 1Password SSH agent (group container socket — 공백 포함 경로라 quote 필요)
+        IdentityAgent = "\"${onePasswordAgentSock}\"";
       };
     }
     // lib.optionalAttrs (hostType == "personal") {
       # MiniPC는 Tailscale IP 전용 — work Mac(Tailnet 미소속)에서는 접속 불가
       "minipc" = {
-        hostname = constants.network.minipcTailscaleIP;
-        user = "greenhead";
+        HostName = constants.network.minipcTailscaleIP;
+        User = "greenhead";
         # mac-ssh 공개키로 고정 + IdentitiesOnly — agent의 mac-ssh 키만 제시한다.
         # 구 id_rsa/id_ecdsa 등 무차별 키 시도(서버 로그 오염·MaxAuthTries lockout 위험)를 차단한다.
-        identityFile = "${homeDir}/.ssh/mac-ssh.pub";
-        extraOptions = {
-          IdentitiesOnly = "yes";
-          ControlMaster = "auto";
-          ControlPath = "~/.ssh/cm-%h-%p-%r";
-          # ControlPersist 600 유지 — #710 analyzing-da-sessions의 ControlMaster 다중화(K=8 worker pool)가 의존.
-          # 영구(yes)는 무인 파이프 호출에서 master가 stdout을 점유해 hang을 유발하므로, 600으로 master 자동 종료를 보장한다.
-          ControlPersist = "600";
-        };
+        IdentityFile = "${homeDir}/.ssh/mac-ssh.pub";
+        IdentitiesOnly = "yes";
+        ControlMaster = "auto";
+        ControlPath = "~/.ssh/cm-%h-%p-%r";
+        # ControlPersist 600 유지 — #710 analyzing-da-sessions의 ControlMaster 다중화(K=8 worker pool)가 의존.
+        # 영구(yes)는 무인 파이프 호출에서 master가 stdout을 점유해 hang을 유발하므로, 600으로 master 자동 종료를 보장한다.
+        ControlPersist = "600";
       };
       # 1Password 장애(데스크탑 quit/Touch ID 고장/계정 잠금) fallback (PRD #780 Phase 2a, FR-9)
       "minipc-emergency" = {
-        hostname = constants.network.minipcTailscaleIP;
-        user = "greenhead";
-        identityFile = "${homeDir}/.ssh/emergency_ed25519";
-        extraOptions = {
-          IdentityAgent = "none"; # 1Password agent 우회 — emergency key 직접 사용
-          IdentitiesOnly = "yes"; # emergency_ed25519만 제시
-        };
+        HostName = constants.network.minipcTailscaleIP;
+        User = "greenhead";
+        IdentityFile = "${homeDir}/.ssh/emergency_ed25519";
+        IdentityAgent = "none"; # 1Password agent 우회 — emergency key 직접 사용
+        IdentitiesOnly = "yes"; # emergency_ed25519만 제시
       };
     };
   };

--- a/modules/nixos/programs/ssh-client/default.nix
+++ b/modules/nixos/programs/ssh-client/default.nix
@@ -7,24 +7,20 @@ in
 {
   programs.ssh = {
     enable = true;
-    # home-manager의 기본 SSH 설정 비활성화 (deprecated 경고 방지)
+    # home-manager의 기본 SSH 설정 비활성화
     enableDefaultConfig = false;
-    matchBlocks = {
+    settings = {
       "*" = {
-        identityFile = sshKeyPath;
-        extraOptions = {
-          AddKeysToAgent = "yes";
-        };
+        IdentityFile = sshKeyPath;
+        AddKeysToAgent = "yes";
       };
       "mac" = {
-        hostname = constants.network.macbookTailscaleIP;
-        user = "greenhead";
-        identityFile = sshKeyPath;
-        extraOptions = {
-          ControlMaster = "auto";
-          ControlPath = "~/.ssh/cm-%h-%p-%r";
-          ControlPersist = "600";
-        };
+        HostName = constants.network.macbookTailscaleIP;
+        User = "greenhead";
+        IdentityFile = sshKeyPath;
+        ControlMaster = "auto";
+        ControlPath = "~/.ssh/cm-%h-%p-%r";
+        ControlPersist = "600";
       };
     };
   };


### PR DESCRIPTION
## Summary
- Home Manager 입력 갱신 후 발생한 SSH deprecation warning을 없애기 위해 Darwin/NixOS SSH 클라이언트 설정을 `programs.ssh.settings`로 마이그레이션합니다.
- 기존 1Password SSH agent, minipc, emergency key, ControlMaster 설정 의미는 유지하면서 OpenSSH directive 이름을 직접 사용합니다.
- `flake.lock` 입력 갱신과 함께 새 Home Manager 문법 호환성을 검증했습니다.

## 기존 문제/배경
`nfu` 이후 시스템 빌드에서 Home Manager가 다음 경고를 출력했습니다.

- `programs.ssh.matchBlocks` is deprecated. Use `programs.ssh.settings`.
- `programs.ssh.matchBlocks.*.extraOptions` is deprecated. Move these OpenSSH options to `programs.ssh.settings.*` using upstream directive names.

경고의 직접 원인은 Darwin SSH 모듈이었고, NixOS SSH 클라이언트 모듈에도 같은 legacy 패턴이 남아 있었습니다. 현재는 alias로 평가되지만, 새 Home Manager에서는 마이그레이션 대상이므로 입력 갱신 PR에 함께 정리해야 합니다.

## CIR (Change Intent Record)
- **기존 상태**: Darwin/NixOS SSH 클라이언트가 `matchBlocks`와 `extraOptions`를 사용했습니다. 이전 Home Manager에서는 정상 평가됐지만 새 입력에서 deprecation warning이 발생했습니다.
- **이번 변경**: Home Manager가 권장하는 `programs.ssh.settings`로 직접 이관하고, `extraOptions`에 있던 OpenSSH 옵션을 각 host block 바로 아래로 이동했습니다.
- **trade-off**: upstream directive 이름을 직접 쓰기 때문에 Nix attr 이름의 친숙함은 줄지만, Home Manager의 새 설정 API와 1:1로 맞아 경고와 향후 제거 위험을 줄입니다.

## ADR
| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| legacy alias 유지 | `matchBlocks`/`extraOptions`를 그대로 둠 | 변경 없음 | 매 빌드 warning 지속, 향후 제거 위험 | ❌ |
| Darwin만 수정 | 현재 macOS warning의 직접 원인만 제거 | 최소 diff | NixOS에 같은 패턴이 남아 다음 갱신/빌드에서 재발 가능 | ❌ |
| Darwin+NixOS 동시 마이그레이션 | 양쪽 SSH 클라이언트를 `settings`로 이관 | 현재 warning과 잠재 warning을 함께 제거 | 두 파일을 동시에 건드림 | ✅ |

## 구현 상세
| 파일 | 변경 | 내용 |
|------|------|------|
| `flake.lock` | 갱신 | `nfu`로 갱신된 Home Manager/nix-darwin/nixpkgs 등 입력 반영 |
| `modules/darwin/programs/ssh/default.nix` | 수정 | `matchBlocks`를 `settings`로 바꾸고 1Password/minipc/emergency SSH directive를 직접 선언 |
| `modules/nixos/programs/ssh-client/default.nix` | 수정 | NixOS SSH client host block도 `settings`와 OpenSSH directive 이름으로 이관 |

### 핵심 코드
```nix
# BEFORE
programs.ssh.matchBlocks."minipc" = {
  hostname = constants.network.minipcTailscaleIP;
  user = "greenhead";
  identityFile = "${homeDir}/.ssh/mac-ssh.pub";
  extraOptions.ControlMaster = "auto";
};

# AFTER
programs.ssh.settings."minipc" = {
  HostName = constants.network.minipcTailscaleIP;
  User = "greenhead";
  IdentityFile = "${homeDir}/.ssh/mac-ssh.pub";
  ControlMaster = "auto";
};
```

## 참고 레퍼런스
- Home Manager `3abeedcf409ecd8fca201646074bfb31797e8cc2` — `programs.ssh.settings`를 권장하고 `matchBlocks`/`extraOptions` deprecation warning을 발생시키는 입력 버전
- nix-darwin `a1fa429e945becaf60468600daf649be4ba0350c` — 이번 lockfile 갱신에 포함된 Darwin system 입력
- nixpkgs `567a49d1913ce81ac6e9582e3553dd90a955875f` — 이번 lockfile 갱신에 포함된 package set 입력

## Human Test Plan
1. `nix flake check --no-build --all-systems`를 실행합니다.
   - **기대**: Darwin/NixOS configuration과 devShell/package outputs 평가가 모두 통과합니다.
   - **실패 시**: Home Manager SSH settings attr 이름과 flake input 호환성을 먼저 확인합니다.

2. `nrp`를 실행합니다.
   - **기대**: preview-only build가 성공하고 `programs.ssh.matchBlocks` / `matchBlocks.*.extraOptions` deprecation warning이 출력되지 않습니다.
   - **실패 시**: `modules/darwin/programs/ssh/default.nix`에 legacy `matchBlocks` 또는 `extraOptions`가 남았는지 확인합니다.

3. `nix build .#nixosConfigurations.greenhead-minipc.config.system.build.toplevel --dry-run`을 실행합니다.
   - **기대**: 원격 접속 없이 NixOS toplevel dry-run 평가가 성공하고 SSH deprecation warning이 출력되지 않습니다.
   - **실패 시**: `modules/nixos/programs/ssh-client/default.nix`의 `settings` block과 OpenSSH directive 이름을 확인합니다.

4. negative check로 `rg "matchBlocks =|extraOptions =" modules/darwin/programs/ssh/default.nix modules/nixos/programs/ssh-client/default.nix`를 실행합니다.
   - **기대**: 출력이 없습니다.
   - **실패 시**: 남은 legacy option을 `programs.ssh.settings.*` 아래 directive로 이동합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized SSH configuration format across system profiles while preserving all existing functionality and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->