### PR TITLE
feat(darwin): ssh minipc 서명 실패 시 진단 힌트 추가

### DIFF
--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -60,6 +60,7 @@ let
   macSshKeyB64 = lib.elemAt (lib.splitString " " constants.sshDeviceKeys.macSsh) 1; # 공개키 가운데 base64 (nix가 split)
   opLaunchCmd = "/usr/bin/open ${lib.escapeShellArgs constants.onePassword.openArgs}"; # 1Password 백그라운드 기동(절대경로)
   minipcHostIP = constants.network.minipcTailscaleIP; # ssh -G effective hostname 판정 기준
+  emergencyHost = "minipc-emergency"; # ssh config host alias(modules/darwin/programs/ssh) — 1Password 장애 fallback 안내 단일 소스
 in
 {
   # macOS용 스크립트 설치
@@ -174,11 +175,16 @@ in
         # IdentityAgent 전체 값(공백 포함 경로)을 추출해 1Password socket과 정확 비교한다.
         _ident=$(print -r -- "$_cfg" | awk 'tolower($1)=="identityagent"{sub(/^[^ ]+[ ]+/, ""); print; exit}')
         if [[ "$_host" == "${minipcHostIP}" && "$_ident" == "${opAgentSock}" ]]; then
-          # 현재 호출의 effective ControlPath에 활성 master가 있으면 새 인증 불필요 → 통과.
+          # 현재 호출의 effective ControlPath에 활성 master가 있으면 새 인증(서명)이 불필요하다.
           # 사용자 "$@"를 -O check에 직접 넘기면 -W/-O와 충돌하므로 effective ControlPath만 -S로 쓴다.
+          # master 활성 여부를 1회 계산해 preflight와 후처리 진단이 공유한다(-O check 중복 호출 방지).
           _cpath=$(print -r -- "$_cfg" | awk 'tolower($1)=="controlpath"{sub(/^[^ ]+[ ]+/, ""); print; exit}')
           local _sock="${opAgentSock}" _b64="${macSshKeyB64}"
-          if { [[ -z "$_cpath" || "$_cpath" == none ]] || ! command ssh -O check -S "$_cpath" "${minipcHostIP}" 2>/dev/null; } \
+          local _master_active=0
+          if [[ -n "$_cpath" && "$_cpath" != none ]] && command ssh -O check -S "$_cpath" "${minipcHostIP}" 2>/dev/null; then
+            _master_active=1
+          fi
+          if (( ! _master_active )) \
             && ! SSH_AUTH_SOCK="$_sock" ssh-add -L 2>/dev/null | grep -qF "$_b64"; then
             # Touch ID 잠금 해제 대기 상한(초) — interactive shell을 오래 막지 않도록. tries = timeout / interval.
             local _poll_interval=0.5 _timeout_seconds=15
@@ -186,17 +192,40 @@ in
             print -u2 "⚠️  ssh minipc 차단: 1Password SSH agent에 mac-ssh 키가 없습니다."
             print -u2 "   원인: 1Password 데스크탑이 미실행/잠금 상태 → mac-ssh 키 미제공."
             print -u2 "   조치: 1Password를 기동합니다 — Touch ID로 잠금 해제하세요."
-            print -u2 "   대안: 즉시 접속이 필요하면  ssh minipc-emergency  (passphrase 직접 입력)."
+            print -u2 "   대안: 즉시 접속이 필요하면  ssh ${emergencyHost}  (passphrase 직접 입력)."
             ${opLaunchCmd} 2>/dev/null
             local _i=0
             while ! SSH_AUTH_SOCK="$_sock" ssh-add -L 2>/dev/null | grep -qF "$_b64"; do
               if (( ++_i > _max_tries )); then
-                print -u2 "   ✗ agent 복구 대기 초과(''${_timeout_seconds}s). 잠금 해제 후 재시도하거나 ssh minipc-emergency 사용."
+                print -u2 "   ✗ agent 복구 대기 초과(''${_timeout_seconds}s). 잠금 해제 후 재시도하거나 ssh ${emergencyHost} 사용."
                 return 1
               fi
               sleep $_poll_interval
             done
             print -u2 "   ✓ agent 복구됨 — 접속합니다."
+          fi
+
+          # ── 후처리 진단(신규): agent 목록엔 있으나 sign만 실패하는 사각지대 안내 ──
+          # 1Password가 "목록은 제공하나 서명(sign)에만 실패"하는 상태(앱 잠금/hang, 서명 승인
+          # 미처리)에서 ssh minipc가 실패하면, raw ssh의 에러만으로는 원인이 1Password인지 알기
+          # 어렵다. 여기에 원인 후보와 복구 경로를 덧붙인다.
+          #
+          # 설계: stderr를 캡처하지 않는다. command ssh를 원본 그대로 실행하므로 hang(procsubst/
+          # ControlPersist master fd 상속)·원격 stderr multiplex 오탐·실시간성 손실·임시파일이
+          # 구조적으로 없다(캡처 기반 접근이 반복 회귀를 낸 뒤의 단순화). 다만 stderr를 읽지 않으므로
+          # "서명 실패"를 단정하지 않고 원인 후보를 제시한다. ssh 클라이언트 레벨 실패(exit 255: 연결·
+          # 인증 계열)에만 발화하며, 원격 명령의 정상 실패는 그 명령의 exit code(≠255)로 전파되어
+          # 여기 걸리지 않는다. master 재사용(_master_active) 경로는 서명이 없어 제외한다.
+          if (( ! _master_active )); then
+            local _rc
+            command ssh "$@"
+            _rc=$?
+            if (( _rc == 255 )); then
+              print -u2 "✗ ssh minipc 실패(exit 255 — 원인은 위 stderr 참조)."
+              print -u2 "   1Password SSH agent 서명 실패라면: 1Password 완전 재시작(Cmd+Q → 재실행 → Touch ID 잠금 해제) 후 재시도."
+              print -u2 "   그래도 안 되면(서버측 키 문제 등): ssh ${emergencyHost}  (passphrase 직접 입력)."
+            fi
+            return $_rc
           fi
         fi
         command ssh "$@"


### PR DESCRIPTION
## Summary

- `ssh minipc`가 **exit 255**로 실패할 때, 원인 후보(1Password SSH agent 서명 실패)와 복구 경로(1Password 재시작 / `ssh minipc-emergency`)를 stderr에 덧붙이는 진단 힌트를 추가한다.
- 기존 preflight의 사각지대 — "agent가 키 **목록**은 제공하나 **서명(sign)**에만 실패" — 를 커버한다.
- 부수적으로 ControlMaster 활성 판정을 1회로 공유(중복 `-O check` 제거)하고, emergency 호스트명을 `let` 상수로 단일화한다.

## 기존 문제/배경

`ssh minipc` 인증은 1Password SSH agent의 mac-ssh 키에 의존한다. 기존 preflight는 "agent 키 목록에 mac-ssh가 **없을** 때"만 개입해 1Password를 기동/대기시킨다. 그러나 1Password가 **"목록은 제공하나 실제 서명(sign)에만 실패"** 하는 상태(앱 잠금/hang, 서명 승인 미처리)에서는 목록이 존재해 preflight를 통과하고, 사용자는 raw ssh의 불친절한 에러(`signing failed` / `communication with agent failed` / `Permission denied (publickey)`)만 보게 되어 **원인이 1Password인지 알 수 없다.** 실제로 이 상태를 겪고 진단하는 과정에서 이 사각지대가 드러났다.

## CIR (Change Intent Record)

ssh minipc 접속 장애를 진단하던 중, 1Password agent가 키 목록은 제공하지만 서명 채널이 죽은 상태였고(1Password 재시작으로 복구), 기존 wrapper가 이 상태를 감지하지 못해 원인 파악이 어렵다는 점이 드러났다. 이에 진단 힌트를 추가하기로 했다.

초기 구현은 ssh의 stderr를 캡처해 서명 실패 시그니처를 확인하고 단정적 진단을 내는 방식이었다. 그러나 검토·전수조사 과정에서 캡처 기반 접근이 연쇄적 부작용을 낳음이 드러났다:

- tee(프로세스 치환) 캡처는 zsh가 외부 명령의 프로세스 치환 종료를 기다리지 않아 진단이 간헐 누락되고, brace group으로 감싸 대기시키면 ControlPersist master가 파일 디스크립터를 상속할 때(특히 `-v` 디버그) 셸이 최대 ControlPersist 시간만큼 hang되는 회귀를 낳았다.
- 파일 캡처 + login(PTY) 한정으로 우회를 시도했으나, `ssh -G`가 login과 원격 명령을 구분하지 못해(둘 다 `requesttty auto`) 원격 명령의 stderr가 로컬로 multiplex되어 오탐하는 회귀가 남았다.

이에 **캡처 자체를 제거**하고, ssh를 원본 그대로 실행한 뒤 클라이언트 레벨 실패(exit 255)에만 원인을 단정하지 않는 추정 힌트를 덧붙이는 방식으로 단순화했다. 이로써 hang·원격 stderr multiplex·실시간성 손실·임시파일 문제가 구조적으로 사라진다. 트레이드오프로 stderr 패턴을 읽지 않아 "서명 실패" 단정은 포기하고 원인 후보 제시로 대체했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| tee 프로세스 치환 캡처 | `2> >(tee)`로 실시간 통과+캡처 후 패턴 grep | 실시간 stderr 보존, 정확한 진단 | 프로세스 치환 race(간헐 누락); brace group 대기 시 ControlPersist master fd 상속 hang | ❌ |
| 파일 캡처 + login 한정 | `2>file` + requesttty로 login만 진단 | hang 없음, 정확한 진단 | `ssh -G`가 login/원격 명령 미구분 → multiplex 오탐 잔존 | ❌ |
| 캡처 없는 exit-255 추정 | stderr 미캡처, exit 255에만 추정 힌트 | hang·multiplex·임시파일 구조적 소멸, 단순·견고 | 원인 단정 불가(추정형), exit 255=네트워크/서버측 거부에도 발화 | ✅ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/shell/darwin.nix` | ssh() wrapper에 exit-255 진단 힌트 추가; `_master_active` 1회 계산·공유; `emergencyHost` let 상수 도입 |

```zsh
if (( ! _master_active )); then
  local _rc
  command ssh "$@"
  _rc=$?
  if (( _rc == 255 )); then
    print -u2 "✗ ssh minipc 실패(exit 255 — 원인은 위 stderr 참조)."
    print -u2 "   1Password SSH agent 서명 실패라면: 1Password 완전 재시작(Cmd+Q → 재실행 → Touch ID 잠금 해제) 후 재시도."
    print -u2 "   그래도 안 되면(서버측 키 문제 등): ssh ${emergencyHost}  (passphrase 직접 입력)."
  fi
  return $_rc
fi
```

캡처가 없어 `command ssh`의 stdin/stdout/stderr가 원본 그대로 흐른다 — 대화형 세션·원격 명령·`-v` 디버그·ControlPersist master 모두 기존 raw ssh와 동일하게 동작하며, 진단은 실패 종료(255) 이후 stderr 한 줄만 추가한다.

## 참고 레퍼런스

- 관련 이슈 없음 (사용자 직접 요청으로 착수).

## Human Test Plan

1. **서명 실패 재현**: 1Password 완전 종료(Cmd+Q) 상태에서 `ssh minipc` → 인증 실패(exit 255)와 함께 "1Password 서명 실패라면 재시작" 힌트가 표시되는지 확인. (실패 시 진단: `ssh minipc; echo $?`로 종료코드가 255인지 확인.)
2. **정상 접속**: 1Password 잠금해제 상태에서 `ssh minipc` → 정상 접속, 힌트 없음.
3. **원격 명령**: `ssh minipc "false"`(exit 1) → 힌트 없음(255 아님). `ssh minipc "echo ok"` → 정상 출력, 힌트 없음.
4. **ControlMaster 재사용**: 활성 master가 있을 때 `ssh minipc` → 진단 경로 skip, 기존과 동일 동작.
5. **디버그 무회귀**: `ssh -v minipc`로 정상 접속 → 즉시 반환(hang 없음).
6. **emergency**: `ssh minipc-emergency` → IdentityAgent none이라 wrapper 우회, 기존 동작.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH connection handling on macOS for personal hosts.
  * Added clearer fallback guidance when SSH agent recovery or signing fails.
  * More reliably detects whether an existing SSH session is active before retrying connection steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->