### PR TITLE
fix(karakeep): log-monitor 상태/큐 재작성을 same-fs 원자적 mv로 교정

### DIFF
--- a/modules/nixos/programs/docker/karakeep-log-monitor/files/log-monitor.sh
+++ b/modules/nixos/programs/docker/karakeep-log-monitor/files/log-monitor.sh
@@ -57,7 +57,7 @@ should_notify_url() {
     return 1
   fi
 
-  tmp=$(mktemp)
+  tmp=$(mktemp -p "$(dirname "$NOTIFY_STATE_FILE")")
   awk -F '\t' -v key="$url" '$1 != key { print }' "$NOTIFY_STATE_FILE" > "$tmp"
   printf "%s\t%s\n" "$url" "$now" >> "$tmp"
   mv "$tmp" "$NOTIFY_STATE_FILE"
@@ -87,7 +87,7 @@ enqueue_failed_url() {
   fi
 
   printf "%s\n" "$failed_url" >> "$FAILED_URL_QUEUE_FILE" || rc=1
-  tmp=$(mktemp)
+  tmp=$(mktemp -p "$(dirname "$FAILED_URL_QUEUE_FILE")")
   if [ "$rc" -eq 0 ]; then
     if ! tail -n "$FAILED_URL_QUEUE_MAX" "$FAILED_URL_QUEUE_FILE" > "$tmp"; then
       rc=1

--- a/plans/README.md
+++ b/plans/README.md
@@ -16,7 +16,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 |------|-------|----------|--------|------------|-------|--------|
 | 001 | Immich DB 재해복구 문서를 백업 이원 구조에 맞게 정정 | P1 | S | — | #938 | TODO |
 | 002 | karakeep webhook 브리지 비특권·sandbox·인증 하드닝 | P1 | M | — | #939 | TODO |
-| 003 | log-monitor 상태/큐 재작성 same-fs 원자적 교체 | P1 | S | — | #940 | TODO |
+| 003 | log-monitor 상태/큐 재작성 same-fs 원자적 교체 | P1 | S | — | #940 | DONE |
 | 004 | 백업 스크립트 추출 + 특성화 테스트 | P2 | M | — | #941 | TODO |
 | 005 | Immich DB(pgvecto-rs) 마이그레이션 spike (조사 전용) | P2 | M | — | #942 | TODO |
 | 006 | gitleaks `.local.md` 전면 예외 제거 → gitignore 대체 | P2 | S | — | #943 | TODO |


### PR DESCRIPTION
## Summary

- `log-monitor.sh`가 durable 재시도 큐(`failed-urls.queue`)와 알림 dedup 상태 파일을 재작성할 때 쓰는 임시 파일을 bare `mktemp`(→ `$TMPDIR`) 대신 **목적지 디렉토리 기준 `mktemp -p`**로 생성해, cross-filesystem `mv`의 비원자성으로 인한 큐 손상 가능성을 제거한다.
- 같은 큐를 소비하는 자매 스크립트 `fallback-sync.sh`가 이미 쓰는 same-fs 원자적 교체 컨벤션으로 정렬한다.

Closes #940

## 기존 문제/배경

`log-monitor.sh`는 Karakeep 크롤 실패를 감지해 실패 URL을 durable 큐에 적재하고 알림 dedup 상태를 관리한다. 두 파일 모두 "임시 파일에 쓰고 `mv`로 교체"하는 패턴인데, 임시 파일이 bare `mktemp`로 생성되어 `$TMPDIR`(tmpfs `/tmp` 또는 systemd `PrivateTmp`)에 놓인다. 목적지는 `/var/lib/karakeep-log-monitor/`.

**문제**: 서로 다른 파일시스템 간 `mv`는 rename(2)이 아니라 copy+unlink로 동작해 **원자적이지 않다**. 복사 도중 프로세스가 죽으면 큐가 부분 기록 상태로 손상되어 실패 URL 재연결 대기열이 유실될 수 있다. 큐는 flock으로 동시성이 보호되지만 cross-fs `mv`의 비원자성은 락과 무관하다.

## CIR (Change Intent Record)

- 발견 경위: 코드베이스 감사(epic #937)의 correctness 검증에서 확인 — 자매 스크립트 `fallback-sync.sh`는 올바른 패턴(`mktemp -p "$STATE_DIR"`)을 쓰는데 이 파일만 컨벤션에서 벗어나 있었다.
- (이번 변경): 실행 plan `plans/003-log-monitor-atomic-mktemp.md`대로 두 `mktemp` 호출만 목적지 디렉토리 기준으로 교체. 다른 로직(flock, 정규식 매칭, 알림 본문)은 불변.

**trade-off**: 수정 후 임시 파일이 `/var/lib/karakeep-log-monitor/`에 생성되므로, `mv` 전에 프로세스가 죽으면 `tmp.XXXXXX` 잔류 파일이 상태 디렉토리에 남을 수 있다 — 무해하며, 현행 cross-fs 손상 위험보다 나은 트레이드오프.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `mktemp -p "$(dirname <목적지>)"` | 임시 파일을 목적지와 같은 디렉토리에 생성 | same-fs rename 보장, 2줄 수정, 기존 컨벤션(fallback-sync.sh)과 정합 | 크래시 시 상태 디렉토리에 tmp 잔류 가능(무해) | ✅ |
| systemd unit에서 `TMPDIR`을 상태 디렉토리로 지정 | 환경 변수로 전역 해결 | 스크립트 무수정 | unit 수정 필요, `PrivateTmp`와 상호작용, 스크립트의 다른 임시 파일 용도까지 영향 — 국소 문제에 과한 범위 | ❌ |
| 신규 테스트 suite 동반 추가 | 회귀 박제 | 재발 방지 강화 | 스크립트가 하단에서 `journalctl -f`를 직접 실행하는 구조라 source 불가 — 테스트 가능하게 만드는 구조 변경은 2줄 수정 대비 과함(YAGNI). grep 기반 검증으로 갈음 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/docker/karakeep-log-monitor/files/log-monitor.sh` | 수정 (2줄) | 두 `mktemp` 호출을 목적지 디렉토리 기준 `-p`로 교체 |
| `plans/README.md` | 수정 (1줄) | plan 003 상태 행 DONE 갱신 |

### 핵심 코드

```bash
# BEFORE (should_notify_url — dedup 상태 재작성)
tmp=$(mktemp)
# AFTER
tmp=$(mktemp -p "$(dirname "$NOTIFY_STATE_FILE")")

# BEFORE (enqueue_failed_url — 큐 트림 후 재작성)
tmp=$(mktemp)
# AFTER
tmp=$(mktemp -p "$(dirname "$FAILED_URL_QUEUE_FILE")")
```

## 참고 레퍼런스

- Issue #940 — 이 변경의 sub-issue (epic #937의 감사 결과)
- `plans/003-log-monitor-atomic-mktemp.md` — 실행 plan (Current state 발췌, done criteria, STOP conditions)
- `modules/nixos/programs/docker/karakeep-fallback-sync/files/fallback-sync.sh` — same-fs `mktemp -p` 컨벤션 exemplar
- [rename(2)](https://man7.org/linux/man-pages/man2/rename.2.html) — 원자성은 같은 파일시스템 내에서만 성립 (`EXDEV`)

## Human Test Plan

### 정적 검증

1. bare `mktemp` 부재 + `-p` 존재 확인 (Negative 포함):
   ```bash
   grep -cE '\$\(mktemp\)' modules/nixos/programs/docker/karakeep-log-monitor/files/log-monitor.sh  # 기대: 0 (exit 1)
   grep -c 'mktemp -p' modules/nixos/programs/docker/karakeep-log-monitor/files/log-monitor.sh      # 기대: 2
   ```
   - **실패 시**: diff가 두 hunk 외 다른 줄을 건드렸는지 확인.
2. `shellcheck -S warning modules/nixos/programs/docker/karakeep-log-monitor/files/log-monitor.sh`
   - **기대**: exit 0. **실패 시**: `dirname` 인용 문제 여부 확인.

### Regression

3. `bash tests/run-all-tests.sh`
   - **기대**: 전부 통과 (이 스크립트는 기존 테스트 대상이 아니므로 무영향이 정상).
   - **실패 시**: 실패한 드라이버가 이 diff와 무관한지 로그로 분리 진단.

### 실경로 (운영자 — `nrs` 적용 후)

4. MiniPC에서 `nrs` 적용 후 karakeep-log-monitor 서비스 재시작 상태에서, 크롤 실패 이벤트 발생(또는 대기) 시:
   - **기대**: Pushover 알림 정상 수신 + `/var/lib/karakeep-log-monitor/failed-urls.queue`에 URL 적재 + 같은 디렉토리에 `tmp.*` 잔류 파일 없음.
   - **실패 시**: `journalctl -u karakeep-log-monitor -n 50`에서 mktemp/mv 오류 확인 (상태 디렉토리 쓰기 권한).


https://claude.ai/code/session_017AHrboa2KjKRoUy4xjgptZ
