### PR TITLE
fix(hooks): fall back to /tmp when TMPDIR is set-but-unusable

### DIFF
--- a/modules/shared/programs/claude/files/lib/hook-runtime.sh
+++ b/modules/shared/programs/claude/files/lib/hook-runtime.sh
@@ -67,9 +67,21 @@ hook_load_lib() {
 #
 # stdout: 생성된 디렉토리 path.
 # exit code: 0 (성공) / 1 (실패).
+#
+# TMPDIR fallback: ${TMPDIR:-/tmp} 는 TMPDIR 이 unset/empty 일 때만 /tmp 로 fallback 한다.
+# 그러나 codex 가 자식 프로세스에 상속시키는 ~/.codex/tmp/... 세션 임시경로처럼 TMPDIR 이
+# "set 이지만 이미 삭제됐거나 쓰기 불가" 인 경우 (set-but-unusable) 는 fallback 되지 않아
+# `mktemp -d "$TMPDIR/..."` 가 부모 부재로 실패한다. pinning-guard 는 이 실패를 fail-closed 로
+# 처리해 Bash/Edit/Write/apply_patch 전 명령을 차단하므로, 여기서 base 가 실제 사용 가능한
+# 디렉토리인지 확인하고 아니면 /tmp 로 fallback 해 가용성 회귀를 막는다. mktemp 가 새 격리
+# 디렉토리를 만드는 것은 동일하므로 pinning 검사의 보안 경계는 그대로 유지된다.
 hook_init_scan_dir() {
   local prefix="${1:-hook-scan}"
-  mktemp -d "${TMPDIR:-/tmp}/${prefix}-XXXXXX"
+  local base="${TMPDIR:-/tmp}"
+  if [ ! -d "$base" ] || [ ! -w "$base" ]; then
+    base=/tmp
+  fi
+  mktemp -d "$base/${prefix}-XXXXXX"
 }
 
 # hook_parse_tool_name

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -125,6 +125,10 @@ run_test "install-lefthook serializes concurrent invocations" test_install_lefth
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
 run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
+run_test "hook_init_scan_dir falls back when TMPDIR missing" test_hook_init_scan_dir_falls_back_when_tmpdir_missing
+run_test "hook_init_scan_dir falls back when TMPDIR unwritable" test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable
+run_test "hook_init_scan_dir uses valid TMPDIR" test_hook_init_scan_dir_uses_valid_tmpdir
+run_test "pinning-guard survives set-but-unusable TMPDIR (e2e)" test_pinning_guard_survives_unusable_tmpdir
 
 # codex-config fixture는 tomlkit이 필요하다. lefthook pre-push는 `nix shell` wrap으로
 # 항상 tomlkit을 제공하지만, 사용자가 직접 실행할 때는 미가용일 수 있다. 미가용이면

--- a/tests/suites/hook-runtime.sh
+++ b/tests/suites/hook-runtime.sh
@@ -1,0 +1,92 @@
+# tests/suites/hook-runtime.sh — hook-runtime.sh 공통 helper 유닛 테스트 (sourced; aggregator가 lib/test-common.sh 후 source)
+# shellcheck shell=bash
+# SC2154: 공통 변수(REPO_ROOT/TEST_TMP_FILE)는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+# hook_init_scan_dir 의 TMPDIR set-but-unusable fallback 계약 회귀 차단.
+#
+# 배경: codex 는 자식 프로세스에 ~/.codex/tmp/... 세션 임시경로를 TMPDIR/PATH 로 상속시키는데,
+# 그 디렉토리가 세션 정리로 삭제되면 TMPDIR 이 "set 이지만 이미 삭제됨" 상태가 된다.
+# ${TMPDIR:-/tmp} 는 unset/empty 만 fallback 하므로 이 경우 mktemp -d "$TMPDIR/..." 가 실패하고,
+# pinning-guard.sh 는 이 실패를 fail-closed 로 처리해 Bash/Edit/Write/apply_patch 전 명령을 차단했다.
+# hook_init_scan_dir 은 base 가 실제 사용 가능한 디렉토리인지 확인하고 아니면 /tmp 로 fallback 한다.
+
+_hook_runtime_lib_path() {
+  printf '%s' "$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh"
+}
+
+# 존재하지 않는 TMPDIR (codex dangling ~/.codex/tmp/... 재현) → /tmp fallback + 성공.
+test_hook_init_scan_dir_falls_back_when_tmpdir_missing() {
+  local sandbox out lib
+  lib="$(_hook_runtime_lib_path)"
+  sandbox=$(new_sandbox)
+  out=$(TMPDIR="$sandbox/does-not-exist" HOOK_RT_LIB="$lib" \
+    bash -c '. "$HOOK_RT_LIB"; hook_init_scan_dir pinning-guard') \
+    || fail "hook_init_scan_dir must exit 0 with a missing TMPDIR"
+  [ -d "$out" ] || fail "expected a created directory, got: $out"
+  case "$out" in
+    /tmp/pinning-guard-*) : ;;
+    *) fail "expected /tmp fallback path, got: $out" ;;
+  esac
+  rmdir "$out" 2>/dev/null || true
+}
+
+# 쓰기 불가 TMPDIR → /tmp fallback + 성공. (root 는 -w 를 우회하므로 skip.)
+test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable() {
+  local sandbox rodir out lib
+  if [ "$(id -u)" = 0 ]; then
+    echo "    (skip: root bypasses -w permission check)" >&2
+    return 0
+  fi
+  lib="$(_hook_runtime_lib_path)"
+  sandbox=$(new_sandbox)
+  rodir="$sandbox/ro"
+  mkdir -p "$rodir"
+  chmod 000 "$rodir"
+  out=$(TMPDIR="$rodir" HOOK_RT_LIB="$lib" \
+    bash -c '. "$HOOK_RT_LIB"; hook_init_scan_dir pinning-guard') \
+    || { chmod 755 "$rodir"; fail "hook_init_scan_dir must exit 0 with an unwritable TMPDIR"; }
+  chmod 755 "$rodir"  # sandbox 자동 cleanup 이 rm -rf 할 수 있도록 권한 복구.
+  [ -d "$out" ] || fail "expected a created directory, got: $out"
+  case "$out" in
+    /tmp/pinning-guard-*) : ;;
+    *) fail "expected /tmp fallback path, got: $out" ;;
+  esac
+  rmdir "$out" 2>/dev/null || true
+}
+
+# 유효한 TMPDIR 은 그대로 사용 — 불필요한 /tmp fallback 금지 (임시경로 격리 의도 보존).
+test_hook_init_scan_dir_uses_valid_tmpdir() {
+  local sandbox out lib
+  lib="$(_hook_runtime_lib_path)"
+  sandbox=$(new_sandbox)
+  out=$(TMPDIR="$sandbox" HOOK_RT_LIB="$lib" \
+    bash -c '. "$HOOK_RT_LIB"; hook_init_scan_dir pinning-guard') \
+    || fail "hook_init_scan_dir must exit 0 with a valid TMPDIR"
+  [ -d "$out" ] || fail "expected a created directory, got: $out"
+  case "$out" in
+    "$sandbox"/pinning-guard-*) : ;;
+    *) fail "expected scan dir under the valid TMPDIR ($sandbox), got: $out" ;;
+  esac
+  rmdir "$out" 2>/dev/null || true
+}
+
+# e2e: codex pinning-guard.sh 가 set-but-unusable TMPDIR 에서 fail-closed 로 명령을 차단하지
+# 않고 정상 통과하는지 — 이 커밋이 고친 실제 사용자 영향(전 명령 deny 억제)을 직접 검증한다.
+# 유닛 테스트는 hook_init_scan_dir 계약(rc=0 + 유효 경로)만 보므로, 그 계약이 실제 guard 의
+# deny 경로를 억제한다는 것까지 e2e 로 못박는다. non-targeted 명령("true")을 써서 pinning 패턴
+# 로직을 타지 않고 scan workspace 초기화 경로만 격리 검증한다.
+test_pinning_guard_survives_unusable_tmpdir() {
+  local sandbox out lib_rt lib_pin hook
+  lib_rt="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh"
+  lib_pin="$REPO_ROOT/modules/shared/programs/claude/files/lib/pinning-patterns.sh"
+  hook="$REPO_ROOT/modules/shared/programs/codex/files/hooks/pinning-guard.sh"
+  sandbox=$(new_sandbox)
+  out=$(printf '%s' '{"tool_name":"Bash","tool_input":{"command":"true"}}' \
+    | env TMPDIR="$sandbox/does-not-exist" \
+        HOOK_RUNTIME_LIB="$lib_rt" PINNING_PATTERNS_LIB="$lib_pin" \
+        bash "$hook") \
+    || fail "pinning-guard.sh must exit 0 under a set-but-unusable TMPDIR"
+  assert_not_contains "$out" '"permissionDecision": "deny"'
+  assert_not_contains "$out" "failed to initialize scan workspace"
+}


