### PR TITLE
fix(skills): run-da reviewer 정적 판정 우선 + 의도된 제거 regression 예외

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/da-domains.md
@@ -72,10 +72,13 @@
 {FOCUS_TARGETS}
 
 Self-verification을 위해 nested `codex exec` 또는 `codex-exec-supervised`를 호출하지 마라.
+정적으로 판정 가능한 관점(예: CLEAN_CODE, READABILITY, 다수의 HALLUCINATION/CONSISTENCY 질문)은 PoC를 수행하지 말고 파일:줄·코드 인용과 문서 근거로만 답하라. "코드를 읽으면 답이 나오는" 질문을 런타임 재현으로 바꾸지 마라 — 런타임 재현은 비용일 뿐 아니라, 재현물을 잘못 작성하면 원본과 반대 결론을 낼 정확성 위험이 있다.
 codex exec fallback 경로처럼 read-only sandbox에서 실행 중이면 파일 증거, 문서 인용, diff 확인만 사용하라.
-PoC가 필요하고 현재 런타임이 out-of-repo write를 허용하면 `umask 077` 아래에서 `mktemp -d`로 만든 repo 밖 private scratch 디렉토리에서만 수행하라.
+PoC는 정적 근거만으로 판정이 불가능한 경우에 한해서만 수행한다. 현재 런타임이 out-of-repo write를 허용하더라도 먼저 "이 질문이 정적으로 답 가능한가"를 자문하고, 가능하면 PoC 대신 인용으로 답하라. PoC가 정말 필요하면 `umask 077` 아래에서 `mktemp -d`로 만든 repo 밖 private scratch 디렉토리에서만 수행한다.
 tracked workspace write, branch mutation, commit/push, GitHub write, main-agent-only command, host mutation은 explicit delegation 없이는 금지다.
 위 규칙을 위반했거나 금지된 작업이 필요하면 finding 대신 `VIOLATION` 형식으로 반환하라.
+
+작업이 의도적으로 제거·축소·교체하는 동작은 regression/side-effect가 아니다. 변경 의도(diff가 향하는 방향)와 일치하는 동작 소멸은 위반으로 보고하지 마라. 제거가 의도인지 diff/컨텍스트로 불확실하면 위반으로 단정하지 말고 그 불확실성을 finding에 명시하라.
 
 다른 bundle({OTHER_BUNDLES})의 우려는 언급하지 마라.
 문제가 없으면 CLEAR를 반환하라.
@@ -89,7 +92,7 @@ tracked workspace write, branch mutation, commit/push, GitHub write, main-agent-
 |-----------------|----------|----------|----------|
 | Correctness | `HALLUCINATION`, `SECURITY` | "이 변경이 실제로 존재하는 동작인가, 그리고 안전한가?"를 검증하라 | 존재하지 않는 API/CLI 플래그/경로, 잘못된 시그니처/인자, trust boundary 오판, 인증/인가 우회, 입력 검증 부재, 과도한 네트워크 노출 |
 | Design | `YAGNI`, `NGMI` | "지금 필요하지 않은 복잡성을 만들거나, 구조적 막다른 길을 만들지 않는가?"를 판단하라 | 사용처 없는 인터페이스/추상화, 미래 대비 과설계, 가정 붕괴 시 전면 재작성 필요한 구조, 잘못된 책임 분리, 확장 경로 차단된 데이터/모듈 경계 |
-| Regression | `SIDE_EFFECT`, `CONSISTENCY` | "기존 동작이나 프로젝트 관례를 조용히 깨지 않는가?"를 추적하라 | 공유 상태의 암묵적 변경, 인터페이스 계약 변경, 환경 변수/경로/포트 변경, import/export 파급, 네이밍/디렉토리/설정 규칙 위반, 기존 패턴 무시 재구현 |
+| Regression | `SIDE_EFFECT`, `CONSISTENCY` | "기존 동작이나 프로젝트 관례를 의도치 않게 조용히 깨지 않는가?"를 추적하라 (의도된 제거·축소는 위반 아님) | 공유 상태의 암묵적 변경, 인터페이스 계약 변경, 환경 변수/경로/포트 변경, import/export 파급, 네이밍/디렉토리/설정 규칙 위반, 기존 패턴 무시 재구현 |
 | Maintainability | `READABILITY`, `CLEAN_CODE` | "다음 개발자(LLM 포함)가 이 변경을 빠르게 이해하고 안전하게 수정할 수 있는가?"를 판단하라 | 함수/변수명과 동작 불일치, why 주석 부재, 복잡한 제어 흐름, 복사-붙여넣기 중복, 매직넘버/매직스트링, 죽은 코드, 방치된 TODO/HACK |
 
 ## 명시적 exhaustive override 매핑

