### PR TITLE
fix(hooks): fragile-hardcoding-guard 정규식 어순 무관화 + 단위 테스트

### DIFF
--- a/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
@@ -92,7 +92,7 @@ if [ "$TOOL_NAME" = "Edit" ] && [ "$SCAN_MODE" = "document" ]; then
   OLD_STRIPPED=$(_strip_fences < "$FILE_PATH")
   # [WHY_EXCLUDE] exclusion 패턴은 SCAN_INPUT 검사와 동일하게 적용하여 일관성 유지
   OLD_LINE_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -E '[0-9]+줄|[0-9]+ lines' | \
-    grep -vE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)' | grep -c '.' || true)
+    grep -vE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)|(이내|이하|미만|이상|설명|요약|제한)[[:space:]]*[0-9]+줄' | grep -c '.' || true)
   OLD_FILE_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -E '[0-9]+개 파일|[0-9]+곳' | \
     grep -vE '[1-9]-[1-9]개 파일' | grep -c '.' || true)
   OLD_PATH_COUNT=$(printf '%s' "$OLD_STRIPPED" | grep -oE '\.claude/skills/[a-z0-9_-]+' | sort -u | wc -l | tr -d ' ')
@@ -103,7 +103,7 @@ WARNINGS=""
 # [WHY] 줄 수는 코드 수정 시 즉시 변경됨 → wc -l로 동적 확인 가능
 # [WHY_EXCLUDE] "N줄 이내/이하/설명" 등은 작성 규칙 표현이지 코드 상태 하드코딩이 아님
 NEW_LINE_COUNT=$(printf '%s' "$SCAN_INPUT" | grep -E '[0-9]+줄|[0-9]+ lines' | \
-  grep -vE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)' | grep -c '.' || true)
+  grep -vE '[0-9]+줄[[:space:]]*(이내|이하|미만|이상|설명|요약|제한)|(이내|이하|미만|이상|설명|요약|제한)[[:space:]]*[0-9]+줄' | grep -c '.' || true)
 [ "$NEW_LINE_COUNT" -gt "$OLD_LINE_COUNT" ] && \
   WARNINGS="${WARNINGS}줄 수 하드코딩. "
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -98,6 +98,8 @@ run_test "install-lefthook preserves custom local core.hooksPath" test_install_l
 run_test "install-lefthook is silent on clean state" test_install_lefthook_silent_on_clean_state
 run_test "install-lefthook serializes concurrent invocations" test_install_lefthook_concurrent_install_serializes
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
+run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
+run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
 
 # codex-config fixture는 tomlkit이 필요하다. lefthook pre-push는 `nix shell` wrap으로
 # 항상 tomlkit을 제공하지만, 사용자가 직접 실행할 때는 미가용일 수 있다. 미가용이면

--- a/tests/suites/fragile-hardcoding-guard.sh
+++ b/tests/suites/fragile-hardcoding-guard.sh
@@ -1,0 +1,35 @@
+# tests/suites/fragile-hardcoding-guard.sh — 도메인 테스트 정의 (sourced; aggregator가 lib/test-common.sh 후 source)
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+# fragile-hardcoding-guard.sh PreToolUse 가드에 JSON stdin을 흘려, "줄 수 하드코딩" 제외(allow)
+# 정규식의 어순 무관 동작과 정탐 보존을 박제한다 (이슈 #918). 가드는 Write/Edit tool_input이고
+# file_path가 SKILL.md 패턴일 때만 검사하며, jq 부재 시 no-op exit 0이다(devShell에 jq 가용).
+# JSON stdin → stdout permissionDecision 검증 패턴은 tests/test-codex-hook-fixtures.sh 참고.
+_fragile_guard_decision() {
+  # $1 = SKILL.md content. 가드의 stdout(+stderr)을 반환한다(deny JSON 또는 빈 출력).
+  local content="$1"
+  printf '{"tool_name":"Write","tool_input":{"file_path":"repo/modules/x/claude/files/skills/demo/SKILL.md","content":"%s"}}' "$content" | \
+    bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh" 2>&1
+}
+
+test_fragile_hardcoding_guard_line_count_word_order_independent() {
+  local out
+  # 오탐 케이스: 제외 키워드("제한")가 "줄" 앞 — 어순 무관화로 통과해야 한다(deny 없음).
+  out=$(_fragile_guard_decision "가이드는 제한 100줄 기준으로 작성한다")
+  assert_not_contains "$out" '"deny"'
+  # 대조군 1: 키워드가 "줄" 뒤(의미 동일) — 통과.
+  out=$(_fragile_guard_decision "가이드는 100줄 제한 기준으로 작성한다")
+  assert_not_contains "$out" '"deny"'
+  # 대조군 2: 기존 어순(수치 뒤 키워드 "이내") — 통과.
+  out=$(_fragile_guard_decision "본문은 100줄 이내로 작성한다")
+  assert_not_contains "$out" '"deny"'
+}
+
+test_fragile_hardcoding_guard_line_count_true_positive_preserved() {
+  local out
+  # 정탐 보존: 제외 키워드가 전혀 없는 순수 "N줄" 하드코딩은 어순 무관화 이후에도 deny된다.
+  out=$(_fragile_guard_decision "이 문서는 120줄로 구성된다")
+  assert_contains "$out" '"permissionDecision": "deny"'
+}


