### PR TITLE
feat: add Codex pairing code skill

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -211,6 +211,10 @@ in
     ".claude/skills/create-pr".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/create-pr";
 
+    # issuing-codex-pairing-code 스킬 (user-scope)
+    ".claude/skills/issuing-codex-pairing-code".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/issuing-codex-pairing-code";
+
     # write-handoff 스킬 (user-scope)
     ".claude/skills/write-handoff".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/write-handoff";

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
@@ -21,6 +21,7 @@ python3 scripts/issue_pairing_code.py --user-requested-code
 
 4. Share only the `Code`, `Expires`, and `Cleanup` lines with the user.
    - Do not store raw pairing codes, raw pairing tokens, full JSON-RPC payloads, or full helper output in committed files, progress notes, PR text, or issue comments.
+   - If the helper reports that the local Codex app-server protocol does not expose `manualPairingCode`, state that no live code was issued because the helper failed before starting app-server.
 5. Leave cleanup under user control unless they ask you to clean up. Use the exact `Cleanup` line printed by the helper; it includes the unique tmux session and private runtime directory for that issuance.
 
 ```bash
@@ -31,6 +32,7 @@ tmux kill-session -t codex-pair-bg-...; rm -rf /private/tmp/codex-pairing-code-.
 
 - Live issuance is Darwin/macOS only.
 - The helper must fail before binary lookup, socket discovery, tmux spawn, or RPC on non-Darwin live runs.
+- The helper must fail before socket discovery, tmux spawn, or RPC when the local Codex app-server protocol does not expose a manual pairing-code response field.
 - The helper uses only a helper-owned private runtime directory and tmux session by default.
 - Do not automatically discover or reuse ambient Codex app-server sockets.
 - Do not use Computer Use, browser UI automation, SSH, launchd/systemd installation, persistent daemon setup, or scheduler cleanup for this flow.

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
@@ -21,8 +21,9 @@ python3 scripts/issue_pairing_code.py --user-requested-code
 
 4. Share only the `Code`, `Expires`, and `Cleanup` lines with the user.
    - Do not store raw pairing codes, raw pairing tokens, full JSON-RPC payloads, or full helper output in committed files, progress notes, PR text, or issue comments.
-   - If the helper reports that the local Codex app-server protocol does not expose `manualPairingCode`, state that no live code was issued because the helper failed before starting app-server.
+   - If the helper reports that the local Codex app-server protocol does not expose `manualPairingCode`, state that no live code was issued because the helper failed before starting app-server. The pairing API is an experimental Codex surface (the helper checks `generate-ts --experimental` output and opts in via `capabilities.experimentalApi`), so this failure means the installed Codex build dropped or renamed the pairing API.
 5. Leave cleanup under user control unless they ask you to clean up. Use the exact `Cleanup` line printed by the helper; it includes the unique tmux session and private runtime directory for that issuance.
+   - After the device pairs, remote control keeps flowing through this helper-owned app-server, so the tmux session must stay alive while the user wants remote control; running the `Cleanup` line also disconnects remote control.
 
 ```bash
 tmux kill-session -t codex-pair-bg-...; rm -rf /private/tmp/codex-pairing-code-...

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
@@ -21,10 +21,10 @@ python3 scripts/issue_pairing_code.py --user-requested-code
 
 4. Share only the `Code`, `Expires`, and `Cleanup` lines with the user.
    - Do not store raw pairing codes, raw pairing tokens, full JSON-RPC payloads, or full helper output in committed files, progress notes, PR text, or issue comments.
-5. Leave cleanup under user control unless they ask you to clean up:
+5. Leave cleanup under user control unless they ask you to clean up. Use the exact `Cleanup` line printed by the helper; it includes the unique tmux session and private runtime directory for that issuance.
 
 ```bash
-tmux kill-session -t codex-pair-bg
+tmux kill-session -t codex-pair-bg-...; rm -rf /private/tmp/codex-pairing-code-...
 ```
 
 ## Guardrails

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: issuing-codex-pairing-code
+description: Issue a Codex remote-control computer pairing/authentication code only when the latest user message explicitly asks to issue or share a Codex pairing code, computer connection code, authentication code, or remote-control code. Do not use for general remote-control diagnostics, setup explanation, connection troubleshooting, or UI navigation unless code issuance is explicitly requested.
+---
+
+# Issue Codex Pairing Code
+
+Use this skill to issue a Codex remote-control computer pairing code through a helper-owned temporary app-server. The skill does not pair the device itself.
+
+## Procedure
+
+1. Confirm the latest user message explicitly asks for a pairing/authentication/computer connection code.
+   - If the user only asks for diagnostics, setup help, or UI navigation, do not run the script. Ask a short clarification instead.
+2. Confirm the host is macOS/Darwin for live issuance.
+   - On Linux/NixOS, do not attempt live issuance. Use `--mock` only for fixture validation and state that NixOS live issuance was not run.
+3. Run the helper from this skill directory:
+
+```bash
+python3 scripts/issue_pairing_code.py --user-requested-code
+```
+
+4. Share only the `Code`, `Expires`, and `Cleanup` lines with the user.
+   - Do not store raw pairing codes, raw pairing tokens, full JSON-RPC payloads, or full helper output in committed files, progress notes, PR text, or issue comments.
+5. Leave cleanup under user control unless they ask you to clean up:
+
+```bash
+tmux kill-session -t codex-pair-bg
+```
+
+## Guardrails
+
+- Live issuance is Darwin/macOS only.
+- The helper must fail before binary lookup, socket discovery, tmux spawn, or RPC on non-Darwin live runs.
+- The helper uses only a helper-owned private runtime directory and tmux session by default.
+- Do not automatically discover or reuse ambient Codex app-server sockets.
+- Do not use Computer Use, browser UI automation, SSH, launchd/systemd installation, persistent daemon setup, or scheduler cleanup for this flow.
+- Codex has no perfect structural auto-trigger block, so the description and this explicit consent gate are both part of the safety boundary.
+
+## Validation
+
+Use mock mode for deterministic checks:
+
+```bash
+python3 scripts/issue_pairing_code.py --mock --json
+```
+
+Run tests from the repo root:
+
+```bash
+python3 -m unittest discover modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests
+```

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/agents/openai.yaml
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Issue Codex Pairing Code"
+  short_description: "Issue a Codex pairing code on request."
+  default_prompt: "Use $issuing-codex-pairing-code to issue a Codex remote-control computer pairing code."

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/agents/openai.yaml
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Issue Codex Pairing Code"
-  short_description: "Issue a Codex pairing code on request."
-  default_prompt: "Use $issuing-codex-pairing-code to issue a Codex remote-control computer pairing code."
+  short_description: "Issue a Codex pairing code only when the latest user message explicitly asks for one."
+  default_prompt: "Use $issuing-codex-pairing-code only when the latest user message explicitly asks to issue or share a Codex remote-control computer pairing code."

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -41,12 +41,18 @@ MOCK_EXPIRES_AT = 1893456000
 CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b")
 SECRET_KEY_RE = re.compile(
     r'("(?:(?:manual)?pairingCode|environmentId|'
-    r'(?:access|auth|bearer|refresh|remote[_-]?control|api|pairing)?'
-    r'(?:Token|Key|Secret)|authorization|CODEX_API_KEY)"\s*:\s*")[^"]+(")',
+    r'[A-Za-z0-9_-]*(?:token|secret)[A-Za-z0-9_-]*|'
+    r'[A-Za-z0-9_-]*api[_-]?key[A-Za-z0-9_-]*|'
+    r'key|authorization|CODEX_API_KEY)"\s*:\s*")[^"]+(")',
     re.IGNORECASE,
 )
 BEARER_TOKEN_RE = re.compile(r"\bBearer\s+[-._~+/A-Za-z0-9]+=*", re.IGNORECASE)
 OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b")
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"\b([A-Za-z0-9_-]*(?:token|secret|api[_-]?key|key)[A-Za-z0-9_-]*"
+    r"\s*[:=]\s*)([^\s,;]+)",
+    re.IGNORECASE,
+)
 
 
 class PairingError(RuntimeError):
@@ -542,6 +548,7 @@ def redact_pairing_payload(value: str) -> str:
     redacted = SECRET_KEY_RE.sub(r"\1[REDACTED]\2", value)
     redacted = BEARER_TOKEN_RE.sub("Bearer [REDACTED]", redacted)
     redacted = OPENAI_KEY_RE.sub("[REDACTED-API-KEY]", redacted)
+    redacted = SECRET_ASSIGNMENT_RE.sub(r"\1[REDACTED]", redacted)
     return CODE_RE.sub("[PAIRING-CODE]", redacted)
 
 

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -38,6 +38,10 @@ DEFAULT_SESSION = "codex-pair-bg"
 CLIENT_NAME = "issuing-codex-pairing-code"
 CLIENT_VERSION = "1.0.0"
 MOCK_EXPIRES_AT = 1893456000
+INITIALIZE_METHOD = "initialize"
+INITIALIZED_NOTIFICATION_METHOD = "initialized"
+REMOTE_CONTROL_ENABLE_METHOD = "remoteControl/enable"
+PAIRING_START_METHOD = "remoteControl/pairing/start"
 CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b")
 SECRET_KEY_RE = re.compile(
     r'("(?:(?:manual)?pairingCode|environmentId|'
@@ -187,24 +191,133 @@ def ensure_pairing_start_returns_manual_code(codex_binary: Path, timeout: float)
                 + redact_pairing_payload(message or "generate-ts failed")
             )
 
-        response_files = list(Path(tmp).rglob("RemoteControlPairingStartResponse.ts"))
-        if not response_files:
-            raise PairingError(
-                "Codex app-server protocol does not expose "
-                "RemoteControlPairingStartResponse; refusing live issuance before "
-                "starting app-server"
-            )
-
-        response_schema = "\n".join(
-            path.read_text(encoding="utf-8", errors="replace")
-            for path in response_files
+        generated_root = Path(tmp)
+        client_request_schema = _read_protocol_schema(
+            generated_root, "ClientRequest.ts", "ClientRequest"
         )
-        if "manualPairingCode" not in response_schema:
-            raise PairingError(
-                "Codex app-server protocol does not expose manualPairingCode in "
-                "RemoteControlPairingStartResponse; refusing live issuance before "
-                "starting app-server"
-            )
+        client_notification_schema = _read_protocol_schema(
+            generated_root, "ClientNotification.ts", "ClientNotification"
+        )
+        client_info_schema = _read_protocol_schema(
+            generated_root, "ClientInfo.ts", "ClientInfo"
+        )
+        initialize_schema = _read_protocol_schema(
+            generated_root, "InitializeParams.ts", "InitializeParams"
+        )
+        capabilities_schema = _read_protocol_schema(
+            generated_root, "InitializeCapabilities.ts", "InitializeCapabilities"
+        )
+        enable_params_schema = _read_protocol_schema(
+            generated_root, "RemoteControlEnableParams.ts", "RemoteControlEnableParams"
+        )
+        pairing_params_schema = _read_protocol_schema(
+            generated_root,
+            "RemoteControlPairingStartParams.ts",
+            "RemoteControlPairingStartParams",
+        )
+        response_schema = _read_protocol_schema(
+            generated_root,
+            "RemoteControlPairingStartResponse.ts",
+            "RemoteControlPairingStartResponse",
+        )
+
+        for schema, needle, type_name, requirement in (
+            (
+                client_request_schema,
+                f'"method": "{INITIALIZE_METHOD}"',
+                "ClientRequest",
+                INITIALIZE_METHOD,
+            ),
+            (
+                client_request_schema,
+                f'"method": "{REMOTE_CONTROL_ENABLE_METHOD}"',
+                "ClientRequest",
+                REMOTE_CONTROL_ENABLE_METHOD,
+            ),
+            (
+                client_request_schema,
+                f'"method": "{PAIRING_START_METHOD}"',
+                "ClientRequest",
+                PAIRING_START_METHOD,
+            ),
+            (
+                client_notification_schema,
+                f'"method": "{INITIALIZED_NOTIFICATION_METHOD}"',
+                "ClientNotification",
+                INITIALIZED_NOTIFICATION_METHOD,
+            ),
+            (client_info_schema, "name: string", "ClientInfo", "client name"),
+            (client_info_schema, "title: string | null", "ClientInfo", "client title"),
+            (client_info_schema, "version: string", "ClientInfo", "client version"),
+            (initialize_schema, "clientInfo: ClientInfo", "InitializeParams", "clientInfo"),
+            (
+                initialize_schema,
+                "capabilities: InitializeCapabilities",
+                "InitializeParams",
+                "capabilities",
+            ),
+            (
+                capabilities_schema,
+                "experimentalApi: boolean",
+                "InitializeCapabilities",
+                "experimentalApi",
+            ),
+            (
+                capabilities_schema,
+                "requestAttestation: boolean",
+                "InitializeCapabilities",
+                "requestAttestation",
+            ),
+            (
+                enable_params_schema,
+                "ephemeral?: boolean",
+                "RemoteControlEnableParams",
+                "ephemeral",
+            ),
+            (
+                pairing_params_schema,
+                "manualCode",
+                "RemoteControlPairingStartParams",
+                "manualCode",
+            ),
+            (
+                response_schema,
+                "manualPairingCode",
+                "RemoteControlPairingStartResponse",
+                "manualPairingCode",
+            ),
+            (
+                response_schema,
+                "expiresAt",
+                "RemoteControlPairingStartResponse",
+                "expiresAt",
+            ),
+        ):
+            _ensure_schema_contains(schema, needle, type_name, requirement)
+
+
+def _read_protocol_schema(root: Path, filename: str, type_name: str) -> str:
+    files = list(root.rglob(filename))
+    if not files:
+        raise PairingError(
+            f"Codex app-server protocol does not expose {type_name}; "
+            "refusing live issuance before starting app-server"
+        )
+    return "\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in files
+    )
+
+
+def _ensure_schema_contains(
+    schema: str, needle: str, type_name: str, requirement: str
+) -> None:
+    if needle not in schema:
+        raise PairingError(
+            "Codex app-server protocol does not expose "
+            f"{requirement} in {type_name}; refusing live issuance before "
+            "starting app-server"
+        )
 
 
 def make_private_runtime_paths() -> RuntimePaths:
