### PR TITLE
feat(darwin): manage Spotlight option-space fallback

### DIFF
--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -228,10 +228,10 @@ Staleness 방지: `rebuild-common.sh`의 `@flakePath@`는 `nixosConfigDefaultPat
 
 Spotlight 설정:
 
-| ID  | 단축키  | 기능               | 상태                    |
-| --- | ------- | ------------------ | ----------------------- |
-| 64  | ⌘Space  | Spotlight 검색     | 비활성화 (Raycast 사용) |
-| 65  | ⌥⌘Space | Finder 검색 윈도우 | 활성화                  |
+| ID  | 단축키  | 기능               | 상태                             |
+| --- | ------- | ------------------ | -------------------------------- |
+| 64  | ⌥Space  | Spotlight 검색     | 활성화 (Raycast 장애 시 fallback) |
+| 65  | ⌥⌘Space | Finder 검색 윈도우 | 활성화                           |
 
 Mission Control 설정:
 

--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -239,7 +239,7 @@ in
     #   184: 스크린샷 도구모음
     #
     # parameters: [ ASCII/keyCode, virtualKeyCode, modifierFlags ]
-    #   modifierFlags: Shift+Cmd=1179648, Ctrl+Shift+Cmd=1441792, Fn=8388608, Opt+Cmd=1572864
+    #   modifierFlags: Shift+Cmd=1179648, Ctrl+Shift+Cmd=1441792, Opt=524288, Fn=8388608, Opt+Cmd=1572864
 
     # --- 스크린샷 (Shottr 연동) ---
     # Shottr 호환: disabled 항목에 반드시 value 블록을 포함해야 macOS WindowServer가
@@ -323,10 +323,17 @@ in
         }
       }'
 
-    # --- Spotlight (Raycast 사용으로 비활성화) ---
-    # 64: Spotlight 검색 (⌘Space) — 비활성화
+    # --- Spotlight ---
+    # 64: Spotlight 검색 (⌥Space) — 활성화 (Raycast 장애 시 fallback)
     ${asUser} defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add \
-      "64" '${mkDisabledNoValue}'
+      "64" '${
+        mkHotkey {
+          enabled = true;
+          ascii = 32;
+          keyCode = 49;
+          modifiers = 524288;
+        }
+      }'
     # 65: Finder 검색 윈도우 (⌥⌘Space) — 활성화
     ${asUser} defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add \
       "65" '${


### PR DESCRIPTION
## Summary
- Raycast 장애 시 사용할 Spotlight fallback 단축키를 Option+Space로 선언 관리합니다.
- 기존 AppleSymbolicHotKeys 개별 갱신 방식은 유지해 Shottr/입력소스/Spotlight 인접 단축키 회귀를 피합니다.

## 기존 문제/배경

현재 macOS 시스템 단축키는 nix-darwin의 `postActivation`에서 선언적으로 관리되지만, Spotlight 검색 보기(ID 64)는 Raycast 사용을 전제로 비활성화되어 있었습니다.

문제는 Raycast가 hang/crash 등으로 일시적으로 사용할 수 없을 때입니다. 사용자가 이미 macOS 설정에서 Spotlight 검색 보기를 Option+Space로 맞춰두더라도, 다음 `nrs` 적용 시 Nix 선언이 다시 비활성 상태로 덮어쓸 수 있습니다.

## CIR (Change Intent Record)

- **v1**: Spotlight 검색 보기(ID 64)는 Raycast 사용을 전제로 비활성화하고, Finder 검색 윈도우(ID 65)만 Option+Command+Space로 유지했습니다.
- **v2**: 사용자가 Raycast 장애 시 Spotlight를 임시 fallback으로 쓰기 위해 ID 64를 Option+Space로 수동 설정했습니다.
- **v3** (이번 변경): 수동 설정과 Nix 선언의 drift를 없애기 위해 ID 64를 Option+Space로 활성화하되, 기존 AppleSymbolicHotKeys `-dict-add` 방식과 `value` block 직렬화는 그대로 유지합니다.

**trade-off**: Option+Space는 전역 시스템 단축키가 되므로 앱 내부에서 같은 조합을 텍스트 입력/Meta-space 용도로 쓰는 경우 Spotlight가 우선합니다. 현재 repo의 Hammerspoon, Shottr, Homerow, Ghostty, keybindings 설정에는 같은 조합 충돌이 없고, 사용자가 이미 같은 조합을 의도적으로 쓰고 있으므로 선언 관리 대상으로 고정합니다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Spotlight ID 64 계속 비활성화 | Raycast를 유일 런처로 보고 기존 상태 유지 | 시스템 단축키 추가 점유 없음 | Raycast 장애 시 수동 fallback 설정이 `nrs`로 되돌아감 | ❌ |
| ID 64를 Command+Space로 복원 | macOS 기본 Spotlight 단축키 사용 | 기본값과 익숙함 | Raycast 주 단축키와 충돌 가능성이 높음 | ❌ |
| ID 64를 Option+Space로 선언 | Raycast와 분리된 Spotlight emergency fallback 확보 | 사용자의 현재 수동 설정과 일치, 인접 단축키 충돌 없음 | Option+Space를 전역 단축키로 점유 | ✅ |
| `CustomUserPreferences."com.apple.symbolichotkeys"` 사용 | Nix defaults 선언으로 옮김 | 표면상 선언이 단순함 | AppleSymbolicHotKeys dict 전체 replace와 disabled/value 직렬화 회귀 위험 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/configuration.nix` | 수정 | Spotlight ID 64를 Option+Space로 활성화하고 modifierFlags 주석에 Option 값을 추가 |
| `.claude/skills/managing-macos/references/features.md` | 수정 | Spotlight symbolic hotkey 표를 Option+Space fallback 상태로 갱신 |

