### PR TITLE
fix(hooks): set TERM for statusline bats

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ pre-commit 정책:
 - `shell-script-tests` — 배포 레이아웃 fixture 테스트. tomlkit bootstrap wrapper [`tests/run-shell-script-tests.sh`](./tests/run-shell-script-tests.sh)가 [`tests/shell-script-tests.sh`](./tests/shell-script-tests.sh)를 호출.
 - `codex-hook-fixtures` — Codex 0.124+ stable hook 회귀 차단 deterministic fixture (`--no-live`) ([`tests/test-codex-hook-fixtures.sh`](./tests/test-codex-hook-fixtures.sh))
 - `flake-check` — `nix flake check --no-build --all-systems`
+- `statusline-bats` — statusline 폭 fallback / SSH 렌더링 Bats 테스트. 비대화형 hook은 Bats/tput용 기본 `TERM`을 주입한다.
 
 `ai-skills-consistency` 훅 동작 ([`scripts/ai/warn-skill-consistency.sh`](./scripts/ai/warn-skill-consistency.sh)):
 - **일반 커밋**: 불일치 감지 시 경고만 출력 (차단 없음)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -108,5 +108,6 @@ pre-push:
       # PATH 와 무관하게 동작하게 한다. `--inputs-from .` 는 repo flake.lock 의
       # nixpkgs 입력을 재사용하여 `nix shell .#pythonWithTomlkit` 패턴과 동일하게
       # 프로젝트 pin 을 우회하지 않게 한다. pre-commit allowlist guard 우회를
-      # 위해 pre-push 에 배치. bats 호출은 ~1초로 짧아 비용 미미.
-      run: nix shell --inputs-from . nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
+      # 위해 pre-push 에 배치. bats 호출은 ~1초로 짧아 비용 미미. Codex 같은
+      # 비대화형 셸은 TERM 을 안 줄 수 있으므로 Bats/tput 용 기본 TERM 을 주입한다.
+      run: env TERM="${TERM:-xterm-256color}" nix shell --inputs-from . nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats

