### PR TITLE
test(infra): 통합 검증 진입점 run-all-tests.sh + README 검증 절

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ NixOS 홈서버 서비스는 `homeserver.*` 옵션으로 선언적으로 활성�
 
 [`lefthook.yml`](./lefthook.yml)로 pre-commit/pre-push 훅 관리.
 
+**통합 검증 (push 전 / 온보딩 시 권장)**: [`bash tests/run-all-tests.sh`](./tests/run-all-tests.sh) — eval-tests · shell-script-tests · codex-hook-fixtures · codex-exec-supervised · flake-check · statusline-bats · precommit-staged-snapshot를 한 번에 순차 실행하고 통과/SKIP/실패를 구분 요약한다(하나라도 실패 시 non-zero). 로컬 훅을 우회(`git commit --no-verify` / `LEFTHOOK=0`)했거나 fresh clone에서 훅 설치 전이라도, 이 명령으로 pre-push 게이트와 테스트 드라이버를 재검증할 수 있다. 단 pre-commit의 staged 스냅샷 정책(`gitleaks` · `nixfmt` · `shellcheck` · skill-noise)은 staged index 기준이라 working-tree 러너 범위 밖이며 커밋 시점 게이트로 별도 적용된다.
+
 **pre-commit** (병렬):
 - `lefthook-guard-self-check` — 메인 repo `.git/hooks/pre-commit`에 staged-config guard marker 부재 시 commit fail-fast (인접 worktree의 lefthook install 덮어쓰기 회귀 방지 layer)
 - `ai-skills-consistency` — staged snapshot 기준 `.claude/skills`, `.agents/skills`, `modules/shared/programs/codex` 구조 일관성
@@ -162,6 +164,9 @@ sudo --preserve-env=SSH_AUTH_SOCK nix run nix-darwin -- switch --flake .
 
 # 6. 이후 설정 적용
 nrs