### PR DESCRIPTION
## 1. Summary

- `fragile-hardcoding-guard.sh`의 "줄 수 하드코딩" 제외(allow) 정규식이 어순에 의존하던 오탐을 교정 — 양방향 인접 매칭으로 변경.
- `tests/suites/fragile-hardcoding-guard.sh` 신설 — 가드 직접 호출 fixture로 오탐/정탐 경계 박제.

Closes #918

## 2. 기존 문제/배경

스킬 문서(`SKILL.md` / `references/`)를 편집할 때 도는 PreToolUse 가드가, "줄 수 하드코딩" 탐지의 제외 정규식이 **어순에 의존**해 정당한 작성 규칙 표현을 오탐(차단)했다. 의미가 같은데 `100줄 제한`은 통과하고 `제한 100줄`은 차단됐다(제외 패턴 `[0-9]+줄[[:space:]]*(키워드)`이 키워드가 "줄" 뒤에 와야만 매칭). 게다가 가드를 검증하는 단위 테스트가 없어 정규식 회귀를 자동으로 잡지 못했다.

## 3. CIR (Change Intent Record)

- **발견 경위**: 코드베이스 감사(epic #912)가 어순 의존 오탐을 식별하고 PoC로 재현(`제한 100줄`→deny, `100줄 제한`→통과).
- **설계 의도**: 가드의 차단 동작 자체(코드에서 동적 확인 가능한 정보의 하드코딩 방지)는 의도된 설계이므로 유지하고, 제외 경계의 어순 의존 오탐만 교정한다.
- **매칭 방식 선택**: "수치+줄"과 제외 키워드를 **어순 무관 단일 단위(양방향 인접)**로 매칭한다 — `[0-9]+줄[[:space:]]*(키워드)` 또는 `(키워드)[[:space:]]*[0-9]+줄`. 라인 전체에 키워드가 있으면 무조건 제외하는 느슨한 방식 대신 인접을 요구해, 어순 무관화가 정탐(키워드 없는 순수 N줄)을 삼키지 않도록 경계를 좁혔다. 표면적 확대 가능성은 fixture로 경계를 고정했다.
- **델타 일관성**: 가드는 Edit 시 OLD/NEW 매치 카운트 델타를 비교하므로(신규 추가분만 차단), `NEW_LINE_COUNT`(105-106)와 `OLD_LINE_COUNT`(94-95) 양쪽을 동일하게 수정했다.
- **범위 제한(YAGNI)**: 파일/경로 카운트 제외(96-98행)는 범위 표현이라 어순 문제와 종류가 다르고 실제 오탐 보고가 줄 수에 한정되므로 건드리지 않았다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 양방향 인접 매칭 | `수치줄+키워드` 또는 `키워드+수치줄` 인접 | 어순 오탐 해소 + 정탐 보존(인접 요구) | 비인접 표현은 미제외 | ✅ |
| 라인 전체 키워드 제외 | 후보 라인에 키워드 있으면 무조건 제외 | 가장 넓은 제외 | 정탐(키워드 우연 동거)을 삼킬 위험 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh` | 줄 수 제외 정규식 양방향 인접화 (NEW/OLD 양쪽) |
| `tests/suites/fragile-hardcoding-guard.sh` (신규) | 가드 JSON stdin fixture — 오탐 통과 / 대조군 통과 / 정탐 deny 박제 |
| `tests/shell-script-tests.sh` | aggregator 등록부에 2개 등록 (84→86) |

## 6. 참고 레퍼런스

- Closes #918
- Parent epic: #912
- 기반: #916(PR #922, suites/ 분할 구조) 위에서 신규 suite 추가

## 7. Human Test Plan

1. 가드 직접 호출: `제한 100줄`·`100줄 제한`·`100줄 이내` content → 빈 출력(통과), `120줄`(키워드 없음) → `permissionDecision: deny`.
2. `nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh` → 86개 통과(fragile-hardcoding-guard 2개 포함).
3. **실패 시 진단**: jq 부재 시 가드가 no-op(exit 0)이므로 정탐 테스트가 실패할 수 있다 — 실행 환경에 jq가 있는지 확인한다.