--- a/modules/shared/programs/claude/files/scripts/tests/statusline.bats
+++ b/modules/shared/programs/claude/files/scripts/tests/statusline.bats
@@ -13,14 +13,17 @@
 
 setup() {
   STATUSLINE="${BATS_TEST_DIRNAME}/../statusline.sh"
-  # tmux SSH 폴백 격리: bats 를 실제 tmux 세션 안에서 실행해도 비-SSH 케이스가
-  # `tmux show-environment SSH_CONNECTION` 폴백으로 SSH branch 에 오염되지 않도록
-  # fake tmux(빈 출력)를 PATH 앞에 둔다. SSH 케이스는 SSH_CONNECTION 을 직접 주입해
-  # 폴백을 타지 않으므로 영향이 없다.
+  # tmux/stty 폴백 격리: bats 를 실제 tmux/TTY 환경에서 실행해도 비-SSH/기본폭
+  # 케이스가 parent session 상태에 오염되지 않도록 fake bin을 PATH 앞에 둔다.
+  # SSH 케이스는 SSH_CONNECTION 을 직접 주입한다. stty fallback은 `</dev/tty`
+  # 리다이렉션 때문에 no-tty 환경에서 fake가 실행되기 전 실패할 수 있으므로,
+  # 여기서는 항상 실패시켜 static default 경로를 deterministic하게 검증한다.
   FAKE_BIN="$BATS_TEST_TMPDIR/fakebin"
   mkdir -p "$FAKE_BIN"
   printf '#!/bin/sh\nexit 0\n' > "$FAKE_BIN/tmux"
   chmod +x "$FAKE_BIN/tmux"
+  printf '#!/bin/sh\nexit 1\n' > "$FAKE_BIN/stty"
+  chmod +x "$FAKE_BIN/stty"
   # resets_at 을 실행 시점 기준 미래로 동적 생성. 절대값 timestamp 를 박으면 시간이
   # 지나며 stale 되어 statusline.sh 의 `remaining > 0` 가드가 `→ remaining` 출력을
   # 건너뛰고 detail=4 검증이 무력화된다.


### PR DESCRIPTION
## Summary
- 비대화형 Codex 셸에서 `statusline-bats` pre-push hook이 `$TERM` 부재로 실패하지 않도록 기본 `TERM`을 주입한다.
- `statusline.bats`가 parent tmux/TTY 상태에 오염되지 않도록 fake `tmux`/`stty`를 테스트 PATH 앞에 둔다.
- README의 pre-push hook 목록에 `statusline-bats`를 추가해 실제 훅 구성과 문서를 맞춘다.

## 기존 문제/배경

Codex 비대화형 셸에서 브랜치를 push할 때 pre-push의 `statusline-bats`가 Bats/tput 경로에서 다음 오류로 실패했다.

```text
tput: No value for $TERM and no -T specified
```

직접 Bats를 TAP 출력으로 실행하는 경로와 달리 Lefthook pre-push 출력 UI에서는 터미널 capability 조회가 필요하다. 비대화형 셸은 `TERM`을 제공하지 않을 수 있으므로, statusline 테스트 자체가 아니라 hook 실행 환경에서 기본 터미널 타입을 보장해야 한다.

추가로 `statusline.bats`는 parent tmux/TTY 상태를 일부 격리하고 있었지만 `stty size </dev/tty` fallback은 실제 터미널 폭을 읽을 수 있어, interactive pre-push 환경에서 기본 폭 테스트가 비결정적으로 흔들릴 수 있었다.

## CIR (Change Intent Record)

- **v1** (이번 변경): `statusline-bats` hook command에만 `TERM` 기본값을 주입해 비대화형 Codex 셸 실패를 최소 범위로 해결.
- **v2** (이번 변경): pre-push hook 목록이 README에 누락되어 있음을 확인하고 문서 동기화 추가.
- **v3** (이번 변경): Bats setup에서 fake `stty`를 항상 실패시키도록 하여 static default 폭 테스트가 parent TTY 상태를 읽지 않게 격리.

**trade-off**: `TERM=xterm-256color`는 statusline Bats command에만 적용된다. 다른 hooks에는 전파하지 않아 영향 범위를 좁히지만, 같은 문제가 다른 Bats hook에 생기면 해당 hook에서 별도로 처리해야 한다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 전역 `TERM` 설정 | pre-push 전체 또는 shell 환경에 기본 `TERM` 주입 | 모든 command에 일괄 적용 | 관계없는 hook의 환경까지 바꿈 | ❌ |
| `statusline-bats` command에만 `TERM` 설정 | 실패한 Bats hook 실행 줄에서만 `TERM` fallback 제공 | 영향 범위 최소, 기존 pin 유지 | 같은 유형의 다른 hook은 별도 대응 필요 | ✅ |
| Bats runner/테스트 출력 모드 변경 | Bats 자체가 `tput`을 호출하지 않게 조정 | `TERM` 의존 제거 가능 | 기존 Lefthook 출력 방식과 어긋날 수 있음 | ❌ |
| 테스트 fake `stty` 추가 | parent TTY 폭을 읽지 않도록 테스트 PATH에 실패하는 `stty` 제공 | static default 테스트 결정성 확보 | 실제 stty 성공 경로 검증은 다루지 않음 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `lefthook.yml` | 수정 | `statusline-bats` 실행 명령에 `env TERM=\"${TERM:-xterm-256color}\"` 추가 |
| `modules/shared/programs/claude/files/scripts/tests/statusline.bats` | 수정 | fake `stty`를 추가해 parent TTY fallback을 차단 |
| `README.md` | 수정 | pre-push hook 목록에 `statusline-bats` 설명 추가 |

### 핵심 코드

```yaml
run: env TERM="${TERM:-xterm-256color}" nix shell --inputs-from . nixpkgs#bats --command bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
```

```bash
printf '#!/bin/sh\nexit 1\n' > "$FAKE_BIN/stty"
chmod +x "$FAKE_BIN/stty"
```

## 참고 레퍼런스

해당 없음.

## Human Test Plan

### 정상 동작 검증

1. `$TERM`이 없는 상태로 statusline pre-push command를 실행한다.
   - 명령: `env -u TERM lefthook run pre-push --command statusline-bats --force`
   - **기대**: `statusline.bats` 25개 테스트가 모두 통과한다.
   - **실패 시**: `lefthook.yml`의 `statusline-bats` command가 `env TERM=...` wrapper를 포함하는지 확인한다.

2. 브랜치를 push한다.
   - 명령: `git push`
   - **기대**: `codex-hook-fixtures`, `flake-check`, `shell-script-tests`, `statusline-bats` pre-push hook이 모두 통과한다.
   - **실패 시**: 실패한 hook 이름을 기준으로 `lefthook.yml`의 해당 command와 devShell/Nix shell PATH를 확인한다.

### 엣지 케이스 / 회귀 검증

3. `statusline.bats` setup의 fake bin 구성을 확인한다.
   - **기대**: fake `tmux`는 SSH fallback 오염을 막고, fake `stty`는 static default 폭 테스트가 실제 TTY 폭을 읽지 못하게 한다.
   - **실패 시**: `PATH="$FAKE_BIN:$PATH"`가 `run_statusline_with_input`에서 유지되는지 확인한다.

4. README pre-push 목록을 확인한다.
   - **기대**: `shell-script-tests`, `codex-hook-fixtures`, `flake-check`, `statusline-bats`가 모두 문서화되어 있다.
   - **실패 시**: `lefthook.yml`의 `pre-push.commands` 목록과 README를 대조한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added statusline fallback test for SSH and non-interactive environments
  * Enhanced test isolation for deterministic terminal behavior verification

* **Chores**
  * Updated pre-push hook configuration to inject default terminal environment variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->