### PR TITLE
fix(hooks): probe temp candidates until mktemp actually succeeds

### DIFF
--- a/modules/shared/programs/claude/files/lib/hook-runtime.sh
+++ b/modules/shared/programs/claude/files/lib/hook-runtime.sh
@@ -71,17 +71,39 @@ hook_load_lib() {
 # TMPDIR fallback: ${TMPDIR:-/tmp} 는 TMPDIR 이 unset/empty 일 때만 /tmp 로 fallback 한다.
 # 그러나 codex 가 자식 프로세스에 상속시키는 ~/.codex/tmp/... 세션 임시경로처럼 TMPDIR 이
 # "set 이지만 이미 삭제됐거나 쓰기 불가" 인 경우 (set-but-unusable) 는 fallback 되지 않아
-# `mktemp -d "$TMPDIR/..."` 가 부모 부재로 실패한다. pinning-guard 는 이 실패를 fail-closed 로
-# 처리해 Bash/Edit/Write/apply_patch 전 명령을 차단하므로, 여기서 base 가 실제 사용 가능한
-# 디렉토리인지 확인하고 아니면 /tmp 로 fallback 해 가용성 회귀를 막는다. mktemp 가 새 격리
+# `mktemp -d "$TMPDIR/..."` 가 부모 부재로 실패한다. systemd private tmp가 삭제된 mount처럼
+# `/tmp` 자체가 stat 가능하지만 생성은 실패하는 경우도 있으므로, 후보 디렉토리는 실제 mktemp
+# 성공까지 확인한다. pinning-guard 는 이 실패를 fail-closed 로 처리해 Bash/Edit/Write/apply_patch
+# 전 명령을 차단하므로, 여기서 usable 후보를 찾아 가용성 회귀를 막는다. mktemp 가 새 격리
 # 디렉토리를 만드는 것은 동일하므로 pinning 검사의 보안 경계는 그대로 유지된다.
 hook_init_scan_dir() {
   local prefix="${1:-hook-scan}"
-  local base="${TMPDIR:-/tmp}"
-  if [ ! -d "$base" ] || [ ! -w "$base" ]; then
-    base=/tmp
+  local requested_base="${TMPDIR:-}"
+  local cache_base=""
+  local base out
+
+  if [ -n "${XDG_CACHE_HOME:-}" ]; then
+    cache_base="$XDG_CACHE_HOME/codex-hooks/tmp"
+  elif [ -n "${HOME:-}" ]; then
+    cache_base="$HOME/.cache/codex-hooks/tmp"
   fi
-  mktemp -d "$base/${prefix}-XXXXXX"
+
+  for base in "$requested_base" /tmp /var/tmp "${XDG_RUNTIME_DIR:-}" "$cache_base"; do
+    [ -n "$base" ] || continue
+    if [ ! -d "$base" ]; then
+      if [ -n "$cache_base" ] && [ "$base" = "$cache_base" ]; then
+        mkdir -p "$base" 2>/dev/null || continue
+      else
+        continue
+      fi
+    fi
+    [ -w "$base" ] || continue
+    if out=$(mktemp -d "$base/${prefix}-XXXXXX" 2>/dev/null); then
+      printf '%s\n' "$out"
+      return 0
+    fi
+  done
+  return 1
 }
 
 # hook_parse_tool_name

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -127,6 +127,7 @@ run_test "fragile-hardcoding-guard line count word order independent" test_fragi
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
 run_test "hook_init_scan_dir falls back when TMPDIR missing" test_hook_init_scan_dir_falls_back_when_tmpdir_missing
 run_test "hook_init_scan_dir falls back when TMPDIR unwritable" test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable
+run_test "hook_init_scan_dir falls back when system tmp unusable" test_hook_init_scan_dir_falls_back_to_user_cache_when_system_tmp_unusable
 run_test "hook_init_scan_dir uses valid TMPDIR" test_hook_init_scan_dir_uses_valid_tmpdir
 run_test "pinning-guard survives set-but-unusable TMPDIR (e2e)" test_pinning_guard_survives_unusable_tmpdir
 

--- a/tests/suites/hook-runtime.sh
+++ b/tests/suites/hook-runtime.sh
@@ -9,13 +9,14 @@
 # 그 디렉토리가 세션 정리로 삭제되면 TMPDIR 이 "set 이지만 이미 삭제됨" 상태가 된다.
 # ${TMPDIR:-/tmp} 는 unset/empty 만 fallback 하므로 이 경우 mktemp -d "$TMPDIR/..." 가 실패하고,
 # pinning-guard.sh 는 이 실패를 fail-closed 로 처리해 Bash/Edit/Write/apply_patch 전 명령을 차단했다.
-# hook_init_scan_dir 은 base 가 실제 사용 가능한 디렉토리인지 확인하고 아니면 /tmp 로 fallback 한다.
+# hook_init_scan_dir 은 base 가 실제 사용 가능한 디렉토리인지 확인하고 아니면 사용 가능한
+# system/user fallback 으로 이동한다.
 
 _hook_runtime_lib_path() {
   printf '%s' "$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh"
 }
 
-# 존재하지 않는 TMPDIR (codex dangling ~/.codex/tmp/... 재현) → /tmp fallback + 성공.
+# 존재하지 않는 TMPDIR (codex dangling ~/.codex/tmp/... 재현) → fallback + 성공.
 test_hook_init_scan_dir_falls_back_when_tmpdir_missing() {
   local sandbox out lib
   lib="$(_hook_runtime_lib_path)"
@@ -25,13 +26,14 @@ test_hook_init_scan_dir_falls_back_when_tmpdir_missing() {
     || fail "hook_init_scan_dir must exit 0 with a missing TMPDIR"
   [ -d "$out" ] || fail "expected a created directory, got: $out"
   case "$out" in
-    /tmp/pinning-guard-*) : ;;
-    *) fail "expected /tmp fallback path, got: $out" ;;
+    "$sandbox"/does-not-exist/*) fail "must not use missing TMPDIR, got: $out" ;;
+    */pinning-guard-*) : ;;
+    *) fail "expected fallback pinning-guard temp path, got: $out" ;;
   esac
   rmdir "$out" 2>/dev/null || true
 }
 
