### PR TITLE
docs(immich): 재해복구 복원 절차를 백업 이원 구조에 맞게 정정

### DIFF
--- a/.claude/skills/running-containers/references/immich-update.md
+++ b/.claude/skills/running-containers/references/immich-update.md
@@ -81,16 +81,30 @@ Immich 서버가 `127.0.0.1`에만 바인딩되어 있으므로, Tailscale IP로
 
 ## DB 백업/복원
 
+Immich DB 백업은 두 계층으로 나뉜다. disko 재설치는 NVMe(`/dev/nvme0n1`)만 포맷하고 HDD(`/dev/sda`)는 보존하므로(`hosts/greenhead-minipc/disko.nix`), 재해복구 시점에 살아남는 것은 HDD에 쌓인 일일 백업뿐이다.
+
+| 계층 | 포맷 | 위치 | 보관 | 재설치 시 | 복원 방법 |
+|------|------|------|------|-----------|-----------|
+| 일일 백업 | `pg_dump -Fc` 커스텀 포맷 `.dump` | `/mnt/data/backups/immich/` (HDD) | 기본 30일 (`homeserver.immichBackup.retentionDays`) | 생존 | `pg_restore` 필요 |
+| 업데이트 직전 백업 | `pg_dump \| gzip` 평문 SQL `.sql.gz` | `/var/lib/immich-update/backups/` (SSD) | 7일 | 소멸 | `gunzip \| psql` |
+
+> `.dump`(커스텀 포맷)와 `.sql.gz`(평문 SQL)는 복원 명령이 서로 다르다. 아래 절차를 파일 종류에 맞게 골라 쓴다.
+
 ### 백업 위치
 
 ```
-/var/lib/immich-update/backups/
+/var/lib/immich-update/backups/        # SSD - 업데이트 직전 (.sql.gz, 7일, 재설치 시 소멸)
 ├── backup-20260206-030000.sql.gz
 ├── backup-20260207-030000.sql.gz
 └── ...
+
+/mnt/data/backups/immich/              # HDD - 일일 (.dump, 재설치 후에도 생존)
+├── immich-db-2026-02-06_030000.dump
+├── immich-db-2026-02-07_030000.dump
+└── ...
 ```
 
-### 수동 복원
+### 수동 복원 — 업데이트 직전 백업 (`.sql.gz`)
 
 ```bash
 # 1. Immich 서비스 중지
@@ -102,6 +116,26 @@ gunzip -c /var/lib/immich-update/backups/backup-YYYYMMDD-HHMMSS.sql.gz | \
 
 # 3. 서비스 재시작
 sudo systemctl start podman-immich-server.service
+```
+
+### 재해복구 복원 — 일일 백업 (`.dump`)
+
+> 주의: `gunzip`/`psql`로는 `.dump`를 복원할 수 없다 (pg_dump 커스텀 포맷은 gzip도 평문 SQL도 아니다). 반드시 `pg_restore`를 사용한다.
+
+```bash
+# 0. 복원 전 TOC 확인 (읽기 전용 — 파일이 유효한 pg_dump 커스텀 포맷인지)
+sudo podman exec -i immich-postgres pg_restore --list \
+  < /mnt/data/backups/immich/immich-db-YYYY-MM-DD_HHMMSS.dump | head
+
+# 1. Immich 서비스 중지 (DB 쓰기 차단)
+sudo systemctl stop podman-immich-server.service podman-immich-machine-learning.service
+
+# 2. 복원 (--clean --if-exists: 기존 오브젝트 드롭 후 재생성)
+sudo podman exec -i immich-postgres pg_restore -U immich -d immich --clean --if-exists \
+  < /mnt/data/backups/immich/immich-db-YYYY-MM-DD_HHMMSS.dump
+
+# 3. 서비스 재시작
+sudo systemctl start podman-immich-server.service podman-immich-machine-learning.service
 ```
 
 ## 트러블슈팅

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ NixOS 홈서버 서비스는 `homeserver.*` 옵션으로 선언적으로 활성�
 - 옵션 선언: [`modules/nixos/options/homeserver.nix`](./modules/nixos/options/homeserver.nix)
 - 활성화 위치: [`modules/nixos/configuration.nix`](./modules/nixos/configuration.nix)
 
