### PR TITLE
fix(monitoring): 알림 브리지 source 로딩 실패 진단 로그

### DIFF
--- a/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh
+++ b/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh
@@ -29,9 +29,12 @@ if [ "$operation" = "crawled" ] && [ -n "$url" ]; then
   # 프로토콜 제거 (도메인+경로 유지, 쿼리스트링/트레일링 슬래시 제거)
   short_url=$(printf '%s' "$url" | sed -E 's|^https?://||; s|\?.*||; s|/$||')
   # shellcheck source=/dev/null
-  source "$PUSHOVER_CRED_FILE"
+  # source 실패 시 진단만 남기고 흐름은 유지한다 — 이 핸들러는 set -e를 쓰지 않으므로(상단
+  # set -uo pipefail) 흐름이 끊기지 않지만, 조용한 실패(알림 누락)의 원인을 journald에 남겨
+  # 운영 진단을 돕는다. 스크립트 말미의 HTTP 200 응답 계약을 깨지 않도록 exit하지 않는다.
+  source "$PUSHOVER_CRED_FILE" || echo "WARN: webhook-bridge: source 실패 PUSHOVER_CRED_FILE=$PUSHOVER_CRED_FILE (Pushover 자격 미로딩 → 알림 누락 가능)" >&2
   # shellcheck source=/dev/null
-  source "$SERVICE_LIB"
+  source "$SERVICE_LIB" || echo "WARN: webhook-bridge: source 실패 SERVICE_LIB=$SERVICE_LIB (send_notification 미가용 → 알림 누락 가능)" >&2
   send_notification "Karakeep" "아카이브 완료: ${short_url}" 0 || true
 fi
 


### PR DESCRIPTION
## 1. Summary

- `webhook-bridge.sh`의 두 `source` 호출(`$PUSHOVER_CRED_FILE`, `$SERVICE_LIB`)에 실패 시 stderr 진단 로그를 추가 — 조용한 알림 누락의 원인을 journald에 남긴다.
- 동작 변경이 아니라 관측성(robustness) 개선. HTTP 200 응답 계약 보존.

Closes #919

## 2. 기존 문제/배경

웹훅 → 알림 브리지 핸들러가 `crawled` 이벤트 처리 시 환경 설정 파일 두 개를 `source`할 때 로딩 실패를 점검하지 않았다. 스크립트는 `set -uo pipefail`이지만 `set -e`가 없어, source가 실패해도 멈추지 않고 계속 진행한다. 그 결과 알림 전송 함수/변수가 준비되지 않은 채 흘러가 알림이 누락될 수 있고, 어디서 무엇이 실패했는지 로그에 남지 않아 운영 진단이 어려웠다.

## 3. CIR (Change Intent Record)

- **발견 경위**: 코드베이스 감사(epic #912)가 두 source의 무방비 로딩을 식별. `send_notification` 호출 자체는 이미 `|| true`로 보호되나 그 앞 두 source는 무방비였다.
- **설계 의도**: 두 source에 `|| echo "WARN: ..." >&2`로 진단만 추가한다. `set -e`를 도입하면 source/파싱 실패 시 200을 반환하기 전에 종료되어 응답 계약이 깨지므로 부적절하다. `exit 1`도 응답에 도달하지 못하므로 금지 — 로그만 남기고 흐름을 유지한다.
- **DA 반영**: 초안 주석이 HTTP 200 응답을 하드코딩된 행 번호로 가리켰으나, 주석 삽입으로 행이 밀려 자기참조가 어긋났다. 행 번호를 의미 기반("스크립트 말미의 HTTP 200 응답")으로 교체해 fragile 참조를 제거했다.

## 4. ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `\|\| echo WARN >&2` | source 실패 시 진단만, 흐름 유지 | 200 계약 보존, 진단 가시성 | (없음) | ✅ |
| `set -e` 도입 | 실패 시 즉시 종료 | 명시적 실패 | 200 미반환 → 응답 계약 위반 | ❌ |
| `exit 1` | 실패 시 조기 종료 | 명시적 | 200 응답 라인 미도달 | ❌ |

## 5. 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh` | 두 source 호출에 `\|\| echo "WARN: ..." >&2` 진단 로그 추가 (+의미 기반 주석) |

## 6. 참고 레퍼런스

- Closes #919
- Parent epic: #912

## 7. Human Test Plan

1. `crawled` 페이로드 + source 실패 환경(`PUSHOVER_CRED_FILE`/`SERVICE_LIB`를 없는 경로로) → stderr에 `WARN: webhook-bridge: source 실패 ...` 2줄 + stdout `HTTP/1.1 200 OK`.
2. `crawled` 아닌 이벤트 → source 미수행, HTTP 200, WARN 0.
3. 정상 경로(유효 cred/lib) → 동작·응답 기존과 동일(WARN 없음).
4. 적용 확인: `nrs`로 `karakeep-webhook-bridge.service` 재시작(완료).