--- a/modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md
@@ -22,7 +22,7 @@ codex exec 경로(Claude Code 세션 · headless 세션)는 [`arbiter-scaling.md
 
 | 역할 | 허용 | 금지 |
 |------|------|------|
-| DA reviewer | 읽기, 검색, out-of-repo private scratch PoC (`mktemp -d`, `umask 077`) | tracked write, branch mutation, commit/push, GitHub write, `wt`/`nrs`/rebuild 계열 |
+| DA reviewer | 읽기, 검색, out-of-repo private scratch PoC (`mktemp -d`, `umask 077`) — 단 정적으로 판정 가능한 관점은 PoC 대신 파일:줄 인용만 ([`da-domains.md`](da-domains.md) 공통 프롬프트의 "정적 판정" 규칙) | tracked write, branch mutation, commit/push, GitHub write, `wt`/`nrs`/rebuild 계열 |
 | Arbiter | 읽기 전용 검증 | 모든 write, scratch PoC, main-agent-only command |
 | Auditor (`parallel-audit`) | 읽기 전용 검증 | 모든 write, scratch PoC, main-agent-only command |
 | 메인 에이전트 | tracked write, external write, main-agent-only command, explicit delegation, Review Intensity 인라인 판정 (모든 룰 평가 표 + first-match 채택) | Arbiter 판정 대체, DA reviewer finding 직접 판정 |


### PR DESCRIPTION
## Summary
- run-da DA reviewer가 정적으로 답할 수 있는 관점(CLEAN_CODE 등)을 런타임 PoC로 풀지 않도록 조건화 (#906)
- 작업이 의도적으로 제거·축소하는 동작을 reviewer가 regression으로 오인하지 않도록 가드 추가 (#908)

Closes #906
Closes #908

## 기존 문제 / 배경
세션 전수조사(epic #903)에서 두 패턴이 최근 시기 포함 반복 관찰됨:
- 읽기 전용 검토 요청에도 reviewer가 코드를 실제 실행(임시 디렉터리 PoC, 테스트 구동)해 토큰이 폭증. 비대화형(codex exec) 경로는 read-only sandbox로 차단되지만, 메인 세션 직접 리뷰(write 허용 런타임)에서는 조건부 PoC 허가가 잔존 갭이었다.
- 사용자가 의도적으로 제거한 동작을 reviewer가 "기존 동작 파괴"로 잡아 LLM이 복구 → 의도 역행, scope 확대.

## CIR (Change Intent Record)
- 발견 경위: 세션 로그 전수조사 → 시계열 검증(증거 시점 → 이후 수정 커밋 → 현재 코드)으로 현재 코드에 잔존하는 갭만 선별.
- #906: 1차 분석은 "codex exec 경로 변질"로 보았으나, 시계열 검증 결과 그 경로는 supervised wrapper(#636)로 이미 해결됨을 확인. 잔존 갭은 메인 세션 직접 리뷰 경로의 조건부 PoC 허가임을 특정하고 본문을 정정했다.
- 설계 의도: 가드 기준을 "셸 호출 횟수"가 아니라 "정적으로 답 가능한가"로 둔다. 횟수 기반은 소규모 변질을 막지 못한다. 런타임 재현은 비용일 뿐 아니라 재현물 오작성 시 정확성 위험이 있음을 명시했다.
- #908: 변경 의도(diff가 향하는 방향)와 일치하는 동작 소멸은 위반이 아님을 reviewer 프롬프트와 도메인 정의에 명시.

## ADR
| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 프롬프트/문서 가드 | reviewer 프롬프트·역할 권한 표·도메인 정의를 조건화 | 저비용·즉시·경로 무관 | 구조적 강제가 아님(준수 의존) | ✅ 채택 |
| sandbox 구조 강제 | 모든 reviewer를 read-only sandbox로 실행 | 구조적 보장 | 메인 세션 직접 리뷰엔 적용 난이도, 큰 작업 | ❌ 후속(별도) |
| 셸 호출 횟수 상한 | N회 초과 시 경고 | 단순 | 소규모 변질을 못 막음 | ❌ 기각 |

## 구현 상세
| 파일 | 변경 |
|---|---|
| `…/run-da/references/da-domains.md` | 공통 reviewer 프롬프트: 정적 판정 가능 관점은 PoC 금지·인용만 + 정확성 위험 명시, PoC는 정적 불가 시에만. 의도된 제거 가드 추가. Regression 도메인 정의에 "의도된 제거·축소는 위반 아님" |
| `…/run-da/references/hardening-contract.md` | DA reviewer 권한에 "정적 판정 가능 관점은 PoC 대신 인용만" 단서 |

## 참고 레퍼런스
- epic #903 (run-da/parallel-audit 조사 기반 개선)
- #906, #908 (본 PR이 닫는 이슈)
- #636 (codex exec 경로 supervised wrapper — 이미 해결, 본 PR 범위 밖)

## Human Test Plan
1. 문서/소규모 변경에 run-da CLEAN_CODE 리뷰 → reviewer가 임시 디렉터리 PoC·테스트 실행 없이 파일:줄 인용으로만 답하는지 확인.
   - 실패 시: `da-domains.md` 공통 프롬프트의 "정적 판정" 문구가 reviewer 프롬프트에 포함됐는지 점검.
2. 기능을 의도적으로 제거하는 변경에 run-da → reviewer가 그 제거를 regression으로 보고하지 않는지 확인.
   - 실패 시: 변경 의도가 reviewer 컨텍스트에 전달되는지, Regression 도메인 정의 문구를 점검.

https://claude.ai/code/session_01BZSSeiX5BDcjN88CRtb65i


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified review guidelines for when to use evidence from files and line references instead of running proof-of-concept checks.
  * Added stricter rules for safe execution during runtime checks, including limits on workspace changes and host-side actions.
  * Improved guidance on handling intentionally removed or changed behavior, and on noting uncertainty when deletion intent is unclear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->