### PR TITLE
fix(codex): reap stale remote-control standalone process

### DIFF
--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -20,6 +20,7 @@ ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
 PUSHOVER_CRED_FILE="${PUSHOVER_CRED_FILE:-}"
 SERVICE_LIB="${SERVICE_LIB:-}"
 CODEX_REMOTE_CONTROL_PS_FILE="${CODEX_REMOTE_CONTROL_PS_FILE:-}"
+CODEX_REMOTE_CONTROL_EXE_FILE="${CODEX_REMOTE_CONTROL_EXE_FILE:-}"
 KILL_LOG="${KILL_LOG:-}"
 
 readonly ACTION_NONE="none"
@@ -435,14 +436,74 @@ is_known_legacy_codex_cmd() {
   return 1
 }
 
-is_stale_unmanaged_line() {
-  local line="$1"
-  is_same_user_app_server_line "$line" || return 1
-  is_managed_standalone_cmd "$CMD_FIELD" && return 1
+# Resolve a PID's actual executable path. The kernel records /proc/$pid/exe at
+# exec() time, so the `current` symlink can be re-pointed afterward without
+# changing an already-running process's executable. A deleted executable is
+# reported with a trailing " (deleted)" marker. Tests inject a PID-to-exe
+# mapping file (one "<pid> <exe path>" line per PID) via CODEX_REMOTE_CONTROL_EXE_FILE.
+pid_exe_path() {
+  local pid="$1"
+  if [ -n "$CODEX_REMOTE_CONTROL_EXE_FILE" ]; then
+    [ -f "$CODEX_REMOTE_CONTROL_EXE_FILE" ] || return 0
+    awk -v pid="$pid" '$1 == pid { sub(/^[[:space:]]*[0-9]+[[:space:]]+/, ""); print; exit }' \
+      "$CODEX_REMOTE_CONTROL_EXE_FILE" 2>/dev/null || true
+  else
+    readlink "/proc/$pid/exe" 2>/dev/null || true
+  fi
+}
+
+# Decide whether an executable path proves a managed-standalone process is stale.
+# It is stale only when the executable clearly originates from the managed
+# standalone tree yet is no longer the desired release: either the binary was
+# deleted (the `current` symlink moved and the old release was removed) or it
+# still lives under an older release directory. Unknown/empty paths are never
+# treated as stale — per-process proof stays required.
+exe_indicates_stale_standalone() {
+  local exe="$1"
+  local clean="$exe"
+  local is_deleted=0
+  case "$exe" in
+    *" (deleted)")
+      clean="${exe% (deleted)}"
+      is_deleted=1
+      ;;
+  esac
+  # Only reason about executables that belong to the managed standalone tree.
+  path_under "$clean" "$STANDALONE_ROOT" || return 1
+  # A deleted managed binary can never be the live desired release.
+  [ "$is_deleted" -eq 1 ] && return 0
+  # A still-present binary under the desired release directory is current.
+  path_under "$clean" "$STANDALONE_RELEASE_DIR" && return 1
+  # Otherwise it runs a superseded release even though `current` has moved on.
+  return 0
+}
+
+# Classify an app-server process — identified by its command line and PID — as
+# stale (return 0) or not (non-zero). Shared by is_stale_unmanaged_line (ps/
+# fixture evidence path) and current_pid_matches_stale_proof (production /proc
+# revalidation before kill) so both paths classify identically; extend the rule
+# here, in one place, rather than in either caller.
+classify_stale_by_cmd_and_pid() {
+  local cmd="$1"
+  local pid="$2"
+  if is_managed_standalone_cmd "$cmd"; then
+    # A managed standalone command line usually means the current release, but
+    # `current` is a symlink: an already-running process can keep executing an
+    # old, since-removed release after `current` moved. Only per-process /proc
+    # executable evidence — not global version drift — can prove that case.
+    exe_indicates_stale_standalone "$(pid_exe_path "$pid")"
+    return $?
+  fi
 
   # Kill safety requires per-process evidence. Global daemon version drift is not
   # enough to prove that an arbitrary same-user app-server PID is stale.
-  is_known_legacy_codex_cmd "$CMD_FIELD"
+  is_known_legacy_codex_cmd "$cmd"
+}
+
+is_stale_unmanaged_line() {
+  local line="$1"
+  is_same_user_app_server_line "$line" || return 1
+  classify_stale_by_cmd_and_pid "$CMD_FIELD" "$PID_FIELD"
 }
 
 pid_is_numeric() {
@@ -479,8 +540,7 @@ current_pid_matches_stale_proof() {
   current_cmd="$(tr '\0' ' ' <"/proc/$pid/cmdline" 2>/dev/null || true)"
   [ -n "$current_cmd" ] || return 1
   is_app_server_line "$current_cmd" || return 1
-  is_managed_standalone_cmd "$current_cmd" && return 1
-  is_known_legacy_codex_cmd "$current_cmd"
+  classify_stale_by_cmd_and_pid "$current_cmd" "$pid"
 }
 
 kill_pid() {

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -78,6 +78,9 @@ if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control repair refuses socket cleanup when PID remains" test_codex_remote_control_repair_refuses_socket_cleanup_when_pid_remains
   run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof
   run_test "codex remote-control repair refuses version-drift-only kill" test_codex_remote_control_repair_does_not_kill_on_version_drift_only
+  run_test "codex remote-control repair preserves current managed app-server" test_codex_remote_control_repair_preserves_current_managed_app_server
+  run_test "codex remote-control repair reaps stale deleted managed app-server" test_codex_remote_control_repair_kills_stale_deleted_managed_app_server
+  run_test "codex remote-control repair reaps superseded managed app-server" test_codex_remote_control_repair_kills_stale_superseded_managed_app_server
   run_test "codex remote-control cleans sockets only when no PID after drift" test_codex_remote_control_socket_cleanup_when_no_pid_after_drift
 else
   echo "==> codex remote-control fixtures: SKIPPED (Linux/NixOS-only service script)" >&2

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -360,6 +360,78 @@ test_codex_remote_control_repair_does_not_kill_on_version_drift_only() {
   [ ! -e "$kill_log" ] || fail "version drift alone should not kill an unknown app-server PID"
 }
 
+test_codex_remote_control_repair_preserves_current_managed_app_server() {
+  local sandbox ps_file exe_file kill_log socket_file user standalone_root release_dir
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  user="$(id -un)"
+  ps_file="$sandbox/ps.txt"
+  exe_file="$sandbox/exe.txt"
+  kill_log="$sandbox/kill.log"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  standalone_root="$COD_RC_HOME/.codex/packages/standalone"
+  release_dir="$standalone_root/releases/0.142.4-x86_64-unknown-linux-musl"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+  printf '55555 %s %s/current/codex app-server daemon pid-update-loop\n' "$user" "$standalone_root" > "$ps_file"
+  printf '55555 %s/bin/codex\n' "$release_dir" > "$exe_file"
+
+  if CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" CODEX_REMOTE_CONTROL_EXE_FILE="$exe_file" KILL_LOG="$kill_log" \
+    _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged; then
+    fail "repair-unmanaged should not kill a managed app-server still running the current release"
+  fi
+  [ ! -e "$kill_log" ] || fail "current managed app-server must not be killed"
+  [ -e "$socket_file" ] || fail "socket must be preserved while current managed app-server runs"
+}
+
+test_codex_remote_control_repair_kills_stale_deleted_managed_app_server() {
+  local sandbox ps_file exe_file kill_log socket_file user standalone_root old_release
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  user="$(id -un)"
+  ps_file="$sandbox/ps.txt"
+  exe_file="$sandbox/exe.txt"
+  kill_log="$sandbox/kill.log"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  standalone_root="$COD_RC_HOME/.codex/packages/standalone"
+  old_release="$standalone_root/releases/0.142.3-x86_64-unknown-linux-musl"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+  # cmdline mentions the managed `current` path, but /proc/$pid/exe resolves to a
+  # deleted old release — the exact incident that previously exited 60.
+  printf '4000136 %s %s/current/codex app-server daemon pid-update-loop\n' "$user" "$standalone_root" > "$ps_file"
+  printf '4000136 %s/bin/codex (deleted)\n' "$old_release" > "$exe_file"
+
+  CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" CODEX_REMOTE_CONTROL_EXE_FILE="$exe_file" KILL_LOG="$kill_log" \
+    _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged
+  assert_file_contains "$kill_log" "4000136"
+  [ ! -e "$socket_file" ] || fail "socket should be removed after reaping a stale deleted managed app-server"
+}
+
+test_codex_remote_control_repair_kills_stale_superseded_managed_app_server() {
+  local sandbox ps_file exe_file kill_log socket_file user standalone_root old_release
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  user="$(id -un)"
+  ps_file="$sandbox/ps.txt"
+  exe_file="$sandbox/exe.txt"
+  kill_log="$sandbox/kill.log"
+  socket_file="$COD_RC_HOME/.codex/app-server-control/app-server-control.sock"
+  standalone_root="$COD_RC_HOME/.codex/packages/standalone"
+  old_release="$standalone_root/releases/0.142.3-x86_64-unknown-linux-musl"
+  mkdir -p "$(dirname "$socket_file")"
+  : > "$socket_file"
+  # `current` moved to the desired release but the old release still exists; the
+  # running process's executable proves it is superseded.
+  printf '4000200 %s %s/current/codex app-server --listen unix:///tmp/current.sock\n' "$user" "$standalone_root" > "$ps_file"
+  printf '4000200 %s/bin/codex\n' "$old_release" > "$exe_file"
+
+  CODEX_REMOTE_CONTROL_PS_FILE="$ps_file" CODEX_REMOTE_CONTROL_EXE_FILE="$exe_file" KILL_LOG="$kill_log" \
+    _codex_rc_env bash "$(_codex_rc_script)" repair-unmanaged
+  assert_file_contains "$kill_log" "4000200"
+  [ ! -e "$socket_file" ] || fail "socket should be removed after reaping a superseded managed app-server"
+}
+
 test_codex_remote_control_socket_cleanup_when_no_pid_after_drift() {
   local sandbox ps_file socket_file status
   sandbox="$(new_sandbox)"


### PR DESCRIPTION
## Summary

- `current` 심링크가 새 릴리스로 이동하고 옛 릴리스가 삭제된 뒤에도, 이미 실행 중이던 app-server 프로세스는 삭제된 옛 바이너리를 계속 실행한다. 이 stale 프로세스를 유지보수 스크립트가 죽이지 못해 `exit=60`으로 원격제어 복구가 막히던 문제를 수정한다.
- PID별 `/proc/$pid/exe` 실행 파일 증거로 "명령줄은 managed `current`를 가리키지만 실제로는 삭제/구버전 릴리스를 실행 중"인 프로세스만 stale로 식별해 안전하게 reap한다.
- kill 안전성(임의 same-user PID·전역 버전 드리프트만으로는 절대 죽이지 않음)은 그대로 유지하고, 판정 로직을 단일 헬퍼로 통합해 두 진입점이 항상 동일하게 분류하도록 한다.

## 기존 문제/배경

MiniPC(`greenhead-minipc`)의 Codex 모바일 원격제어가 다운되어 iPhone ChatGPT 앱이 연결되지 않았고, 다음 Pushover 알림이 발생했다:

```
Codex Remote Control Failed
exit=60, reason=refusing-socket-cleanup-while-app-server-pid-exists, auth=chatgpt
```

원인은 `current` 심링크의 시간차였다. app-server는 이전 standalone 릴리스에서 기동됐고, 이후 `current`가 새 버전으로 갱신되고 옛 릴리스 디렉토리가 제거됐다. 그 결과 살아있는 프로세스의 명령줄은 여전히 managed `current` 경로를 언급하지만, 커널이 기록한 실행 파일(`/proc/<pid>/exe`)은 삭제된 옛 릴리스 바이너리(`... (deleted)`)를 가리켰다.

기존 유지보수 스크립트는 "명령줄이 managed standalone 경로이면 = current = 죽이면 안 됨"이라는 불변식을 가정했다. 그래서 이 stale PID를 절대 stale로 보지 않아 kill을 거부했고, 이어서 app-server PID가 살아있다는 이유로 소켓/락 정리마저 거부했다. 서비스는 `exit=60`으로 실패하고 원격제어는 계속 다운 상태로 남았다. (해당 인시던트는 별도로 수동 복구되었으며, 본 PR은 재발 방지가 목적이다.)

이 불변식은 원격제어 가드가 처음 도입될 때 세워진 것으로, "managed 경로 = current"라는 전제가 불완전했다. `current`는 심링크이므로, 이미 실행 중인 프로세스는 심링크가 이동한 뒤에도 옛(삭제된) 릴리스를 계속 실행할 수 있다.

## CIR (Change Intent Record)

- **발견 경위**: 라이브 원격제어 다운 → Pushover `exit=60` 알림 → `status.json`의 `lastRepairReason=refusing-socket-cleanup-while-app-server-pid-exists`, `pidEvidence`가 managed `current` 명령줄을 보여줌. 수동 조사 결과 해당 PID의 `/proc/<pid>/exe`가 삭제된 이전 릴리스로 resolve됨을 확인.
- **설계 의도**: "명령줄이 managed 경로"라는 신호만으로는 current/stale을 구분할 수 없다. 유일하게 신뢰할 수 있는 per-process 증거는 커널이 exec 시점에 고정한 실행 파일 경로(`/proc/<pid>/exe`)다. 이것이 (a) managed standalone 트리에서 나왔고 (b) 삭제됐거나 desired 릴리스 디렉토리 밖이면 그 프로세스는 확실히 stale이다.
- **안전 경계 유지**: 이번 변경은 가드를 느슨하게 풀지 않는다. 알 수 없는 same-user app-server, 전역 daemon 버전 드리프트만으로는 여전히 아무것도 죽이지 않는다. per-process 증거가 있어야만 죽인다. known legacy(unmanaged) 명령과 managed standalone 명령의 기존 구분도 보존한다.
- **중복 제거 결정**: 판정 로직은 ps/fixture 증거 경로와 프로덕션 kill 직전 `/proc` 재검증 경로 두 곳에서 필요하다. 두 곳에 같은 로직을 복제하면 한쪽만 수정될 때 조용히 어긋나 유효한 kill이 거부될 수 있으므로, 공통 헬퍼로 단일화해 규칙을 한 곳에서만 관리하도록 했다.
- **범위**: 순수 shell 로직 + 테스트 변경이며 systemd 서비스 정의(ExecStart, environment, 보안 옵션)는 불변이다. 새 env var는 테스트 fixture 전용으로, 프로덕션 서비스 환경에는 노출되지 않아 프로덕션은 항상 실 `/proc/<pid>/exe`를 읽는다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| managed 명령줄 = current 취급 (기존) | 명령줄이 standalone 트리를 언급하면 무조건 안전 | 단순 | 심링크 이동 후 삭제된 옛 릴리스를 실행하는 stale을 못 잡음 → `exit=60` | ❌ |
| 전역 버전 드리프트로 kill | daemon 버전 불일치가 보이면 app-server PID를 죽임 | 구현 단순 | 특정 PID가 stale이라는 증명이 아님 → 임의 same-user 프로세스 오살상 위험 | ❌ |
| per-process `/proc/$pid/exe` 증거 | 프로세스별 실제 실행 파일이 삭제/구버전 릴리스면 stale로 판정 | 오탐 없이 실제 stale만 reap, 안전 경계 유지 | 리눅스 `/proc` 의존 (프로덕션 대상이 NixOS라 적합) | ✅ |
| 판정 로직 두 진입점에 복제 | is_stale_unmanaged_line / current_pid_matches_stale_proof에 각각 작성 | 지역성 | 한쪽만 수정 시 divergence → 유효 kill 거부 | ❌ |
| 공통 헬퍼로 판정 단일화 | `classify_stale_by_cmd_and_pid`를 두 진입점이 공유 | 단일 진실 원천, divergence 리스크 제거 | (없음) | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh` | `pid_exe_path`·`exe_indicates_stale_standalone`·`classify_stale_by_cmd_and_pid` 헬퍼 추가, `is_stale_unmanaged_line`과 `current_pid_matches_stale_proof`가 공통 헬퍼를 사용하도록 통합, fixture용 `CODEX_REMOTE_CONTROL_EXE_FILE` env var 추가 |
| `tests/suites/codex-remote-control.sh` | fixture 3종 추가: current 릴리스 보존(미살상), 삭제된 옛 릴리스 reap(인시던트 재현), 대체된(superseded) 옛 릴리스 reap |
| `tests/shell-script-tests.sh` | 신규 테스트 3종 등록 |

핵심 판정 헬퍼:

```bash
exe_indicates_stale_standalone() {
  local exe="$1"
  local clean="$exe"
  local is_deleted=0
  case "$exe" in
    *" (deleted)")
      clean="${exe% (deleted)}"
      is_deleted=1
      ;;
  esac
  # Only reason about executables that belong to the managed standalone tree.
  path_under "$clean" "$STANDALONE_ROOT" || return 1
  # A deleted managed binary can never be the live desired release.
  [ "$is_deleted" -eq 1 ] && return 0
  # A still-present binary under the desired release directory is current.
  path_under "$clean" "$STANDALONE_RELEASE_DIR" && return 1
  # Otherwise it runs a superseded release even though `current` has moved on.
  return 0
}
```

두 진입점이 공유하는 단일 판정:

```bash
classify_stale_by_cmd_and_pid() {
  local cmd="$1"
  local pid="$2"
  if is_managed_standalone_cmd "$cmd"; then
    exe_indicates_stale_standalone "$(pid_exe_path "$pid")"
    return $?
  fi
  # Global daemon version drift is not enough to prove a same-user PID is stale.
  is_known_legacy_codex_cmd "$cmd"
}
```

프로덕션에서 `pid_exe_path`는 `readlink /proc/$pid/exe`를 읽고, 테스트에서는 `CODEX_REMOTE_CONTROL_EXE_FILE`로 주입한 PID→exe 매핑 파일을 읽는다. 빈/미지의 exe 경로는 절대 stale로 분류되지 않아 per-process 증거 요구가 유지된다.

## 참고 레퍼런스

- 관련 이슈/PR: 없음 (라이브 운영 인시던트의 재발 방지 대응).
- 원격제어 가드 최초 도입: `feat(codex): guard mobile remote-control app server` 커밋 — 본 PR이 보완하는 "managed 경로 = do not kill" 불변식의 출처.
- 리눅스 `proc(5)` — `/proc/[pid]/exe`는 실행 파일의 심볼릭 링크이며, 실행 파일이 삭제되면 링크 값에 `" (deleted)"`가 덧붙는다.

## Human Test Plan

전제: 이 스크립트는 `greenhead-minipc`(NixOS)의 `codex-remote-control-ensure.service`로 배포된다. macOS에서는 대상이 아니다.

1. **배포**: MiniPC에서 `nrs`로 빌드/스위치한다.
   - 기대: 빌드 성공, 서비스 유닛 갱신.
   - 실패 시: `nrs` preview/build 로그에서 shell 스크립트 derivation 오류 확인.
2. **정상 상태 확인**: `sudo systemctl start codex-remote-control-ensure.service` 후 `jq . /var/lib/codex-remote-control/status.json`.
   - 기대: `remoteControlEnabled=true`, `serverName=greenhead-minipc`, `daemonStatus`가 정상, `exitCode=0`.
   - 실패 시: `lastRepairReason` 확인. 특히 `refusing-socket-cleanup-while-app-server-pid-exists`가 다시 나오면 stale 판정이 동작하지 않은 것이므로 `pidEvidence`와 해당 PID의 `readlink /proc/<pid>/exe`를 대조.
3. **iPhone 연결**: iPhone ChatGPT 앱에서 `greenhead-minipc` 원격제어 연결을 시도한다.
   - 기대: 연결 성공.
4. **버전 전이 회귀 관찰 (자연 발생)**: 다음 Codex standalone 버전 bump가 배포되어 `current` 심링크가 이동한 뒤 서비스가 실행될 때, 옛 릴리스를 실행 중이던 app-server가 남아 있으면 서비스가 이를 reap하고 새 버전으로 복구하는지 관찰한다.
   - 기대: `exit=60` 없이 healthy 복구. `lastAction`이 정상 재시작 계열.
   - 실패 시: `status.json`의 `pidEvidence`와 stale PID의 `/proc/<pid>/exe`를 확인해 판정 조건(삭제/구버전) 매칭 여부를 진단.
5. **회귀 미발생 확인 (자동)**: `bash tests/shell-script-tests.sh` — codex remote-control fixture 전체가 통과해야 한다(현재 릴리스 보존/삭제 reap/superseded reap 및 기존 안전성 케이스 포함).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of stale app-server processes so the current managed server is preserved while older or superseded ones are cleaned up correctly.
  * Added support for executable-path-based checks, making process repair more reliable when command-line data alone is misleading.

* **Tests**
  * Expanded repair coverage with new cases for preserving the active server and removing stale deleted or superseded servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->