@@ -432,24 +545,34 @@ class WsUnixClient:
         except OSError as error:
             raise PairingError(f"WebSocket send failed: {error}") from error
 
-    def receive_text(self) -> str:
+    def receive_text(self, deadline: float | None = None) -> str:
         if self.sock is None:
             raise PairingError("WebSocket is not connected")
-        while True:
-            opcode, payload = _read_ws_frame(self.sock)
-            if opcode == 0x1:
-                try:
-                    return payload.decode("utf-8")
-                except UnicodeDecodeError as error:
-                    raise PairingError("WebSocket text frame is not valid UTF-8") from error
-            if opcode == 0x8:
-                raise PairingError("WebSocket closed by app-server")
-            if opcode == 0x9:
-                self.sock.sendall(_encode_ws_frame(payload, opcode=0xA, mask=True))
-                continue
-            if opcode == 0xA:
-                continue
-            raise PairingError(f"unsupported WebSocket opcode: {opcode}")
+        previous_timeout = self.sock.gettimeout()
+        try:
+            while True:
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise PairingError("WebSocket receive deadline expired")
+                    self.sock.settimeout(remaining)
+                opcode, payload = _read_ws_frame(self.sock)
+                if opcode == 0x1:
+                    try:
+                        return payload.decode("utf-8")
+                    except UnicodeDecodeError as error:
+                        raise PairingError("WebSocket text frame is not valid UTF-8") from error
+                if opcode == 0x8:
+                    raise PairingError("WebSocket closed by app-server")
+                if opcode == 0x9:
+                    self.sock.sendall(_encode_ws_frame(payload, opcode=0xA, mask=True))
+                    continue
+                if opcode == 0xA:
+                    continue
+                raise PairingError(f"unsupported WebSocket opcode: {opcode}")
+        finally:
+            if self.sock is not None:
+                self.sock.settimeout(previous_timeout)
 
     def close(self) -> None:
         if self.sock is not None:
@@ -462,11 +585,13 @@ class WsUnixClient:
 
 
 class JsonRpcClient:
-    def __init__(self, ws: WsUnixClient) -> None:
+    def __init__(self, ws: WsUnixClient, timeout: float) -> None:
         self.ws = ws
+        self.timeout = timeout
         self.next_id = 1
 
     def request(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        deadline = time.monotonic() + self.timeout
         request_id = self.next_id
         self.next_id += 1
         message: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
@@ -474,7 +599,16 @@ class JsonRpcClient:
             message["params"] = params
         self.ws.send_text(json.dumps(message, separators=(",", ":")))
         while True:
-            raw = self.ws.receive_text()
+            if time.monotonic() >= deadline:
+                raise PairingError(f"JSON-RPC request timed out after {self.timeout:g}s")
+            try:
+                raw = self.ws.receive_text(deadline=deadline)
+            except PairingError as error:
+                if time.monotonic() >= deadline:
+                    raise PairingError(
+                        f"JSON-RPC request timed out after {self.timeout:g}s"
+                    ) from error
+                raise
             try:
                 response = json.loads(raw)
             except json.JSONDecodeError as error:
@@ -496,18 +630,24 @@ class JsonRpcClient:
 
 def issue_pairing_code(socket_path: Path, timeout: float, cleanup_command: str) -> PairingResult:
     with WsUnixClient(socket_path, timeout) as ws:
-        rpc = JsonRpcClient(ws)
+        rpc = JsonRpcClient(ws, timeout)
         rpc.request(
-            "initialize",
+            INITIALIZE_METHOD,
             {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
+                "capabilities": {
+                    "experimentalApi": False,
+                    "requestAttestation": False,
+                },
+                "clientInfo": {
+                    "name": CLIENT_NAME,
+                    "title": None,
+                    "version": CLIENT_VERSION,
+                },
             },
         )
-        rpc.notify("initialized", {})
-        rpc.request("remoteControl/enable", {"ephemeral": True})
-        result = rpc.request("remoteControl/pairing/start", {"manualCode": True})
+        rpc.notify(INITIALIZED_NOTIFICATION_METHOD, {})
+        rpc.request(REMOTE_CONTROL_ENABLE_METHOD, {"ephemeral": True})
+        result = rpc.request(PAIRING_START_METHOD, {"manualCode": True})
 
     if not isinstance(result, dict):
         raise PairingError("pairing/start returned a non-object result")

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -450,6 +450,7 @@ class WsUnixClient:
     def connect(self) -> None:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.settimeout(self.timeout)
+        deadline = time.monotonic() + self.timeout
         try:
             sock.connect(str(self.socket_path))
             key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
@@ -463,8 +464,9 @@ class WsUnixClient:
                 "\r\n"
             )
             sock.sendall(request.encode("ascii"))
-            response = self._read_http_response(sock)
+            response = self._read_http_response(sock, deadline)
             self._verify_handshake(response, key)
+            sock.settimeout(self.timeout)
             self.sock = sock
         except PairingError:
             sock.close()
@@ -476,9 +478,16 @@ class WsUnixClient:
             sock.close()
             raise
 
-    def _read_http_response(self, sock: socket.socket) -> str:
+    def _read_http_response(self, sock: socket.socket, deadline: float) -> str:
+        # per-recv timeout만으로는 서버가 timeout보다 짧은 간격으로 바이트를
+        # 흘리면 handshake 전체가 --timeout을 초과할 수 있다. recv마다 남은
+        # 시간으로 재설정해 handshake 전체를 하나의 deadline에 묶는다.
         data = bytearray()
         while b"\r\n\r\n" not in data:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise PairingError("WebSocket handshake timed out")
+            sock.settimeout(remaining)
             chunk = sock.recv(4096)
             if not chunk:
                 raise PairingError("connection closed during WebSocket handshake")

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -35,7 +35,6 @@ from typing import Any
 
 WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 DEFAULT_SESSION = "codex-pair-bg"
-HELPER_MARKER = "issuing-codex-pairing-code\n"
 CLIENT_NAME = "issuing-codex-pairing-code"
 CLIENT_VERSION = "1.0.0"
 MOCK_EXPIRES_AT = 1893456000
@@ -54,7 +53,6 @@ class RuntimePaths:
     root: Path
     socket_path: Path
     log_path: Path
-    marker_path: Path
     session_name: str
 
 
@@ -156,17 +154,10 @@ def make_private_runtime_paths() -> RuntimePaths:
     if stat.S_IMODE(st.st_mode) & 0o077:
         root.chmod(0o700)
 
-    marker_path = root / ".owner"
-    if marker_path.exists() and marker_path.read_text(encoding="utf-8") != HELPER_MARKER:
-        raise PairingError(f"runtime directory marker mismatch: {root}")
-    marker_path.write_text(HELPER_MARKER, encoding="utf-8")
-    marker_path.chmod(0o600)
-
     return RuntimePaths(
         root=root,
         socket_path=root / "app.sock",
         log_path=root / "app-server.log",
-        marker_path=marker_path,
         session_name=session_name,
     )
 
@@ -211,7 +202,6 @@ def ensure_helper_app_server(codex_binary: Path, paths: RuntimePaths, timeout: f
             "app-server",
             "--listen",
             shlex.quote(listen_arg),
-            "--analytics-default-enabled",
             f"2>{shlex.quote(str(paths.log_path))}",
         ]
     )
@@ -495,13 +485,14 @@ def build_mock_result() -> PairingResult:
 
 
 def print_result(result: PairingResult, as_json: bool) -> None:
+    expires_at_kst = format_expiry_kst(result.expires_at)
     if as_json:
         print(
             json.dumps(
                 {
                     "manualPairingCode": result.manual_pairing_code,
                     "expiresAt": result.expires_at,
-                    "expiresAtKst": format_expiry_kst(result.expires_at),
+                    "expiresAtKst": expires_at_kst,
                     "cleanup": result.cleanup_command,
                 },
                 separators=(",", ":"),
@@ -510,12 +501,13 @@ def print_result(result: PairingResult, as_json: bool) -> None:
         return
 
     print(f"Code: {result.manual_pairing_code}")
-    print(f"Expires: {format_expiry_kst(result.expires_at)}")
+    print(f"Expires: {expires_at_kst}")
     print(f"Cleanup: {result.cleanup_command}")
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
+    cleanup_command: str | None = None
     try:
         ensure_consent(args)
         ensure_live_platform_allowed(args.mock)
@@ -535,6 +527,8 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     except PairingError as error:
         print(f"error: {redact_pairing_payload(str(error))}", file=sys.stderr)
+        if cleanup_command is not None:
+            print(f"Cleanup: {cleanup_command}", file=sys.stderr)
         return 1
 
 

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -171,12 +171,16 @@ def run_checked(
 
 
 def ensure_pairing_start_returns_manual_code(codex_binary: Path, timeout: float) -> None:
+    # remoteControl/pairing/* 은 experimental API라 --experimental 없이는
+    # generate-ts 출력에서 필터링된다 (stable-only가 기본). 플래그 없이 검사하면
+    # 기능이 실존하는 버전에서도 항상 fail closed된다.
     with tempfile.TemporaryDirectory(prefix="codex-pairing-protocol-") as tmp:
         result = run_checked(
             [
                 str(codex_binary),
                 "app-server",
                 "generate-ts",
+                "--experimental",
                 "--out",
                 tmp,
             ],
@@ -191,21 +195,12 @@ def ensure_pairing_start_returns_manual_code(codex_binary: Path, timeout: float)
                 + redact_pairing_payload(message or "generate-ts failed")
             )
 
+        # needle은 pairing 계약의 핵심(메서드 노출 + 요청/응답 필드)으로 한정한다.
+        # 그 밖의 타입/필드 검사는 ts-rs 출력 포맷에 결합되어, pairing과 무관한
+        # 포맷 변화만으로 false negative(부당한 fail closed)를 만든다.
         generated_root = Path(tmp)
         client_request_schema = _read_protocol_schema(
             generated_root, "ClientRequest.ts", "ClientRequest"
-        )
-        client_notification_schema = _read_protocol_schema(
-            generated_root, "ClientNotification.ts", "ClientNotification"
-        )
-        client_info_schema = _read_protocol_schema(
-            generated_root, "ClientInfo.ts", "ClientInfo"
-        )
-        initialize_schema = _read_protocol_schema(
-            generated_root, "InitializeParams.ts", "InitializeParams"
-        )
-        capabilities_schema = _read_protocol_schema(
-            generated_root, "InitializeCapabilities.ts", "InitializeCapabilities"
         )
         enable_params_schema = _read_protocol_schema(
             generated_root, "RemoteControlEnableParams.ts", "RemoteControlEnableParams"
@@ -224,12 +219,6 @@ def ensure_pairing_start_returns_manual_code(codex_binary: Path, timeout: float)
         for schema, needle, type_name, requirement in (
             (
                 client_request_schema,
-                f'"method": "{INITIALIZE_METHOD}"',
-                "ClientRequest",
-                INITIALIZE_METHOD,
-            ),
-            (
-                client_request_schema,
                 f'"method": "{REMOTE_CONTROL_ENABLE_METHOD}"',
                 "ClientRequest",
                 REMOTE_CONTROL_ENABLE_METHOD,
@@ -241,36 +230,8 @@ def ensure_pairing_start_returns_manual_code(codex_binary: Path, timeout: float)
                 PAIRING_START_METHOD,
             ),
             (
-                client_notification_schema,
-                f'"method": "{INITIALIZED_NOTIFICATION_METHOD}"',
-                "ClientNotification",
-                INITIALIZED_NOTIFICATION_METHOD,
-            ),
-            (client_info_schema, "name: string", "ClientInfo", "client name"),
-            (client_info_schema, "title: string | null", "ClientInfo", "client title"),
-            (client_info_schema, "version: string", "ClientInfo", "client version"),
-            (initialize_schema, "clientInfo: ClientInfo", "InitializeParams", "clientInfo"),
-            (
-                initialize_schema,
-                "capabilities: InitializeCapabilities",
-                "InitializeParams",
-                "capabilities",
-            ),
-            (
-                capabilities_schema,
-                "experimentalApi: boolean",
-                "InitializeCapabilities",
-                "experimentalApi",
-            ),
-            (
-                capabilities_schema,
-                "requestAttestation: boolean",
-                "InitializeCapabilities",
-                "requestAttestation",
-            ),
-            (
                 enable_params_schema,
-                "ephemeral?: boolean",
+                "ephemeral",
                 "RemoteControlEnableParams",
                 "ephemeral",
             ),
@@ -300,7 +261,8 @@ def _read_protocol_schema(root: Path, filename: str, type_name: str) -> str:
     files = list(root.rglob(filename))
     if not files:
         raise PairingError(
-            f"Codex app-server protocol does not expose {type_name}; "
+            f"Codex app-server protocol does not expose {type_name} "
+            "(checked with generate-ts --experimental); "
             "refusing live issuance before starting app-server"
         )
     return "\n".join(
@@ -315,8 +277,9 @@ def _ensure_schema_contains(
     if needle not in schema:
         raise PairingError(
             "Codex app-server protocol does not expose "
-            f"{requirement} in {type_name}; refusing live issuance before "
-            "starting app-server"
+            f"{requirement} in {type_name} "
+            "(checked with generate-ts --experimental); "
+            "refusing live issuance before starting app-server"
         )
 
 
@@ -634,8 +597,10 @@ def issue_pairing_code(socket_path: Path, timeout: float, cleanup_command: str) 
         rpc.request(
             INITIALIZE_METHOD,
             {
+                # remoteControl/pairing/* 은 experimental capability opt-in이 없으면
+                # -32600 "requires experimentalApi capability"로 거부된다 (0.142.5 실측).
                 "capabilities": {
-                    "experimentalApi": False,
+                    "experimentalApi": True,
                     "requestAttestation": False,
                 },
                 "clientInfo": {

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -38,6 +38,7 @@ DEFAULT_SESSION = "codex-pair-bg"
 HELPER_MARKER = "issuing-codex-pairing-code\n"
 CLIENT_NAME = "issuing-codex-pairing-code"
 CLIENT_VERSION = "1.0.0"
+MOCK_EXPIRES_AT = 1893456000
 CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b")
 SECRET_KEY_RE = re.compile(
     r'("(?:manualPairingCode|pairingCode|environmentId)"\s*:\s*")[^"]+(")'
@@ -89,11 +90,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=10.0,
         help="Timeout in seconds for app-server startup and RPC waits.",
     )
-    parser.add_argument(
-        "--session",
-        default=DEFAULT_SESSION,
-        help=f"Helper-owned tmux session name. Default: {DEFAULT_SESSION}",
-    )
     return parser.parse_args(argv)
 
 
@@ -139,17 +135,18 @@ def select_codex_binary() -> Path:
     )
 
 
-def make_private_runtime_paths(session_name: str) -> RuntimePaths:
+def make_private_runtime_paths() -> RuntimePaths:
+    session_name = f"{DEFAULT_SESSION}-{os.getpid()}-{secrets.token_hex(4)}"
     runtime_override = os.environ.get("CODEX_PAIRING_RUNTIME_DIR")
     if runtime_override:
-        root = Path(runtime_override).expanduser()
+        base = Path(runtime_override).expanduser()
     else:
         base = Path("/private/tmp") if platform.system() == "Darwin" else Path(tempfile.gettempdir())
-        root = base / f"codex-pairing-code-{os.getuid()}"
 
     old_umask = os.umask(0o077)
     try:
-        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        base.mkdir(mode=0o700, parents=True, exist_ok=True)
+        root = Path(tempfile.mkdtemp(prefix="codex-pairing-code-", dir=str(base)))
     finally:
         os.umask(old_umask)
 
@@ -164,10 +161,6 @@ def make_private_runtime_paths(session_name: str) -> RuntimePaths:
         raise PairingError(f"runtime directory marker mismatch: {root}")
     marker_path.write_text(HELPER_MARKER, encoding="utf-8")
     marker_path.chmod(0o600)
-
-    safe_session = re.sub(r"[^A-Za-z0-9_.-]", "-", session_name)
-    if safe_session != session_name or not safe_session:
-        raise PairingError("tmux session name contains unsupported characters")
 
     return RuntimePaths(
         root=root,
@@ -203,8 +196,10 @@ def ensure_helper_app_server(codex_binary: Path, paths: RuntimePaths, timeout: f
         raise PairingError("tmux is required to keep the helper-owned app-server alive")
 
     if _tmux_has_session(paths.session_name):
-        _wait_for_socket(paths.socket_path, timeout)
-        return
+        raise PairingError(
+            "helper tmux session already exists; clean it up before retrying: "
+            f"tmux kill-session -t {paths.session_name}"
+        )
 
     if paths.socket_path.exists():
         paths.socket_path.unlink()
@@ -272,7 +267,10 @@ def _encode_ws_frame(payload: bytes, opcode: int = 0x1, mask: bool = True) -> by
 def _recv_exact(sock: socket.socket, size: int) -> bytes:
     chunks = bytearray()
     while len(chunks) < size:
-        chunk = sock.recv(size - len(chunks))
+        try:
+            chunk = sock.recv(size - len(chunks))
+        except OSError as error:
+            raise PairingError(f"WebSocket receive failed: {error}") from error
         if not chunk:
             raise PairingError("connection closed while reading WebSocket frame")
         chunks.extend(chunk)
@@ -329,6 +327,12 @@ class WsUnixClient:
             response = self._read_http_response(sock)
             self._verify_handshake(response, key)
             self.sock = sock
+        except PairingError:
+            sock.close()
+            raise
+        except OSError as error:
+            sock.close()
+            raise PairingError(f"WebSocket connection failed: {error}") from error
         except Exception:
             sock.close()
             raise
@@ -360,7 +364,10 @@ class WsUnixClient:
     def send_text(self, text: str) -> None:
         if self.sock is None:
             raise PairingError("WebSocket is not connected")
-        self.sock.sendall(_encode_ws_frame(text.encode("utf-8"), opcode=0x1, mask=True))
+        try:
+            self.sock.sendall(_encode_ws_frame(text.encode("utf-8"), opcode=0x1, mask=True))
+        except OSError as error:
+            raise PairingError(f"WebSocket send failed: {error}") from error
 
     def receive_text(self) -> str:
         if self.sock is None:
@@ -368,7 +375,10 @@ class WsUnixClient:
         while True:
             opcode, payload = _read_ws_frame(self.sock)
             if opcode == 0x1:
-                return payload.decode("utf-8")
+                try:
+                    return payload.decode("utf-8")
+                except UnicodeDecodeError as error:
+                    raise PairingError("WebSocket text frame is not valid UTF-8") from error
             if opcode == 0x8:
                 raise PairingError("WebSocket closed by app-server")
             if opcode == 0x9:
@@ -402,7 +412,12 @@ class JsonRpcClient:
         self.ws.send_text(json.dumps(message, separators=(",", ":")))
         while True:
             raw = self.ws.receive_text()
-            response = json.loads(raw)
+            try:
+                response = json.loads(raw)
+            except json.JSONDecodeError as error:
+                raise PairingError("JSON-RPC response is not valid JSON") from error
+            if not isinstance(response, dict):
+                raise PairingError("JSON-RPC response is not an object")
             if response.get("id") != request_id:
                 continue
             if "error" in response:
@@ -448,7 +463,10 @@ def format_expiry_kst(expires_at: Any) -> str:
         if expires_at.isdigit():
             timestamp = int(expires_at)
         else:
-            parsed = dt.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            try:
+                parsed = dt.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            except ValueError as error:
+                raise PairingError("expiresAt string is not a valid timestamp") from error
             return parsed.astimezone(kst).strftime("%Y-%m-%d %H:%M:%S %Z")
     elif isinstance(expires_at, (int, float)):
         timestamp = float(expires_at)
@@ -457,7 +475,10 @@ def format_expiry_kst(expires_at: Any) -> str:
 
     if timestamp > 10_000_000_000:
         timestamp = timestamp / 1000
-    return dt.datetime.fromtimestamp(timestamp, tz=kst).strftime("%Y-%m-%d %H:%M:%S %Z")
+    try:
+        return dt.datetime.fromtimestamp(timestamp, tz=kst).strftime("%Y-%m-%d %H:%M:%S %Z")
+    except (OSError, OverflowError, ValueError) as error:
+        raise PairingError("expiresAt value is out of supported range") from error
 
 
 def redact_pairing_payload(value: str) -> str:
@@ -466,11 +487,10 @@ def redact_pairing_payload(value: str) -> str:
 
 
 def build_mock_result() -> PairingResult:
-    expires_at = int(time.time()) + 600
     return PairingResult(
         manual_pairing_code="MOCK-0000",
-        expires_at=expires_at,
-        cleanup_command=f"tmux kill-session -t {DEFAULT_SESSION}",
+        expires_at=MOCK_EXPIRES_AT,
+        cleanup_command="true # mock mode has no live session",
     )
 
 
@@ -504,8 +524,11 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         codex_binary = select_codex_binary()
-        paths = make_private_runtime_paths(args.session)
-        cleanup_command = f"tmux kill-session -t {paths.session_name}"
+        paths = make_private_runtime_paths()
+        cleanup_command = (
+            f"tmux kill-session -t {shlex.quote(paths.session_name)}; "
+            f"rm -rf {shlex.quote(str(paths.root))}"
+        )
         ensure_helper_app_server(codex_binary, paths, args.timeout)
         result = issue_pairing_code(paths.socket_path, args.timeout, cleanup_command)
         print_result(result, args.json)

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -80,7 +80,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--json",
         action="store_true",
-        help="Print machine-readable output with only the manual code and expiry.",
+        help="Print machine-readable output with the manual code, expiry, and cleanup command.",
     )
     parser.add_argument(
         "--timeout",
@@ -131,6 +131,49 @@ def select_codex_binary() -> Path:
     raise PairingError(
         "could not find an executable Codex binary; set CODEX_PAIRING_CODEX_BIN"
     )
+
+
+def ensure_pairing_start_returns_manual_code(codex_binary: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="codex-pairing-protocol-") as tmp:
+        result = subprocess.run(
+            [
+                str(codex_binary),
+                "app-server",
+                "generate-ts",
+                "--out",
+                tmp,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip()
+            raise PairingError(
+                "could not verify Codex app-server pairing protocol before live issuance: "
+                + redact_pairing_payload(message or "generate-ts failed")
+            )
+
+        response_files = list(Path(tmp).rglob("RemoteControlPairingStartResponse.ts"))
+        if not response_files:
+            raise PairingError(
+                "Codex app-server protocol does not expose "
+                "RemoteControlPairingStartResponse; refusing live issuance before "
+                "starting app-server"
+            )
+
+        response_schema = "\n".join(
+            path.read_text(encoding="utf-8", errors="replace")
+            for path in response_files
+        )
+        if "manualPairingCode" not in response_schema:
+            raise PairingError(
+                "Codex app-server protocol does not expose manualPairingCode in "
+                "RemoteControlPairingStartResponse; refusing live issuance before "
+                "starting app-server"
+            )
 
 
 def make_private_runtime_paths() -> RuntimePaths:
@@ -516,6 +559,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         codex_binary = select_codex_binary()
+        ensure_pairing_start_returns_manual_code(codex_binary)
         paths = make_private_runtime_paths()
         cleanup_command = (
             f"tmux kill-session -t {shlex.quote(paths.session_name)}; "

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Issue a Codex remote-control pairing code through a helper-owned app-server.
+
+Internal boundaries:
+- platform and consent gates run before any live side effect
+- runtime path creation owns only this helper's private directory
+- WebSocket framing is isolated from JSON-RPC sequencing
+- output formatting redacts all non-manual pairing payloads
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import re
+import secrets
+import shlex
+import shutil
+import socket
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+DEFAULT_SESSION = "codex-pair-bg"
+HELPER_MARKER = "issuing-codex-pairing-code\n"
+CLIENT_NAME = "issuing-codex-pairing-code"
+CLIENT_VERSION = "1.0.0"
+CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b")
+SECRET_KEY_RE = re.compile(
+    r'("(?:manualPairingCode|pairingCode|environmentId)"\s*:\s*")[^"]+(")'
+)
+
+
+class PairingError(RuntimeError):
+    """User-facing helper failure with secret-safe messaging."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RuntimePaths:
+    root: Path
+    socket_path: Path
+    log_path: Path
+    marker_path: Path
+    session_name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class PairingResult:
+    manual_pairing_code: str
+    expires_at: Any
+    cleanup_command: str
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Issue a Codex remote-control computer pairing code."
+    )
+    parser.add_argument(
+        "--user-requested-code",
+        action="store_true",
+        help="Required for live issuance after explicit user consent.",
+    )
+    parser.add_argument(
+        "--mock",
+        action="store_true",
+        help="Return deterministic fixture output without live Codex, tmux, or sockets.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable output with only the manual code and expiry.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Timeout in seconds for app-server startup and RPC waits.",
+    )
+    parser.add_argument(
+        "--session",
+        default=DEFAULT_SESSION,
+        help=f"Helper-owned tmux session name. Default: {DEFAULT_SESSION}",
+    )
+    return parser.parse_args(argv)
+
+
+def ensure_consent(args: argparse.Namespace) -> None:
+    if not args.mock and not args.user_requested_code:
+        raise PairingError(
+            "live issuance requires --user-requested-code after explicit user consent"
+        )
+
+
+def ensure_live_platform_allowed(is_mock: bool) -> None:
+    if is_mock:
+        return
+    if platform.system() != "Darwin":
+        raise PairingError(
+            "live pairing-code issuance is supported only on macOS/Darwin; "
+            "use --mock for fixture validation on Linux/NixOS"
+        )
+
+
+def select_codex_binary() -> Path:
+    override = os.environ.get("CODEX_PAIRING_CODEX_BIN")
+    candidates: list[Path] = []
+    if override:
+        candidates.append(Path(override).expanduser())
+    candidates.extend(
+        [
+            Path("/Applications/Codex.app/Contents/Resources/codex"),
+            Path("~/.codex/packages/standalone/current/codex").expanduser(),
+            Path("~/.codex/packages/standalone/current/bin/codex").expanduser(),
+        ]
+    )
+    path_codex = shutil.which("codex")
+    if path_codex:
+        candidates.append(Path(path_codex))
+
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+
+    raise PairingError(
+        "could not find an executable Codex binary; set CODEX_PAIRING_CODEX_BIN"
+    )
+
+
+def make_private_runtime_paths(session_name: str) -> RuntimePaths:
+    runtime_override = os.environ.get("CODEX_PAIRING_RUNTIME_DIR")
+    if runtime_override:
+        root = Path(runtime_override).expanduser()
+    else:
+        base = Path("/private/tmp") if platform.system() == "Darwin" else Path(tempfile.gettempdir())
+        root = base / f"codex-pairing-code-{os.getuid()}"
+
+    old_umask = os.umask(0o077)
+    try:
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    finally:
+        os.umask(old_umask)
+
+    st = root.stat()
+    if st.st_uid != os.getuid():
+        raise PairingError(f"runtime directory is not owned by current user: {root}")
+    if stat.S_IMODE(st.st_mode) & 0o077:
+        root.chmod(0o700)
+
+    marker_path = root / ".owner"
+    if marker_path.exists() and marker_path.read_text(encoding="utf-8") != HELPER_MARKER:
+        raise PairingError(f"runtime directory marker mismatch: {root}")
+    marker_path.write_text(HELPER_MARKER, encoding="utf-8")
+    marker_path.chmod(0o600)
+
+    safe_session = re.sub(r"[^A-Za-z0-9_.-]", "-", session_name)
+    if safe_session != session_name or not safe_session:
+        raise PairingError("tmux session name contains unsupported characters")
+
+    return RuntimePaths(
+        root=root,
+        socket_path=root / "app.sock",
+        log_path=root / "app-server.log",
+        marker_path=marker_path,
+        session_name=session_name,
+    )
+
+
+def _tmux_has_session(session_name: str) -> bool:
+    result = subprocess.run(
+        ["tmux", "has-session", "-t", session_name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _socket_connects(socket_path: Path, timeout: float = 0.25) -> bool:
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(str(socket_path))
+            return True
+    except OSError:
+        return False
+
+
+def ensure_helper_app_server(codex_binary: Path, paths: RuntimePaths, timeout: float) -> None:
+    if not shutil.which("tmux"):
+        raise PairingError("tmux is required to keep the helper-owned app-server alive")
+
+    if _tmux_has_session(paths.session_name):
+        _wait_for_socket(paths.socket_path, timeout)
+        return
+
+    if paths.socket_path.exists():
+        paths.socket_path.unlink()
+
+    listen_arg = f"unix://{paths.socket_path}"
+    command = " ".join(
+        [
+            shlex.quote(str(codex_binary)),
+            "app-server",
+            "--listen",
+            shlex.quote(listen_arg),
+            "--analytics-default-enabled",
+            f"2>{shlex.quote(str(paths.log_path))}",
+        ]
+    )
+    result = subprocess.run(
+        ["tmux", "new-session", "-d", "-s", paths.session_name, command],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise PairingError(redact_pairing_payload(result.stderr.strip() or "tmux failed"))
+
+    _wait_for_socket(paths.socket_path, timeout)
+
+
+def _wait_for_socket(socket_path: Path, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if socket_path.exists() and _socket_connects(socket_path):
+            return
+        time.sleep(0.1)
+    raise PairingError(f"app-server socket did not become ready: {socket_path}")
+
+
+def _websocket_accept_value(key: str) -> str:
+    digest = hashlib.sha1((key + WEBSOCKET_GUID).encode("ascii")).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _encode_ws_frame(payload: bytes, opcode: int = 0x1, mask: bool = True) -> bytes:
+    first = 0x80 | (opcode & 0x0F)
+    length = len(payload)
+    header = bytearray([first])
+    mask_bit = 0x80 if mask else 0
+    if length < 126:
+        header.append(mask_bit | length)
+    elif length <= 0xFFFF:
+        header.append(mask_bit | 126)
+        header.extend(struct.pack("!H", length))
+    else:
+        header.append(mask_bit | 127)
+        header.extend(struct.pack("!Q", length))
+
+    if not mask:
+        return bytes(header) + payload
+
+    masking_key = secrets.token_bytes(4)
+    masked = bytes(byte ^ masking_key[index % 4] for index, byte in enumerate(payload))
+    return bytes(header) + masking_key + masked
+
+
+def _recv_exact(sock: socket.socket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise PairingError("connection closed while reading WebSocket frame")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def _read_ws_frame(sock: socket.socket) -> tuple[int, bytes]:
+    first_two = _recv_exact(sock, 2)
+    first, second = first_two
+    opcode = first & 0x0F
+    masked = bool(second & 0x80)
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recv_exact(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recv_exact(sock, 8))[0]
+
+    masking_key = _recv_exact(sock, 4) if masked else b""
+    payload = _recv_exact(sock, length) if length else b""
+    if masked:
+        payload = bytes(byte ^ masking_key[index % 4] for index, byte in enumerate(payload))
+    return opcode, payload
+
+
+class WsUnixClient:
+    def __init__(self, socket_path: Path, timeout: float) -> None:
+        self.socket_path = socket_path
+        self.timeout = timeout
+        self.sock: socket.socket | None = None
+
+    def __enter__(self) -> "WsUnixClient":
+        self.connect()
+        return self
+
+    def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+        self.close()
+
+    def connect(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(self.timeout)
+        try:
+            sock.connect(str(self.socket_path))
+            key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
+            request = (
+                "GET /rpc HTTP/1.1\r\n"
+                "Host: localhost\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Key: {key}\r\n"
+                "Sec-WebSocket-Version: 13\r\n"
+                "\r\n"
+            )
+            sock.sendall(request.encode("ascii"))
+            response = self._read_http_response(sock)
+            self._verify_handshake(response, key)
+            self.sock = sock
+        except Exception:
+            sock.close()
+            raise
+
+    def _read_http_response(self, sock: socket.socket) -> str:
+        data = bytearray()
+        while b"\r\n\r\n" not in data:
+            chunk = sock.recv(4096)
+            if not chunk:
+                raise PairingError("connection closed during WebSocket handshake")
+            data.extend(chunk)
+            if len(data) > 65536:
+                raise PairingError("WebSocket handshake response too large")
+        return data.decode("iso-8859-1")
+
+    def _verify_handshake(self, response: str, key: str) -> None:
+        lines = response.split("\r\n")
+        if not lines or " 101 " not in lines[0]:
+            raise PairingError(f"WebSocket upgrade failed: {lines[0] if lines else 'no status'}")
+        headers: dict[str, str] = {}
+        for line in lines[1:]:
+            if ":" in line:
+                name, value = line.split(":", 1)
+                headers[name.strip().lower()] = value.strip()
+        expected = _websocket_accept_value(key)
+        if headers.get("sec-websocket-accept") != expected:
+            raise PairingError("WebSocket Sec-WebSocket-Accept verification failed")
+
+    def send_text(self, text: str) -> None:
+        if self.sock is None:
+            raise PairingError("WebSocket is not connected")
+        self.sock.sendall(_encode_ws_frame(text.encode("utf-8"), opcode=0x1, mask=True))
+
+    def receive_text(self) -> str:
+        if self.sock is None:
+            raise PairingError("WebSocket is not connected")
+        while True:
+            opcode, payload = _read_ws_frame(self.sock)
+            if opcode == 0x1:
+                return payload.decode("utf-8")
+            if opcode == 0x8:
+                raise PairingError("WebSocket closed by app-server")
+            if opcode == 0x9:
+                self.sock.sendall(_encode_ws_frame(payload, opcode=0xA, mask=True))
+                continue
+            if opcode == 0xA:
+                continue
+            raise PairingError(f"unsupported WebSocket opcode: {opcode}")
+
+    def close(self) -> None:
+        if self.sock is not None:
+            try:
+                self.sock.sendall(_encode_ws_frame(b"", opcode=0x8, mask=True))
+            except OSError:
+                pass
+            self.sock.close()
+            self.sock = None
+
+
+class JsonRpcClient:
+    def __init__(self, ws: WsUnixClient) -> None:
+        self.ws = ws
+        self.next_id = 1
+
+    def request(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        request_id = self.next_id
+        self.next_id += 1
+        message: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        self.ws.send_text(json.dumps(message, separators=(",", ":")))
+        while True:
+            raw = self.ws.receive_text()
+            response = json.loads(raw)
+            if response.get("id") != request_id:
+                continue
+            if "error" in response:
+                raise PairingError(redact_pairing_payload(json.dumps(response["error"])))
+            return response.get("result")
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        message: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        self.ws.send_text(json.dumps(message, separators=(",", ":")))
+
+
+def issue_pairing_code(socket_path: Path, timeout: float, cleanup_command: str) -> PairingResult:
+    with WsUnixClient(socket_path, timeout) as ws:
+        rpc = JsonRpcClient(ws)
+        rpc.request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": CLIENT_NAME, "version": CLIENT_VERSION},
+            },
+        )
+        rpc.notify("initialized", {})
+        rpc.request("remoteControl/enable", {"ephemeral": True})
+        result = rpc.request("remoteControl/pairing/start", {"manualCode": True})
+
+    if not isinstance(result, dict):
+        raise PairingError("pairing/start returned a non-object result")
+    manual_code = result.get("manualPairingCode")
+    expires_at = result.get("expiresAt")
+    if not isinstance(manual_code, str) or not manual_code:
+        raise PairingError("pairing/start result did not include manualPairingCode")
+    if expires_at is None:
+        raise PairingError("pairing/start result did not include expiresAt")
+    return PairingResult(manual_code, expires_at, cleanup_command)
+
+
+def format_expiry_kst(expires_at: Any) -> str:
+    kst = dt.timezone(dt.timedelta(hours=9), "KST")
+    if isinstance(expires_at, str):
+        if expires_at.isdigit():
+            timestamp = int(expires_at)
+        else:
+            parsed = dt.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            return parsed.astimezone(kst).strftime("%Y-%m-%d %H:%M:%S %Z")
+    elif isinstance(expires_at, (int, float)):
+        timestamp = float(expires_at)
+    else:
+        raise PairingError("unsupported expiresAt type")
+
+    if timestamp > 10_000_000_000:
+        timestamp = timestamp / 1000
+    return dt.datetime.fromtimestamp(timestamp, tz=kst).strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def redact_pairing_payload(value: str) -> str:
+    redacted = SECRET_KEY_RE.sub(r"\1[REDACTED]\2", value)
+    return CODE_RE.sub("[PAIRING-CODE]", redacted)
+
+
+def build_mock_result() -> PairingResult:
+    expires_at = int(time.time()) + 600
+    return PairingResult(
+        manual_pairing_code="MOCK-0000",
+        expires_at=expires_at,
+        cleanup_command=f"tmux kill-session -t {DEFAULT_SESSION}",
+    )
+
+
+def print_result(result: PairingResult, as_json: bool) -> None:
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "manualPairingCode": result.manual_pairing_code,
+                    "expiresAt": result.expires_at,
+                    "expiresAtKst": format_expiry_kst(result.expires_at),
+                    "cleanup": result.cleanup_command,
+                },
+                separators=(",", ":"),
+            )
+        )
+        return
+
+    print(f"Code: {result.manual_pairing_code}")
+    print(f"Expires: {format_expiry_kst(result.expires_at)}")
+    print(f"Cleanup: {result.cleanup_command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        ensure_consent(args)
+        ensure_live_platform_allowed(args.mock)
+        if args.mock:
+            print_result(build_mock_result(), args.json)
+            return 0
+
+        codex_binary = select_codex_binary()
+        paths = make_private_runtime_paths(args.session)
+        cleanup_command = f"tmux kill-session -t {paths.session_name}"
+        ensure_helper_app_server(codex_binary, paths, args.timeout)
+        result = issue_pairing_code(paths.socket_path, args.timeout, cleanup_command)
+        print_result(result, args.json)
+        return 0
+    except PairingError as error:
+        print(f"error: {redact_pairing_payload(str(error))}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py
@@ -40,8 +40,13 @@ CLIENT_VERSION = "1.0.0"
 MOCK_EXPIRES_AT = 1893456000
 CODE_RE = re.compile(r"\b[A-Z0-9]{4}-[A-Z0-9]{4}\b")
 SECRET_KEY_RE = re.compile(
-    r'("(?:manualPairingCode|pairingCode|environmentId)"\s*:\s*")[^"]+(")'
+    r'("(?:(?:manual)?pairingCode|environmentId|'
+    r'(?:access|auth|bearer|refresh|remote[_-]?control|api|pairing)?'
+    r'(?:Token|Key|Secret)|authorization|CODEX_API_KEY)"\s*:\s*")[^"]+(")',
+    re.IGNORECASE,
 )
+BEARER_TOKEN_RE = re.compile(r"\bBearer\s+[-._~+/A-Za-z0-9]+=*", re.IGNORECASE)
+OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b")
 
 
 class PairingError(RuntimeError):
@@ -133,9 +138,31 @@ def select_codex_binary() -> Path:
     )
 
 
-def ensure_pairing_start_returns_manual_code(codex_binary: Path) -> None:
+def run_checked(
+    command: list[str],
+    *,
+    timeout: float,
+    stdout: Any = subprocess.PIPE,
+    stderr: Any = subprocess.PIPE,
+    text: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            text=text,
+            stdout=stdout,
+            stderr=stderr,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        program = Path(command[0]).name if command else "command"
+        raise PairingError(f"{program} timed out after {timeout:g}s") from error
+
+
+def ensure_pairing_start_returns_manual_code(codex_binary: Path, timeout: float) -> None:
     with tempfile.TemporaryDirectory(prefix="codex-pairing-protocol-") as tmp:
-        result = subprocess.run(
+        result = run_checked(
             [
                 str(codex_binary),
                 "app-server",
@@ -143,11 +170,9 @@ def ensure_pairing_start_returns_manual_code(codex_binary: Path) -> None:
                 "--out",
                 tmp,
             ],
-            text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=10,
-            check=False,
+            timeout=timeout,
         )
         if result.returncode != 0:
             message = result.stderr.strip() or result.stdout.strip()
@@ -206,11 +231,11 @@ def make_private_runtime_paths() -> RuntimePaths:
 
 
 def _tmux_has_session(session_name: str) -> bool:
-    result = subprocess.run(
+    result = run_checked(
         ["tmux", "has-session", "-t", session_name],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        check=False,
+        timeout=2,
     )
     return result.returncode == 0
 
@@ -248,12 +273,11 @@ def ensure_helper_app_server(codex_binary: Path, paths: RuntimePaths, timeout: f
             f"2>{shlex.quote(str(paths.log_path))}",
         ]
     )
-    result = subprocess.run(
+    result = run_checked(
         ["tmux", "new-session", "-d", "-s", paths.session_name, command],
-        text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        check=False,
+        timeout=timeout,
     )
     if result.returncode != 0:
         raise PairingError(redact_pairing_payload(result.stderr.strip() or "tmux failed"))
@@ -516,6 +540,8 @@ def format_expiry_kst(expires_at: Any) -> str:
 
 def redact_pairing_payload(value: str) -> str:
     redacted = SECRET_KEY_RE.sub(r"\1[REDACTED]\2", value)
+    redacted = BEARER_TOKEN_RE.sub("Bearer [REDACTED]", redacted)
+    redacted = OPENAI_KEY_RE.sub("[REDACTED-API-KEY]", redacted)
     return CODE_RE.sub("[PAIRING-CODE]", redacted)
 
 
@@ -559,7 +585,7 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         codex_binary = select_codex_binary()
-        ensure_pairing_start_returns_manual_code(codex_binary)
+        ensure_pairing_start_returns_manual_code(codex_binary, args.timeout)
         paths = make_private_runtime_paths()
         cleanup_command = (
             f"tmux kill-session -t {shlex.quote(paths.session_name)}; "

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -138,15 +138,25 @@ class PairingCodeHelperTests(unittest.TestCase):
             '{"manualPairingCode":"MH67-9LKZ","pairingCode":"secret",'
             '"environmentId":"env-123","pairingToken":"tok-secret",'
             '"authToken":"auth-secret","accessToken":"access-secret",'
-            '"CODEX_API_KEY":"sk-abcdefghijklmnopqrstuvwxyz",'
-            '"Authorization":"Bearer very-secret-token","other":"ABCD-1234"}'
+            '"CODEX_API_KEY":"sk-abcdefghijklmnopqrstuvwxyz","api_key":"api-secret",'
+            '"x-api-key":"x-secret",'
+            '"Authorization":"Bearer very-secret-token","other":"ABCD-1234"} '
+            "token=plain-token key=plain-key secret:plain-secret"
         )
         redacted = issue_pairing_code.redact_pairing_payload(raw)
         self.assertNotIn("MH67-9LKZ", redacted)
-        self.assertNotIn("secret", redacted)
+        self.assertNotIn('"pairingCode":"secret"', redacted)
+        self.assertNotIn("tok-secret", redacted)
+        self.assertNotIn("auth-secret", redacted)
+        self.assertNotIn("access-secret", redacted)
+        self.assertNotIn("api-secret", redacted)
+        self.assertNotIn("x-secret", redacted)
         self.assertNotIn("env-123", redacted)
         self.assertNotIn("sk-abcdefghijklmnopqrstuvwxyz", redacted)
         self.assertNotIn("very-secret-token", redacted)
+        self.assertNotIn("plain-token", redacted)
+        self.assertNotIn("plain-key", redacted)
+        self.assertNotIn("plain-secret", redacted)
         self.assertNotIn("ABCD-1234", redacted)
 
     def test_runtime_dir_is_private(self) -> None:

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -12,7 +12,6 @@ import socket
 import sys
 import tempfile
 import threading
-import time
 import unittest
 from pathlib import Path
 from unittest import mock

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -329,6 +329,7 @@ class PairingCodeHelperTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             socket_path = Path(tmp) / "app.sock"
             seen_methods: list[str] = []
+            seen_params: dict[str, object] = {}
             ready = threading.Event()
 
             def server() -> None:
@@ -358,6 +359,7 @@ class PairingCodeHelperTests(unittest.TestCase):
                                 break
                             message = json.loads(payload.decode("utf-8"))
                             seen_methods.append(message["method"])
+                            seen_params[message["method"]] = message.get("params")
                             if "id" not in message:
                                 continue
                             if message["method"] == "remoteControl/pairing/start":
@@ -396,6 +398,12 @@ class PairingCodeHelperTests(unittest.TestCase):
                 "remoteControl/pairing/start",
             ],
         )
+        initialize_params = seen_params["initialize"]
+        assert isinstance(initialize_params, dict)
+        self.assertIs(initialize_params["capabilities"]["experimentalApi"], True)
+        enable_params = seen_params["remoteControl/enable"]
+        assert isinstance(enable_params, dict)
+        self.assertIs(enable_params["ephemeral"], True)
 
     def test_binary_selection_honors_env_override(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -415,6 +423,23 @@ class PairingCodeHelperTests(unittest.TestCase):
             issue_pairing_code.subprocess, "run", side_effect=generate_schema
         ):
             issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
+
+    def test_protocol_check_requests_experimental_surface(self) -> None:
+        # pairing API는 experimental이라 --experimental 없는 generate-ts 출력에서는
+        # 필터링된다. 플래그가 빠지면 지원 버전에서도 항상 fail closed된다.
+        captured_args: list[str] = []
+
+        def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
+            captured_args.extend(args)
+            out_dir = Path(args[args.index("--out") + 1])
+            _write_valid_protocol_schema(out_dir)
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            issue_pairing_code.subprocess, "run", side_effect=generate_schema
+        ):
+            issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
+        self.assertIn("--experimental", captured_args)
 
     def test_protocol_check_rejects_missing_manual_code_schema(self) -> None:
         def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
@@ -517,6 +542,7 @@ def _write_valid_protocol_schema(
     client_request: str | None = None,
     response: str | None = None,
 ) -> None:
+    # 픽스처 형태는 codex 0.142.5 `generate-ts --experimental` 실측 출력 기준.
     v2 = out_dir / "v2"
     v2.mkdir(parents=True)
     (out_dir / "ClientRequest.ts").write_text(
@@ -528,37 +554,20 @@ def _write_valid_protocol_schema(
         ),
         encoding="utf-8",
     )
-    (out_dir / "ClientNotification.ts").write_text(
-        'export type ClientNotification = { "method": "initialized" };\n',
-        encoding="utf-8",
-    )
-    (out_dir / "ClientInfo.ts").write_text(
-        "export type ClientInfo = { name: string, title: string | null, version: string };\n",
-        encoding="utf-8",
-    )
-    (out_dir / "InitializeParams.ts").write_text(
-        "export type InitializeParams = { clientInfo: ClientInfo, "
-        "capabilities: InitializeCapabilities | null };\n",
-        encoding="utf-8",
-    )
-    (out_dir / "InitializeCapabilities.ts").write_text(
-        "export type InitializeCapabilities = { experimentalApi: boolean, "
-        "requestAttestation: boolean };\n",
-        encoding="utf-8",
-    )
     (v2 / "RemoteControlEnableParams.ts").write_text(
-        "export type RemoteControlEnableParams = { ephemeral?: boolean };\n",
+        "export type RemoteControlEnableParams = { ephemeral?: boolean, };\n",
         encoding="utf-8",
     )
     (v2 / "RemoteControlPairingStartParams.ts").write_text(
-        "export type RemoteControlPairingStartParams = { manualCode?: boolean };\n",
+        "export type RemoteControlPairingStartParams = { manualCode?: boolean, };\n",
         encoding="utf-8",
     )
     (v2 / "RemoteControlPairingStartResponse.ts").write_text(
         response
         or (
             "export type RemoteControlPairingStartResponse = "
-            "{ manualPairingCode: string, expiresAt: number };\n"
+            "{ pairingCode: string, manualPairingCode: string | null, "
+            "environmentId: string, expiresAt: bigint, };\n"
         ),
         encoding="utf-8",
     )

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -94,10 +94,11 @@ class PairingCodeHelperTests(unittest.TestCase):
 
             thread = threading.Thread(target=server)
             thread.start()
-            ready.wait(2)
+            self.assertTrue(ready.wait(2), "server did not start in time")
             with issue_pairing_code.WsUnixClient(socket_path, 2):
                 pass
             thread.join(2)
+            self.assertFalse(thread.is_alive(), "server thread did not exit")
         self.assertNotIn("Sec-WebSocket-Extensions", captured["request"])
 
     def test_invalid_websocket_accept_is_rejected(self) -> None:
@@ -127,11 +128,12 @@ class PairingCodeHelperTests(unittest.TestCase):
 
             thread = threading.Thread(target=server)
             thread.start()
-            ready.wait(2)
+            self.assertTrue(ready.wait(2), "server did not start in time")
             with self.assertRaises(issue_pairing_code.PairingError):
                 with issue_pairing_code.WsUnixClient(socket_path, 2):
                     pass
             thread.join(2)
+            self.assertFalse(thread.is_alive(), "server thread did not exit")
 
     def test_redaction_removes_codes_and_secret_fields(self) -> None:
         raw = (
@@ -242,12 +244,12 @@ class PairingCodeHelperTests(unittest.TestCase):
         self.assertEqual(first.expires_at, issue_pairing_code.MOCK_EXPIRES_AT)
 
     def test_json_rpc_rejects_malformed_json(self) -> None:
-        rpc = issue_pairing_code.JsonRpcClient(_FakeWs(["not-json"]))
+        rpc = issue_pairing_code.JsonRpcClient(_FakeWs(["not-json"]), 1)
         with self.assertRaises(issue_pairing_code.PairingError):
             rpc.request("remoteControl/pairing/start", {"manualCode": True})
 
     def test_json_rpc_rejects_non_object_response(self) -> None:
-        rpc = issue_pairing_code.JsonRpcClient(_FakeWs(["[]"]))
+        rpc = issue_pairing_code.JsonRpcClient(_FakeWs(["[]"]), 1)
         with self.assertRaises(issue_pairing_code.PairingError):
             rpc.request("remoteControl/pairing/start", {"manualCode": True})
 
@@ -264,7 +266,7 @@ class PairingCodeHelperTests(unittest.TestCase):
                 },
             }
         )
-        rpc = issue_pairing_code.JsonRpcClient(_FakeWs([response]))
+        rpc = issue_pairing_code.JsonRpcClient(_FakeWs([response]), 1)
         with self.assertRaises(issue_pairing_code.PairingError) as caught:
             rpc.request("remoteControl/pairing/start", {"manualCode": True})
         message = str(caught.exception)
@@ -280,9 +282,21 @@ class PairingCodeHelperTests(unittest.TestCase):
                     json.dumps({"jsonrpc": "2.0", "id": 999, "result": {"ignored": True}}),
                     json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}),
                 ]
-            )
+            ),
+            1,
         )
         self.assertEqual(rpc.request("initialize"), {"ok": True})
+
+    def test_json_rpc_overall_deadline_rejects_endless_mismatched_ids(self) -> None:
+        rpc = issue_pairing_code.JsonRpcClient(
+            _FakeWs([json.dumps({"jsonrpc": "2.0", "id": 999, "result": {}})]),
+            1,
+        )
+        with mock.patch.object(
+            issue_pairing_code.time, "monotonic", side_effect=[0.0, 0.5, 1.1]
+        ):
+            with self.assertRaisesRegex(issue_pairing_code.PairingError, "timed out after 1s"):
+                rpc.request("initialize")
 
     def test_format_expiry_rejects_malformed_string(self) -> None:
         with self.assertRaises(issue_pairing_code.PairingError):
@@ -364,11 +378,12 @@ class PairingCodeHelperTests(unittest.TestCase):
 
             thread = threading.Thread(target=server)
             thread.start()
-            ready.wait(2)
+            self.assertTrue(ready.wait(2), "server did not start in time")
             result = issue_pairing_code.issue_pairing_code(
                 socket_path, 2, "tmux kill-session -t codex-pair-bg"
             )
             thread.join(2)
+            self.assertFalse(thread.is_alive(), "server thread did not exit")
 
         self.assertEqual(result.manual_pairing_code, "MOCK-0000")
         self.assertEqual(result.expires_at, 1893456000)
@@ -393,13 +408,7 @@ class PairingCodeHelperTests(unittest.TestCase):
     def test_protocol_check_accepts_manual_code_schema(self) -> None:
         def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
             out_dir = Path(args[args.index("--out") + 1])
-            schema_dir = out_dir / "v2"
-            schema_dir.mkdir(parents=True)
-            (schema_dir / "RemoteControlPairingStartResponse.ts").write_text(
-                "export type RemoteControlPairingStartResponse = "
-                "{ manualPairingCode: string; expiresAt: number };\n",
-                encoding="utf-8",
-            )
+            _write_valid_protocol_schema(out_dir)
             return mock.Mock(returncode=0, stdout="", stderr="")
 
         with mock.patch.object(
@@ -410,11 +419,9 @@ class PairingCodeHelperTests(unittest.TestCase):
     def test_protocol_check_rejects_missing_manual_code_schema(self) -> None:
         def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
             out_dir = Path(args[args.index("--out") + 1])
-            schema_dir = out_dir / "v2"
-            schema_dir.mkdir(parents=True)
-            (schema_dir / "RemoteControlPairingStartResponse.ts").write_text(
-                "export type RemoteControlPairingStartResponse = { expiresAt: number };\n",
-                encoding="utf-8",
+            _write_valid_protocol_schema(
+                out_dir,
+                response="export type RemoteControlPairingStartResponse = { expiresAt: number };\n",
             )
             return mock.Mock(returncode=0, stdout="", stderr="")
 
@@ -422,6 +429,22 @@ class PairingCodeHelperTests(unittest.TestCase):
             issue_pairing_code.subprocess, "run", side_effect=generate_schema
         ):
             with self.assertRaisesRegex(issue_pairing_code.PairingError, "manualPairingCode"):
+                issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
+
+    def test_protocol_check_rejects_missing_pairing_start_method(self) -> None:
+        def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
+            out_dir = Path(args[args.index("--out") + 1])
+            _write_valid_protocol_schema(
+                out_dir,
+                client_request='export type ClientRequest = { "method": "initialize" } | '
+                '{ "method": "remoteControl/enable" };\n',
+            )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            issue_pairing_code.subprocess, "run", side_effect=generate_schema
+        ):
+            with self.assertRaisesRegex(issue_pairing_code.PairingError, "remoteControl/pairing/start"):
                 issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
 
     def test_protocol_check_timeout_is_pairing_error(self) -> None:
@@ -479,10 +502,66 @@ class _FakeWs:
     def send_text(self, _text: str) -> None:
         pass
 
-    def receive_text(self) -> str:
+    def receive_text(self, deadline: float | None = None) -> str:
+        _ = deadline
         if not self.responses:
             raise issue_pairing_code.PairingError("no fake response left")
+        if len(self.responses) == 1:
+            return self.responses[0]
         return self.responses.pop(0)
+
+
+def _write_valid_protocol_schema(
+    out_dir: Path,
+    *,
+    client_request: str | None = None,
+    response: str | None = None,
+) -> None:
+    v2 = out_dir / "v2"
+    v2.mkdir(parents=True)
+    (out_dir / "ClientRequest.ts").write_text(
+        client_request
+        or (
+            'export type ClientRequest = { "method": "initialize" } | '
+            '{ "method": "remoteControl/enable" } | '
+            '{ "method": "remoteControl/pairing/start" };\n'
+        ),
+        encoding="utf-8",
+    )
+    (out_dir / "ClientNotification.ts").write_text(
+        'export type ClientNotification = { "method": "initialized" };\n',
+        encoding="utf-8",
+    )
+    (out_dir / "ClientInfo.ts").write_text(
+        "export type ClientInfo = { name: string, title: string | null, version: string };\n",
+        encoding="utf-8",
+    )
+    (out_dir / "InitializeParams.ts").write_text(
+        "export type InitializeParams = { clientInfo: ClientInfo, "
+        "capabilities: InitializeCapabilities | null };\n",
+        encoding="utf-8",
+    )
+    (out_dir / "InitializeCapabilities.ts").write_text(
+        "export type InitializeCapabilities = { experimentalApi: boolean, "
+        "requestAttestation: boolean };\n",
+        encoding="utf-8",
+    )
+    (v2 / "RemoteControlEnableParams.ts").write_text(
+        "export type RemoteControlEnableParams = { ephemeral?: boolean };\n",
+        encoding="utf-8",
+    )
+    (v2 / "RemoteControlPairingStartParams.ts").write_text(
+        "export type RemoteControlPairingStartParams = { manualCode?: boolean };\n",
+        encoding="utf-8",
+    )
+    (v2 / "RemoteControlPairingStartResponse.ts").write_text(
+        response
+        or (
+            "export type RemoteControlPairingStartResponse = "
+            "{ manualPairingCode: string, expiresAt: number };\n"
+        ),
+        encoding="utf-8",
+    )
 
 
 if __name__ == "__main__":

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "issue_pairing_code.py"
+)
+SPEC = importlib.util.spec_from_file_location("issue_pairing_code", SCRIPT)
+assert SPEC and SPEC.loader
+issue_pairing_code = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = issue_pairing_code
+SPEC.loader.exec_module(issue_pairing_code)
+
+
+class PairingCodeHelperTests(unittest.TestCase):
+    def test_non_darwin_live_fails_before_binary_lookup(self) -> None:
+        with mock.patch.object(issue_pairing_code.platform, "system", return_value="Linux"):
+            with mock.patch.object(issue_pairing_code, "select_codex_binary") as select_binary:
+                rc = _run_main_silent(["--user-requested-code", "--json"])
+        self.assertEqual(rc, 1)
+        select_binary.assert_not_called()
+
+    def test_missing_consent_fails_before_live_work(self) -> None:
+        with mock.patch.object(issue_pairing_code.platform, "system", return_value="Darwin"):
+            with mock.patch.object(issue_pairing_code, "select_codex_binary") as select_binary:
+                rc = _run_main_silent(["--json"])
+        self.assertEqual(rc, 1)
+        select_binary.assert_not_called()
+
+    def test_mock_mode_skips_platform_and_binary_lookup(self) -> None:
+        with mock.patch.object(issue_pairing_code.platform, "system", return_value="Linux"):
+            with mock.patch.object(issue_pairing_code, "select_codex_binary") as select_binary:
+                rc = _run_main_silent(["--mock", "--json"])
+        self.assertEqual(rc, 0)
+        select_binary.assert_not_called()
+
+    def test_websocket_accept_value(self) -> None:
+        key = base64.b64encode(b"the sample nonce").decode("ascii")
+        self.assertEqual(
+            issue_pairing_code._websocket_accept_value(key),
+            "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+        )
+
+    def test_client_frame_is_masked(self) -> None:
+        frame = issue_pairing_code._encode_ws_frame(b"hello", mask=True)
+        self.assertTrue(frame[1] & 0x80)
+
+    def test_handshake_request_does_not_offer_compression(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = Path(tmp) / "app.sock"
+            captured = {}
+            ready = threading.Event()
+
+            def server() -> None:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
+                    srv.bind(str(socket_path))
+                    srv.listen(1)
+                    ready.set()
+                    conn, _ = srv.accept()
+                    with conn:
+                        request = b""
+                        while b"\r\n\r\n" not in request:
+                            request += conn.recv(4096)
+                        captured["request"] = request.decode("ascii")
+                        key = _header_value(captured["request"], "Sec-WebSocket-Key")
+                        accept = issue_pairing_code._websocket_accept_value(key)
+                        conn.sendall(
+                            (
+                                "HTTP/1.1 101 Switching Protocols\r\n"
+                                "Upgrade: websocket\r\n"
+                                "Connection: Upgrade\r\n"
+                                f"Sec-WebSocket-Accept: {accept}\r\n"
+                                "\r\n"
+                            ).encode("ascii")
+                        )
+                        issue_pairing_code._read_ws_frame(conn)
+
+            thread = threading.Thread(target=server)
+            thread.start()
+            ready.wait(2)
+            with issue_pairing_code.WsUnixClient(socket_path, 2):
+                pass
+            thread.join(2)
+        self.assertNotIn("Sec-WebSocket-Extensions", captured["request"])
+
+    def test_invalid_websocket_accept_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = Path(tmp) / "app.sock"
+            ready = threading.Event()
+
+            def server() -> None:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
+                    srv.bind(str(socket_path))
+                    srv.listen(1)
+                    ready.set()
+                    conn, _ = srv.accept()
+                    with conn:
+                        request = b""
+                        while b"\r\n\r\n" not in request:
+                            request += conn.recv(4096)
+                        conn.sendall(
+                            (
+                                "HTTP/1.1 101 Switching Protocols\r\n"
+                                "Upgrade: websocket\r\n"
+                                "Connection: Upgrade\r\n"
+                                "Sec-WebSocket-Accept: invalid\r\n"
+                                "\r\n"
+                            ).encode("ascii")
+                        )
+
+            thread = threading.Thread(target=server)
+            thread.start()
+            ready.wait(2)
+            with self.assertRaises(issue_pairing_code.PairingError):
+                with issue_pairing_code.WsUnixClient(socket_path, 2):
+                    pass
+            thread.join(2)
+
+    def test_redaction_removes_codes_and_secret_fields(self) -> None:
+        raw = (
+            '{"manualPairingCode":"MH67-9LKZ","pairingCode":"secret",'
+            '"environmentId":"env-123","other":"ABCD-1234"}'
+        )
+        redacted = issue_pairing_code.redact_pairing_payload(raw)
+        self.assertNotIn("MH67-9LKZ", redacted)
+        self.assertNotIn("secret", redacted)
+        self.assertNotIn("env-123", redacted)
+        self.assertNotIn("ABCD-1234", redacted)
+
+    def test_runtime_dir_is_private_and_marked(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = Path(tmp) / "runtime"
+            with mock.patch.dict(os.environ, {"CODEX_PAIRING_RUNTIME_DIR": str(runtime)}):
+                paths = issue_pairing_code.make_private_runtime_paths("codex-pair-bg")
+            self.assertEqual(paths.root, runtime)
+            self.assertEqual(
+                paths.marker_path.read_text(encoding="utf-8"),
+                issue_pairing_code.HELPER_MARKER,
+            )
+            self.assertEqual(paths.root.stat().st_mode & 0o077, 0)
+
+    def test_rpc_sequence_extracts_manual_code_and_expiry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = Path(tmp) / "app.sock"
+            seen_methods: list[str] = []
+            ready = threading.Event()
+
+            def server() -> None:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
+                    srv.bind(str(socket_path))
+                    srv.listen(1)
+                    ready.set()
+                    conn, _ = srv.accept()
+                    with conn:
+                        request = b""
+                        while b"\r\n\r\n" not in request:
+                            request += conn.recv(4096)
+                        key = _header_value(request.decode("ascii"), "Sec-WebSocket-Key")
+                        accept = issue_pairing_code._websocket_accept_value(key)
+                        conn.sendall(
+                            (
+                                "HTTP/1.1 101 Switching Protocols\r\n"
+                                "Upgrade: websocket\r\n"
+                                "Connection: Upgrade\r\n"
+                                f"Sec-WebSocket-Accept: {accept}\r\n"
+                                "\r\n"
+                            ).encode("ascii")
+                        )
+                        while True:
+                            opcode, payload = issue_pairing_code._read_ws_frame(conn)
+                            if opcode == 0x8:
+                                break
+                            message = json.loads(payload.decode("utf-8"))
+                            seen_methods.append(message["method"])
+                            if "id" not in message:
+                                continue
+                            if message["method"] == "remoteControl/pairing/start":
+                                result = {
+                                    "manualPairingCode": "MOCK-0000",
+                                    "pairingCode": "raw-secret",
+                                    "environmentId": "env-secret",
+                                    "expiresAt": 1893456000,
+                                }
+                            else:
+                                result = {}
+                            response = json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result})
+                            conn.sendall(
+                                issue_pairing_code._encode_ws_frame(
+                                    response.encode("utf-8"), mask=False
+                                )
+                            )
+
+            thread = threading.Thread(target=server)
+            thread.start()
+            ready.wait(2)
+            result = issue_pairing_code.issue_pairing_code(
+                socket_path, 2, "tmux kill-session -t codex-pair-bg"
+            )
+            thread.join(2)
+
+        self.assertEqual(result.manual_pairing_code, "MOCK-0000")
+        self.assertEqual(result.expires_at, 1893456000)
+        self.assertEqual(
+            seen_methods,
+            [
+                "initialize",
+                "initialized",
+                "remoteControl/enable",
+                "remoteControl/pairing/start",
+            ],
+        )
+
+    def test_binary_selection_honors_env_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "codex"
+            binary.write_text("#!/bin/sh\n", encoding="utf-8")
+            binary.chmod(0o700)
+            with mock.patch.dict(os.environ, {"CODEX_PAIRING_CODEX_BIN": str(binary)}):
+                self.assertEqual(issue_pairing_code.select_codex_binary(), binary)
+
+
+def _header_value(request: str, name: str) -> str:
+    needle = name.lower() + ":"
+    for line in request.split("\r\n"):
+        if line.lower().startswith(needle):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"missing header: {name}")
+
+
+def _run_main_silent(argv: list[str]) -> int:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        return issue_pairing_code.main(argv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -136,12 +136,17 @@ class PairingCodeHelperTests(unittest.TestCase):
     def test_redaction_removes_codes_and_secret_fields(self) -> None:
         raw = (
             '{"manualPairingCode":"MH67-9LKZ","pairingCode":"secret",'
-            '"environmentId":"env-123","other":"ABCD-1234"}'
+            '"environmentId":"env-123","pairingToken":"tok-secret",'
+            '"authToken":"auth-secret","accessToken":"access-secret",'
+            '"CODEX_API_KEY":"sk-abcdefghijklmnopqrstuvwxyz",'
+            '"Authorization":"Bearer very-secret-token","other":"ABCD-1234"}'
         )
         redacted = issue_pairing_code.redact_pairing_payload(raw)
         self.assertNotIn("MH67-9LKZ", redacted)
         self.assertNotIn("secret", redacted)
         self.assertNotIn("env-123", redacted)
+        self.assertNotIn("sk-abcdefghijklmnopqrstuvwxyz", redacted)
+        self.assertNotIn("very-secret-token", redacted)
         self.assertNotIn("ABCD-1234", redacted)
 
     def test_runtime_dir_is_private(self) -> None:
@@ -236,9 +241,65 @@ class PairingCodeHelperTests(unittest.TestCase):
         with self.assertRaises(issue_pairing_code.PairingError):
             rpc.request("remoteControl/pairing/start", {"manualCode": True})
 
+    def test_json_rpc_error_is_redacted(self) -> None:
+        response = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {
+                    "message": "failed",
+                    "manualPairingCode": "MH67-9LKZ",
+                    "pairingToken": "tok-secret",
+                    "Authorization": "Bearer very-secret-token",
+                },
+            }
+        )
+        rpc = issue_pairing_code.JsonRpcClient(_FakeWs([response]))
+        with self.assertRaises(issue_pairing_code.PairingError) as caught:
+            rpc.request("remoteControl/pairing/start", {"manualCode": True})
+        message = str(caught.exception)
+        self.assertNotIn("MH67-9LKZ", message)
+        self.assertNotIn("tok-secret", message)
+        self.assertNotIn("very-secret-token", message)
+        self.assertIn("[REDACTED]", message)
+
+    def test_json_rpc_ignores_mismatched_id_before_success(self) -> None:
+        rpc = issue_pairing_code.JsonRpcClient(
+            _FakeWs(
+                [
+                    json.dumps({"jsonrpc": "2.0", "id": 999, "result": {"ignored": True}}),
+                    json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}),
+                ]
+            )
+        )
+        self.assertEqual(rpc.request("initialize"), {"ok": True})
+
     def test_format_expiry_rejects_malformed_string(self) -> None:
         with self.assertRaises(issue_pairing_code.PairingError):
             issue_pairing_code.format_expiry_kst("not-a-date")
+
+    def test_format_expiry_kst_supported_inputs(self) -> None:
+        cases = [
+            (1893456000, "2030-01-01 09:00:00 KST"),
+            (1893456000000, "2030-01-01 09:00:00 KST"),
+            ("1893456000", "2030-01-01 09:00:00 KST"),
+            ("2030-01-01T00:00:00Z", "2030-01-01 09:00:00 KST"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(issue_pairing_code.format_expiry_kst(value), expected)
+
+    def test_format_expiry_rejects_unsupported_and_out_of_range_values(self) -> None:
+        with self.assertRaises(issue_pairing_code.PairingError):
+            issue_pairing_code.format_expiry_kst([])
+        with self.assertRaises(issue_pairing_code.PairingError):
+            issue_pairing_code.format_expiry_kst(float("inf"))
+
+    def test_mock_json_includes_expected_expiry_kst(self) -> None:
+        rc, stdout, _stderr = _run_main_capture(["--mock", "--json"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["expiresAtKst"], "2030-01-01 09:00:00 KST")
 
     def test_rpc_sequence_extracts_manual_code_and_expiry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -334,7 +395,7 @@ class PairingCodeHelperTests(unittest.TestCase):
         with mock.patch.object(
             issue_pairing_code.subprocess, "run", side_effect=generate_schema
         ):
-            issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"))
+            issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
 
     def test_protocol_check_rejects_missing_manual_code_schema(self) -> None:
         def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
@@ -351,7 +412,16 @@ class PairingCodeHelperTests(unittest.TestCase):
             issue_pairing_code.subprocess, "run", side_effect=generate_schema
         ):
             with self.assertRaisesRegex(issue_pairing_code.PairingError, "manualPairingCode"):
-                issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"))
+                issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
+
+    def test_protocol_check_timeout_is_pairing_error(self) -> None:
+        with mock.patch.object(
+            issue_pairing_code.subprocess,
+            "run",
+            side_effect=issue_pairing_code.subprocess.TimeoutExpired("codex", 1),
+        ):
+            with self.assertRaisesRegex(issue_pairing_code.PairingError, "timed out"):
+                issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"), 1)
 
     def test_protocol_check_failure_prevents_runtime_creation(self) -> None:
         with mock.patch.object(issue_pairing_code.platform, "system", return_value="Darwin"):

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -203,18 +203,19 @@ class PairingCodeHelperTests(unittest.TestCase):
                 with mock.patch.object(
                     issue_pairing_code, "select_codex_binary", return_value=Path("/bin/codex")
                 ):
-                    with mock.patch.object(
-                        issue_pairing_code, "make_private_runtime_paths", return_value=paths
-                    ):
-                        with mock.patch.object(issue_pairing_code, "ensure_helper_app_server"):
-                            with mock.patch.object(
-                                issue_pairing_code,
-                                "issue_pairing_code",
-                                side_effect=issue_pairing_code.PairingError("rpc failed"),
-                            ):
-                                rc, stdout, stderr = _run_main_capture(
-                                    ["--user-requested-code"]
-                                )
+                    with mock.patch.object(issue_pairing_code, "ensure_pairing_start_returns_manual_code"):
+                        with mock.patch.object(
+                            issue_pairing_code, "make_private_runtime_paths", return_value=paths
+                        ):
+                            with mock.patch.object(issue_pairing_code, "ensure_helper_app_server"):
+                                with mock.patch.object(
+                                    issue_pairing_code,
+                                    "issue_pairing_code",
+                                    side_effect=issue_pairing_code.PairingError("rpc failed"),
+                                ):
+                                    rc, stdout, stderr = _run_main_capture(
+                                        ["--user-requested-code"]
+                                    )
         self.assertEqual(rc, 1)
         self.assertEqual(stdout, "")
         self.assertIn("error: rpc failed", stderr)
@@ -318,6 +319,58 @@ class PairingCodeHelperTests(unittest.TestCase):
             binary.chmod(0o700)
             with mock.patch.dict(os.environ, {"CODEX_PAIRING_CODEX_BIN": str(binary)}):
                 self.assertEqual(issue_pairing_code.select_codex_binary(), binary)
+
+    def test_protocol_check_accepts_manual_code_schema(self) -> None:
+        def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
+            out_dir = Path(args[args.index("--out") + 1])
+            schema_dir = out_dir / "v2"
+            schema_dir.mkdir(parents=True)
+            (schema_dir / "RemoteControlPairingStartResponse.ts").write_text(
+                "export type RemoteControlPairingStartResponse = "
+                "{ manualPairingCode: string; expiresAt: number };\n",
+                encoding="utf-8",
+            )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            issue_pairing_code.subprocess, "run", side_effect=generate_schema
+        ):
+            issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"))
+
+    def test_protocol_check_rejects_missing_manual_code_schema(self) -> None:
+        def generate_schema(args: list[str], **_kwargs: object) -> mock.Mock:
+            out_dir = Path(args[args.index("--out") + 1])
+            schema_dir = out_dir / "v2"
+            schema_dir.mkdir(parents=True)
+            (schema_dir / "RemoteControlPairingStartResponse.ts").write_text(
+                "export type RemoteControlPairingStartResponse = { expiresAt: number };\n",
+                encoding="utf-8",
+            )
+            return mock.Mock(returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(
+            issue_pairing_code.subprocess, "run", side_effect=generate_schema
+        ):
+            with self.assertRaisesRegex(issue_pairing_code.PairingError, "manualPairingCode"):
+                issue_pairing_code.ensure_pairing_start_returns_manual_code(Path("/bin/codex"))
+
+    def test_protocol_check_failure_prevents_runtime_creation(self) -> None:
+        with mock.patch.object(issue_pairing_code.platform, "system", return_value="Darwin"):
+            with mock.patch.object(
+                issue_pairing_code, "select_codex_binary", return_value=Path("/bin/codex")
+            ):
+                with mock.patch.object(
+                    issue_pairing_code,
+                    "ensure_pairing_start_returns_manual_code",
+                    side_effect=issue_pairing_code.PairingError("protocol drift"),
+                ):
+                    with mock.patch.object(issue_pairing_code, "make_private_runtime_paths") as paths:
+                        rc, stdout, stderr = _run_main_capture(["--user-requested-code"])
+        self.assertEqual(rc, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("error: protocol drift", stderr)
+        self.assertNotIn("Cleanup:", stderr)
+        paths.assert_not_called()
 
 
 def _header_value(request: str, name: str) -> str:

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -12,6 +12,7 @@ import socket
 import sys
 import tempfile
 import threading
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -134,6 +135,46 @@ class PairingCodeHelperTests(unittest.TestCase):
                     pass
             thread.join(2)
             self.assertFalse(thread.is_alive(), "server thread did not exit")
+
+    def test_handshake_enforces_overall_deadline(self) -> None:
+        # 서버가 per-recv timeout보다 짧은 간격으로 바이트를 흘리는 drip-feed:
+        # recv마다 윈도우가 리셋되면 handshake가 --timeout을 무한히 초과한다.
+        with tempfile.TemporaryDirectory() as tmp:
+            socket_path = Path(tmp) / "app.sock"
+            ready = threading.Event()
+            stop = threading.Event()
+
+            def server() -> None:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as srv:
+                    srv.bind(str(socket_path))
+                    srv.listen(1)
+                    ready.set()
+                    conn, _ = srv.accept()
+                    with conn:
+                        request = b""
+                        while b"\r\n\r\n" not in request:
+                            request += conn.recv(4096)
+                        while not stop.is_set():
+                            try:
+                                conn.sendall(b"H")
+                            except OSError:
+                                break
+                            stop.wait(0.1)
+
+            thread = threading.Thread(target=server)
+            thread.start()
+            self.assertTrue(ready.wait(2), "server did not start in time")
+            started = time.monotonic()
+            try:
+                with self.assertRaises(issue_pairing_code.PairingError):
+                    with issue_pairing_code.WsUnixClient(socket_path, 0.5):
+                        pass
+                elapsed = time.monotonic() - started
+            finally:
+                stop.set()
+            thread.join(2)
+            self.assertFalse(thread.is_alive(), "server thread did not exit")
+        self.assertLess(elapsed, 5, "handshake was not bounded by a shared deadline")
 
     def test_redaction_removes_codes_and_secret_fields(self) -> None:
         raw = (

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -147,15 +147,53 @@ class PairingCodeHelperTests(unittest.TestCase):
 
     def test_runtime_dir_is_private_and_marked(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            runtime = Path(tmp) / "runtime"
-            with mock.patch.dict(os.environ, {"CODEX_PAIRING_RUNTIME_DIR": str(runtime)}):
-                paths = issue_pairing_code.make_private_runtime_paths("codex-pair-bg")
-            self.assertEqual(paths.root, runtime)
+            runtime_parent = Path(tmp) / "runtime-parent"
+            with mock.patch.dict(os.environ, {"CODEX_PAIRING_RUNTIME_DIR": str(runtime_parent)}):
+                paths = issue_pairing_code.make_private_runtime_paths()
+            self.assertEqual(paths.root.parent, runtime_parent)
+            self.assertTrue(paths.session_name.startswith("codex-pair-bg-"))
+            self.assertTrue(paths.root.name.startswith("codex-pairing-code-"))
             self.assertEqual(
                 paths.marker_path.read_text(encoding="utf-8"),
                 issue_pairing_code.HELPER_MARKER,
             )
             self.assertEqual(paths.root.stat().st_mode & 0o077, 0)
+
+    def test_existing_tmux_session_fails_closed_before_socket_wait(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = issue_pairing_code.RuntimePaths(
+                root=Path(tmp),
+                socket_path=Path(tmp) / "app.sock",
+                log_path=Path(tmp) / "app-server.log",
+                marker_path=Path(tmp) / ".owner",
+                session_name="codex-pair-bg-existing",
+            )
+            with mock.patch.object(issue_pairing_code.shutil, "which", return_value="/usr/bin/tmux"):
+                with mock.patch.object(issue_pairing_code, "_tmux_has_session", return_value=True):
+                    with mock.patch.object(issue_pairing_code, "_wait_for_socket") as wait:
+                        with self.assertRaises(issue_pairing_code.PairingError):
+                            issue_pairing_code.ensure_helper_app_server(Path("/bin/codex"), paths, 1)
+        wait.assert_not_called()
+
+    def test_mock_result_is_deterministic(self) -> None:
+        first = issue_pairing_code.build_mock_result()
+        second = issue_pairing_code.build_mock_result()
+        self.assertEqual(first, second)
+        self.assertEqual(first.expires_at, issue_pairing_code.MOCK_EXPIRES_AT)
+
+    def test_json_rpc_rejects_malformed_json(self) -> None:
+        rpc = issue_pairing_code.JsonRpcClient(_FakeWs(["not-json"]))
+        with self.assertRaises(issue_pairing_code.PairingError):
+            rpc.request("remoteControl/pairing/start", {"manualCode": True})
+
+    def test_json_rpc_rejects_non_object_response(self) -> None:
+        rpc = issue_pairing_code.JsonRpcClient(_FakeWs(["[]"]))
+        with self.assertRaises(issue_pairing_code.PairingError):
+            rpc.request("remoteControl/pairing/start", {"manualCode": True})
+
+    def test_format_expiry_rejects_malformed_string(self) -> None:
+        with self.assertRaises(issue_pairing_code.PairingError):
+            issue_pairing_code.format_expiry_kst("not-a-date")
 
     def test_rpc_sequence_extracts_manual_code_and_expiry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -250,6 +288,19 @@ def _run_main_silent(argv: list[str]) -> int:
     stderr = io.StringIO()
     with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
         return issue_pairing_code.main(argv)
+
+
+class _FakeWs:
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = responses
+
+    def send_text(self, _text: str) -> None:
+        pass
+
+    def receive_text(self) -> str:
+        if not self.responses:
+            raise issue_pairing_code.PairingError("no fake response left")
+        return self.responses.pop(0)
 
 
 if __name__ == "__main__":

--- a/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
+++ b/modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py
@@ -145,7 +145,7 @@ class PairingCodeHelperTests(unittest.TestCase):
         self.assertNotIn("env-123", redacted)
         self.assertNotIn("ABCD-1234", redacted)
 
-    def test_runtime_dir_is_private_and_marked(self) -> None:
+    def test_runtime_dir_is_private(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             runtime_parent = Path(tmp) / "runtime-parent"
             with mock.patch.dict(os.environ, {"CODEX_PAIRING_RUNTIME_DIR": str(runtime_parent)}):
@@ -153,10 +153,6 @@ class PairingCodeHelperTests(unittest.TestCase):
             self.assertEqual(paths.root.parent, runtime_parent)
             self.assertTrue(paths.session_name.startswith("codex-pair-bg-"))
             self.assertTrue(paths.root.name.startswith("codex-pairing-code-"))
-            self.assertEqual(
-                paths.marker_path.read_text(encoding="utf-8"),
-                issue_pairing_code.HELPER_MARKER,
-            )
             self.assertEqual(paths.root.stat().st_mode & 0o077, 0)
 
     def test_existing_tmux_session_fails_closed_before_socket_wait(self) -> None:
@@ -165,7 +161,6 @@ class PairingCodeHelperTests(unittest.TestCase):
                 root=Path(tmp),
                 socket_path=Path(tmp) / "app.sock",
                 log_path=Path(tmp) / "app-server.log",
-                marker_path=Path(tmp) / ".owner",
                 session_name="codex-pair-bg-existing",
             )
             with mock.patch.object(issue_pairing_code.shutil, "which", return_value="/usr/bin/tmux"):
@@ -174,6 +169,56 @@ class PairingCodeHelperTests(unittest.TestCase):
                         with self.assertRaises(issue_pairing_code.PairingError):
                             issue_pairing_code.ensure_helper_app_server(Path("/bin/codex"), paths, 1)
         wait.assert_not_called()
+
+    def test_app_server_command_does_not_enable_analytics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = issue_pairing_code.RuntimePaths(
+                root=Path(tmp),
+                socket_path=Path(tmp) / "app.sock",
+                log_path=Path(tmp) / "app-server.log",
+                session_name="codex-pair-bg-command",
+            )
+            completed = mock.Mock(returncode=0, stderr="")
+            with mock.patch.object(issue_pairing_code.shutil, "which", return_value="/usr/bin/tmux"):
+                with mock.patch.object(issue_pairing_code, "_tmux_has_session", return_value=False):
+                    with mock.patch.object(issue_pairing_code, "_wait_for_socket"):
+                        with mock.patch.object(
+                            issue_pairing_code.subprocess, "run", return_value=completed
+                        ) as run:
+                            issue_pairing_code.ensure_helper_app_server(
+                                Path("/bin/codex"), paths, 1
+                            )
+            command = run.call_args.args[0][-1]
+        self.assertNotIn("--analytics-default-enabled", command)
+
+    def test_live_failure_after_runtime_creation_prints_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = issue_pairing_code.RuntimePaths(
+                root=Path(tmp),
+                socket_path=Path(tmp) / "app.sock",
+                log_path=Path(tmp) / "app-server.log",
+                session_name="codex-pair-bg-failure",
+            )
+            with mock.patch.object(issue_pairing_code.platform, "system", return_value="Darwin"):
+                with mock.patch.object(
+                    issue_pairing_code, "select_codex_binary", return_value=Path("/bin/codex")
+                ):
+                    with mock.patch.object(
+                        issue_pairing_code, "make_private_runtime_paths", return_value=paths
+                    ):
+                        with mock.patch.object(issue_pairing_code, "ensure_helper_app_server"):
+                            with mock.patch.object(
+                                issue_pairing_code,
+                                "issue_pairing_code",
+                                side_effect=issue_pairing_code.PairingError("rpc failed"),
+                            ):
+                                rc, stdout, stderr = _run_main_capture(
+                                    ["--user-requested-code"]
+                                )
+        self.assertEqual(rc, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("error: rpc failed", stderr)
+        self.assertIn("Cleanup: tmux kill-session -t codex-pair-bg-failure; rm -rf ", stderr)
 
     def test_mock_result_is_deterministic(self) -> None:
         first = issue_pairing_code.build_mock_result()
@@ -284,10 +329,15 @@ def _header_value(request: str, name: str) -> str:
 
 
 def _run_main_silent(argv: list[str]) -> int:
+    return _run_main_capture(argv)[0]
+
+
+def _run_main_capture(argv: list[str]) -> tuple[int, str, str]:
     stdout = io.StringIO()
     stderr = io.StringIO()
     with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-        return issue_pairing_code.main(argv)
+        rc = issue_pairing_code.main(argv)
+    return rc, stdout.getvalue(), stderr.getvalue()
 
 
 class _FakeWs:

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -43,6 +43,7 @@ let
     "analyzing-da-sessions"
     "create-issue"
     "create-pr"
+    "issuing-codex-pairing-code"
     "parallel-audit"
     "playwright-cli"
     "review-pr-feedback"

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -21,6 +21,7 @@ EXPECTED_EXPOSED=(
   analyzing-da-sessions
   create-issue
   create-pr
+  issuing-codex-pairing-code
   parallel-audit
   playwright-cli
   review-pr-feedback


### PR DESCRIPTION
## Summary
- Add a global/user-scope `issuing-codex-pairing-code` skill for both Claude and Codex.
- Implement a stdlib-only helper that issues a Codex remote-control pairing code only after explicit user request and strict preflight gates.
- Opt into the Codex experimental API surface (`generate-ts --experimental` preflight + `capabilities.experimentalApi: true` at initialize) so live issuance actually works on builds that ship the pairing API.
- Expose the skill through the existing shared skill projection and verifier paths.

## 기존 문제/배경

Codex Desktop remote-control pairing previously required an ad-hoc workaround because UI automation cannot inspect/control Codex.app directly. That flow was useful, but it was not reusable as a global Agent Skill and had several sharp edges:

- The code issuance flow needed a repeatable, tool-neutral entrypoint for both Claude Code and Codex.
- The helper must not rely on miniPC SSH, browser automation, Computer Use, ambient app-server sockets, or persistent daemons.
- Pairing codes and related tokens are sensitive, so raw payloads must not be persisted in progress notes, PR text, or logs.
- Current local Codex app-server protocol surfaces can drift; unsupported protocol shapes should fail before starting app-server or enabling remote control.

## CIR (Change Intent Record)

- **Initial approach** (이번 변경): convert the verified temporary app-server pairing workflow into a global user-scope skill.
- **Safety hardening** (이번 변경): make live issuance Darwin-only, require an explicit `--user-requested-code` flag, create a unique helper-owned runtime/tmux session, avoid ambient socket reuse, and print cleanup instructions on live failures after runtime allocation.
- **Protocol compatibility decision** (이번 변경): add a generated-protocol preflight before runtime/tmux/RPC work. If the local Codex app-server protocol does not expose a manual pairing-code response field, the helper fails closed before app-server starts.
- **Experimental API opt-in fix** (이번 변경, 리뷰 실측 반영): `remoteControl/pairing/*` is an experimental Codex API. The initial preflight ran `generate-ts` without `--experimental` (the pairing types are filtered from the stable-only default output) and initialize declared `experimentalApi: false` (the server rejects the pairing RPC with `-32600 requires experimentalApi capability`), so live issuance was double-blocked on every Codex version — including 0.142.5, which actually ships the API. Fixed by generating the experimental surface in preflight and opting into `experimentalApi` at initialize; preflight needles were shrunk to the pairing contract itself because the removed ts-rs format-coupled checks could only produce false fail-closed results.
- **Secret handling decision** (이번 변경): redact pairing codes, token/key/secret fields, Bearer tokens, and OpenAI-style API keys from error paths.

**trade-off**: the helper is intentionally conservative. The pairing API is experimental with no backwards-compatibility guarantees, so the preflight verifies the experimental generated protocol before any live side effect; if a future Codex build drops or renames the pairing surface, the helper fails closed before app-server starts instead of failing late on an undocumented response shape.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Computer Use/browser UI automation | Click through Codex Desktop settings UI | Mirrors what a person sees | Codex.app UI is blocked; brittle and not headless-friendly | ❌ |
| Reuse ambient app-server socket | Discover and use any existing local Codex socket | Fewer processes | Can attach to the wrong app-server and mixes ownership/cleanup boundaries | ❌ |
| Persistent daemon/scheduler | Install a long-lived service for pairing issuance | Could be convenient after setup | More state, more cleanup, higher blast radius | ❌ |
| Helper-owned temporary app-server | Start a unique tmux session and private runtime directory for one issuance | Clear ownership, cleanup command, no ambient reuse | Requires tmux and protocol compatibility | ✅ |
| Stable-only protocol preflight | Verify `generate-ts` default output before live work | No experimental dependency | Pairing API is experimental-only, so this blocks live issuance on every version including supported ones | ❌ |
| Experimental-surface preflight + runtime opt-in | Verify `generate-ts --experimental` output and declare `experimentalApi: true` | Matches the documented pairing contract; fail closed still guards drift | Depends on an experimental API with no compatibility guarantees | ✅ |
| Fail open on undocumented pairing response | Attempt live RPC even if generated protocol does not expose the manual code field | Might work on some builds | Can start remote-control state and fail late; hard to reason about drift | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/SKILL.md` | 추가 | trigger, procedure, guardrails, validation command 정의 |
| `modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/agents/openai.yaml` | 추가 | Codex skill UI metadata |
| `modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py` | 추가 | stdlib-only pairing helper, WebSocket JSON-RPC client, fail-closed experimental-surface preflight, redaction, cleanup output |
| `modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests/test_issue_pairing_code.py` | 추가 | consent/platform/preflight/WebSocket/redaction/expiry/mock/cleanup tests |
| `modules/shared/programs/claude/default.nix` | 수정 | Claude user-scope skill symlink exposure |
| `modules/shared/programs/codex/default.nix` | 수정 | Codex global exposed skill list에 추가 |
| `scripts/ai/verify-ai-compat.sh` | 수정 | shared global skill expected exposure list 갱신 |

### 핵심 코드

```python
ensure_consent(args)
ensure_live_platform_allowed(args.mock)
codex_binary = select_codex_binary()
ensure_pairing_start_returns_manual_code(codex_binary, args.timeout)  # generate-ts --experimental
paths = make_private_runtime_paths()
```

This ordering keeps unsupported platforms and unsupported app-server protocol shapes from reaching socket discovery, tmux startup, or remote-control RPC calls.

## 참고 레퍼런스

- upstream 계약: `codex-rs/app-server/README.md`의 "Experimental API Opt-in" 및 `remoteControl/pairing/start` 섹션 (rust-v0.142.5) — pairing RPC는 `capabilities.experimentalApi` opt-in 필수, `generate-ts`는 기본 stable-only 필터.

## Human Test Plan

### 자동 검증

1. `python3 -m unittest discover modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/tests`
   - **기대**: 30 tests pass.
   - **실패 시**: failing test name으로 consent/platform/protocol/redaction/expiry boundary를 먼저 확인한다.

2. `python3 modules/shared/programs/claude/files/skills/issuing-codex-pairing-code/scripts/issue_pairing_code.py --mock --json`
   - **기대**: deterministic mock JSON with `manualPairingCode`, `expiresAt`, `expiresAtKst`, and `cleanup`.
   - **실패 시**: `build_mock_result()`와 `format_expiry_kst()`를 확인한다.

3. `nix shell --impure --expr 'with import <nixpkgs> {}; python3.withPackages (ps: [ ps.pyyaml ])' --command python3 "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" modules/shared/programs/claude/files/skills/issuing-codex-pairing-code`
   - **기대**: `Skill is valid!`.
   - **실패 시**: `SKILL.md` frontmatter와 `agents/openai.yaml` schema를 확인한다.

4. `./scripts/ai/verify-ai-compat.sh`
   - **기대**: verification complete, including `issuing-codex-pairing-code` exposure for shared global skills.
   - **실패 시**: Claude symlink exposure, Codex `exposedCodexSkills`, and verifier expected list를 비교한다.

### 수동/라이브 검증

5. macOS host에서 skill helper를 live mode로 실행한다.
   - **기대**: `Code`, `Expires`, `Cleanup`이 출력된다. codex 0.142.5 (Codex.app 내장 바이너리)에서 실 발급 성공을 확인했다 (코드 값은 비저장, 검증 직후 Cleanup 라인 실행으로 tmux 세션/런타임 디렉토리 제거 확인).
   - **미래 버전에서 실패 시**: helper가 app-server 시작 전에 protocol error로 fail closed하는지, `codex app-server generate-ts --experimental`이 `RemoteControlPairingStartResponse`에 `manualPairingCode`를 노출하는지 확인한다.

6. Negative checks.
   - **기대**: docs/PR/progress artifacts에 raw pairing code/token 없음.
   - **기대**: helper command에 `--analytics-default-enabled` 없음.
   - **기대**: Linux/NixOS live mode는 binary lookup, socket, tmux, RPC 전에 실패한다.
   - **기대**: `experimentalApi: false`로는 pairing RPC가 `-32600`으로 거부된다 (0.142.5 실측) — helper는 `true`를 선언한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Claude/Codex skill, **issuing-codex-pairing-code**, to generate a Codex remote-control pairing code when explicitly requested.
  * Included skill documentation and a CLI-driven pairing-code flow with macOS-only live issuance plus a deterministic `--mock` mode.
  * Updated Codex skill exposure to include the new skill.
* **Tests**
  * Added unit test coverage for consent/platform gating, protocol/WebSocket handling, payload redaction, expiry formatting, and cleanup/failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->