### PR DESCRIPTION
## Summary

- codex 세션이 자식 프로세스에 상속시키는 휘발성 `TMPDIR`(`~/.codex/tmp/...`)이 세션 정리로 삭제되면, `pinning-guard` hook이 scan workspace 초기화(`mktemp -d`) 실패를 fail-closed로 처리해 **모든 Bash/Edit/Write/apply_patch 명령을 차단**하던 문제를 수정한다.
- `hook_init_scan_dir`이 `TMPDIR`이 실제 사용 가능한 디렉토리인지 확인하고, set-but-unusable이면 `/tmp`로 fallback한다.
- Claude/Codex 공유 SSOT 한 곳 수정으로 4개 hook(pinning-guard/pinning-alert × claude/codex)을 모두 커버한다.

## 기존 문제/배경

codex에서 `rg`, `git status`, `pwd`, `true` 등 **모든 명령**이 다음 메시지로 차단되는 현상이 발생했다:

```
PreToolUse hook (blocked)
[pinning-guard] failed to initialize scan workspace; denying by fail-closed policy.
```

`pinning-guard` hook은 검사용 임시 디렉토리를 `hook_init_scan_dir`로 만든다:

```bash
mktemp -d "${TMPDIR:-/tmp}/${prefix}-XXXXXX"
```