### 핵심 코드

```nix
# BEFORE: ID 64 Spotlight 검색 비활성화
"64" '${mkDisabledNoValue}'

# AFTER: ID 64 Spotlight 검색을 Option+Space로 활성화
"64" '${
  mkHotkey {
    enabled = true;
    ascii = 32;
    keyCode = 49;
    modifiers = 524288;
  }
}'
```

## 참고 레퍼런스

- PR #98 — Shottr 글로벌 핫키 미작동을 계기로 symbolic hotkeys를 dict 전체 replace가 아닌 개별 `-dict-add` 방식으로 개선한 기존 결정.

## Human Test Plan

1. `nrs`를 실행한다.
   - **기대**: activation이 성공하고 Spotlight 검색 보기 단축키가 Option+Space로 유지된다.
   - **실패 시**: `defaults read com.apple.symbolichotkeys AppleSymbolicHotKeys | grep -A 8 '"64"'`로 ID 64의 enabled/value를 확인한다.

2. macOS 시스템 설정 → 키보드 → 키보드 단축키 → Spotlight를 연다.
   - **기대**: “Spotlight 검색 보기”가 켜져 있고 단축키가 Option+Space로 표시된다.
   - **실패 시**: `activateSettings -u` 경로와 `cfprefsd` 재읽기 여부를 확인한다.

3. Option+Space를 누른다.
   - **기대**: Spotlight 검색 UI가 열린다.
   - **실패 시**: Raycast/Hammerspoon 등 다른 앱이 Option+Space를 선점했는지 확인한다.

4. 인접 단축키를 회귀 확인한다.
   - **기대**: Finder 검색 윈도우는 Option+Command+Space로 계속 열리고, Shottr의 Shift+Command+3 단축키와 Caps Lock 입력소스 전환은 기존처럼 동작한다.
   - **실패 시**: ID 65, Shottr 앱 defaults, ID 61 값을 각각 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the macOS setup notes to reflect the current Spotlight shortcut and its fallback behavior.
  - Clarified the shortcut table formatting for easier reading.

- **Bug Fixes**
  - Enabled the Spotlight hotkey for `Option + Space` so it now works as a fallback when the primary search tool is unavailable.
  - Kept the Finder search shortcut unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->