-**서비스 카테고리**: Immich(사진), Karakeep(웹 아카이버/북마크), Copyparty(파일 서버), Uptime Kuma(모니터링), Caddy(HTTPS 리버스 프록시). 각 서비스별 백업/업데이트 체크/알림 서브시스템 포함.
+**서비스 카테고리**: Immich(사진), Karakeep(웹 아카이버/북마크), Copyparty(파일 서버), Uptime Kuma(모니터링), Caddy(HTTPS 리버스 프록시). 전 서비스에 업데이트 체크/알림 서브시스템을, Immich·Karakeep에는 DB 백업 서브시스템을 포함합니다.
 
 ### 상수 관리
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 
 | Plan | Title | Priority | Effort | Depends on | Issue | Status |
 |------|-------|----------|--------|------------|-------|--------|
-| 001 | Immich DB 재해복구 문서를 백업 이원 구조에 맞게 정정 | P1 | S | — | #938 | TODO |
+| 001 | Immich DB 재해복구 문서를 백업 이원 구조에 맞게 정정 | P1 | S | — | #938 | DONE |
 | 002 | karakeep webhook 브리지 비특권·sandbox·인증 하드닝 | P1 | M | — | #939 | TODO |
 | 003 | log-monitor 상태/큐 재작성 same-fs 원자적 교체 | P1 | S | — | #940 | DONE |
 | 004 | 백업 스크립트 추출 + 특성화 테스트 | P2 | M | — | #941 | TODO |


### PR DESCRIPTION
## Summary

- Immich 재해복구 문서가 **재해에서 살아남는 유일한 백업(HDD `.dump`)의 복원 절차를 다루지 않고**, 기존 문서의 `gunzip | psql` 명령은 그 포맷(`pg_dump -Fc` 커스텀)에서 실패하는 문제를 정정한다 — 백업 이원 구조 표 + `pg_restore` 재해복구 절차를 추가.
- README의 과잉 약속("각 서비스별 백업 … 포함")을 실태(백업: Immich·Karakeep / 업데이트 체크·알림: 전 서비스)로 정정한다.

Closes #938

## 기존 문제/배경

Immich 백업은 두 계층이다: HDD 일일 백업(`pg_dump -Fc` → `/mnt/data/backups/immich/*.dump`, 기본 30일)과 SSD 업데이트 직전 백업(`pg_dump | gzip` → `/var/lib/immich-update/backups/*.sql.gz`, 7일). disko 재설치는 NVMe(SSD)만 포맷하고 HDD는 보존하므로, 재해 시 살아남는 것은 `.dump`뿐이다.

**문제**: 문서화된 유일한 복원 절차는 `gunzip | psql` — 즉 재설치 시 소멸하는 `.sql.gz`만 다룬다. 커스텀 포맷 `.dump`는 gzip도 평문 SQL도 아니라 이 명령이 실패하며, `pg_restore`가 필요하다. 실제 재해복구 순간에 "가진 백업은 복원법을 모르고, 복원법 있는 백업은 이미 사라진" 상태가 된다.

## CIR (Change Intent Record)