-# 쓰기 불가 TMPDIR → /tmp fallback + 성공. (root 는 -w 를 우회하므로 skip.)
+# 쓰기 불가 TMPDIR → fallback + 성공. (root 는 -w 를 우회하므로 skip.)
 test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable() {
   local sandbox rodir out lib
   if [ "$(id -u)" = 0 ]; then
@@ -49,8 +51,39 @@ test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable() {
   chmod 755 "$rodir"  # sandbox 자동 cleanup 이 rm -rf 할 수 있도록 권한 복구.
   [ -d "$out" ] || fail "expected a created directory, got: $out"
   case "$out" in
-    /tmp/pinning-guard-*) : ;;
-    *) fail "expected /tmp fallback path, got: $out" ;;
+    "$rodir"/*) fail "must not use unwritable TMPDIR, got: $out" ;;
+    */pinning-guard-*) : ;;
+    *) fail "expected fallback pinning-guard temp path, got: $out" ;;
+  esac
+  rmdir "$out" 2>/dev/null || true
+}
+
+# `/tmp`/`/var/tmp`가 stat 가능해도 mktemp 생성이 실패하는 host 상태까지 fallback 한다.
+test_hook_init_scan_dir_falls_back_to_user_cache_when_system_tmp_unusable() {
+  local sandbox out lib
+  lib="$(_hook_runtime_lib_path)"
+  sandbox=$(new_sandbox)
+  out=$(TMPDIR="$sandbox/does-not-exist" XDG_CACHE_HOME="$sandbox/cache" HOOK_RT_LIB="$lib" \
+    bash -c '
+      unset XDG_RUNTIME_DIR   # 후보 순회에서 host /run/user/* 가 먼저 잡히지 않도록 격리
+      . "$HOOK_RT_LIB"
+      # mktemp -d "<base>/<prefix>-XXXXXX" 형태라 경로는 $1 이 아님 — 모든 인자를 검사한다.
+      mktemp() {
+        local a
+        for a in "$@"; do
+          case "$a" in
+            "$XDG_CACHE_HOME"/*) : ;;               # user cache fallback 은 허용
+            /tmp/* | /var/tmp/*) return 1 ;;        # system tmp 는 생성 실패 모사
+          esac
+        done
+        command mktemp "$@"
+      }
+      hook_init_scan_dir pinning-guard
+    ') || fail "hook_init_scan_dir must use user cache when system tmp candidates fail"
+  [ -d "$out" ] || fail "expected a created directory, got: $out"
+  case "$out" in
+    "$sandbox"/cache/codex-hooks/tmp/pinning-guard-*) : ;;
+    *) fail "expected user cache fallback path, got: $out" ;;
   esac
   rmdir "$out" 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary

- #933의 `hook_init_scan_dir` fallback은 base가 `-d && -w`인지만 확인하고 곧바로 `mktemp`를 시도해서, **`/tmp`가 stat은 되지만 실제 생성은 실패하는 host 상태**(systemd private tmp가 삭제된 mount 등)를 넘기지 못했다. codex 세션에서 `[pinning-guard] failed to initialize scan workspace`가 **무조건 재현**되던 잔여 케이스다.
- `hook_init_scan_dir`이 여러 임시경로 후보(requested TMPDIR → `/tmp` → `/var/tmp` → `XDG_RUNTIME_DIR` → user cache)를 **실제 `mktemp` 성공까지** 순회하도록 강화한다.

## 기존 문제/배경

#933 배포 후에도 codex(특히 SSH/Termius 세션)에서 pinning-guard가 전 명령을 fail-closed로 차단하는 현상이 계속 재현됐다.

원인: #933의 fallback은 다음처럼 stat/write-bit heuristic만 봤다.

```sh
local base="${TMPDIR:-/tmp}"
if [ ! -d "$base" ] || [ ! -w "$base" ]; then base=/tmp; fi
mktemp -d "$base/${prefix}-XXXXXX"
```

`/tmp`가 디렉토리로 존재하고(`-d`) 쓰기 비트가 있어도(`-w`), 실제 `mktemp -d`는 실패할 수 있다 — 대표적으로 systemd `PrivateTmp` mount가 정리되어 `/tmp` inode는 stat되지만 생성이 거부되는 상태다. 이 경우 `hook_init_scan_dir`이 실패값을 반환하고 pinning-guard가 fail-closed deny로 처리해, `rg`/`git status` 등 모든 명령이 차단됐다.

## CIR (Change Intent Record)

- #933에서 단순 fallback(`-d && -w` → `/tmp`)을 도입했다. 당시 감사(DA/parallel-audit)에서 "`-d && -w`는 mktemp 실패 디렉토리를 under-detect하는 heuristic proxy"라는 finding이 제기됐으나 "실환경 트리거 없음(YAGNI)"으로 기각됐다.
- 실제로는 codex 세션 환경에 그 트리거(stat OK but mktemp FAIL)가 존재했고, #933 배포 후에도 재현됐다. 즉 그 finding은 유효했다.
- 방향 전환: base 사용 가능성을 stat/write-bit로 **추정**하지 말고, **실제 `mktemp` 성공을 진실의 소스**로 삼는다. 여러 후보를 순회하며 첫 성공을 쓰고, 모두 실패해야 fail-closed로 남긴다(보안 경계 유지). user cache는 마지막 후보로 두되 없으면 `mkdir -p`로 생성한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `-d && -w` 후 단일 mktemp (#933) | stat/write-bit로 usable 판정 | 단순 | stat OK but mktemp FAIL 미처리 → 재현 지속 | ❌ |
| 다단계 후보 probe (실제 mktemp까지) | 여러 base를 순회하며 실제 생성 성공 확인 | heuristic 오탐 제거, host 이상 상태에 견고 | 코드량 증가 | ✅ |
| `/tmp` 강제 사용 | 항상 `/tmp` | 가장 단순 | `/tmp` 자체가 실패하는 케이스 미해결 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/lib/hook-runtime.sh` | 수정 | `hook_init_scan_dir` 다단계 후보 probe (Claude/Codex 공유 SSOT) |
| `tests/suites/hook-runtime.sh` | 수정 | `mktemp` mock으로 system tmp가 실제 실패하는 host를 재현하는 유닛 테스트 추가. 기존 테스트를 `/tmp` 하드코딩에서 일반 fallback 경로 검증으로 완화 |
| `tests/shell-script-tests.sh` | 수정 | 새 테스트 러너 등록 |

### 핵심 코드

```sh
for base in "$requested_base" /tmp /var/tmp "${XDG_RUNTIME_DIR:-}" "$cache_base"; do
  [ -n "$base" ] || continue
  if [ ! -d "$base" ]; then
    if [ -n "$cache_base" ] && [ "$base" = "$cache_base" ]; then
      mkdir -p "$base" 2>/dev/null || continue
    else
      continue
    fi
  fi
  [ -w "$base" ] || continue
  if out=$(mktemp -d "$base/${prefix}-XXXXXX" 2>/dev/null); then   # 실제 생성 성공까지 확인
    printf '%s\n' "$out"; return 0
  fi
done
return 1
```

## 참고 레퍼런스

- PR #933 — 선행 `hook_init_scan_dir` fallback (이 PR이 그 미비점을 보완)
- PR #932 — codex remote-control stale process 정리
- PR #931 — codex hook config sync 수정

## Human Test Plan

### 정상 동작 검증

1. `bash tests/run-shell-script-tests.sh` 실행.
   - **기대**: `hook_init_scan_dir falls back when system tmp unusable`를 포함한 hook-runtime 테스트가 통과. 이 테스트는 `mktemp`를 mock해 `/tmp`·`/var/tmp` 생성이 실패하는 host를 재현하고, user cache(`XDG_CACHE_HOME/codex-hooks/tmp`)로 fallback함을 확인한다.
   - **실패 시**: `hook_init_scan_dir`의 후보 순회 순서와 `mktemp` 성공 판정 분기를 확인한다.

2. codex 실사용: codex 세션에서 `rg`/`git status` 등이 정상 실행되는지.
   - **실패 시**: 막힌 세션에서 `hook_init_scan_dir`이 어느 후보까지 시도하는지 추적한다(각 base의 실제 `mktemp` 결과).

### 회귀 검증

3. 정상 `TMPDIR` 격리 보존: 유효한 `TMPDIR`을 주면 scan dir이 그 아래 생성되고 불필요한 fallback이 일어나지 않는지(`test_hook_init_scan_dir_uses_valid_tmpdir`).
4. `#933`의 단순 fallback으로는 stat OK but mktemp FAIL 상태에서 여전히 실패함을 대조 — 이 PR이 그 케이스를 넘김을 확인.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary directory selection to better handle missing or unwritable system temp locations.
  * Added broader fallback support, including alternate system paths and user cache-based locations.
  * Updated tests to cover invalid temp directories and verify fallback behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->