### PR TITLE
feat(immich): 원본 사진 HDD 일일 미러 — 무백업 SSD 단독 존재 해소

### DIFF
--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -120,6 +120,7 @@
   homeserver.karakeepSinglefileBridge.enable = true; # SingleFile 대용량 자동 분기 (링크+보관 fullPageArchive)
   homeserver.karakeepUpdate.enable = true; # Karakeep 버전 체크 + 업데이트 알림
   homeserver.immichBackup.enable = true; # Immich PostgreSQL 매일 백업 (HDD)
+  homeserver.immichOriginalsMirror.enable = true; # Immich 원본 사진/영상 HDD 일일 미러
   homeserver.reverseProxy.enable = true; # Caddy HTTPS 리버스 프록시
   homeserver.smokeTest.enable = true; # 런타임 스모크 테스트 (헬스체크 + 백업 신선도)
   homeserver.opnix.enable = true; # 1Password SA token materialization + gh 인증

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -32,6 +32,15 @@
       };
     };
 
+    immichOriginalsMirror = {
+      enable = lib.mkEnableOption "Immich originals daily rsync mirror to HDD";
+      mirrorTime = lib.mkOption {
+        type = lib.types.str;
+        default = "*-*-* 04:30:00";
+        description = "OnCalendar time for daily originals mirror";
+      };
+    };
+
     uptimeKuma = {
       enable = lib.mkEnableOption "Uptime Kuma monitoring service";
       port = lib.mkOption {
@@ -201,6 +210,7 @@
     ../programs/copyparty-update # Copyparty 버전 체크 및 업데이트
     ../programs/docker/copyparty.nix # Copyparty 파일 서버
     ../programs/docker/immich-backup.nix # Immich PostgreSQL 매일 백업
+    ../programs/docker/immich-originals-mirror.nix # Immich 원본 사진/영상 HDD 일일 미러
     ../programs/docker/karakeep.nix # Karakeep 웹 아카이버/북마크 관리 (3컨테이너)
     ../programs/docker/karakeep-backup.nix # Karakeep SQLite 매일 백업
     ../programs/docker/karakeep-notify.nix # Karakeep 웹훅→Pushover 브리지

--- a/modules/nixos/programs/docker/immich-originals-mirror.nix
+++ b/modules/nixos/programs/docker/immich-originals-mirror.nix
@@ -1,0 +1,87 @@
+# modules/nixos/programs/docker/immich-originals-mirror.nix
+# Immich 원본 사진/영상 일일 미러 (SSD upload-cache → HDD)
+# rsync --archive --delete 미러: 원본은 무변경(읽기 전용), 목적지가 소스에 수렴한다.
+# "무백업 SSD 단독 존재" 해소 — 원본이 disko 포맷 대상 SSD에만 존재하던 백업 자세 결함 시정.
+# service-lib.sh로 Pushover 알림(실패 시만). oneshot systemd service + daily timer.
+{
+  config,
+  pkgs,
+  lib,
+  constants,
+  ...
+}:
+
+let
+  cfg = config.homeserver.immichOriginalsMirror;
+  immichCfg = config.homeserver.immich;
+  inherit (constants.paths) immichUploadCache mediaData;
+
+  srcDir = immichUploadCache;
+  destDir = "${mediaData}/backups/immich-originals";
+  pushoverCredPath = config.age.secrets.pushover-immich.path;
+  serviceLib = import ../../lib/service-lib.nix { inherit pkgs; };
+
+  mirrorScript = pkgs.writeShellApplication {
+    name = "immich-originals-mirror";
+    runtimeInputs = with pkgs; [
+      rsync
+      coreutils
+      curl # service-lib.sh의 send_notification에서 사용
+    ];
+    text = builtins.readFile ./immich-originals-mirror/files/immich-originals-mirror.sh;
+  };
+in
+{
+  config = lib.mkIf (cfg.enable && immichCfg.enable) {
+    # Pushover 시크릿 (immich.nix와 동일 선언 — 모듈 시스템이 merge)
+    age.secrets.pushover-immich = {
+      file = ../../../../secrets/pushover-immich.age;
+      owner = "root";
+      mode = "0400";
+    };
+
+    # 미러 서비스 (oneshot)
+    systemd.services.immich-originals-mirror = {
+      description = "Immich originals mirror (rsync SSD upload-cache → HDD)";
+
+      unitConfig = {
+        ConditionPathExists = pushoverCredPath;
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${mirrorScript}/bin/immich-originals-mirror";
+        TimeoutSec = "3h"; # 초회 105G 전체 복사 대비
+        ProtectSystem = "strict";
+        ReadWritePaths = [ destDir ];
+        ReadOnlyPaths = [ srcDir ];
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+      };
+
+      environment = {
+        PUSHOVER_CRED_FILE = pushoverCredPath;
+        SERVICE_LIB = "${serviceLib}";
+        SRC_DIR = srcDir;
+        DEST_DIR = destDir;
+      };
+    };
+
+    # 타이머 (기본 매일 04:30 KST — DB 백업 05:30 이전, IO 경합 회피)
+    systemd.timers.immich-originals-mirror = {
+      description = "Daily Immich originals mirror to HDD";
+      wantedBy = [ "timers.target" ];
+
+      timerConfig = {
+        OnCalendar = cfg.mirrorTime;
+        Persistent = true;
+        RandomizedDelaySec = "5m";
+      };
+    };
+
+    # 목적지 디렉토리 생성 (원본 자산이므로 0700)
+    systemd.tmpfiles.rules = [
+      "d ${destDir} 0700 root root -"
+    ];
+  };
+}

--- a/modules/nixos/programs/docker/immich-originals-mirror/files/immich-originals-mirror.sh
+++ b/modules/nixos/programs/docker/immich-originals-mirror/files/immich-originals-mirror.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# modules/nixos/programs/docker/immich-originals-mirror/files/immich-originals-mirror.sh
+# Immich 원본 사진/영상을 SSD(upload-cache) → HDD로 일일 rsync 미러링.
+# 원본이 disko 포맷 대상 SSD에만 존재하는 "무백업 단독 존재"를 해소한다(백업 자세 시정).
+# oneshot systemd service가 SRC_DIR/DEST_DIR/PUSHOVER_CRED_FILE/SERVICE_LIB를 주입한다.
+#
+# 삭제 전파(--delete) 결정: 이 미러는 원본의 삭제를 그대로 따라간다(진짜 미러).
+# 실수 삭제 방어는 Immich 앱 휴지통(기본 30일)과 오프사이트 계층(별도 plan)의 몫이라는
+# 계층 설계를 따른다 — 이 스크립트 자체는 지연 삭제(--backup-dir)를 하지 않는다.
+set -euo pipefail
+
+# service-lib.sh 로드(send_notification) + Pushover 자격
+# shellcheck source=/dev/null
+source "$PUSHOVER_CRED_FILE"
+# shellcheck source=/dev/null
+source "$SERVICE_LIB"
+
+# 에러 핸들러: 실패 시에만 Pushover 알림 (성공 시 무알림)
+cleanup_on_error() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    send_notification "Immich Originals Mirror" \
+      "원본 미러 실패 (exit $exit_code). journalctl -u immich-originals-mirror 확인 필요." 1
+  fi
+}
+trap cleanup_on_error EXIT
+
+echo "=== Immich originals mirror start: $(date -Iseconds) ==="
+
+# 1. 소스 가드(핵심 데이터 보존 계약) — SRC_DIR이 존재하고 비어있지 않아야 한다.
+#    빈 소스로 `rsync --delete`를 돌리면 목적지 전체가 삭제되므로(데이터 소실),
+#    소스가 비어 보이면(컨테이너 중지·마운트 누락 등) 미러를 실행하지 않고 중단한다.
+# shellcheck disable=SC2012  # 파일명 파싱이 아니라 "비었는지"만 판정하므로 목록 나열로 충분
+if [ ! -d "$SRC_DIR" ] || [ -z "$(ls -A "$SRC_DIR")" ]; then
+  echo "ERROR: Source empty or missing: $SRC_DIR (미러 중단 — 빈 소스로 목적지 삭제 방지)" >&2
+  exit 1
+fi
+
+# 2. 목적지 준비 + 디스크 여유 하한(플로어) 검사.
+#    하한 가드일 뿐이며, 초회 전체 복사에 필요한 정확한 용량 부족은 rsync가 자체 종료
+#    코드로 잡는다(아래 4번). immich-backup.nix의 5GB 검사 패턴을 준용한다.
+mkdir -p "$DEST_DIR"
+AVAIL_KB=$(df --output=avail "$DEST_DIR" | tail -1)
+AVAIL_GB=$((AVAIL_KB / 1024 / 1024))
+if [ "$AVAIL_GB" -lt 5 ]; then
+  echo "ERROR: Destination disk space low (${AVAIL_GB}GB available, need >=5GB floor)" >&2
+  exit 1
+fi
+echo "Destination disk space OK: ${AVAIL_GB}GB available"
+
+# 3. rsync 미러 실행 (--delete: 삭제 전파, 상단 주석의 계층 설계 근거).
+#    --stats 요약은 stdout으로 journald에 남긴다.
+echo "Running rsync mirror: $SRC_DIR/ -> $DEST_DIR/"
+RSYNC_RC=0
+rsync --archive --delete --human-readable --stats "$SRC_DIR/" "$DEST_DIR/" || RSYNC_RC=$?
+
+# 4. rsync 종료 코드 처리.
+#    0  = 정상.
+#    24 = 전송 중 소스 파일이 사라짐(라이브 업로드 중 파일 이동은 자연 현상) → 경고 후 정상.
+#    그 외 non-zero = 실패(trap이 Pushover 알림).
+if [ "$RSYNC_RC" -eq 0 ]; then
+  echo "Mirror completed cleanly."
+elif [ "$RSYNC_RC" -eq 24 ]; then
+  echo "WARN: rsync exit 24 (source files vanished during transfer) — treated as success."
+else
+  echo "ERROR: rsync failed (exit $RSYNC_RC)" >&2
+  exit "$RSYNC_RC"
+fi
+
+echo "=== Immich originals mirror completed: $(date -Iseconds) ==="

--- a/plans/README.md
+++ b/plans/README.md
@@ -32,7 +32,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 | 016 | 홈서버 백업/복구 자세 설계 spike | P2 | M | — | #953 | DONE |
 | 017 | 유지보수 창 3작업 묶음 실행 계획서 | P3 | S | 005, 016 (hard) | #954 | DONE |
 | 018 | 하네스 추출 가능성 판정 spike | P3 | M | — | #955 | TODO |
-| 019 | Immich 원본 사진 HDD 일일 미러 (016 추천 A 구현) | P1 | M | — | #961 | TODO |
+| 019 | Immich 원본 사진 HDD 일일 미러 (016 추천 A 구현) | P1 | M | — | #961 | DONE (머지 후 운영자 nrs+초회 미러 필요) |
 | 020 | 소용량 데이터 restic→R2 오프사이트 백업 (016 추천 B 구현) | P2 | M-L | 운영자 사전 준비 (R2/1Password) | #962 | TODO |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -125,6 +125,7 @@ run_test "install-lefthook serializes concurrent invocations" test_install_lefth
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
 run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
+run_test "immich originals mirror skips rsync on empty source" test_immich_originals_mirror_empty_source_skips_rsync
 run_test "hook_init_scan_dir falls back when TMPDIR missing" test_hook_init_scan_dir_falls_back_when_tmpdir_missing
 run_test "hook_init_scan_dir falls back when TMPDIR unwritable" test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable
 run_test "hook_init_scan_dir falls back when system tmp unusable" test_hook_init_scan_dir_falls_back_to_user_cache_when_system_tmp_unusable

--- a/tests/suites/immich-originals-mirror-guard.sh
+++ b/tests/suites/immich-originals-mirror-guard.sh
@@ -1,0 +1,38 @@
+# tests/suites/immich-originals-mirror-guard.sh — 도메인 테스트 정의 (sourced; aggregator가 lib/test-common.sh 후 source)
+# shellcheck shell=bash
+# SC2154: 공통 변수(REPO_ROOT 등)는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+# immich-originals-mirror.sh의 빈-소스 가드를 박제한다: SRC_DIR이 비어 있으면 rsync를
+# 절대 호출하지 않고 non-zero로 중단해야 한다. (빈 소스로 `rsync --delete` 미러 시 목적지
+# 전체가 삭제되므로 — 이 서비스의 핵심 데이터 보존 계약. plan 019 STEP 1 가드.)
+test_immich_originals_mirror_empty_source_skips_rsync() {
+  local script sandbox src dest bin marker rc
+  script="$REPO_ROOT/modules/nixos/programs/docker/immich-originals-mirror/files/immich-originals-mirror.sh"
+  sandbox="$(new_sandbox)"
+  src="$sandbox/src" # 의도적으로 빈 디렉토리
+  dest="$sandbox/dest"
+  bin="$sandbox/bin"
+  marker="$sandbox/rsync-was-called"
+  mkdir -p "$src" "$dest" "$bin"
+
+  # 스텁 rsync: 호출되면 마커를 남긴다. 가드가 살아 있으면 이 마커는 생기지 않아야 한다.
+  cat > "$bin/rsync" <<EOF
+#!/usr/bin/env bash
+touch "$marker"
+EOF
+  chmod +x "$bin/rsync"
+
+  # 스텁 자격/라이브러리: send_notification은 no-op (trap이 호출).
+  printf 'PUSHOVER_TOKEN=x\nPUSHOVER_USER=x\n' > "$sandbox/cred"
+  printf 'send_notification() { :; }\n' > "$sandbox/service-lib"
+
+  rc=0
+  PATH="$bin:$PATH" \
+    SRC_DIR="$src" DEST_DIR="$dest" \
+    PUSHOVER_CRED_FILE="$sandbox/cred" SERVICE_LIB="$sandbox/service-lib" \
+    bash "$script" >/dev/null 2>&1 || rc=$?
+
+  [[ "$rc" -ne 0 ]] || fail "expected non-zero exit on empty SRC_DIR (got $rc)"
+  [[ ! -e "$marker" ]] || fail "rsync must NOT be called when SRC_DIR is empty (목적지 삭제 방지)"
+}


### PR DESCRIPTION
## Summary

- Immich 원본 사진/영상(~105G, SSD `upload-cache` 단독 존재·**백업 0**)을 HDD(`/mnt/data/backups/immich-originals`)로 **일일 rsync 미러**하는 `immich-originals-mirror` 서비스를 추가한다 — 재설치(disko가 SSD 포맷)·SSD 단일 장애 시 원본 전량 소실 구조의 시정.
- 유지보수 창 runbook의 **필수 사전 게이트**(#960 후속 격상)가 이 서비스의 적용+초회 미러 완료를 전제한다.

Closes #961

## 기존 문제/배경

백업 자세 spike(#959, `plans/016-findings-backup-posture.md`)의 중대 발견: 원본이 HDD가 아니라 disko 포맷 대상 SSD의 `upload-cache`에만 있고(중첩 마운트 `immich.nix:154-155`, 스토리지 템플릿 비활성 시 원본이 `upload/`에 영속), 어떤 백업도 없다. 재해복구 시 DB 덤프(HDD)는 살아도 원본은 영구 소실 — 자산 없는 껍데기 DB만 남는다.

## CIR (Change Intent Record)

- 발견 경위: epic #937 감사 → 016 spike의 실호스트 실측. 구현 방향은 운영자 결정(016 open questions 답): **원본 위치 유지 + 백업 추가**, 스토리지 템플릿 비활성 유지, 오프사이트는 별도(#962).
- (이번 변경): 실행 plan `plans/019-immich-originals-mirror.md`대로 구현. 기존 관례(writeShellApplication + oneshot/timer + Pushover 실패 알림 + `homeserver.*` 옵션) 준수, 스크립트는 `files/` 분리 패턴(karakeep-notify 선례)으로 처음부터 작성.

**trade-off (삭제 전파)**: `rsync --delete` 진짜 미러 — 원본에서 삭제하면 미러에서도 삭제된다. 실수 삭제 방어는 Immich 앱 휴지통(기본 30일)과 오프사이트 계층(#962)의 몫이라는 016 계층 설계를 따르며, 이 결정은 스크립트 상단 주석으로 박제했다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| rsync `--delete` 미러 + 빈-소스 가드 | 목적지가 소스에 수렴 | 단순, 스토리지 예측 가능, 원본 무변경(읽기 전용) | 삭제 전파 (휴지통/오프사이트가 방어) | ✅ |
| `--backup-dir` 지연 삭제 | 삭제분 보관 | 실수 삭제 자체 방어 | 스토리지 성장 관리 필요 — 최소 운영 부담 원칙 위배 | ❌ |
| 원본을 HDD로 이전 | 구조 자체 시정 | 미러 불필요 | 105G 이동+다운타임(유지보수 창 사안), 운영자가 "위치 유지" 결정 | ❌ (open question 4로 창에서 재검토 가능) |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/docker/immich-originals-mirror/files/immich-originals-mirror.sh` | 신규 | 빈-소스 가드(빈 소스 + `--delete` = 목적지 전멸 방지, exit 1) → 디스크 플로어 검사 → rsync 미러 → exit 24(라이브 업로드 중 vanished)는 경고 후 정상 |
| `modules/nixos/programs/docker/immich-originals-mirror.nix` | 신규 | oneshot(`ProtectSystem=strict`, `ReadOnlyPaths`=원본, `ReadWritePaths`=목적지, `TimeoutSec=3h`) + 일일 타이머(04:30 — DB 백업 05:30 전) + tmpfiles 0700 |
| `modules/nixos/options/homeserver.nix` | 수정 | `immichOriginalsMirror` 옵션(enable/mirrorTime) + import |
| `modules/nixos/configuration.nix` | 수정 | 활성화 1줄 |
| `tests/suites/immich-originals-mirror-guard.sh` + `tests/shell-script-tests.sh` | 신규/수정 | 빈-소스 가드 박제(스텁 rsync 마커 — 가드 작동 시 rsync 미호출 assert) + run_test 등록 |
| `plans/README.md` | 수정 (1행) | plan 019 상태 DONE |

sandbox 참고: 이 서비스는 podman이 불필요해 `ProtectSystem=strict`가 가능 — 기존 backup 모듈(podman exec 필요)보다 강한 격리.

## 참고 레퍼런스

- Issue #961 — 이 plan의 sub-issue (epic #937) / #959 — 근거 spike 보고서
- `plans/019-immich-originals-mirror.md` — 실행 plan (SSOT)
- `plans/017-maintenance-window-runbook.md` — 이 서비스를 필수 사전 게이트로 요구
- [rsync exit values](https://download.samba.org/pub/rsync/rsync.1) — exit 24 = partial transfer due to vanished source files

## Human Test Plan

### 정적 검증 (병렬 가능)

1. `grep -rn "immichOriginalsMirror" modules/nixos/ | wc -l` → 옵션/모듈/활성화 배선 확인 (3곳).
2. `bash tests/run-all-tests.sh` → 전부 통과 (빈-소스 가드 테스트 포함).

### 실경로 (운영자 — 머지 후 필수)

3. `nrs` 적용 → `sudo systemctl start immich-originals-mirror.service` 수동 1회.
   - **기대**: 초회 전체 복사(~105G, 수십 분) 완료, `journalctl -u immich-originals-mirror`에 rsync `--stats` 요약 + "completed".
   - **실패 시**: journal의 ERROR 라인(소스 가드/디스크 플로어/rsync exit code) 확인.
4. `sudo du -sh /var/lib/docker-data/immich/upload-cache /mnt/data/backups/immich-originals` → 두 값 근사 일치.
5. Negative: `systemctl status immich-originals-mirror.timer` → 다음 04:30 트리거 예약 확인.
6. Regression: Immich 웹 UI 정상(원본은 읽기 전용 접근 — `ReadOnlyPaths`), 기존 `immich-db-backup` 타이머 무영향.

### 후속 참고

- 이 서비스의 초회 미러 완료가 **유지보수 창 필수 사전 게이트의 충족 조건**이다 (runbook §시작 전 준비).


https://claude.ai/code/session_017AHrboa2KjKRoUy4xjgptZ
