### PR TITLE
feat(ci): push-time 검증용 GitHub Actions CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,43 @@
+name: check
+
+# 로컬 lefthook 훅과 독립적인 선택적 2차 안전망(강제 머지 게이트가 아니다). 로컬 훅을
+# 우회(git commit --no-verify / LEFTHOOK=0)했거나 fresh clone에서 훅 설치 전인 변경도 PR
+# 시점에 동일 검증으로 한 번 더 거른다. 단일 메인테이너 + PR 기반 워크플로라 과도한 게이트는
+# 의도적으로 피하고, 검증 명령은 lefthook.yml / tests/run-all-tests.sh와 동일한 것을 재사용한다.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix (flakes enabled)
+        uses: DeterminateSystems/nix-installer-action@main
+
+      # --inputs-from . 로 repo flake.lock에 핀된 nixpkgs의 nixfmt/shellcheck를 쓴다(devShell·로컬
+      # lefthook 훅과 동일 store path). floating registry(nixpkgs# 단독)는 unstable 채널을 해석해
+      # 로컬과 도구 버전이 어긋나면 통과 코드가 CI에서만 실패하는 드리프트를 만들므로 피한다.
+      - name: nixfmt --check (전체 .nix)
+        run: |
+          nix shell --inputs-from . nixpkgs#nixfmt --command \
+            bash -c 'find . -name "*.nix" -not -path "./.git/*" -print0 | xargs -0 -r nixfmt --check'
+
+      - name: shellcheck (전체 .sh)
+        run: |
+          nix shell --inputs-from . nixpkgs#shellcheck --command \
+            bash -c 'find . -name "*.sh" -not -path "./.git/*" -print0 | xargs -0 -r shellcheck -S warning'
+
+      # 통합 검증: tests/run-all-tests.sh가 flake-check(nix flake check --no-build --all-systems)와
+      # 전 테스트 드라이버를 순차 실행한다(#913에서 도입한 단일 진입점 재사용 — CI가 검증 명령을
+      # 중복 정의하지 않는다). 환경/도구 미가용 드라이버는 스크립트가 SKIP으로 집계한다.
+      - name: 통합 검증 (run-all-tests.sh)
+        run: bash tests/run-all-tests.sh


### PR DESCRIPTION
## 1. Summary

- `.github/workflows/check.yml` 신설 — push/PR 시점에 원격에서 품질 검증을 재실행하는 GitHub Actions CI.
- `pull_request` 트리거 → nix+flakes 설치 후 nixfmt --check(전체 .nix) + shellcheck -S warning(전체 .sh) + `tests/run-all-tests.sh`(flake-check + 7 드라이버).
- **강제 머지 게이트가 아니라 로컬 훅과 독립적인 선택적 2차 안전망**.

Closes #914

## 2. 기존 문제/배경

모든 품질 검증이 로컬 git 훅(lefthook)에만 걸려 있고 원격 CI가 없었다. 로컬 훅은 `git commit --no-verify` · `LEFTHOOK=0`으로 우회되고, fresh clone에서는 devShell 진입(훅 설치) 전까지 훅이 비어 있다. 이 경로 중 하나라도 거치면 회귀가 검증 없이 머지될 수 있다.

## 3. CIR (Change Intent Record)

- **발견 경위**: 코드베이스 감사(epic #912)가 원격 CI 부재를 식별. `.github/` 디렉토리 자체가 없었다.
- **검증 명령 재사용**: CI가 검증을 중복 정의하지 않도록 lefthook.yml / `tests/run-all-tests.sh`(#913에서 도입한 단일 진입점)와 동일한 명령을 재사용했다. flake-check는 run-all-tests에 포함되어 별도 step이 없다.
- **toolchain 핀(설계 보강)**: nixfmt/shellcheck를 `nix shell --inputs-from . nixpkgs#...`로 호출해 repo flake.lock에 핀된 도구(devShell·로컬 훅과 동일 store path)를 쓴다. floating registry(`nixpkgs#` 단독)는 unstable 채널을 해석해 로컬과 도구 버전이 어긋나면 로컬 통과 코드가 CI에서만 실패하는 드리프트를 만들기 때문이다. 이는 repo의 기존 관례(`run-all-tests.sh` / lefthook의 `--inputs-from . nixpkgs#bats`)와 일치한다.
- **범위 제한(YAGNI)**: 단일 메인테이너 + PR 기반 워크플로라 실제 위험이 완화돼 있어, 강제 게이트가 아닌 선택적 안전망으로 좁게 도입했다. 과도한 게이트는 의도적으로 회피했다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `--inputs-from .` 핀 toolchain | flake.lock의 nixfmt/shellcheck 사용 | 로컬 훅과 동일 버전 → 드리프트성 실패 제거 | (없음) | ✅ |
| floating `nixpkgs#` | 전역 registry(unstable) 사용 | 짧은 표기 | 버전 스큐로 spurious CI 실패 | ❌ |
| 선택적 안전망 | 강제 게이트 아님 | 단일 메인테이너 YAGNI 균형 | 머지 자동 차단은 안 함 | ✅ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `.github/workflows/check.yml` (신규) | pull_request 트리거, DeterminateSystems nix-installer-action, nixfmt/shellcheck(핀) + run-all-tests, permissions contents:read, concurrency cancel-in-progress |

## 6. 참고 레퍼런스

- Closes #914
- Parent epic: #912
- 선행: #913(PR #923, run-all-tests 단일 진입점) — CI가 이를 재사용

## 7. Human Test Plan

1. 이 PR 생성 시 `check` 워크플로가 트리거되어 nixfmt/shellcheck/run-all-tests가 실행된다(이 PR의 Actions 탭에서 결과 확인).
2. 로컬 동등 검증(완료): `nix shell --inputs-from . nixpkgs#nixfmt --command ... nixfmt --check`(.nix exit 0), `... nixpkgs#shellcheck ... shellcheck -S warning`(118개 .sh 경고 0), `bash tests/run-all-tests.sh`(7드라이버 통과), `actionlint .github/workflows/check.yml`(통과).
3. **실패 시 진단**: Actions 로그의 실패 step(nixfmt/shellcheck/run-all-tests) 출력으로 원인을 확인한다. CI 환경(devShell 미진입) 특성상 precommit-staged-snapshot은 도구 부재 시 SKIP될 수 있다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated check on pull requests to validate formatting, shell scripts, and the full test suite.
* **Chores**
  * Improved continuous integration with faster run cancellation for newer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->