- 발견 경위: 코드베이스 감사(epic #937)의 docs 검증에서 확인 — 백업 스크립트(`immich-backup.nix`)의 실제 포맷과 스킬 문서의 복원 명령이 불일치했다.
- (이번 변경): 실행 plan `plans/001-immich-restore-docs.md`대로 문서만 수정. 백업 동작 변경은 별도 plan(백업 스크립트 추출+테스트, #941)의 몫.

해당 없음에 가까운 단순 문서 정정 — 대안 검토는 아래 ADR의 범위 결정 한 건.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 문서 정정만 (이원 구조 표 + `.dump` 복원 절차) | 실태를 정확히 기술 | 즉시 적용, 무위험 | 백업 자세 자체(같은 HDD, 오프사이트 부재)는 미해결 | ✅ |
| 백업 구조 개선을 함께 | 근본 개선 | — | 별도 설계가 필요한 큰 범위 — 백업 자세 spike(#953)가 담당 | ❌ |
| Karakeep 복원 문서도 함께 신설 | 커버리지 확대 | — | Karakeep 백업(`.db.gz`)은 gunzip으로 자명 — YAGNI | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `.claude/skills/running-containers/references/immich-update.md` | 수정 | "DB 백업/복원" 절에 이원 구조 표 + 두 위치 병기 + "재해복구 복원 — 일일 백업 (`.dump`)" 절 신설 (`pg_restore --list` TOC 확인 → 서비스 중지 → `pg_restore --clean --if-exists` → 재시작), 기존 절은 "수동 복원 — 업데이트 직전 백업 (`.sql.gz`)"로 개칭·보존 |
| `README.md` | 수정 (1문장) | 백업 약속 문구를 실태로 정정 |
| `plans/README.md` | 수정 (1행) | plan 001 상태 DONE 갱신 |

문서에 기입된 모든 경로/옵션은 SSOT에서 실측: `libraries/constants.nix`(mediaData/dockerData), `homeserver.nix`(retentionDays 기본 30), `immich-backup.nix`(포맷·파일명 패턴), `update-script.sh`(7일 보관), `disko.nix`(NVMe만 포맷).

## 참고 레퍼런스

- Issue #938 — 이 변경의 sub-issue (epic #937 감사 결과)
- `plans/001-immich-restore-docs.md` — 실행 plan (근거 발췌·done criteria)
- `modules/nixos/programs/docker/immich-backup.nix` — HDD 일일 백업 SSOT (`pg_dump -Fc`)
- `hosts/greenhead-minipc/disko.nix` — 재설치 시 HDD 보존 근거
- [pg_restore 공식 문서](https://www.postgresql.org/docs/current/app-pgrestore.html) — 커스텀 포맷 복원 도구

## Human Test Plan

### 문서 정확성 검증

1. 이원 구조 표의 경로·옵션이 SSOT와 일치하는지 확인:
   ```bash
   grep -n "mediaData\|dockerData" libraries/constants.nix
   grep -n -A3 "retentionDays" modules/nixos/options/homeserver.nix | head -6
   grep -n "pg_dump -Fc" modules/nixos/programs/docker/immich-backup.nix
   ```
   - **기대**: 문서의 `/mnt/data`·`/var/lib/docker-data`·기본 30일·`-Fc` 포맷과 일치.
2. Negative: 기존 절차 보존 + 과잉 약속 부재:
   ```bash
   grep -c "gunzip" .claude/skills/running-containers/references/immich-update.md  # 기대: 1 이상 (기존 .sql.gz 절차 보존)
   grep -n "각 서비스별 백업" README.md                                            # 기대: 0건 (exit 1)
   ```

### 실경로 (운영자 — 선택, 읽기 전용)

3. HDD 백업이 실존하는 MiniPC에서 TOC 확인만 실행 (데이터 무변경):
   ```bash
   sudo podman exec -i immich-postgres pg_restore --list \
     < "$(ls -t /mnt/data/backups/immich/immich-db-*.dump | head -1)" | head
   ```
   - **기대**: TOC 목록 출력 (문서의 0단계 명령이 실파일에서 동작함을 확인).
   - **실패 시**: 백업 파일 존재 여부(`ls /mnt/data/backups/immich/`)와 immich-postgres 컨테이너 상태 확인.
4. Regression: 문서 변경뿐이므로 서비스 동작 무영향 — `bash tests/run-all-tests.sh` 통과로 갈음.

### 후속 참고

- 실제 복원 전체 드릴(`--clean --if-exists` 실행)은 유지보수 창 사안 — 백업 자세 spike(#953)의 복원 드릴 정의에서 다룬다.


https://claude.ai/code/session_017AHrboa2KjKRoUy4xjgptZ