+
+# 7. 전체 검증 (push 전·온보딩 시 권장)
+bash tests/run-all-tests.sh
 ```
 
 ### 새 호스트 추가 / MiniPC 설치

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# tests/run-all-tests.sh — 통합 검증 진입점
+#
+# 저장소의 모든 테스트 드라이버 + flake 평가 게이트를 한 번에 순차 실행한다. push 전(로컬
+# 훅 우회 여부와 무관하게 재검증)과 신규 머신 온보딩 시 실행을 권장한다. 향후 원격 CI도 이
+# 단일 진입점을 재사용해 중복 정의를 피한다.
+#
+# 커버리지 경계: 이 진입점은 pre-push 게이트(shell-script-tests · codex-hook-fixtures ·
+#   flake-check · statusline-bats) + eval-tests + 어느 훅에도 미연결된 tests/test-*.sh 단위
+#   드라이버(codex-exec-supervised · precommit-staged-snapshot)를 포함한다. 벤치마크
+#   tests/bench-shell-startup.sh는 회귀 게이트가 아니라 측정 도구이므로(자체 헤더에 명시) 제외한다.
+#   pre-commit의 staged 스냅샷 정책(gitleaks · nixfmt · shellcheck · skill-noise)은 staged index
+#   기준이라 working-tree 통합 러너의 범위가 아니며, 커밋 시점 게이트로 별도 적용된다.
+#
+# 실패 정책: set -e 미사용 — 한 드라이버가 실패해도 나머지를 계속 실행하여 전체 그림을
+#   확보한 뒤, 끝에서 통과/SKIP/실패를 구분 요약하고 하나라도 실패하면 non-zero로 종료한다.
+#
+# 런타임 의존성: 드라이버마다 다르다(일부는 `nix shell` wrap 필요). 각 호출 방식은
+#   lefthook.yml의 해당 항목과 동일하게 유지한다(이 파일이 그 단일 진입점). 호출 방식을
+#   바꿀 때는 lefthook.yml과 함께 갱신한다.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+PASSED=()
+SKIPPED=()
+FAILED=()
+
+# 드라이버를 실행하고 통과/SKIP/실패로 분류한다. SKIP은 드라이버가 환경/도구 미가용 시
+# stdout/stderr에 "SKIP:" 마커를 출력하고 exit 0으로 종료하는 경우(예: precommit-staged-snapshot)
+# 를 가리키며, 미실행을 통과로 오인하지 않도록 요약에서 별도로 집계한다.
+run_driver() {
+  local name="$1"
+  shift
+  local log
+  log="$(mktemp "${TMPDIR:-/tmp}/run-all-tests.XXXXXX")"
+  printf '\n━━━ %s ━━━\n' "$name"
+  if "$@" 2>&1 | tee "$log"; then
+    if grep -q 'SKIP:' "$log"; then
+      printf '⊘ %s (skipped — 환경/도구 미가용)\n' "$name"
+      SKIPPED+=("$name")
+    else
+      printf '✓ %s\n' "$name"
+      PASSED+=("$name")
+    fi
+  else
+    printf '✗ %s\n' "$name"
+    FAILED+=("$name")
+  fi
+  rm -f "$log"
+}
+
+# 1) eval-tests — Nix 평가(E2E 설정 검증, 선택적 lazy 평가). wrap 불필요.
+run_driver "eval-tests" bash tests/run-eval-tests.sh
+
+# 2) shell-script-tests — 배포 레이아웃 fixture. runner가 repo-pinned pythonWithTomlkit으로
+#    self-wrap하지만, 미가용 환경 대비 명시적으로 nix shell wrap + _TOMLKIT_BOOTSTRAP_READY=1로
+#    중첩 nix shell 재실행을 방지한다(lefthook pre-push와 동일).
+run_driver "shell-script-tests" \
+  nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 \
+  bash tests/run-shell-script-tests.sh
+
+# 3) codex-hook-fixtures — Codex stable hook 회귀 차단 결정적 fixture. --no-live, Python stdlib only.
+run_driver "codex-hook-fixtures" bash tests/test-codex-hook-fixtures.sh --no-live
+
+# 4) codex-exec-supervised — codex-exec-supervised wrapper의 env validation 경계(타임아웃 cap/양수/
+#    non-numeric) 단위 검증. invalid-env 케이스는 codex/setsid/timeout 부재 환경에서도 실행되어
+#    핵심 거부 경계를 항상 검증한다. valid-env 케이스는 deps 부재 시 "WARN" + exit 0으로
+#    capability-skip된다("SKIP:" 마커가 아니므로 SKIP 집계엔 잡히지 않고 PASS로 표기되나, 항상
+#    실행되는 거부 경계 검증이 핵심이므로 PASS 집계는 유효).
+run_driver "codex-exec-supervised" bash tests/test-codex-exec-supervised.sh
+
+# 5) flake-check — 전 시스템 flake 평가 게이트(repo 전역). eval-tests의 선택적 평가가 강제하지
+#    않는 darwin/nixos configuration toplevel 평가 오류까지 검출하므로 커버리지가 고유하다.
+run_driver "flake-check" nix flake check --no-build --all-systems
+
+# 6) statusline-bats — statusline Bats 테스트. nixpkgs#bats를 nix shell로 제공하고 TERM을 주입한다.
+run_driver "statusline-bats" \
+  env TERM="${TERM:-xterm-256color}" nix shell --inputs-from . nixpkgs#bats --command \
+  bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
+
+# 7) precommit-staged-snapshot — 어느 훅에도 연결되지 않은 수동 전용 드라이버를 통합에 포함한다.
+#    devShell 전체 도구(git/jq 등)를 요구하며, 미가용 시 스크립트가 자체적으로 "SKIP: ... not found"
+#    출력 + exit 0 처리하므로(tests/test-precommit-staged-snapshot.sh) 통합에 포함해도 환경 부재 시
+#    실패하지 않고, 위 run_driver가 이를 SKIP으로 분류한다.
+run_driver "precommit-staged-snapshot" bash tests/test-precommit-staged-snapshot.sh
+
+printf '\n━━━ 요약 ━━━\n'
+printf '통과 %d · SKIP %d · 실패 %d\n' "${#PASSED[@]}" "${#SKIPPED[@]}" "${#FAILED[@]}"
+if (( ${#SKIPPED[@]} )); then
+  printf '⊘ SKIP(미실행): %s\n' "${SKIPPED[*]}"
+fi
+if (( ${#FAILED[@]} )); then
+  printf '✗ 실패: %s\n' "${FAILED[*]}"
+  exit 1
+fi
+printf '✓ 실패 없음 (SKIP이 있으면 환경/도구 미가용으로 미실행 — 위 목록 확인)\n'


### PR DESCRIPTION
## 1. Summary

- `tests/run-all-tests.sh` 신설 — 저장소의 모든 테스트 드라이버 + flake 평가 게이트를 한 번에 순차 실행하는 통합 검증 진입점.
- 7개 드라이버(eval-tests · shell-script-tests · codex-hook-fixtures · codex-exec-supervised · flake-check · statusline-bats · precommit-staged-snapshot)를 실행하고 **통과/SKIP/실패를 구분 요약**(하나라도 실패 시 non-zero).
- README "검증 / 훅" 절 + "새 Mac 설정"에 통합 명령 안내.

Closes #913

## 2. 기존 문제/배경

테스트 드라이버가 `tests/`와 `modules/...`에 흩어져 있고, 이들을 한 번에 실행하는 진입점이 없었다. `lefthook.yml`이 드라이버를 pre-commit/pre-push로 나눠 개별 호출하지만(일부는 `nix shell` wrap 필요), 사람이 push 전 전체를 수동으로 돌리려면 명령을 일일이 기억해야 했다. 신규 머신 온보딩 시 검증 절차도 불명확했다.

## 3. CIR (Change Intent Record)

- **발견 경위**: 코드베이스 감사(epic #912)가 통합 검증 명령 부재를 식별. 이는 원격 CI 도입(#914)의 선행 조건이기도 하다(CI가 호출할 단일 진입점을 먼저 확보).
- **드라이버 집합 결정**: pre-push 게이트(shell-script-tests · codex-hook-fixtures · **flake-check** · statusline-bats) + eval-tests + 어느 훅에도 미연결된 `tests/test-*.sh` 단위 드라이버(**codex-exec-supervised** · precommit-staged-snapshot)를 모두 포함했다. flake-check(전 시스템 flake 평가)는 eval-tests의 선택적 평가가 강제하지 않는 config toplevel 평가 오류를 잡아 커버리지가 고유하므로 포함이 필수였다. 벤치마크 `bench-shell-startup.sh`는 회귀 게이트가 아니라 측정 도구이므로 제외했다. pre-commit의 staged 스냅샷 정책(gitleaks/nixfmt/shellcheck/skill-noise)은 staged index 기준이라 working-tree 러너 범위 밖으로 명시했다.
- **실패 정책**: `set -e` 미사용 — 한 드라이버가 실패해도 나머지를 계속 실행해 전체 그림을 확보한 뒤 끝에서 요약하고 non-zero로 종료한다. CI/온보딩에서 어느 드라이버가 실패하는지 한 번에 보기 위함.
- **SKIP 충실도**: 미실행(환경/도구 미가용 SKIP)을 통과로 오인하지 않도록 통과/SKIP/실패를 분리 집계한다. precommit-staged-snapshot의 `SKIP:` 마커를 감지하며, codex-exec-supervised의 capability-skip은 `WARN`(거부 경계 검증은 항상 수행)이라 PASS로 집계해도 핵심 검증이 유효함을 주석에 명시했다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 실패 누적 후 요약 | set -e 미사용, 전체 실행 후 통과/SKIP/실패 집계 | 한 번에 전체 그림, CI 친화 | 실패해도 끝까지 실행(시간) | ✅ |
| 첫 실패 즉시 중단 | set -e | 빠른 피드백 | 어느 게이트들이 실패하는지 부분 정보만 | ❌ |
| flake-check 포함 | 6번째 드라이버로 추가 | pre-push 게이트 + 고유 커버리지 재현 | 가장 무거운 게이트(eval 비용) | ✅ |
| precommit/codex-exec 포함 | 미연결 단위 드라이버를 통합에 흡수 | "전체 재검증" 주장 충족, 회귀 게이트 확보 | manual-only 드라이버 환경 의존(SKIP 가드로 완화) | ✅ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `tests/run-all-tests.sh` (신규) | 7 드라이버 순차 실행 + 통과/SKIP/실패 3구분 요약. 각 드라이버 호출은 lefthook.yml과 동일하게 유지 |
| `README.md` | "검증 / 훅" 절에 통합 명령 + 커버리지 경계 안내, "새 Mac 설정"에 검증 단계 추가 |

`run_driver`는 드라이버 출력을 `tee`로 캡처해 `SKIP:` 마커를 감지하고 통과/SKIP/실패를 분류한다. `tests/run-shell-script-tests.sh` 등 기존 lefthook 호출 인터페이스는 불변이며, 이 진입점이 그 단일 재사용 지점이다.

## 6. 참고 레퍼런스

- Closes #913
- Parent epic: #912
- 후속: #914 (push-time CI — 이 단일 진입점을 재사용)

## 7. Human Test Plan

1. `bash tests/run-all-tests.sh` → 7개 드라이버 순차 실행 후 `통과 7 · SKIP 0 · 실패 0` + `✓ 실패 없음`, exit 0.
2. 한 드라이버를 의도적으로 실패시키면 나머지는 계속 실행되고 끝에 `✗ 실패: <name>` + non-zero.
3. devShell 도구가 없는 환경에서 precommit-staged-snapshot은 `⊘ (skipped)`로 집계되고 "통과"로 오인되지 않는다.
4. **실패 시 진단**: 특정 드라이버 실패 시 해당 `━━━ <name> ━━━` 블록의 출력으로 원인을 확인한다.