`${TMPDIR:-/tmp}`는 `TMPDIR`이 **unset/empty일 때만** `/tmp`로 fallback한다. codex는 세션마다 `~/.codex/tmp/arg0/codex-arg0XXXX` 임시 디렉토리를 만들어 자식 프로세스 환경(`PATH`, 정황상 `TMPDIR`)에 상속시키는데, 이 디렉토리가 세션 정리로 삭제되면 `TMPDIR`이 "set이지만 이미 삭제됨"(set-but-unusable) 상태가 된다. 이때 `mktemp -d "$TMPDIR/..."`는 부모 디렉토리 부재로 실패한다.

이 초기화는 tool_name 분기(Bash/Edit/Write/apply_patch) 직후이자 pinning 패턴 검사 **이전**에 일어나므로, 초기화가 실패하면 명령 내용과 무관하게 해당 계열 전 명령이 fail-closed로 차단된다. (진단 중, 살아있는 codex remote-control app-server가 이미 삭제된 `~/.codex/tmp/arg0/codex-arg0Fm2hAH`를 `PATH`에 물고 있는 dangling 상태를 실측 확인했다.)

## CIR (Change Intent Record)

- **발견 경위**: 모바일에서 codex 전 명령이 fail-closed로 차단되는 스크린샷 진단으로 시작. hook 소스에서 `hook_init_scan_dir`의 `mktemp -d` 실패가 유일 트리거임을 재현(`TMPDIR=/nonexistent` → 동일 deny 메시지)했고, codex가 `~/.codex/tmp/arg0/...` 휘발성 임시경로를 환경에 상속시키고 그것이 삭제되어 dangling되는 것이 근본 원인임을 프로세스 environ 실측으로 확인했다.
- **설계 의도**: 근본 원인은 codex의 TMPDIR 상속이지만 그것은 codex 내부 동작이라 이 저장소의 통제 밖이므로, 방어는 hook 쪽에서 한다. `${TMPDIR:-/tmp}`의 한계(set-but-broken 미처리)를 base 유효성 검사로 보완한다.
- **보안 경계**: mktemp가 새 격리 디렉토리를 만드는 동작 자체는 변하지 않으므로 pinning 검사의 보안 경계는 그대로다. 이는 fail-open이 아니라 "정상 임시경로 확보 후 정상 검사"다. `/tmp`마저 쓸 수 없는 진짜 고장 상태에서는 여전히 fail-closed로 남는다(의도된 동작).

