### PR TITLE
feat(codex): guard mobile remote-control app server

### DIFF
--- a/.claude/skills/configuring-codex/SKILL.md
+++ b/.claude/skills/configuring-codex/SKILL.md
@@ -74,6 +74,10 @@ darwin=signed macho)라 소스 컴파일·patchelf 없이 fetch + install만 하
   `cleanupMiseCodexShim`, `cleanupManualNodeCodex`). 이들은 codex를 설치하지 않고, 과거 설치 방식
   (GitHub ELF/brew cask, mise npm backend shim, 수동 npm 글로벌) 잔재가 PATH에서 codex(nix profile)를
   shadow하지 못하게 정리만 한다.
+- NixOS MiniPC의 Codex App mobile remote-control은 예외적으로 별도 standalone package를
+  `~/.codex/packages/standalone/current/` 아래에 둔다. 이 standalone은 app-server payload 전용이며,
+  일반 `command -v codex`를 shadow하면 안 된다. 특히 `~/.local/bin/codex -> ~/.codex/packages/standalone/...`
+  symlink는 회귀로 취급하고 `codex-remote-control-ensure.service`/`verify-ai-compat.sh`가 제거 또는 실패 처리한다.
 
 업데이트(한 줄로 최신 stable):
 
@@ -107,6 +111,7 @@ node는 mise에 남으므로(codex만 부분 폐기, #890) 수동 글로벌이 `
 ```bash
 whence -p codex   # PATH 첫 매치 (nix profile/store여야 정상; mise shims 경로면 잔존 shim 회귀)
 type -a codex     # 모든 후보 (node/<ver>/bin이 앞이면 수동 글로벌 잔재)
+readlink -f ~/.codex/packages/standalone/current/bin/codex  # remote-control standalone 예외 경로
 ```
 
 검증: `codex --version`, `./scripts/ai/verify-ai-compat.sh`(codex PATH resolve 가드 포함).

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -224,7 +224,17 @@ ChatGPT mobile Codex sync를 위한 app-server는 일반 CLI와 별도의 standa
 - 일반 `command -v codex`는 계속 Nix-managed profile/store 경로여야 한다.
 - `~/.local/bin/codex`가 standalone을 가리키는 symlink이면 PATH shadow 회귀이므로 제거 대상이다.
 - `update-codex`는 CLI asset hash와 standalone package hash를 함께 갱신한다.
-- timer는 `codex doctor`를 실행하지 않고, auth/status/start 경로만 가볍게 확인한다.
+- timer는 `codex doctor`를 실행하지 않는다. 대신 `ensure-running`이 pinned standalone 동기화,
+  ChatGPT auth 확인, daemon/start 상태 확인, 버전 drift 재시작, stale socket 정리, 그리고 같은 사용자 +
+  legacy app-server per-process 증거가 있는 경우에만 stale PID repair를 수행한다.
+
+운영 확인:
+
+```bash
+systemctl status codex-remote-control-ensure.service codex-remote-control-ensure.timer
+journalctl -u codex-remote-control-ensure.service -n 80 --no-pager
+jq '{exitCode,lastAction,lastRepairReason,authMode,normalCodexResolved,managedCodexVersion,appServerVersion,remoteControlEnabled}' /var/lib/codex-remote-control/status.json
+```
 
 ## 참고 문서
 

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -105,6 +105,7 @@ codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' 
 6. pre-commit `ai-skills-consistency` 훅 확인 (관련 staged 변경 시 fail, 긴급 우회: `SKIP_AI_SKILL_CHECK=1`)
 7. `command -v codex`가 nix profile/store 경로로 resolve되는지 확인 — mise shims 경로면 잔존 shim이 codex(nix profile)를 shadow하는 회귀(#890)이며, `verify-ai-compat.sh`의 codex PATH resolve 가드가 자동 검사한다
 8. `cleanupManualNodeCodex`가 수동 `npm install -g @openai/codex` 잔재를 제거하는지 확인 — node가 mise에 남으므로 수동 글로벌이 PATH상 codex(nix profile)를 가리는 회귀의 근원
+9. NixOS MiniPC remote-control standalone은 `~/.codex/packages/standalone/current/` 아래 app-server payload로만 허용한다. `~/.local/bin/codex`가 이 standalone을 가리키면 일반 Codex CLI를 shadow하는 회귀다.
 
 ## 2026-05-02 업데이트: SKILL.md 도구-중립성 lint
 
@@ -205,11 +206,25 @@ prefix의 npm으로 `env PATH="$node_prefix/bin:${pkgs.mise}/bin:$PATH" "$npm_bi
 ```bash
 whence -p codex   # PATH 첫 매치 (nix profile/store여야 정상; mise shims면 잔존 shim 회귀, node/<ver>/bin이면 수동 글로벌 잔재)
 type -a codex     # 모든 후보
+readlink -f ~/.codex/packages/standalone/current/bin/codex  # Codex App remote-control standalone payload
 ```
 
 `codex`는 셸 alias로 래핑되어 있다 — Linux는 안내 `echo`를 `>&2`로 먼저 출력한 뒤
 `command codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen`를 실행하고, macOS는 선행 echo 없이
 같은 `command codex …`를 실행한다. 따라서 바이너리 자체 경로는 `whence -p codex`로 확인한다.
+
+### 2026-06-29 업데이트: remote-control standalone 예외
+
+ChatGPT mobile Codex sync를 위한 app-server는 일반 CLI와 별도의 standalone package layout을 사용한다.
+이 payload는 `modules/shared/programs/codex/codex-pin.json`의 pinned `standalonePackage` asset/hash에서
+동기화하며, systemd `codex-remote-control-ensure.service`가
+`~/.codex/packages/standalone/releases/<version>-x86_64-unknown-linux-musl/`와 `current` symlink를 관리한다.
+
+경계:
+- 일반 `command -v codex`는 계속 Nix-managed profile/store 경로여야 한다.
+- `~/.local/bin/codex`가 standalone을 가리키는 symlink이면 PATH shadow 회귀이므로 제거 대상이다.
+- `update-codex`는 CLI asset hash와 standalone package hash를 함께 갱신한다.
+- timer는 `codex doctor`를 실행하지 않고, auth/status/start 경로만 가볍게 확인한다.
 
 ## 참고 문서
 

--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -123,4 +123,5 @@
   homeserver.reverseProxy.enable = true; # Caddy HTTPS 리버스 프록시
   homeserver.smokeTest.enable = true; # 런타임 스모크 테스트 (헬스체크 + 백업 신선도)
   homeserver.opnix.enable = true; # 1Password SA token materialization + gh 인증
+  homeserver.codexRemoteControl.enable = true; # Codex mobile remote-control app-server 회귀 방지
 }

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -183,6 +183,10 @@
     opnix = {
       enable = lib.mkEnableOption "1Password Service Account secrets materialization (opnix)";
     };
+
+    codexRemoteControl = {
+      enable = lib.mkEnableOption "Codex mobile remote-control app-server regression guard";
+    };
   };
 
   # 모든 서비스 모듈을 정적으로 import (Nix 모듈 시스템은 조건부 import 불가)
@@ -208,5 +212,6 @@
     ../programs/smoke-test.nix # 런타임 스모크 테스트 (헬스체크 + 백업 신선도)
     ../programs/opnix # 1Password Service Account 시크릿 materialization
     ../programs/opnix-rotate.nix # SA token 90일 rotation 알림 (opnix.enable 게이팅)
+    ../programs/codex-remote-control.nix # Codex mobile remote-control app-server 회귀 방지
   ];
 }

--- a/modules/nixos/programs/codex-remote-control.nix
+++ b/modules/nixos/programs/codex-remote-control.nix
@@ -38,6 +38,7 @@ let
       coreutils
       curl
       findutils
+      gawk
       gnugrep
       gnused
       gnutar

--- a/modules/nixos/programs/codex-remote-control.nix
+++ b/modules/nixos/programs/codex-remote-control.nix
@@ -1,0 +1,132 @@
+# Codex mobile remote-control regression guard for greenhead-minipc.
+{
+  config,
+  pkgs,
+  lib,
+  username,
+  ...
+}:
+
+let
+  cfg = config.homeserver.codexRemoteControl;
+  pin = builtins.fromJSON (builtins.readFile ../../shared/programs/codex/codex-pin.json);
+  system = pkgs.stdenv.hostPlatform.system;
+  platform = pin.platforms.${system} or (throw "codexRemoteControl: unsupported system '${system}'");
+  standalonePackageMeta =
+    platform.standalonePackage
+      or (throw "codexRemoteControl: ${system} needs platforms.${system}.standalonePackage in codex-pin.json");
+  standaloneTriple =
+    if system == "x86_64-linux" then
+      "x86_64-unknown-linux-musl"
+    else
+      throw "codexRemoteControl: standalone remote-control is only supported on x86_64-linux";
+
+  homeDir = "/home/${username}";
+  codexHome = "${homeDir}/.codex";
+  stateDir = "/var/lib/codex-remote-control";
+  pushoverCredPath = config.age.secrets.pushover-system-monitor.path;
+  serviceLib = import ../lib/service-lib.nix { inherit pkgs; };
+
+  standalonePackage = pkgs.fetchurl {
+    url = "https://github.com/openai/codex/releases/download/${pin.tag}/${standalonePackageMeta.asset}";
+    hash = standalonePackageMeta.hash;
+  };
+
+  maintenanceCli = pkgs.writeShellApplication {
+    name = "codex-remote-control-maint";
+    runtimeInputs = with pkgs; [
+      coreutils
+      curl
+      findutils
+      gnugrep
+      gnused
+      gnutar
+      gzip
+      jq
+      procps
+      util-linux
+    ];
+    text = builtins.readFile ./codex-remote-control/files/codex-remote-control-maint.sh;
+  };
+in
+{
+  config = lib.mkIf cfg.enable {
+    age.secrets.pushover-system-monitor = {
+      file = ../../../secrets/pushover-system-monitor.age;
+      owner = "root";
+      mode = "0400";
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${codexHome} 0700 ${username} users -"
+      "d ${codexHome}/packages 0700 ${username} users -"
+      "d ${codexHome}/packages/standalone 0700 ${username} users -"
+      "d ${stateDir} 0750 ${username} users -"
+    ];
+
+    systemd.services.codex-remote-control-ensure = {
+      description = "Ensure Codex mobile remote-control app-server is current";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      unitConfig = {
+        ConditionPathExists = [
+          homeDir
+          pushoverCredPath
+        ];
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = username;
+        Group = "users";
+        WorkingDirectory = homeDir;
+        TimeoutSec = "120";
+        ExecStart = "${maintenanceCli}/bin/codex-remote-control-maint ensure-running";
+        LoadCredential = [ "pushover-system-monitor:${pushoverCredPath}" ];
+
+        # The maintenance service mutates only the Codex app-server package/state and its own status.
+        # The spawned app-server inherits this namespace, so broaden only if future Codex remote sessions
+        # prove they need workspace writes from the daemon itself.
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        ReadWritePaths = [
+          codexHome
+          stateDir
+        ];
+        ReadOnlyPaths = [ "${standalonePackage}" ];
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+      };
+
+      environment = {
+        HOME = homeDir;
+        CODEX_HOME = codexHome;
+        STATE_DIR = stateDir;
+        DESIRED_VERSION = pin.version;
+        STANDALONE_TRIPLE = standaloneTriple;
+        STANDALONE_PACKAGE = "${standalonePackage}";
+        SERVICE_LIB = "${serviceLib}";
+        ALERT_COOLDOWN_SECONDS = "1800";
+        # writeShellApplication prepends its runtime inputs; this tail lets `command -v codex`
+        # resolve to the Nix-managed user profile after stale ~/.local/bin shadows are removed.
+        PATH = lib.mkForce "/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin";
+      };
+    };
+
+    systemd.timers.codex-remote-control-ensure = {
+      description = "Periodic Codex mobile remote-control ensure";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2m";
+        OnUnitActiveSec = "30m";
+        RandomizedDelaySec = "1m";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/modules/nixos/programs/codex-remote-control.nix
+++ b/modules/nixos/programs/codex-remote-control.nix
@@ -84,12 +84,13 @@ in
         TimeoutSec = "120";
         ExecStart = "${maintenanceCli}/bin/codex-remote-control-maint ensure-running";
         LoadCredential = [ "pushover-system-monitor:${pushoverCredPath}" ];
+        KillMode = "process";
 
         # The maintenance service mutates only the Codex app-server package/state and its own status.
-        # The spawned app-server inherits this namespace, so broaden only if future Codex remote sessions
-        # prove they need workspace writes from the daemon itself.
+        # Codex remote-control app-server can serve sessions that write under ~/Workspace, so do not
+        # mount $HOME read-only here. The shell code still limits its own mutations to codexHome/stateDir.
         ProtectSystem = "strict";
-        ProtectHome = "read-only";
+        ProtectHome = false;
         ReadWritePaths = [
           codexHome
           stateDir

--- a/modules/nixos/programs/codex-remote-control.nix
+++ b/modules/nixos/programs/codex-remote-control.nix
@@ -87,9 +87,9 @@ in
         KillMode = "process";
 
         # The maintenance service mutates only the Codex app-server package/state and its own status.
-        # Codex remote-control app-server can serve sessions that write under ~/Workspace, so do not
-        # mount $HOME read-only here. The shell code still limits its own mutations to codexHome/stateDir.
-        ProtectSystem = "strict";
+        # Codex remote-control app-server can serve sessions that write under ~/Workspace. Keep
+        # /usr, /boot, /efi, and /etc read-only, but do not make the whole home tree read-only.
+        ProtectSystem = "full";
         ProtectHome = false;
         ReadWritePaths = [
           codexHome

--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -1,0 +1,635 @@
+#!/usr/bin/env bash
+# Maintain the Codex mobile remote-control app-server on greenhead-minipc.
+set -euo pipefail
+
+CODEX_OPERATOR="${CODEX_OPERATOR:-codex}"
+NORMAL_CODEX_NAME="${NORMAL_CODEX_NAME:-codex}"
+HOME="${HOME:-/home/greenhead}"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+STATE_DIR="${STATE_DIR:-/var/lib/codex-remote-control}"
+DESIRED_VERSION="${DESIRED_VERSION:-}"
+STANDALONE_TRIPLE="${STANDALONE_TRIPLE:-x86_64-unknown-linux-musl}"
+STANDALONE_PACKAGE="${STANDALONE_PACKAGE:-}"
+STANDALONE_ROOT="${STANDALONE_ROOT:-$CODEX_HOME/packages/standalone}"
+STANDALONE_RELEASE_DIR="${STANDALONE_RELEASE_DIR:-$STANDALONE_ROOT/releases/${DESIRED_VERSION}-${STANDALONE_TRIPLE}}"
+STANDALONE_CURRENT="${STANDALONE_CURRENT:-$STANDALONE_ROOT/current}"
+STANDALONE_BIN="$STANDALONE_CURRENT/bin/codex"
+STATUS_FILE="$STATE_DIR/status.json"
+LOCK_FILE="$STATE_DIR/maintenance.lock"
+ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
+PUSHOVER_CRED_FILE="${PUSHOVER_CRED_FILE:-}"
+SERVICE_LIB="${SERVICE_LIB:-}"
+CODEX_REMOTE_CONTROL_PS_FILE="${CODEX_REMOTE_CONTROL_PS_FILE:-}"
+KILL_LOG="${KILL_LOG:-}"
+
+LAST_ACTION="none"
+LAST_REPAIR_REASON=""
+OPERATOR_CLI=""
+OPERATOR_CLI_RESOLVED=""
+NORMAL_CODEX_PATH=""
+NORMAL_CODEX_RESOLVED=""
+STANDALONE_VERSION=""
+LOGIN_STATUS=""
+AUTH_MODE="unknown"
+DAEMON_STATUS="unknown"
+MANAGED_CODEX_VERSION=""
+APP_SERVER_VERSION=""
+REMOTE_CONTROL_ENABLED="null"
+SERVER_NAME=""
+PID_EVIDENCE=""
+START_STDERR=""
+DAEMON_STDERR=""
+
+die() {
+  echo "ERROR: $*" >&2
+  return 1
+}
+
+require_config() {
+  [ -n "$DESIRED_VERSION" ] || die "DESIRED_VERSION is required"
+  [ -n "$STANDALONE_PACKAGE" ] || die "STANDALONE_PACKAGE is required"
+}
+
+mkdir_state() {
+  mkdir -p "$STATE_DIR"
+}
+
+with_lock() {
+  mkdir_state
+  exec 9>"$LOCK_FILE"
+  flock 9
+  "$@"
+}
+
+path_under() {
+  local path="$1"
+  local root="$2"
+  case "$path" in
+    "$root" | "$root"/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+text_mentions_path() {
+  local text="$1"
+  local root="$2"
+  case "$text" in
+    *"$root"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+version_from_output() {
+  awk '{print $NF}' <<<"$1"
+}
+
+resolve_operator_cli() {
+  if OPERATOR_CLI="$(command -v "$CODEX_OPERATOR" 2>/dev/null)" && [ -n "$OPERATOR_CLI" ]; then
+    OPERATOR_CLI_RESOLVED="$(readlink -f "$OPERATOR_CLI" 2>/dev/null || printf '%s' "$OPERATOR_CLI")"
+  else
+    OPERATOR_CLI=""
+    OPERATOR_CLI_RESOLVED=""
+  fi
+}
+
+resolve_normal_codex() {
+  if NORMAL_CODEX_PATH="$(command -v "$NORMAL_CODEX_NAME" 2>/dev/null)" && [ -n "$NORMAL_CODEX_PATH" ]; then
+    NORMAL_CODEX_RESOLVED="$(readlink -f "$NORMAL_CODEX_PATH" 2>/dev/null || printf '%s' "$NORMAL_CODEX_PATH")"
+  else
+    NORMAL_CODEX_PATH=""
+    NORMAL_CODEX_RESOLVED=""
+  fi
+}
+
+check_standalone_version() {
+  STANDALONE_VERSION=""
+  if [ -x "$STANDALONE_BIN" ]; then
+    STANDALONE_VERSION="$(version_from_output "$("$STANDALONE_BIN" --version 2>/dev/null || true)")"
+  fi
+}
+
+ensure_path_invariant() {
+  local local_codex="$HOME/.local/bin/codex"
+  local target=""
+
+  if [ -L "$local_codex" ]; then
+    target="$(readlink -f "$local_codex" 2>/dev/null || true)"
+    if [ -n "$target" ] && path_under "$target" "$STANDALONE_ROOT"; then
+      rm -f "$local_codex"
+      LAST_ACTION="removed-standalone-path-shadow"
+    fi
+  fi
+
+  resolve_normal_codex
+  if [ -n "$NORMAL_CODEX_RESOLVED" ] && path_under "$NORMAL_CODEX_RESOLVED" "$STANDALONE_ROOT"; then
+    LAST_REPAIR_REASON="normal-codex-resolves-to-standalone"
+    return 20
+  fi
+  case "$NORMAL_CODEX_RESOLVED" in
+    /nix/store/*-codex-* | /etc/profiles/per-user/*/bin/codex | /run/current-system/sw/bin/codex | "")
+      return 0
+      ;;
+    *)
+      LAST_REPAIR_REASON="normal-codex-not-nix-managed:$NORMAL_CODEX_PATH->$NORMAL_CODEX_RESOLVED"
+      return 21
+      ;;
+  esac
+}
+
+sync_standalone_package() {
+  require_config || return $?
+  ensure_path_invariant || return $?
+  check_standalone_version
+
+  if [ "$STANDALONE_VERSION" = "$DESIRED_VERSION" ] \
+    && [ -x "$STANDALONE_RELEASE_DIR/bin/codex" ] \
+    && [ -L "$STANDALONE_CURRENT" ]; then
+    [ -L "$STANDALONE_RELEASE_DIR/codex" ] || ln -sfn bin/codex "$STANDALONE_RELEASE_DIR/codex"
+    LAST_ACTION="${LAST_ACTION:-standalone-already-current}"
+    return 0
+  fi
+
+  [ -f "$STANDALONE_PACKAGE" ] || {
+    LAST_REPAIR_REASON="standalone-package-missing:$STANDALONE_PACKAGE"
+    return 22
+  }
+
+  mkdir -p "$STANDALONE_ROOT/releases"
+  local staging
+  staging="$(mktemp -d "$STANDALONE_ROOT/releases/.staging-${DESIRED_VERSION}.XXXXXX")"
+  tar -xzf "$STANDALONE_PACKAGE" -C "$staging"
+  if [ ! -x "$staging/bin/codex" ]; then
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-package-missing-bin-codex"
+    return 23
+  fi
+
+  local extracted_version
+  extracted_version="$(version_from_output "$("$staging/bin/codex" --version 2>/dev/null || true)")"
+  if [ "$extracted_version" != "$DESIRED_VERSION" ]; then
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-package-version-mismatch:$extracted_version"
+    return 24
+  fi
+
+  chmod -R u+rwX,go-rwx "$staging"
+  ln -sfn bin/codex "$staging/codex"
+  rm -rf "$STANDALONE_RELEASE_DIR"
+  mv "$staging" "$STANDALONE_RELEASE_DIR"
+
+  if [ -e "$STANDALONE_CURRENT" ] && [ ! -L "$STANDALONE_CURRENT" ]; then
+    rm -rf "$STANDALONE_CURRENT"
+  fi
+  ln -sfn "$STANDALONE_RELEASE_DIR" "$STANDALONE_ROOT/.current.tmp"
+  mv -Tf "$STANDALONE_ROOT/.current.tmp" "$STANDALONE_CURRENT"
+  STANDALONE_VERSION="$DESIRED_VERSION"
+  LAST_ACTION="synced-standalone-package"
+}
+
+capture_login_status() {
+  LOGIN_STATUS="$("$CODEX_OPERATOR" login status 2>&1 || true)"
+  case "$LOGIN_STATUS" in
+    *"Logged in using ChatGPT"*)
+      AUTH_MODE="chatgpt"
+      return 0
+      ;;
+    *"API key"* | *"api key"* | *"API_KEY"*)
+      AUTH_MODE="api-key"
+      LAST_REPAIR_REASON="auth-not-chatgpt"
+      return 30
+      ;;
+    *)
+      AUTH_MODE="unknown"
+      LAST_REPAIR_REASON="auth-status-not-chatgpt"
+      return 31
+      ;;
+  esac
+}
+
+capture_daemon_version() {
+  local out
+  local err
+  err="$(mktemp)"
+  if out="$("$CODEX_OPERATOR" app-server daemon version 2>"$err")"; then
+    DAEMON_STDERR="$(cat "$err")"
+    rm -f "$err"
+    if jq -e 'type == "object"' >/dev/null 2>&1 <<<"$out"; then
+      DAEMON_STATUS="$(jq -r '.status // "unknown"' <<<"$out")"
+      MANAGED_CODEX_VERSION="$(jq -r '.managedCodexVersion // ""' <<<"$out")"
+      APP_SERVER_VERSION="$(jq -r '.appServerVersion // ""' <<<"$out")"
+      return 0
+    fi
+    DAEMON_STATUS="malformed-json"
+    DAEMON_STDERR="$out"
+    return 40
+  fi
+
+  DAEMON_STDERR="$(cat "$err")"
+  rm -f "$err"
+  DAEMON_STATUS="not-running"
+  return 41
+}
+
+contains_unmanaged_error() {
+  local text="$1"
+  case "$text" in
+    *"not managed by codex app-server daemon"* | *"WebSocket protocol error"* | *"Connection reset without closing handshake"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+remote_start() {
+  local out
+  local err
+  err="$(mktemp)"
+  if out="$("$CODEX_OPERATOR" remote-control start --json 2>"$err")"; then
+    START_STDERR="$(cat "$err")"
+    rm -f "$err"
+    if jq -e 'type == "object"' >/dev/null 2>&1 <<<"$out"; then
+      SERVER_NAME="$(jq -r '.serverName // ""' <<<"$out")"
+      MANAGED_CODEX_VERSION="$(jq -r '.daemon.managedCodexVersion // .managedCodexVersion // ""' <<<"$out")"
+      APP_SERVER_VERSION="$(jq -r '.daemon.appServerVersion // .appServerVersion // ""' <<<"$out")"
+      DAEMON_STATUS="$(jq -r '.daemon.status // .status // "unknown"' <<<"$out")"
+      if jq -e '(.remoteControlEnabled == true) or (.status == "connected")' >/dev/null 2>&1 <<<"$out"; then
+        REMOTE_CONTROL_ENABLED="true"
+        return 0
+      fi
+      REMOTE_CONTROL_ENABLED="false"
+      LAST_REPAIR_REASON="remote-control-start-not-connected"
+      return 50
+    fi
+    REMOTE_CONTROL_ENABLED="false"
+    LAST_REPAIR_REASON="remote-control-start-malformed-json"
+    return 51
+  fi
+
+  START_STDERR="$(cat "$err")"
+  rm -f "$err"
+  REMOTE_CONTROL_ENABLED="false"
+  if contains_unmanaged_error "$START_STDERR"; then
+    LAST_REPAIR_REASON="remote-control-start-unmanaged"
+    return 75
+  fi
+  LAST_REPAIR_REASON="remote-control-start-failed"
+  return 52
+}
+
+remote_stop() {
+  local out
+  local err
+  err="$(mktemp)"
+  if out="$("$CODEX_OPERATOR" remote-control stop --json 2>"$err")"; then
+    rm -f "$err"
+    return 0
+  fi
+  out="$(cat "$err")"
+  rm -f "$err"
+  if contains_unmanaged_error "$out"; then
+    LAST_REPAIR_REASON="remote-control-stop-unmanaged"
+    return 75
+  fi
+  LAST_REPAIR_REASON="remote-control-stop-failed"
+  return 53
+}
+
+collect_pid_evidence() {
+  if [ -n "$CODEX_REMOTE_CONTROL_PS_FILE" ]; then
+    PID_EVIDENCE="$(cat "$CODEX_REMOTE_CONTROL_PS_FILE" 2>/dev/null || true)"
+  else
+    local current_user
+    current_user="$(id -un)"
+    PID_EVIDENCE="$(
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        printf '%s %s %s\n' "$(awk '{print $1}' <<<"$line")" "$current_user" "$(sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//' <<<"$line")"
+      done < <(pgrep -a -u "$(id -u)" -f 'codex .*app-server|app-server --listen unix://' || true)
+    )"
+  fi
+}
+
+parse_pid_line() {
+  local line="$1"
+  PID_FIELD="$(awk '{print $1}' <<<"$line")"
+  USER_FIELD="$(awk '{print $2}' <<<"$line")"
+  CMD_FIELD="$(sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+[^[:space:]]+[[:space:]]+//' <<<"$line")"
+}
+
+is_app_server_line() {
+  local cmd="$1"
+  case "$cmd" in
+    *"app-server --listen unix://"* | *"codex app-server"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_stale_unmanaged_line() {
+  local line="$1"
+  local current_user
+  current_user="$(id -un)"
+  parse_pid_line "$line"
+  [ "$USER_FIELD" = "$current_user" ] || return 1
+  is_app_server_line "$CMD_FIELD" || return 1
+  if text_mentions_path "$CMD_FIELD" "$STANDALONE_ROOT"; then
+    return 1
+  fi
+  case "$CMD_FIELD" in
+    *"/.local/share/mise/installs/npm-openai-codex/"* | *"npm-openai-codex"* | *"/.local/share/mise/installs/node/"* | *"/vendor/"*"unknown-linux-musl/bin/codex app-server"*)
+      return 0
+      ;;
+  esac
+  if [ -n "$APP_SERVER_VERSION" ] && [ "$APP_SERVER_VERSION" != "$DESIRED_VERSION" ]; then
+    return 0
+  fi
+  return 1
+}
+
+kill_pid() {
+  local pid="$1"
+  if [ -n "$KILL_LOG" ]; then
+    printf '%s\n' "$pid" >>"$KILL_LOG"
+  else
+    kill "$pid" 2>/dev/null || true
+    sleep 1
+    kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+  fi
+}
+
+app_server_pid_exists() {
+  collect_pid_evidence
+  [ -z "$PID_EVIDENCE" ] && return 1
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    parse_pid_line "$line"
+    if is_app_server_line "$CMD_FIELD"; then
+      return 0
+    fi
+  done <<<"$PID_EVIDENCE"
+  return 1
+}
+
+cleanup_socket_files() {
+  local mode="${1:-no-pid-required}"
+  if [ "$mode" != "after-verified-kill" ] && app_server_pid_exists; then
+    LAST_REPAIR_REASON="refusing-socket-cleanup-while-app-server-pid-exists"
+    return 60
+  fi
+
+  rm -f \
+    "$CODEX_HOME/app-server-control/app-server-control.sock" \
+    "$CODEX_HOME/app-server-control/desktop-ssh-websocket-v0.sock" \
+    "$CODEX_HOME/app-server-control/app-server-startup.lock" \
+    "$CODEX_HOME/app-server-daemon/app-server.pid.lock" \
+    "$CODEX_HOME/app-server-daemon/app-server-updater.pid.lock" \
+    "$CODEX_HOME/app-server-daemon/daemon.lock"
+  LAST_ACTION="cleaned-stale-app-server-sockets"
+}
+
+repair_unmanaged_core() {
+  require_config || return $?
+  collect_pid_evidence
+  local killed=0
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    if is_stale_unmanaged_line "$line"; then
+      parse_pid_line "$line"
+      kill_pid "$PID_FIELD"
+      killed=$((killed + 1))
+    fi
+  done <<<"$PID_EVIDENCE"
+
+  if [ "$killed" -eq 0 ]; then
+    LAST_REPAIR_REASON="unmanaged-error-without-stale-pid-proof"
+    return 61
+  fi
+
+  cleanup_socket_files after-verified-kill || return $?
+  LAST_REPAIR_REASON="killed-stale-unmanaged-app-server:$killed"
+  LAST_ACTION="repaired-unmanaged-app-server"
+}
+
+ensure_running_core() {
+  require_config || return $?
+  resolve_operator_cli
+  [ -n "$OPERATOR_CLI" ] || {
+    LAST_REPAIR_REASON="operator-codex-not-found"
+    return 25
+  }
+
+  sync_standalone_package || return $?
+  capture_login_status || return $?
+
+  if capture_daemon_version; then
+    if [ "$MANAGED_CODEX_VERSION" != "$DESIRED_VERSION" ] || [ "$APP_SERVER_VERSION" != "$DESIRED_VERSION" ]; then
+      LAST_REPAIR_REASON="daemon-version-drift:${MANAGED_CODEX_VERSION}/${APP_SERVER_VERSION}"
+      local stop_rc=0
+      remote_stop || stop_rc=$?
+      if [ "$stop_rc" -ne 0 ]; then
+        if [ "$stop_rc" -eq 75 ]; then
+          repair_unmanaged_core || return $?
+        else
+          return "$stop_rc"
+        fi
+      fi
+      cleanup_socket_files no-pid-required || return $?
+      remote_start || {
+        local rc=$?
+        if [ "$rc" -eq 75 ]; then
+          repair_unmanaged_core || return $?
+          remote_start || return $?
+        else
+          return "$rc"
+        fi
+      }
+      LAST_ACTION="restarted-version-drift"
+      return 0
+    fi
+  else
+    if contains_unmanaged_error "$DAEMON_STDERR"; then
+      repair_unmanaged_core || return $?
+    fi
+  fi
+
+  if ! remote_start; then
+    local rc=$?
+    if [ "$rc" -eq 75 ]; then
+      repair_unmanaged_core || return $?
+      remote_start || return $?
+    else
+      return "$rc"
+    fi
+  fi
+  [ "$LAST_ACTION" != "none" ] || LAST_ACTION="remote-control-healthy"
+}
+
+collect_probe() {
+  resolve_operator_cli
+  resolve_normal_codex
+  check_standalone_version
+  capture_login_status || true
+  capture_daemon_version || true
+}
+
+status_json() {
+  local exit_code="${1:-0}"
+  jq -n \
+    --arg timestamp "$(date -Is)" \
+    --arg operatorCli "$OPERATOR_CLI_RESOLVED" \
+    --arg normalCodexPath "$NORMAL_CODEX_PATH" \
+    --arg normalCodexResolved "$NORMAL_CODEX_RESOLVED" \
+    --arg standalonePath "$STANDALONE_BIN" \
+    --arg desiredVersion "$DESIRED_VERSION" \
+    --arg standaloneVersion "$STANDALONE_VERSION" \
+    --arg managedCodexVersion "$MANAGED_CODEX_VERSION" \
+    --arg appServerVersion "$APP_SERVER_VERSION" \
+    --arg authMode "$AUTH_MODE" \
+    --arg loginStatus "$LOGIN_STATUS" \
+    --arg daemonStatus "$DAEMON_STATUS" \
+    --arg serverName "$SERVER_NAME" \
+    --arg lastAction "$LAST_ACTION" \
+    --arg lastRepairReason "$LAST_REPAIR_REASON" \
+    --arg pidEvidence "$PID_EVIDENCE" \
+    --argjson remoteControlEnabled "$REMOTE_CONTROL_ENABLED" \
+    --argjson exitCode "$exit_code" \
+    '{
+      timestamp: $timestamp,
+      operatorCli: $operatorCli,
+      normalCodexPath: $normalCodexPath,
+      normalCodexResolved: $normalCodexResolved,
+      standalonePath: $standalonePath,
+      desiredVersion: $desiredVersion,
+      standaloneVersion: $standaloneVersion,
+      managedCodexVersion: $managedCodexVersion,
+      appServerVersion: $appServerVersion,
+      remoteControlEnabled: $remoteControlEnabled,
+      authMode: $authMode,
+      loginStatus: $loginStatus,
+      daemonStatus: $daemonStatus,
+      serverName: $serverName,
+      lastAction: $lastAction,
+      lastRepairReason: $lastRepairReason,
+      pidEvidence: $pidEvidence,
+      exitCode: $exitCode
+    }'
+}
+
+write_status() {
+  local exit_code="${1:-0}"
+  mkdir_state
+  local tmp
+  tmp="$(mktemp "$STATE_DIR/status.XXXXXX")"
+  status_json "$exit_code" >"$tmp"
+  mv "$tmp" "$STATUS_FILE"
+}
+
+load_alerting() {
+  # shellcheck source=/dev/null
+  [ -n "$SERVICE_LIB" ] && [ -f "$SERVICE_LIB" ] && source "$SERVICE_LIB"
+  local pushover_cred="$PUSHOVER_CRED_FILE"
+  if [ -z "$pushover_cred" ] && [ -n "${CREDENTIALS_DIRECTORY:-}" ]; then
+    pushover_cred="$CREDENTIALS_DIRECTORY/pushover-system-monitor"
+  fi
+  if [ -n "$pushover_cred" ] && [ -r "$pushover_cred" ]; then
+    # shellcheck source=/dev/null
+    source "$pushover_cred"
+  fi
+}
+
+send_alerts() {
+  local exit_code="$1"
+  command -v send_notification >/dev/null 2>&1 || return 0
+  [ -n "${PUSHOVER_TOKEN:-}" ] && [ -n "${PUSHOVER_USER:-}" ] || return 0
+
+  local now
+  now="$(date +%s)"
+  local state_file="$STATE_DIR/last-health-state"
+  local last_failure_file="$STATE_DIR/last-failure-alert"
+  local previous="unknown"
+  [ -f "$state_file" ] && previous="$(cat "$state_file" 2>/dev/null || echo unknown)"
+
+  if [ "$exit_code" -eq 0 ]; then
+    if [ "$previous" = "failed" ]; then
+      send_notification "Codex Remote Control Recovered" \
+        "greenhead-minipc remote-control is healthy (${APP_SERVER_VERSION:-unknown})." 0
+    fi
+    echo "healthy" >"$state_file"
+    return 0
+  fi
+
+  local last=0
+  [ -f "$last_failure_file" ] && last="$(cat "$last_failure_file" 2>/dev/null || echo 0)"
+  if [ $((now - last)) -ge "$ALERT_COOLDOWN_SECONDS" ]; then
+    send_notification "Codex Remote Control Failed" \
+      "exit=${exit_code}, reason=${LAST_REPAIR_REASON:-unknown}, auth=${AUTH_MODE:-unknown}" 0
+    echo "$now" >"$last_failure_file"
+  fi
+  echo "failed" >"$state_file"
+}
+
+cmd_probe() {
+  require_config || return $?
+  collect_probe
+  status_json 0
+}
+
+cmd_health_json() {
+  if [ -f "$STATUS_FILE" ]; then
+    cat "$STATUS_FILE"
+  else
+    cmd_probe
+  fi
+}
+
+cmd_ensure_standalone() {
+  local rc=0
+  with_lock sync_standalone_package || rc=$?
+  collect_probe
+  write_status "$rc" || true
+  return "$rc"
+}
+
+cmd_repair_unmanaged() {
+  local rc=0
+  with_lock repair_unmanaged_core || rc=$?
+  collect_probe
+  write_status "$rc" || true
+  return "$rc"
+}
+
+cmd_ensure_running() {
+  local rc=0
+  with_lock ensure_running_core || rc=$?
+  collect_probe
+  write_status "$rc" || true
+  load_alerting
+  send_alerts "$rc" || true
+  return "$rc"
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: codex-remote-control-maint <probe|ensure-standalone|ensure-running|repair-unmanaged|health-json>
+EOF
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    probe) cmd_probe ;;
+    ensure-standalone) cmd_ensure_standalone ;;
+    ensure-running) cmd_ensure_running ;;
+    repair-unmanaged) cmd_repair_unmanaged ;;
+    health-json) cmd_health_json ;;
+    -h | --help | help) usage ;;
+    *)
+      usage
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -37,6 +37,7 @@ readonly RC_REMOTE_START_NOT_CONNECTED=50
 readonly RC_REMOTE_START_MALFORMED_JSON=51
 readonly RC_REMOTE_START_FAILED=52
 readonly RC_REMOTE_STOP_FAILED=53
+readonly RC_REMOTE_START_VERSION_DRIFT=54
 readonly RC_SOCKET_CLEANUP_REFUSED=60
 readonly RC_UNMANAGED_WITHOUT_STALE_PROOF=61
 readonly RC_UNMANAGED=75
@@ -81,9 +82,18 @@ mkdir_state() {
 }
 
 with_lock() {
-  mkdir_state
-  exec 9>"$LOCK_FILE"
-  flock 9
+  mkdir_state || {
+    LAST_REPAIR_REASON="state-dir-unavailable"
+    return 1
+  }
+  exec 9>"$LOCK_FILE" || {
+    LAST_REPAIR_REASON="lock-open-failed"
+    return 1
+  }
+  flock 9 || {
+    LAST_REPAIR_REASON="lock-acquire-failed"
+    return 1
+  }
   "$@"
 }
 
@@ -268,6 +278,10 @@ contains_unmanaged_error() {
   esac
 }
 
+remote_start_versions_current() {
+  [ "$MANAGED_CODEX_VERSION" = "$DESIRED_VERSION" ] && [ "$APP_SERVER_VERSION" = "$DESIRED_VERSION" ]
+}
+
 remote_start() {
   local out
   local err
@@ -281,6 +295,11 @@ remote_start() {
       APP_SERVER_VERSION="$(jq -r '.daemon.appServerVersion // .appServerVersion // ""' <<<"$out")"
       DAEMON_STATUS="$(jq -r '.daemon.status // .status // "unknown"' <<<"$out")"
       if jq -e '(.remoteControlEnabled == true) or (.status == "connected")' >/dev/null 2>&1 <<<"$out"; then
+        if ! remote_start_versions_current; then
+          REMOTE_CONTROL_ENABLED="false"
+          LAST_REPAIR_REASON="remote-control-start-version-drift:${MANAGED_CODEX_VERSION:-missing}/${APP_SERVER_VERSION:-missing}"
+          return "$RC_REMOTE_START_VERSION_DRIFT"
+        fi
         REMOTE_CONTROL_ENABLED="true"
         return 0
       fi
@@ -386,14 +405,63 @@ is_stale_unmanaged_line() {
   is_known_legacy_codex_cmd "$CMD_FIELD"
 }
 
+pid_is_numeric() {
+  case "$1" in
+    "" | *[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+remove_pid_from_fixture() {
+  local pid="$1"
+  [ -n "$CODEX_REMOTE_CONTROL_PS_FILE" ] && [ -f "$CODEX_REMOTE_CONTROL_PS_FILE" ] || return 0
+  local tmp
+  tmp="$(mktemp)"
+  awk -v pid="$pid" '$1 != pid' "$CODEX_REMOTE_CONTROL_PS_FILE" >"$tmp"
+  mv "$tmp" "$CODEX_REMOTE_CONTROL_PS_FILE"
+}
+
+current_pid_matches_stale_proof() {
+  local pid="$1"
+  pid_is_numeric "$pid" || return 1
+
+  # Fixture mode uses fake PIDs; production revalidates live /proc state below.
+  [ -z "$KILL_LOG" ] || return 0
+  [ -r "/proc/$pid/status" ] && [ -r "/proc/$pid/cmdline" ] || return 1
+
+  local current_uid
+  local pid_uid
+  local current_cmd
+  current_uid="$(id -u)"
+  pid_uid="$(awk '/^Uid:/{print $2; exit}' "/proc/$pid/status" 2>/dev/null || true)"
+  [ "$pid_uid" = "$current_uid" ] || return 1
+
+  current_cmd="$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)"
+  [ -n "$current_cmd" ] || return 1
+  is_app_server_line "$current_cmd" || return 1
+  is_managed_standalone_cmd "$current_cmd" && return 1
+  is_known_legacy_codex_cmd "$current_cmd"
+}
+
 kill_pid() {
   local pid="$1"
+  current_pid_matches_stale_proof "$pid" || {
+    LAST_REPAIR_REASON="stale-pid-revalidation-failed:$pid"
+    return "$RC_UNMANAGED_WITHOUT_STALE_PROOF"
+  }
   if [ -n "$KILL_LOG" ]; then
     printf '%s\n' "$pid" >>"$KILL_LOG"
+    remove_pid_from_fixture "$pid"
   else
     kill "$pid" 2>/dev/null || true
     sleep 1
-    kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
+    if kill -0 "$pid" 2>/dev/null; then
+      current_pid_matches_stale_proof "$pid" || {
+        LAST_REPAIR_REASON="stale-pid-revalidation-failed-before-kill9:$pid"
+        return "$RC_UNMANAGED_WITHOUT_STALE_PROOF"
+      }
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
   fi
 }
 
@@ -411,8 +479,8 @@ app_server_pid_exists() {
 }
 
 cleanup_socket_files() {
-  local mode="${1:-$SOCKET_CLEANUP_NO_PID_REQUIRED}"
-  if [ "$mode" != "$SOCKET_CLEANUP_AFTER_VERIFIED_KILL" ] && app_server_pid_exists; then
+  : "${1:-$SOCKET_CLEANUP_NO_PID_REQUIRED}"
+  if app_server_pid_exists; then
     LAST_REPAIR_REASON="refusing-socket-cleanup-while-app-server-pid-exists"
     return "$RC_SOCKET_CLEANUP_REFUSED"
   fi
@@ -436,7 +504,7 @@ repair_unmanaged_core() {
     [ -n "$line" ] || continue
     if is_stale_unmanaged_line "$line"; then
       parse_pid_line "$line"
-      kill_pid "$PID_FIELD"
+      kill_pid "$PID_FIELD" || return $?
       killed=$((killed + 1))
     fi
   done <<<"$PID_EVIDENCE"
@@ -493,13 +561,14 @@ ensure_running_core() {
     fi
   fi
 
-  if ! remote_start; then
-    local rc=$?
-    if [ "$rc" -eq "$RC_UNMANAGED" ]; then
+  local start_rc=0
+  remote_start || start_rc=$?
+  if [ "$start_rc" -ne 0 ]; then
+    if [ "$start_rc" -eq "$RC_UNMANAGED" ]; then
       repair_unmanaged_core || return $?
       remote_start || return $?
     else
-      return "$rc"
+      return "$start_rc"
     fi
   fi
   set_last_action_if_none "remote-control-healthy"
@@ -509,8 +578,16 @@ collect_probe() {
   resolve_operator_cli
   resolve_normal_codex
   check_standalone_version
-  capture_login_status || true
-  capture_daemon_version || true
+  if [ -n "$OPERATOR_CLI" ]; then
+    capture_login_status || true
+    capture_daemon_version || true
+  fi
+}
+
+collect_probe_preserving_reason() {
+  local previous_reason="$LAST_REPAIR_REASON"
+  collect_probe
+  [ -z "$previous_reason" ] || LAST_REPAIR_REASON="$previous_reason"
 }
 
 status_json() {
@@ -558,10 +635,13 @@ status_json() {
 
 write_status() {
   local exit_code="${1:-0}"
-  mkdir_state
+  mkdir_state || return $?
   local tmp
-  tmp="$(mktemp "$STATE_DIR/status.XXXXXX")"
-  status_json "$exit_code" >"$tmp"
+  tmp="$(mktemp "$STATE_DIR/status.XXXXXX")" || return $?
+  status_json "$exit_code" >"$tmp" || {
+    rm -f "$tmp"
+    return 1
+  }
   mv "$tmp" "$STATUS_FILE"
 }
 
@@ -626,7 +706,11 @@ cmd_health_json() {
 cmd_ensure_standalone() {
   local rc=0
   with_lock sync_standalone_package || rc=$?
-  collect_probe
+  if [ "$rc" -eq 0 ]; then
+    collect_probe
+  else
+    collect_probe_preserving_reason
+  fi
   write_status "$rc" || true
   return "$rc"
 }
@@ -634,7 +718,11 @@ cmd_ensure_standalone() {
 cmd_repair_unmanaged() {
   local rc=0
   with_lock repair_unmanaged_core || rc=$?
-  collect_probe
+  if [ "$rc" -eq 0 ]; then
+    collect_probe
+  else
+    collect_probe_preserving_reason
+  fi
   write_status "$rc" || true
   return "$rc"
 }
@@ -642,7 +730,9 @@ cmd_repair_unmanaged() {
 cmd_ensure_running() {
   local rc=0
   with_lock ensure_running_core || rc=$?
-  collect_probe
+  if [ "$rc" -ne 0 ]; then
+    collect_probe_preserving_reason
+  fi
   write_status "$rc" || true
   load_alerting
   send_alerts "$rc" || true

--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -190,10 +190,20 @@ sync_standalone_package() {
     return "$RC_STANDALONE_PACKAGE_MISSING"
   }
 
-  mkdir -p "$STANDALONE_ROOT/releases"
+  mkdir -p "$STANDALONE_ROOT/releases" || {
+    LAST_REPAIR_REASON="standalone-sync-failed:mkdir-releases"
+    return 1
+  }
   local staging
-  staging="$(mktemp -d "$STANDALONE_ROOT/releases/.staging-${DESIRED_VERSION}.XXXXXX")"
-  tar -xzf "$STANDALONE_PACKAGE" -C "$staging"
+  staging="$(mktemp -d "$STANDALONE_ROOT/releases/.staging-${DESIRED_VERSION}.XXXXXX")" || {
+    LAST_REPAIR_REASON="standalone-sync-failed:mktemp"
+    return 1
+  }
+  tar -xzf "$STANDALONE_PACKAGE" -C "$staging" || {
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-sync-failed:extract"
+    return 1
+  }
   if [ ! -x "$staging/bin/codex" ]; then
     rm -rf "$staging"
     LAST_REPAIR_REASON="standalone-package-missing-bin-codex"
@@ -208,34 +218,64 @@ sync_standalone_package() {
     return "$RC_STANDALONE_PACKAGE_VERSION_MISMATCH"
   fi
 
-  chmod -R u+rwX,go-rwx "$staging"
-  ln -sfn bin/codex "$staging/codex"
-  rm -rf "$STANDALONE_RELEASE_DIR"
-  mv "$staging" "$STANDALONE_RELEASE_DIR"
+  chmod -R u+rwX,go-rwx "$staging" || {
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-sync-failed:chmod"
+    return 1
+  }
+  ln -sfn bin/codex "$staging/codex" || {
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-sync-failed:release-link"
+    return 1
+  }
+  rm -rf "$STANDALONE_RELEASE_DIR" || {
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-sync-failed:remove-old-release"
+    return 1
+  }
+  mv "$staging" "$STANDALONE_RELEASE_DIR" || {
+    rm -rf "$staging"
+    LAST_REPAIR_REASON="standalone-sync-failed:move-release"
+    return 1
+  }
 
   if [ -e "$STANDALONE_CURRENT" ] && [ ! -L "$STANDALONE_CURRENT" ]; then
-    rm -rf "$STANDALONE_CURRENT"
+    rm -rf "$STANDALONE_CURRENT" || {
+      LAST_REPAIR_REASON="standalone-sync-failed:remove-current"
+      return 1
+    }
   fi
-  ln -sfn "$STANDALONE_RELEASE_DIR" "$STANDALONE_ROOT/.current.tmp"
-  mv -Tf "$STANDALONE_ROOT/.current.tmp" "$STANDALONE_CURRENT"
+  ln -sfn "$STANDALONE_RELEASE_DIR" "$STANDALONE_ROOT/.current.tmp" || {
+    LAST_REPAIR_REASON="standalone-sync-failed:current-link"
+    return 1
+  }
+  mv -Tf "$STANDALONE_ROOT/.current.tmp" "$STANDALONE_CURRENT" || {
+    rm -f "$STANDALONE_ROOT/.current.tmp"
+    LAST_REPAIR_REASON="standalone-sync-failed:current-swap"
+    return 1
+  }
   STANDALONE_VERSION="$DESIRED_VERSION"
   LAST_ACTION="synced-standalone-package"
 }
 
 capture_login_status() {
-  LOGIN_STATUS="$("$CODEX_OPERATOR" login status 2>&1 || true)"
-  case "$LOGIN_STATUS" in
+  local raw_status
+  raw_status="$("$CODEX_OPERATOR" login status 2>&1 || true)"
+  case "$raw_status" in
     *"Logged in using ChatGPT"*)
       AUTH_MODE="chatgpt"
+      LOGIN_STATUS="$AUTH_MODE"
       return 0
       ;;
     *"API key"* | *"api key"* | *"API_KEY"*)
       AUTH_MODE="api-key"
+      LOGIN_STATUS="$AUTH_MODE"
       LAST_REPAIR_REASON="auth-not-chatgpt"
       return "$RC_AUTH_API_KEY"
       ;;
     *)
       AUTH_MODE="unknown"
+      LOGIN_STATUS="$AUTH_MODE"
       LAST_REPAIR_REASON="auth-status-not-chatgpt"
       return "$RC_AUTH_NOT_CHATGPT"
       ;;
@@ -530,6 +570,7 @@ ensure_running_core() {
   sync_standalone_package || return $?
   capture_login_status || return $?
 
+  local daemon_rc=0
   if capture_daemon_version; then
     if [ "$MANAGED_CODEX_VERSION" != "$DESIRED_VERSION" ] || [ "$APP_SERVER_VERSION" != "$DESIRED_VERSION" ]; then
       LAST_REPAIR_REASON="daemon-version-drift:${MANAGED_CODEX_VERSION}/${APP_SERVER_VERSION}"
@@ -556,6 +597,11 @@ ensure_running_core() {
       return 0
     fi
   else
+    daemon_rc=$?
+    if [ "$daemon_rc" -eq "$RC_DAEMON_MALFORMED_JSON" ]; then
+      LAST_REPAIR_REASON="daemon-version-malformed-json"
+      return "$daemon_rc"
+    fi
     if contains_unmanaged_error "$DAEMON_STDERR"; then
       repair_unmanaged_core || return $?
     fi

--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -22,7 +22,28 @@ SERVICE_LIB="${SERVICE_LIB:-}"
 CODEX_REMOTE_CONTROL_PS_FILE="${CODEX_REMOTE_CONTROL_PS_FILE:-}"
 KILL_LOG="${KILL_LOG:-}"
 
-LAST_ACTION="none"
+readonly ACTION_NONE="none"
+readonly RC_NORMAL_CODEX_STANDALONE=20
+readonly RC_NORMAL_CODEX_NOT_NIX=21
+readonly RC_STANDALONE_PACKAGE_MISSING=22
+readonly RC_STANDALONE_PACKAGE_MISSING_BIN=23
+readonly RC_STANDALONE_PACKAGE_VERSION_MISMATCH=24
+readonly RC_OPERATOR_CODEX_NOT_FOUND=25
+readonly RC_AUTH_API_KEY=30
+readonly RC_AUTH_NOT_CHATGPT=31
+readonly RC_DAEMON_MALFORMED_JSON=40
+readonly RC_DAEMON_NOT_RUNNING=41
+readonly RC_REMOTE_START_NOT_CONNECTED=50
+readonly RC_REMOTE_START_MALFORMED_JSON=51
+readonly RC_REMOTE_START_FAILED=52
+readonly RC_REMOTE_STOP_FAILED=53
+readonly RC_SOCKET_CLEANUP_REFUSED=60
+readonly RC_UNMANAGED_WITHOUT_STALE_PROOF=61
+readonly RC_UNMANAGED=75
+readonly SOCKET_CLEANUP_AFTER_VERIFIED_KILL="after-verified-kill"
+readonly SOCKET_CLEANUP_NO_PID_REQUIRED="no-pid-required"
+
+LAST_ACTION="$ACTION_NONE"
 LAST_REPAIR_REASON=""
 OPERATOR_CLI=""
 OPERATOR_CLI_RESOLVED=""
@@ -43,6 +64,11 @@ DAEMON_STDERR=""
 die() {
   echo "ERROR: $*" >&2
   return 1
+}
+
+set_last_action_if_none() {
+  local action="$1"
+  [ "$LAST_ACTION" != "$ACTION_NONE" ] || LAST_ACTION="$action"
 }
 
 require_config() {
@@ -123,7 +149,7 @@ ensure_path_invariant() {
   resolve_normal_codex
   if [ -n "$NORMAL_CODEX_RESOLVED" ] && path_under "$NORMAL_CODEX_RESOLVED" "$STANDALONE_ROOT"; then
     LAST_REPAIR_REASON="normal-codex-resolves-to-standalone"
-    return 20
+    return "$RC_NORMAL_CODEX_STANDALONE"
   fi
   case "$NORMAL_CODEX_RESOLVED" in
     /nix/store/*-codex-* | /etc/profiles/per-user/*/bin/codex | /run/current-system/sw/bin/codex | "")
@@ -131,7 +157,7 @@ ensure_path_invariant() {
       ;;
     *)
       LAST_REPAIR_REASON="normal-codex-not-nix-managed:$NORMAL_CODEX_PATH->$NORMAL_CODEX_RESOLVED"
-      return 21
+      return "$RC_NORMAL_CODEX_NOT_NIX"
       ;;
   esac
 }
@@ -145,13 +171,13 @@ sync_standalone_package() {
     && [ -x "$STANDALONE_RELEASE_DIR/bin/codex" ] \
     && [ -L "$STANDALONE_CURRENT" ]; then
     [ -L "$STANDALONE_RELEASE_DIR/codex" ] || ln -sfn bin/codex "$STANDALONE_RELEASE_DIR/codex"
-    LAST_ACTION="${LAST_ACTION:-standalone-already-current}"
+    set_last_action_if_none "standalone-already-current"
     return 0
   fi
 
   [ -f "$STANDALONE_PACKAGE" ] || {
     LAST_REPAIR_REASON="standalone-package-missing:$STANDALONE_PACKAGE"
-    return 22
+    return "$RC_STANDALONE_PACKAGE_MISSING"
   }
 
   mkdir -p "$STANDALONE_ROOT/releases"
@@ -161,7 +187,7 @@ sync_standalone_package() {
   if [ ! -x "$staging/bin/codex" ]; then
     rm -rf "$staging"
     LAST_REPAIR_REASON="standalone-package-missing-bin-codex"
-    return 23
+    return "$RC_STANDALONE_PACKAGE_MISSING_BIN"
   fi
 
   local extracted_version
@@ -169,7 +195,7 @@ sync_standalone_package() {
   if [ "$extracted_version" != "$DESIRED_VERSION" ]; then
     rm -rf "$staging"
     LAST_REPAIR_REASON="standalone-package-version-mismatch:$extracted_version"
-    return 24
+    return "$RC_STANDALONE_PACKAGE_VERSION_MISMATCH"
   fi
 
   chmod -R u+rwX,go-rwx "$staging"
@@ -196,12 +222,12 @@ capture_login_status() {
     *"API key"* | *"api key"* | *"API_KEY"*)
       AUTH_MODE="api-key"
       LAST_REPAIR_REASON="auth-not-chatgpt"
-      return 30
+      return "$RC_AUTH_API_KEY"
       ;;
     *)
       AUTH_MODE="unknown"
       LAST_REPAIR_REASON="auth-status-not-chatgpt"
-      return 31
+      return "$RC_AUTH_NOT_CHATGPT"
       ;;
   esac
 }
@@ -221,13 +247,13 @@ capture_daemon_version() {
     fi
     DAEMON_STATUS="malformed-json"
     DAEMON_STDERR="$out"
-    return 40
+    return "$RC_DAEMON_MALFORMED_JSON"
   fi
 
   DAEMON_STDERR="$(cat "$err")"
   rm -f "$err"
   DAEMON_STATUS="not-running"
-  return 41
+  return "$RC_DAEMON_NOT_RUNNING"
 }
 
 contains_unmanaged_error() {
@@ -260,11 +286,11 @@ remote_start() {
       fi
       REMOTE_CONTROL_ENABLED="false"
       LAST_REPAIR_REASON="remote-control-start-not-connected"
-      return 50
+      return "$RC_REMOTE_START_NOT_CONNECTED"
     fi
     REMOTE_CONTROL_ENABLED="false"
     LAST_REPAIR_REASON="remote-control-start-malformed-json"
-    return 51
+    return "$RC_REMOTE_START_MALFORMED_JSON"
   fi
 
   START_STDERR="$(cat "$err")"
@@ -272,10 +298,10 @@ remote_start() {
   REMOTE_CONTROL_ENABLED="false"
   if contains_unmanaged_error "$START_STDERR"; then
     LAST_REPAIR_REASON="remote-control-start-unmanaged"
-    return 75
+    return "$RC_UNMANAGED"
   fi
   LAST_REPAIR_REASON="remote-control-start-failed"
-  return 52
+  return "$RC_REMOTE_START_FAILED"
 }
 
 remote_stop() {
@@ -290,10 +316,10 @@ remote_stop() {
   rm -f "$err"
   if contains_unmanaged_error "$out"; then
     LAST_REPAIR_REASON="remote-control-stop-unmanaged"
-    return 75
+    return "$RC_UNMANAGED"
   fi
   LAST_REPAIR_REASON="remote-control-stop-failed"
-  return 53
+  return "$RC_REMOTE_STOP_FAILED"
 }
 
 collect_pid_evidence() {
@@ -326,25 +352,38 @@ is_app_server_line() {
   esac
 }
 
-is_stale_unmanaged_line() {
+is_same_user_app_server_line() {
   local line="$1"
   local current_user
   current_user="$(id -un)"
   parse_pid_line "$line"
   [ "$USER_FIELD" = "$current_user" ] || return 1
-  is_app_server_line "$CMD_FIELD" || return 1
-  if text_mentions_path "$CMD_FIELD" "$STANDALONE_ROOT"; then
-    return 1
-  fi
-  case "$CMD_FIELD" in
+  is_app_server_line "$CMD_FIELD"
+}
+
+is_managed_standalone_cmd() {
+  local cmd="$1"
+  text_mentions_path "$cmd" "$STANDALONE_ROOT"
+}
+
+is_known_legacy_codex_cmd() {
+  local cmd="$1"
+  case "$cmd" in
     *"/.local/share/mise/installs/npm-openai-codex/"* | *"npm-openai-codex"* | *"/.local/share/mise/installs/node/"* | *"/vendor/"*"unknown-linux-musl/bin/codex app-server"*)
       return 0
       ;;
   esac
-  if [ -n "$APP_SERVER_VERSION" ] && [ "$APP_SERVER_VERSION" != "$DESIRED_VERSION" ]; then
-    return 0
-  fi
   return 1
+}
+
+is_stale_unmanaged_line() {
+  local line="$1"
+  is_same_user_app_server_line "$line" || return 1
+  is_managed_standalone_cmd "$CMD_FIELD" && return 1
+
+  # Kill safety requires per-process evidence. Global daemon version drift is not
+  # enough to prove that an arbitrary same-user app-server PID is stale.
+  is_known_legacy_codex_cmd "$CMD_FIELD"
 }
 
 kill_pid() {
@@ -372,10 +411,10 @@ app_server_pid_exists() {
 }
 
 cleanup_socket_files() {
-  local mode="${1:-no-pid-required}"
-  if [ "$mode" != "after-verified-kill" ] && app_server_pid_exists; then
+  local mode="${1:-$SOCKET_CLEANUP_NO_PID_REQUIRED}"
+  if [ "$mode" != "$SOCKET_CLEANUP_AFTER_VERIFIED_KILL" ] && app_server_pid_exists; then
     LAST_REPAIR_REASON="refusing-socket-cleanup-while-app-server-pid-exists"
-    return 60
+    return "$RC_SOCKET_CLEANUP_REFUSED"
   fi
 
   rm -f \
@@ -404,10 +443,10 @@ repair_unmanaged_core() {
 
   if [ "$killed" -eq 0 ]; then
     LAST_REPAIR_REASON="unmanaged-error-without-stale-pid-proof"
-    return 61
+    return "$RC_UNMANAGED_WITHOUT_STALE_PROOF"
   fi
 
-  cleanup_socket_files after-verified-kill || return $?
+  cleanup_socket_files "$SOCKET_CLEANUP_AFTER_VERIFIED_KILL" || return $?
   LAST_REPAIR_REASON="killed-stale-unmanaged-app-server:$killed"
   LAST_ACTION="repaired-unmanaged-app-server"
 }
@@ -417,7 +456,7 @@ ensure_running_core() {
   resolve_operator_cli
   [ -n "$OPERATOR_CLI" ] || {
     LAST_REPAIR_REASON="operator-codex-not-found"
-    return 25
+    return "$RC_OPERATOR_CODEX_NOT_FOUND"
   }
 
   sync_standalone_package || return $?
@@ -429,16 +468,16 @@ ensure_running_core() {
       local stop_rc=0
       remote_stop || stop_rc=$?
       if [ "$stop_rc" -ne 0 ]; then
-        if [ "$stop_rc" -eq 75 ]; then
+        if [ "$stop_rc" -eq "$RC_UNMANAGED" ]; then
           repair_unmanaged_core || return $?
         else
           return "$stop_rc"
         fi
       fi
-      cleanup_socket_files no-pid-required || return $?
+      cleanup_socket_files "$SOCKET_CLEANUP_NO_PID_REQUIRED" || return $?
       remote_start || {
         local rc=$?
-        if [ "$rc" -eq 75 ]; then
+        if [ "$rc" -eq "$RC_UNMANAGED" ]; then
           repair_unmanaged_core || return $?
           remote_start || return $?
         else
@@ -456,14 +495,14 @@ ensure_running_core() {
 
   if ! remote_start; then
     local rc=$?
-    if [ "$rc" -eq 75 ]; then
+    if [ "$rc" -eq "$RC_UNMANAGED" ]; then
       repair_unmanaged_core || return $?
       remote_start || return $?
     else
       return "$rc"
     fi
   fi
-  [ "$LAST_ACTION" != "none" ] || LAST_ACTION="remote-control-healthy"
+  set_last_action_if_none "remote-control-healthy"
 }
 
 collect_probe() {

--- a/modules/shared/programs/codex/codex-pin.json
+++ b/modules/shared/programs/codex/codex-pin.json
@@ -9,7 +9,11 @@
     },
     "x86_64-linux": {
       "asset": "codex-x86_64-unknown-linux-musl.tar.gz",
-      "hash": "sha256-8KxDdRxtOympc6hgqN5SitecsgzBKWYRkwo9XJHd75U="
+      "hash": "sha256-8KxDdRxtOympc6hgqN5SitecsgzBKWYRkwo9XJHd75U=",
+      "standalonePackage": {
+        "asset": "codex-package-x86_64-unknown-linux-musl.tar.gz",
+        "hash": "sha256-edBJQnUUqSmOd76SrZu7dKNGtQ+mWYUfgH2nNj2hHL0="
+      }
     }
   }
 }

--- a/modules/shared/scripts/update-codex.sh
+++ b/modules/shared/scripts/update-codex.sh
@@ -3,8 +3,9 @@
 #
 # codex는 declarative nix overlay(modules/shared/programs/codex/package.nix)로 설치되며 버전은
 # codex-pin.json에 핀된다. 이 스크립트는 OpenAI GitHub 릴리스에서 최신 stable(rust-vX.Y.Z)을
-# 찾아 핀된 플랫폼들의 해시를 prefetch해 핀을 갱신하고 nrs로 적용한다. nixpkgs lag·제3자 flake
-# 없이 "한 줄로 최신"을 받기 위한 경로.
+# 찾아 핀된 플랫폼들의 CLI asset 해시와, 선언된 경우 Codex App remote-control standalone package
+# 해시를 함께 prefetch해 핀을 갱신하고 nrs로 적용한다. nixpkgs lag·제3자 flake 없이 "한 줄로
+# 최신"을 받기 위한 경로.
 #
 # 사용법:
 #   update-codex            # 최신 stable로 핀 갱신 + nrs
@@ -97,6 +98,19 @@ for plat in $(jq -r '.platforms | keys[]' "$PIN"); do
   }
   echo "$h"
   jq --arg p "$plat" --arg h "$h" '.platforms[$p].hash=$h' "$tmp" >"$tmp".2 && mv "$tmp".2 "$tmp"
+
+  standalone_asset="$(jq -r --arg p "$plat" '.platforms[$p].standalonePackage.asset // empty' "$PIN")"
+  if [ -n "$standalone_asset" ]; then
+    printf '  prefetch %-44s' "$standalone_asset"
+    standalone_hash="$(nix store prefetch-file --json "$base/$standalone_asset" 2>/dev/null | jq -r '.hash')" || {
+      echo "FAIL"
+      echo "update-codex: $standalone_asset prefetch 실패 — 릴리스에 standalone package asset이 없거나 네트워크 오류" >&2
+      exit 1
+    }
+    echo "$standalone_hash"
+    jq --arg p "$plat" --arg h "$standalone_hash" \
+      '.platforms[$p].standalonePackage.hash=$h' "$tmp" >"$tmp".2 && mv "$tmp".2 "$tmp"
+  fi
 done
 jq --arg v "$ver" --arg t "$tag" '.version=$v | .tag=$t' "$tmp" >"$tmp".2 && mv "$tmp".2 "$tmp"
 mv "$tmp" "$PIN"

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -676,6 +676,30 @@ else
   warn "codex가 PATH에서 resolve되지 않음 — codex(nix overlay) 미활성(nrs 전) 또는 비대화형 노출 회귀 가능"
 fi
 
+standalone_codex="$HOME/.codex/packages/standalone/current/bin/codex"
+standalone_root="$HOME/.codex/packages/standalone"
+if [ -e "$standalone_codex" ] || [ -L "$standalone_codex" ]; then
+  standalone_resolved="$(readlink -f "$standalone_codex" 2>/dev/null || echo "$standalone_codex")"
+  case "$standalone_resolved" in
+    "$standalone_root"/releases/*/bin/codex)
+      pass "Codex App remote-control standalone 경로 정상: $standalone_codex → $standalone_resolved"
+      ;;
+    *)
+      fail "Codex App remote-control standalone이 관리 경로 밖을 가리킴: $standalone_codex → $standalone_resolved"
+      ;;
+  esac
+fi
+
+legacy_local_codex="$HOME/.local/bin/codex"
+if [ -L "$legacy_local_codex" ]; then
+  legacy_local_resolved="$(readlink -f "$legacy_local_codex" 2>/dev/null || echo "$legacy_local_codex")"
+  case "$legacy_local_resolved" in
+    "$standalone_root"/*)
+      fail "\$HOME/.local/bin/codex가 Codex App standalone을 PATH shadow함: $legacy_local_codex → $legacy_local_resolved"
+      ;;
+  esac
+fi
+
 echo ""
 echo "=== AGENTS.md 심링크 확인 ==="
 

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -643,6 +643,8 @@ fi
 echo ""
 echo "=== Codex 바이너리 PATH resolve 확인 ==="
 
+standalone_root="$HOME/.codex/packages/standalone"
+
 # 회귀 가드 (#890): codex는 declarative nix overlay(nix profile/store)로 설치된다. mise npm
 # backend에서 이관된 뒤로, 잔존 mise codex shim이 PATH 앞에서 codex(nix profile)를 shadow하면 안 된다 —
 # config 미등록 dangling shim 호출은 mise version resolve(fork 폭주, os error 35)를 재유발한다.
@@ -663,6 +665,9 @@ if codex_path="$(command -v codex 2>/dev/null)" && [ -n "$codex_path" ]; then
     *)
       codex_resolved="$(readlink -f "$codex_path" 2>/dev/null || echo "$codex_path")"
       case "$codex_resolved" in
+        "$standalone_root"/*)
+          fail "codex가 Codex App standalone으로 resolve됨 ($codex_path → $codex_resolved) — remote-control payload가 일반 CLI PATH를 shadow함"
+          ;;
         /nix/store/*-codex-*)
           pass "codex PATH resolve 정상 (nix overlay): $codex_path"
           ;;
@@ -677,7 +682,6 @@ else
 fi
 
 standalone_codex="$HOME/.codex/packages/standalone/current/bin/codex"
-standalone_root="$HOME/.codex/packages/standalone"
 if [ -e "$standalone_codex" ] || [ -L "$standalone_codex" ]; then
   standalone_resolved="$(readlink -f "$standalone_codex" 2>/dev/null || echo "$standalone_codex")"
   case "$standalone_resolved" in

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -60,15 +60,25 @@ run_test "wt cleanup removes exact Claude local plugin manifest entries" test_wt
 run_test "wt cleanup stops when plugin manifest cleanup fails" test_wt_cleanup_stops_when_plugin_manifest_cleanup_fails
 run_test "wt plugin manifest missing and invalid inputs are safe" test_wt_plugin_manifest_missing_and_invalid_are_safe
 run_test "codex activation .agents symlink guard static" test_codex_activation_agents_symlink_guard_static
-run_test "codex remote-control probe parses daemon JSON" test_codex_remote_control_probe_parses_daemon_json
-run_test "codex remote-control probe marks malformed daemon JSON" test_codex_remote_control_probe_marks_malformed_daemon_json
-run_test "codex remote-control starts when daemon absent" test_codex_remote_control_ensure_running_starts_when_absent
-run_test "codex remote-control auth failure is non-destructive" test_codex_remote_control_auth_failure_is_non_destructive
-run_test "codex remote-control removes standalone PATH shadow" test_codex_remote_control_removes_standalone_path_shadow
-run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
-run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof
-run_test "codex remote-control repair refuses version-drift-only kill" test_codex_remote_control_repair_does_not_kill_on_version_drift_only
-run_test "codex remote-control cleans sockets only when no PID after drift" test_codex_remote_control_socket_cleanup_when_no_pid_after_drift
+if [ "$(uname -s)" = "Linux" ]; then
+  run_test "codex remote-control probe parses daemon JSON" test_codex_remote_control_probe_parses_daemon_json
+  run_test "codex remote-control probe marks malformed daemon JSON" test_codex_remote_control_probe_marks_malformed_daemon_json
+  run_test "codex remote-control starts when daemon absent" test_codex_remote_control_ensure_running_starts_when_absent
+  run_test "codex remote-control rejects stale start versions" test_codex_remote_control_rejects_stale_start_versions
+  run_test "codex remote-control auth failure is non-destructive" test_codex_remote_control_auth_failure_is_non_destructive
+  run_test "codex remote-control missing operator reason is preserved" test_codex_remote_control_missing_operator_reason_is_preserved
+  run_test "codex remote-control removes standalone PATH shadow" test_codex_remote_control_removes_standalone_path_shadow
+  run_test "codex remote-control rejects direct standalone PATH shadow" test_codex_remote_control_rejects_direct_standalone_path_shadow
+  run_test "codex remote-control rejects non-Nix PATH shadow" test_codex_remote_control_rejects_non_nix_path_shadow
+  run_test "codex remote-control lock failure does not run core action" test_codex_remote_control_lock_failure_does_not_run_core_action
+  run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
+  run_test "codex remote-control repair refuses socket cleanup when PID remains" test_codex_remote_control_repair_refuses_socket_cleanup_when_pid_remains
+  run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof
+  run_test "codex remote-control repair refuses version-drift-only kill" test_codex_remote_control_repair_does_not_kill_on_version_drift_only
+  run_test "codex remote-control cleans sockets only when no PID after drift" test_codex_remote_control_socket_cleanup_when_no_pid_after_drift
+else
+  echo "==> codex remote-control fixtures: SKIPPED (Linux/NixOS-only service script)" >&2
+fi
 run_test "wt recreate guard uses physical paths" test_wt_recreate_guard_uses_physical_paths
 run_test "wt cleanup auto removes merged worktree" test_wt_cleanup_auto_removes_merged_worktree
 run_test "wt cleanup auto skips dirty merged worktree" test_wt_cleanup_auto_skips_dirty_merged_worktree

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -60,6 +60,14 @@ run_test "wt cleanup removes exact Claude local plugin manifest entries" test_wt
 run_test "wt cleanup stops when plugin manifest cleanup fails" test_wt_cleanup_stops_when_plugin_manifest_cleanup_fails
 run_test "wt plugin manifest missing and invalid inputs are safe" test_wt_plugin_manifest_missing_and_invalid_are_safe
 run_test "codex activation .agents symlink guard static" test_codex_activation_agents_symlink_guard_static
+run_test "codex remote-control probe parses daemon JSON" test_codex_remote_control_probe_parses_daemon_json
+run_test "codex remote-control probe marks malformed daemon JSON" test_codex_remote_control_probe_marks_malformed_daemon_json
+run_test "codex remote-control starts when daemon absent" test_codex_remote_control_ensure_running_starts_when_absent
+run_test "codex remote-control auth failure is non-destructive" test_codex_remote_control_auth_failure_is_non_destructive
+run_test "codex remote-control removes standalone PATH shadow" test_codex_remote_control_removes_standalone_path_shadow
+run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
+run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof
+run_test "codex remote-control cleans sockets only when no PID after drift" test_codex_remote_control_socket_cleanup_when_no_pid_after_drift
 run_test "wt recreate guard uses physical paths" test_wt_recreate_guard_uses_physical_paths
 run_test "wt cleanup auto removes merged worktree" test_wt_cleanup_auto_removes_merged_worktree
 run_test "wt cleanup auto skips dirty merged worktree" test_wt_cleanup_auto_skips_dirty_merged_worktree

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -67,6 +67,7 @@ run_test "codex remote-control auth failure is non-destructive" test_codex_remot
 run_test "codex remote-control removes standalone PATH shadow" test_codex_remote_control_removes_standalone_path_shadow
 run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
 run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof
+run_test "codex remote-control repair refuses version-drift-only kill" test_codex_remote_control_repair_does_not_kill_on_version_drift_only
 run_test "codex remote-control cleans sockets only when no PID after drift" test_codex_remote_control_socket_cleanup_when_no_pid_after_drift
 run_test "wt recreate guard uses physical paths" test_wt_recreate_guard_uses_physical_paths
 run_test "wt cleanup auto removes merged worktree" test_wt_cleanup_auto_removes_merged_worktree

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -63,13 +63,16 @@ run_test "codex activation .agents symlink guard static" test_codex_activation_a
 if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control probe parses daemon JSON" test_codex_remote_control_probe_parses_daemon_json
   run_test "codex remote-control probe marks malformed daemon JSON" test_codex_remote_control_probe_marks_malformed_daemon_json
+  run_test "codex remote-control ensure-running rejects malformed daemon JSON" test_codex_remote_control_ensure_running_rejects_malformed_daemon_json
   run_test "codex remote-control starts when daemon absent" test_codex_remote_control_ensure_running_starts_when_absent
   run_test "codex remote-control rejects stale start versions" test_codex_remote_control_rejects_stale_start_versions
   run_test "codex remote-control auth failure is non-destructive" test_codex_remote_control_auth_failure_is_non_destructive
+  run_test "codex remote-control login status is sanitized" test_codex_remote_control_login_status_is_sanitized
   run_test "codex remote-control missing operator reason is preserved" test_codex_remote_control_missing_operator_reason_is_preserved
   run_test "codex remote-control removes standalone PATH shadow" test_codex_remote_control_removes_standalone_path_shadow
   run_test "codex remote-control rejects direct standalone PATH shadow" test_codex_remote_control_rejects_direct_standalone_path_shadow
   run_test "codex remote-control rejects non-Nix PATH shadow" test_codex_remote_control_rejects_non_nix_path_shadow
+  run_test "codex remote-control sync failure is not marked successful" test_codex_remote_control_sync_failure_is_not_marked_successful
   run_test "codex remote-control lock failure does not run core action" test_codex_remote_control_lock_failure_does_not_run_core_action
   run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
   run_test "codex remote-control repair refuses socket cleanup when PID remains" test_codex_remote_control_repair_refuses_socket_cleanup_when_pid_remains

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -204,6 +204,21 @@ test_codex_remote_control_repair_does_not_kill_without_stale_proof() {
   [ -e "$socket_file" ] || fail "socket should be preserved while app-server PID exists without stale proof"
 }
 
+test_codex_remote_control_repair_does_not_kill_on_version_drift_only() {
+  local sandbox ps_file kill_log user
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  user="$(id -un)"
+  ps_file="$sandbox/ps.txt"
+  kill_log="$sandbox/kill.log"
+  printf '88888 %s /opt/codex/bin/codex app-server --listen unix:///tmp/unknown.sock\n' "$user" > "$ps_file"
+
+  if APP_SERVER_VERSION="0.133.0" CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" KILL_LOG="$kill_log" _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged; then
+    fail "repair-unmanaged should fail when only global version drift points at an unknown app-server PID"
+  fi
+  [ ! -e "$kill_log" ] || fail "version drift alone should not kill an unknown app-server PID"
+}
+
 test_codex_remote_control_socket_cleanup_when_no_pid_after_drift() {
   local sandbox ps_file socket_file status
   sandbox="$(new_sandbox)"

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -132,6 +132,20 @@ test_codex_remote_control_probe_marks_malformed_daemon_json() {
     || fail "probe did not mark malformed daemon JSON: $out"
 }
 
+test_codex_remote_control_ensure_running_rejects_malformed_daemon_json() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  if FAKE_DAEMON_MALFORMED=1 _codex_rc_env bash "$(_codex_rc_script)" ensure-running; then
+    fail "ensure-running should fail on malformed daemon JSON"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.daemonStatus == "malformed-json" and .lastRepairReason == "daemon-version-malformed-json" and .exitCode == 40' <<<"$status" >/dev/null \
+    || fail "malformed daemon JSON was not recorded as unhealthy: $status"
+  assert_not_contains "$(cat "$COD_RC_LOG")" 'remote-control start --json'
+}
+
 test_codex_remote_control_ensure_running_starts_when_absent() {
   local sandbox status
   sandbox="$(new_sandbox)"
@@ -172,6 +186,18 @@ test_codex_remote_control_auth_failure_is_non_destructive() {
   jq -e '.authMode == "api-key" and .exitCode != 0' <<<"$status" >/dev/null \
     || fail "auth failure status not recorded: $status"
   assert_not_contains "$(cat "$COD_RC_LOG")" 'remote-control start --json'
+}
+
+test_codex_remote_control_login_status_is_sanitized() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  FAKE_LOGIN_STATUS='Logged in using ChatGPT as private@example.com' _codex_rc_env bash "$(_codex_rc_script)" ensure-running
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.authMode == "chatgpt" and .loginStatus == "chatgpt"' <<<"$status" >/dev/null \
+    || fail "loginStatus should contain only sanitized auth mode: $status"
+  assert_not_contains "$status" 'private@example.com'
 }
 
 test_codex_remote_control_missing_operator_reason_is_preserved() {
@@ -233,6 +259,20 @@ test_codex_remote_control_rejects_non_nix_path_shadow() {
   status="$(cat "$COD_RC_STATE/status.json")"
   jq -e '(.lastRepairReason | startswith("normal-codex-not-nix-managed:")) and .exitCode == 21' <<<"$status" >/dev/null \
     || fail "non-Nix PATH shadow was not recorded: $status"
+}
+
+test_codex_remote_control_sync_failure_is_not_marked_successful() {
+  local sandbox bad_release status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  bad_release="$sandbox/missing-parent/release"
+
+  if STANDALONE_RELEASE_DIR="$bad_release" _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone 2>/dev/null; then
+    fail "ensure-standalone should fail when release move cannot complete"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.lastRepairReason == "standalone-sync-failed:move-release" and .lastAction != "synced-standalone-package" and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "failed standalone sync was incorrectly marked successful: $status"
 }
 
 test_codex_remote_control_lock_failure_does_not_run_core_action() {

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -1,0 +1,224 @@
+# tests/suites/codex-remote-control.sh — Codex remote-control maintenance fixtures
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2164
+
+_codex_rc_script() {
+  printf '%s\n' "$REPO_ROOT/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh"
+}
+
+_codex_rc_make_package() {
+  local tarball="$1"
+  local work_dir="$2"
+  local version="${3:-0.142.4}"
+
+  mkdir -p "$work_dir/pkg/bin" "$work_dir/pkg/codex-path" "$work_dir/pkg/codex-resources"
+  cat > "$work_dir/pkg/bin/codex" <<'EOS'
+#!/usr/bin/env bash
+echo "codex-cli ${FAKE_STANDALONE_VERSION:-0.142.4}"
+EOS
+  chmod +x "$work_dir/pkg/bin/codex"
+  printf '{"version":"%s"}\n' "$version" > "$work_dir/pkg/codex-package.json"
+  tar -czf "$tarball" -C "$work_dir/pkg" .
+}
+
+_codex_rc_make_fake_codex() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/codex" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_CODEX_LOG:-/dev/null}"
+
+case "$*" in
+  "--version")
+    echo "codex-cli ${FAKE_CODEX_VERSION:-0.142.4}"
+    ;;
+  "login status")
+    echo "${FAKE_LOGIN_STATUS:-Logged in using ChatGPT}"
+    exit "${FAKE_LOGIN_RC:-0}"
+    ;;
+  "app-server daemon version")
+    if [ "${FAKE_DAEMON_MALFORMED:-0}" = "1" ]; then
+      echo "{bad json"
+      exit 0
+    fi
+    if [ "${FAKE_DAEMON_RC:-0}" != "0" ]; then
+      echo "${FAKE_DAEMON_ERR:-daemon not running}" >&2
+      exit "$FAKE_DAEMON_RC"
+    fi
+    if [ -n "${FAKE_DAEMON_JSON:-}" ]; then
+      printf '%s\n' "$FAKE_DAEMON_JSON"
+    else
+      printf '{"status":"running","managedCodexVersion":"0.142.4","appServerVersion":"0.142.4"}\n'
+    fi
+    ;;
+  "remote-control start --json")
+    if [ "${FAKE_START_RC:-0}" != "0" ]; then
+      echo "${FAKE_START_ERR:-start failed}" >&2
+      exit "$FAKE_START_RC"
+    fi
+    if [ -n "${FAKE_START_JSON:-}" ]; then
+      printf '%s\n' "$FAKE_START_JSON"
+    else
+      printf '{"mode":"daemon","status":"connected","serverName":"greenhead-minipc","daemon":{"status":"alreadyRunning","managedCodexVersion":"0.142.4","appServerVersion":"0.142.4"}}\n'
+    fi
+    ;;
+  "remote-control stop --json")
+    if [ "${FAKE_STOP_RC:-0}" != "0" ]; then
+      echo "${FAKE_STOP_ERR:-stop failed}" >&2
+      exit "$FAKE_STOP_RC"
+    fi
+    printf '{"status":"stopped"}\n'
+    ;;
+  *)
+    echo "unexpected fake codex invocation: $*" >&2
+    exit 99
+    ;;
+esac
+EOS
+  chmod +x "$bin_dir/codex"
+}
+
+_codex_rc_setup() {
+  local sandbox="$1"
+  COD_RC_HOME="$sandbox/home"
+  COD_RC_STATE="$sandbox/state"
+  COD_RC_FAKE_BIN="$sandbox/fake-bin"
+  COD_RC_PKG="$sandbox/codex-package.tar.gz"
+  COD_RC_LOG="$sandbox/codex.log"
+  COD_RC_NORMAL="/nix/store/nonexistent-codex-0.142.4/bin/codex"
+  mkdir -p "$COD_RC_HOME" "$COD_RC_STATE"
+  _codex_rc_make_fake_codex "$COD_RC_FAKE_BIN"
+  _codex_rc_make_package "$COD_RC_PKG" "$sandbox/package-work"
+}
+
+_codex_rc_env() {
+  env \
+    HOME="$COD_RC_HOME" \
+    CODEX_HOME="$COD_RC_HOME/.codex" \
+    STATE_DIR="$COD_RC_STATE" \
+    DESIRED_VERSION="0.142.4" \
+    STANDALONE_PACKAGE="$COD_RC_PKG" \
+    STANDALONE_TRIPLE="x86_64-unknown-linux-musl" \
+    CODEX_OPERATOR="$COD_RC_FAKE_BIN/codex" \
+    NORMAL_CODEX_NAME="$COD_RC_NORMAL" \
+    FAKE_CODEX_LOG="$COD_RC_LOG" \
+    PATH="$COD_RC_FAKE_BIN:$PATH" \
+    "$@"
+}
+
+test_codex_remote_control_probe_parses_daemon_json() {
+  local sandbox out
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  out="$(_codex_rc_env bash "$(_codex_rc_script)" probe)"
+  jq -e '.daemonStatus == "running" and .managedCodexVersion == "0.142.4" and .appServerVersion == "0.142.4"' <<<"$out" >/dev/null \
+    || fail "probe did not parse daemon version JSON: $out"
+}
+
+test_codex_remote_control_probe_marks_malformed_daemon_json() {
+  local sandbox out
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  out="$(FAKE_DAEMON_MALFORMED=1 _codex_rc_env bash "$(_codex_rc_script)" probe)"
+  jq -e '.daemonStatus == "malformed-json"' <<<"$out" >/dev/null \
+    || fail "probe did not mark malformed daemon JSON: $out"
+}
+
+test_codex_remote_control_ensure_running_starts_when_absent() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  FAKE_DAEMON_RC=1 _codex_rc_env bash "$(_codex_rc_script)" ensure-running
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.remoteControlEnabled == true and .serverName == "greenhead-minipc" and .exitCode == 0' <<<"$status" >/dev/null \
+    || fail "ensure-running did not record successful remote-control start: $status"
+  grep -Fqx 'remote-control start --json' "$COD_RC_LOG" \
+    || fail "ensure-running did not invoke remote-control start"
+}
+
+test_codex_remote_control_auth_failure_is_non_destructive() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  if FAKE_LOGIN_STATUS='Logged in using API key' _codex_rc_env bash "$(_codex_rc_script)" ensure-running; then
+    fail "ensure-running should fail for API-key auth"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.authMode == "api-key" and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "auth failure status not recorded: $status"
+  assert_not_contains "$(cat "$COD_RC_LOG")" 'remote-control start --json'
+}
+
+test_codex_remote_control_removes_standalone_path_shadow() {
+  local sandbox local_codex
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone
+  mkdir -p "$COD_RC_HOME/.local/bin"
+  local_codex="$COD_RC_HOME/.local/bin/codex"
+  ln -s "$COD_RC_HOME/.codex/packages/standalone/current/bin/codex" "$local_codex"
+
+  PATH="$COD_RC_HOME/.local/bin:$PATH" _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone
+  [ ! -e "$local_codex" ] && [ ! -L "$local_codex" ] \
+    || fail "standalone PATH shadow symlink was not removed"
+}
+
+test_codex_remote_control_repair_kills_proven_stale_unmanaged_process() {
+  local sandbox ps_file kill_log socket_file user
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  user="$(id -un)"
+  ps_file="$sandbox/ps.txt"
+  kill_log="$sandbox/kill.log"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+  printf '12345 %s /home/%s/.local/share/mise/installs/npm-openai-codex/latest/bin/codex app-server --listen unix:///tmp/stale.sock\n' "$user" "$user" > "$ps_file"
+
+  CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" KILL_LOG="$kill_log" _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged
+  assert_file_contains "$kill_log" "12345"
+  [ ! -e "$socket_file" ] || fail "socket should be removed after verified stale kill"
+}
+
+test_codex_remote_control_repair_does_not_kill_without_stale_proof() {
+  local sandbox ps_file kill_log socket_file
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  ps_file="$sandbox/ps.txt"
+  kill_log="$sandbox/kill.log"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+  printf '77777 other /home/other/.local/share/mise/installs/npm-openai-codex/latest/bin/codex app-server --listen unix:///tmp/stale.sock\n' > "$ps_file"
+
+  if CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" KILL_LOG="$kill_log" _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged; then
+    fail "repair-unmanaged should fail without same-user stale PID proof"
+  fi
+  [ ! -e "$kill_log" ] || fail "repair-unmanaged killed a process without stale proof"
+  [ -e "$socket_file" ] || fail "socket should be preserved while app-server PID exists without stale proof"
+}
+
+test_codex_remote_control_socket_cleanup_when_no_pid_after_drift() {
+  local sandbox ps_file socket_file status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  ps_file="$sandbox/ps-empty.txt"
+  : > "$ps_file"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+
+  FAKE_DAEMON_JSON='{"status":"running","managedCodexVersion":"0.133.0","appServerVersion":"0.133.0"}' \
+    CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running
+  status="$(cat "$COD_RC_STATE/status.json")"
+  [ ! -e "$socket_file" ] || fail "socket should be removed when no app-server PID exists during drift restart"
+  jq -e '.lastAction == "restarted-version-drift" and .exitCode == 0' <<<"$status" >/dev/null \
+    || fail "drift restart status not recorded: $status"
+}

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -93,17 +93,22 @@ _codex_rc_setup() {
 }
 
 _codex_rc_env() {
+  local state_dir="${STATE_DIR:-$COD_RC_STATE}"
+  local codex_operator="${CODEX_OPERATOR:-$COD_RC_FAKE_BIN/codex}"
+  local normal_codex_name="${NORMAL_CODEX_NAME:-$COD_RC_NORMAL}"
+  local path_value="${CODEX_RC_PATH:-$COD_RC_FAKE_BIN:$PATH}"
+
   env \
     HOME="$COD_RC_HOME" \
     CODEX_HOME="$COD_RC_HOME/.codex" \
-    STATE_DIR="$COD_RC_STATE" \
+    STATE_DIR="$state_dir" \
     DESIRED_VERSION="0.142.4" \
     STANDALONE_PACKAGE="$COD_RC_PKG" \
     STANDALONE_TRIPLE="x86_64-unknown-linux-musl" \
-    CODEX_OPERATOR="$COD_RC_FAKE_BIN/codex" \
-    NORMAL_CODEX_NAME="$COD_RC_NORMAL" \
+    CODEX_OPERATOR="$codex_operator" \
+    NORMAL_CODEX_NAME="$normal_codex_name" \
     FAKE_CODEX_LOG="$COD_RC_LOG" \
-    PATH="$COD_RC_FAKE_BIN:$PATH" \
+    PATH="$path_value" \
     "$@"
 }
 
@@ -140,6 +145,21 @@ test_codex_remote_control_ensure_running_starts_when_absent() {
     || fail "ensure-running did not invoke remote-control start"
 }
 
+test_codex_remote_control_rejects_stale_start_versions() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  if FAKE_DAEMON_RC=1 \
+    FAKE_START_JSON='{"mode":"daemon","status":"connected","serverName":"greenhead-minipc","daemon":{"status":"started","managedCodexVersion":"0.133.0","appServerVersion":"0.133.0"}}' \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running; then
+    fail "ensure-running should reject connected start output with stale versions"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.remoteControlEnabled == false and (.lastRepairReason | startswith("remote-control-start-version-drift:0.133.0/0.133.0")) and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "stale start versions were not recorded as unhealthy: $status"
+}
+
 test_codex_remote_control_auth_failure_is_non_destructive() {
   local sandbox status
   sandbox="$(new_sandbox)"
@@ -152,6 +172,19 @@ test_codex_remote_control_auth_failure_is_non_destructive() {
   jq -e '.authMode == "api-key" and .exitCode != 0' <<<"$status" >/dev/null \
     || fail "auth failure status not recorded: $status"
   assert_not_contains "$(cat "$COD_RC_LOG")" 'remote-control start --json'
+}
+
+test_codex_remote_control_missing_operator_reason_is_preserved() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  if CODEX_OPERATOR="$sandbox/missing-codex" _codex_rc_env bash "$(_codex_rc_script)" ensure-running; then
+    fail "ensure-running should fail when operator codex is missing"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.lastRepairReason == "operator-codex-not-found" and .exitCode == 25' <<<"$status" >/dev/null \
+    || fail "missing operator reason was not preserved: $status"
 }
 
 test_codex_remote_control_removes_standalone_path_shadow() {
@@ -169,6 +202,52 @@ test_codex_remote_control_removes_standalone_path_shadow() {
     || fail "standalone PATH shadow symlink was not removed"
 }
 
+test_codex_remote_control_rejects_direct_standalone_path_shadow() {
+  local sandbox status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone
+
+  if NORMAL_CODEX_NAME=codex \
+    CODEX_RC_PATH="$COD_RC_HOME/.codex/packages/standalone/current/bin:$COD_RC_FAKE_BIN:$PATH" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone; then
+    fail "ensure-standalone should fail when normal codex resolves to standalone"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.lastRepairReason == "normal-codex-resolves-to-standalone" and .exitCode == 20' <<<"$status" >/dev/null \
+    || fail "direct standalone PATH shadow was not recorded: $status"
+}
+
+test_codex_remote_control_rejects_non_nix_path_shadow() {
+  local sandbox non_nix_bin status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  non_nix_bin="$sandbox/non-nix"
+  mkdir -p "$non_nix_bin"
+  cp "$COD_RC_FAKE_BIN/codex" "$non_nix_bin/codex"
+
+  if NORMAL_CODEX_NAME=codex CODEX_RC_PATH="$non_nix_bin:$COD_RC_FAKE_BIN:$PATH" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone; then
+    fail "ensure-standalone should fail when normal codex resolves to non-Nix path"
+  fi
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '(.lastRepairReason | startswith("normal-codex-not-nix-managed:")) and .exitCode == 21' <<<"$status" >/dev/null \
+    || fail "non-Nix PATH shadow was not recorded: $status"
+}
+
+test_codex_remote_control_lock_failure_does_not_run_core_action() {
+  local sandbox bad_state
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  bad_state="$sandbox/not-a-directory"
+  : > "$bad_state"
+
+  if STATE_DIR="$bad_state" _codex_rc_env bash "$(_codex_rc_script)" ensure-running 2>/dev/null; then
+    fail "ensure-running should fail when state dir cannot be created"
+  fi
+  assert_not_contains "$(cat "$COD_RC_LOG" 2>/dev/null || true)" 'remote-control start --json'
+}
+
 test_codex_remote_control_repair_kills_proven_stale_unmanaged_process() {
   local sandbox ps_file kill_log socket_file user
   sandbox="$(new_sandbox)"
@@ -184,6 +263,28 @@ test_codex_remote_control_repair_kills_proven_stale_unmanaged_process() {
   CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" KILL_LOG="$kill_log" _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged
   assert_file_contains "$kill_log" "12345"
   [ ! -e "$socket_file" ] || fail "socket should be removed after verified stale kill"
+}
+
+test_codex_remote_control_repair_refuses_socket_cleanup_when_pid_remains() {
+  local sandbox ps_file kill_log socket_file user
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  user="$(id -un)"
+  ps_file="$sandbox/ps.txt"
+  kill_log="$sandbox/kill.log"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+  {
+    printf '12345 %s /home/%s/.local/share/mise/installs/npm-openai-codex/latest/bin/codex app-server --listen unix:///tmp/stale.sock\n' "$user" "$user"
+    printf '23456 %s %s/bin/codex app-server --listen unix:///tmp/current.sock\n' "$user" "$COD_RC_HOME/.codex/packages/standalone/current"
+  } > "$ps_file"
+
+  if CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" KILL_LOG="$kill_log" _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged; then
+    fail "repair-unmanaged should refuse socket cleanup while another app-server PID remains"
+  fi
+  assert_file_contains "$kill_log" "12345"
+  [ -e "$socket_file" ] || fail "socket should be preserved while current app-server PID remains"
 }
 
 test_codex_remote_control_repair_does_not_kill_without_stale_proof() {


### PR DESCRIPTION
## Summary
- `greenhead-minipc`의 ChatGPT mobile Codex remote-control app-server를 pinned standalone package와 systemd timer로 자동 복구한다.
- stale unmanaged app-server, socket/lock 잔재, standalone PATH shadow, 버전 drift를 좁은 조건에서만 정리하도록 회귀 가드를 추가한다.
- update/verifier/docs/fixture tests를 함께 갱신해 일반 Codex CLI는 계속 Nix-managed 경로를 사용하도록 고정한다.

## 기존 문제/배경

ChatGPT mobile 앱의 Codex session sync가 한동안 정상 동작하다가 끊겼고, 조사 중 현재 Codex CLI는 최신 버전인데 app-server는 오래된 unmanaged process로 남아 있는 상태가 확인됐다.

문제는 두 가지였다.

- 일반 CLI와 mobile remote-control app-server payload가 같은 PATH 표면을 공유하면 `~/.local/bin/codex` 같은 잔재가 Nix-managed Codex를 shadow할 수 있다.
- stale app-server socket/lock과 unmanaged daemon이 남으면 `remote-control start`가 managed daemon으로 복구되지 못하고 mobile app에는 offline/연결 실패처럼 보인다.

## CIR (Change Intent Record)

- **v1 (이번 변경)**: mobile remote-control app-server를 일반 Codex CLI와 분리된 standalone payload로 관리하되, 버전 소스는 기존 `codex-pin.json` 하나로 유지하기로 했다.
- **v2 (이번 변경)**: 매 실행마다 최신 릴리스를 가져오는 방식은 재현성, hash 검증, 무인 업데이트 위험 때문에 배제했다. 대신 `update-codex`가 CLI asset hash와 standalone package hash를 함께 갱신한다.
- **v3 (이번 변경)**: stale process 정리는 자동화하되, 같은 사용자 app-server이고 legacy Codex 경로라는 per-process 증거가 있을 때만 kill하도록 제한했다. 버전 drift만으로 임의 PID를 죽이는 방식은 배제했다.
- **v4 (이번 변경)**: app-server child가 workspace 파일을 써야 하므로 service hardening은 유지하되 home 전체 read-only 정책은 쓰지 않는다. system directory는 read-only로 두고 `KillMode=process`로 oneshot 종료가 app-server child를 죽이지 않게 했다.

**trade-off**: 완전한 supervisor나 dashboard 대신 작은 timer + shell CLI만 둔다. 관측성과 자동복구 범위는 제한적이지만, 이번 회귀의 원인인 버전 drift, stale socket, PATH shadow를 직접 막고 과한 상시 daemon을 추가하지 않는다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| pinned standalone + systemd timer | `codex-pin.json`의 standalone package를 `~/.codex/packages/standalone/current`에 동기화하고 30분 timer로 확인 | 재현 가능, NixOS에 맞음, mobile app-server와 일반 CLI 분리 | Codex release asset hash를 pin에 추가해야 함 | ✅ |
| runtime latest install | timer가 매번 최신 Codex standalone을 설치 | 구현이 단순해 보임 | 무인 latest, hash/rollback 약함, 회귀 재현 어려움 | ❌ |
| generic supervisor/fleet manager | 별도 daemon, metrics, queue, dashboard까지 추가 | 장기적으로 확장 가능 | 현재 문제 대비 과함, 운영 표면 증가 | ❌ |
| strict home read-only hardening | systemd service에서 home write를 대부분 차단 | 표면 축소 | remote-control app-server가 workspace를 쓰는 실제 사용을 깨뜨림 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/codex-remote-control.nix` | 추가 | NixOS option-gated service/timer, pinned standalone package fetch, credentials, hardening 설정 |
| `modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh` | 추가 | `probe`, `ensure-standalone`, `ensure-running`, `repair-unmanaged`, `health-json` 구현 |
| `modules/shared/programs/codex/codex-pin.json` | 수정 | `x86_64-linux` standalone package asset/hash 추가 |
| `modules/shared/scripts/update-codex.sh` | 수정 | standalone package hash도 함께 prefetch/update |
| `scripts/ai/verify-ai-compat.sh` | 수정 | 일반 `codex`가 standalone으로 resolve되면 실패 처리 |
| `modules/nixos/options/homeserver.nix`, `modules/nixos/configuration.nix` | 수정 | `homeserver.codexRemoteControl.enable` option/import/enable wiring |
| `tests/suites/codex-remote-control.sh`, `tests/shell-script-tests.sh` | 추가/수정 | daemon JSON, auth, PATH shadow, stale PID, socket cleanup, version drift fixture coverage |
| `.claude/skills/configuring-codex/*` | 수정 | remote-control standalone 예외와 운영 확인 절차 문서화 |

### 핵심 코드

```bash
# 일반 CLI는 standalone payload를 shadow하면 안 된다.
if path_under "$NORMAL_CODEX_RESOLVED" "$STANDALONE_ROOT"; then
  LAST_REPAIR_REASON="normal-codex-resolves-to-standalone"
  return "$RC_NORMAL_CODEX_STANDALONE"
fi

# connected 상태만으로 healthy 처리하지 않고 pinned version 일치까지 요구한다.
remote_start_versions_current() {
  [ "$MANAGED_CODEX_VERSION" = "$DESIRED_VERSION" ] && [ "$APP_SERVER_VERSION" = "$DESIRED_VERSION" ]
}
```

## 참고 레퍼런스

- 해당 없음. 이 PR은 로컬 mobile remote-control 회귀 조사와 복구 작업에서 나온 NixOS 구성 변경이다.

## Human Test Plan

### 자동 검증

1. `bash tests/run-shell-script-tests.sh`를 실행한다.
   - **기대**: remote-control fixtures 포함 전체 shell suite가 통과한다.
   - **실패 시**: `tests/suites/codex-remote-control.sh`의 실패 fixture와 `status.json` assertion을 먼저 확인한다.

2. `nix develop -c nix build .#nixosConfigurations.greenhead-minipc.config.system.build.toplevel --no-link`를 실행한다.
   - **기대**: NixOS system build가 성공한다.
   - **실패 시**: `codex-remote-control.nix`의 `runtimeInputs`, `fetchurl` hash, systemd option type을 확인한다.

3. `./scripts/ai/verify-ai-compat.sh`를 실행한다.
   - **기대**: 일반 `codex`는 Nix overlay/store 경로로 resolve되고, standalone payload는 관리 경로 아래에만 존재한다.
   - **실패 시**: `command -v codex`, `readlink -f ~/.codex/packages/standalone/current/bin/codex`, `~/.local/bin/codex` symlink를 확인한다.

### NixOS 활성화 검증

4. `nrs`를 실행한다.
   - **기대**: system switch가 성공하고 `codex-remote-control-ensure.timer`가 로드된다.
   - **실패 시**: build preview와 agenix credential path를 확인한다.

5. `systemctl status codex-remote-control-ensure.service codex-remote-control-ensure.timer`와 `/var/lib/codex-remote-control/status.json`을 확인한다.
   - **기대**: service `Result=success`, `exitCode=0`, `authMode=chatgpt`, `managedCodexVersion/appServerVersion`이 pinned version, `remoteControlEnabled=true`.
   - **실패 시**: `journalctl -u codex-remote-control-ensure.service -n 80 --no-pager`와 `lastRepairReason`을 확인한다.

6. `codex app-server daemon version`, `codex login status`, `codex doctor --summary --ascii --no-color`를 실행한다.
   - **기대**: app-server와 CLI version이 일치하고 ChatGPT login이며 doctor fail이 없다.
   - **실패 시**: stale socket/lock, API-key auth, PATH shadow 여부를 확인한다.

### Mobile 확인

7. ChatGPT mobile 앱의 Codex 연결 목록에서 `greenhead-minipc`를 확인하고 새 prompt를 보낸다.
   - **기대**: offline이 아니며 mobile prompt가 이 machine의 Codex session으로 동기화된다.
   - **실패 시**: status JSON의 `remoteControlEnabled`, `serverName`, `lastRepairReason`과 timer journal을 먼저 확인한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex mobile remote-control support with automated setup, health checks, and periodic maintenance on NixOS.
  * Added support for tracking an additional pinned Codex standalone package alongside the main app.

* **Bug Fixes**
  * Tightened checks to prevent Codex CLI path shadowing and unsafe symlink setups.
  * Improved recovery for stale or unmanaged remote-control processes and cleanup of related sockets/locks.

* **Tests**
  * Added extensive fixture coverage for remote-control startup, repair, version drift, and path-validation scenarios.

* **Documentation**
  * Updated troubleshooting and operational runbooks with new verification commands and exception-handling guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->