**trade-off**: `-d && -w` 프리체크는 heuristic proxy라 no-execute-bit(mode 0600) 같은 특이 디렉토리는 under-detect할 수 있으나, 실제 사건(세션 임시경로 "삭제")은 `-d` 검사가 완전히 커버한다. 세션 teardown이 만들지 않는 이론적 상태까지 방어하는 것은 YAGNI로 판단해 포함하지 않았다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `${TMPDIR:-/tmp}` 유지 (현상) | unset/empty만 fallback | 단순 | set-but-unusable 미처리 → 전 명령 차단 | ❌ |
| base 유효성(`-d && -w`) 확인 후 /tmp fallback | 사용 가능하면 TMPDIR 그대로, 아니면 /tmp | 유효 TMPDIR 격리 보존 + set-but-broken 방어 | 프리체크 1분기 추가 | ✅ |
| TMPDIR 무시하고 /tmp 강제 | 항상 /tmp 사용 | 가장 단순 | 사용자가 의도한 유효 TMPDIR(대용량 tmpfs 등) 무시, 격리 의도 상실 | ❌ |
| `mktemp --tmpdir=<base>` 위임 | mktemp 옵션에 위임 | 코드 짧음 | missing base에선 동일하게 실패(재현 확인) → 문제 미해결 | ❌ |
| codex 쪽 TMPDIR 상속 정리 | 근본 원인 제거 | 근본적 | codex 내부 동작이라 통제 밖, hook은 여전히 방어 필요 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/lib/hook-runtime.sh` | 수정 | `hook_init_scan_dir`에 base 유효성 검사 후 `/tmp` fallback (Claude/Codex 공유 SSOT) |
| `tests/suites/hook-runtime.sh` | 신규 | 유닛 3종(missing / unwritable / valid TMPDIR) + e2e 1종(codex pinning-guard가 broken TMPDIR에서 deny하지 않음) |
| `tests/shell-script-tests.sh` | 수정 | 신규 테스트 4종 러너 등록 |

### 핵심 코드

```bash
# BEFORE: TMPDIR 이 set-but-unusable 이면 fallback 되지 않아 mktemp 실패
mktemp -d "${TMPDIR:-/tmp}/${prefix}-XXXXXX"

# AFTER: base 가 실제 디렉토리이며 쓰기 가능한지 확인, 아니면 /tmp
local base="${TMPDIR:-/tmp}"
if [ ! -d "$base" ] || [ ! -w "$base" ]; then
  base=/tmp
fi
mktemp -d "$base/${prefix}-XXXXXX"
```

## 참고 레퍼런스

- PR #931 — codex hook config sync 수정 (동일 hook 인프라)
- PR #932 — codex remote-control stale standalone process 정리 (이 PR의 rebase base; 진단 중 dangling `~/.codex/tmp` PATH를 물고 있던 app-server가 remote-control 계열이다)
- SSOT: `modules/shared/programs/claude/files/lib/hook-runtime.sh` — Claude/Codex 4개 hook이 공유하는 공통 helper 라이브러리

## Human Test Plan

### 정상 동작 검증

1. broken TMPDIR로 codex `pinning-guard.sh`를 직접 실행한다 (repo 루트에서):
   ```bash
   printf '{"tool_name":"Bash","tool_input":{"command":"true"}}' \
     | env TMPDIR=/nonexistent/broken \
         HOOK_RUNTIME_LIB=modules/shared/programs/claude/files/lib/hook-runtime.sh \
         PINNING_PATTERNS_LIB=modules/shared/programs/claude/files/lib/pinning-patterns.sh \
         bash modules/shared/programs/codex/files/hooks/pinning-guard.sh
   ```
   - **기대**: 무출력 + exit 0 (deny 없음).
   - **실패 시**: `permissionDecision: deny` / "failed to initialize scan workspace"가 나오면 fallback 미적용 → `hook_init_scan_dir`의 base 프리체크를 확인한다.

2. 정상 TMPDIR 격리 보존 (regression): 유효한 `TMPDIR`을 지정하면 scan dir이 그 아래 생성되고 불필요한 `/tmp` fallback이 일어나지 않는지 확인한다.
   - **실패 시**: 프리체크가 유효 디렉토리를 오탐하는지 `-d`/`-w` 로직을 확인한다.

3. 테스트 스위트를 실행한다:
   ```bash
   bash tests/run-shell-script-tests.sh
   ```
   - **기대**: `hook_init_scan_dir` 유닛 3종 + `pinning-guard survives set-but-unusable TMPDIR (e2e)`가 통과한다.

### Negative / 회귀 검증

4. 수정 전 로직이 실제 회귀였는지 대조한다: `git show main:modules/shared/programs/claude/files/lib/hook-runtime.sh`의 old `hook_init_scan_dir`로 1번 e2e를 돌리면 broken TMPDIR에서 `deny`가 발생한다 — 이 PR이 그것을 억제함을 확인한다.

5. codex 실사용(사진 재현 시나리오): 실제 codex 세션에서 `rg` / `git status` 등이 정상 실행되는지 확인한다.
   - **실패 시**: 막힌 세션 PID로 `tr '\0' '\n' < /proc/<PID>/environ | grep TMPDIR`로 상속된 TMPDIR 값과 그 경로의 존재/쓰기 가능 여부를 실측한다.
