### PR TITLE
docs(skills): using-codex-exec를 codex-cli 0.142.5 실측으로 현행화 (#861)

### DIFF
--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -16,8 +16,8 @@ description: |
 
 ## 작성 기준
 
-- 확인 날짜: 2026-04-21
-- 확인 버전: codex-cli 0.122.0
+- 확인 날짜: 2026-07-03
+- 확인 버전: codex-cli 0.142.5
 - 재검증: `codex --version && codex exec --help && codex exec review --help`
 
 CLI 버전이 바뀌면 플래그/동작이 달라질 수 있으므로, 실행 전 도움말로 확인한다.
@@ -61,7 +61,7 @@ codex exec 실행이 필요한가?
 │  └─ YES → codex exec resume --last 또는 <session-id>
 │           ⚠️ --ephemeral 세션은 resume 불가
 │
-└─ 일반 실행 → codex exec --full-auto [-o result.md]
+└─ 일반 실행 → codex exec -s workspace-write [-o result.md]
                → references/patterns.md 패턴 1 참조
 ```
 
@@ -79,14 +79,13 @@ codex exec 실행이 필요한가?
 
 | 플래그 | 설명 |
 |--------|------|
-| `-i, --image <FILE>` | 이미지 첨부 |
-| `-s, --sandbox <MODE>` | 샌드박스 정책 (read-only, workspace-write, danger-full-access) |
+| `-i, --image <FILE>...` | 이미지 첨부 (0.142.5 기준 다중 지정 가능) |
+| `-s, --sandbox <SANDBOX_MODE>` | 샌드박스 정책 (read-only, workspace-write, danger-full-access) — review/resume은 미지원 |
 | `-C, --cd <DIR>` | 작업 디렉토리 지정 |
 | `--add-dir <DIR>` | 추가 쓰기 가능 디렉토리 |
-| `--output-schema <FILE>` | JSON Schema 출력 형식 |
 | `--oss` | 오픈소스 프로바이더 |
-| `--local-provider <PROVIDER>` | 로컬 프로바이더 (lmstudio/ollama) |
-| `-p, --profile <PROFILE>` | config.toml 프로필 |
+| `--local-provider <OSS_PROVIDER>` | 로컬 프로바이더 (lmstudio/ollama) |
+| `-p, --profile <CONFIG_PROFILE_V2>` | `$CODEX_HOME/<name>.config.toml`을 기본 유저 config 위에 레이어 |
 | `--color <COLOR>` | 색상 설정 (always/never/auto) |
 
 ### review 전용 플래그
@@ -96,24 +95,31 @@ codex exec 실행이 필요한가?
 | `--uncommitted` | 미커밋 변경 리뷰 |
 | `--base <BRANCH>` | 베이스 브랜치 대비 리뷰 |
 | `--commit <SHA>` | 특정 커밋 리뷰 |
-| `--title <TITLE>` | 리뷰 요약 제목 (scope flag와 조합 가능, 상호 배타 규칙에 미참여. 단독 사용 시 `--commit <SHA>` 필요) |
+| `--title <TITLE>` | 리뷰 요약 제목 (scope flag와 조합 가능, 상호 배타 규칙에 미참여. 단독 사용 시 `--commit <SHA>` 필요 — 재확인: 2026-07-03, 0.142.5) |
 
-### exec · review 공통 플래그
+### exec · review · resume 공통 플래그
 
 | 플래그 | 설명 |
 |--------|------|
 | `-c, --config <key=value>` | config 오버라이드 |
 | `--enable <FEATURE>` | 피처 활성화 |
 | `--disable <FEATURE>` | 피처 비활성화 |
+| `--strict-config` | config.toml에 인식 불가 필드가 있으면 에러 (신규, 0.142.5) |
 | `-m, --model <MODEL>` | 모델 선택 (생략 권장 — config.toml 기본값 사용) |
-| `--full-auto` | 자동 실행 (-a on-request, --sandbox workspace-write) |
-| `--dangerously-bypass-approvals-and-sandbox` | 샌드박스 우회 (--yolo 숨은 alias) |
+| `--output-schema <FILE>` | JSON Schema 출력 형식 — 0.142.5부터 review/resume도 지원 (이전에는 exec 전용) |
+| `--dangerously-bypass-approvals-and-sandbox` | 샌드박스 우회 (`--yolo` 숨은 alias) |
+| `--dangerously-bypass-hook-trust` | 영속 hook trust 없이 활성 hook 실행 허용 (신규, 0.142.5 — 자동화 전용, 위험) |
 | `--skip-git-repo-check` | Git 저장소 체크 건너뜀 |
 | `--ephemeral` | 세션 파일 미저장 |
 | `--ignore-user-config` | `$CODEX_HOME/config.toml` 로드 차단 (auth만 유지) |
 | `--ignore-rules` | user/project execpolicy `.rules` 파일 로드 차단 |
 | `--json` | JSONL 이벤트 출력 |
-| `-o, --output-last-message <FILE>` | 마지막 메시지 파일 저장 (review에서 upstream bug #12502로 빈 파일 생성) |
+| `-o, --output-last-message <FILE>` | 마지막 메시지 파일 저장 (review의 upstream bug #12502는 0.142.5에서 해소됨 — known-issues.md §2 참조) |
+
+⚠️ 승인(approval) 관련 CLI 플래그는 존재하지 않는다. `exec`/`review`/`resume`은 headless 실행이므로 승인 프롬프트 자체가 불가능하고, approval은 항상 `never`로 고정된다 (`--ignore-user-config`로 확인한 CLI 기본값 기준, 2026-07-03 실측). 과거 버전에 있던 자동 실행 플래그(승인 자동화 + `--sandbox workspace-write`를 한 번에 지정)는 0.142.5에서 완전히 제거되었다. 동일 의도의 실행은 아래로 대체한다:
+
+- `exec`: `-s workspace-write` (승인은 이미 자동이므로 샌드박스 tier만 지정하면 된다)
+- `review`/`resume`: 전용 sandbox 플래그가 없으므로 `config.toml`의 `sandbox_mode`를 따르거나, 필요 시 `--dangerously-bypass-approvals-and-sandbox`를 사용한다
 
 ### ⚠️ review 상호 배타 규칙
 
@@ -133,6 +139,8 @@ error: the argument '[PROMPT]' cannot be used with '--base <BRANCH>'
 error: the argument '--base <BRANCH>' cannot be used with '--uncommitted'
 ```
 
+재확인: 2026-07-03, 0.142.5에서도 4개 변형 모두 동일하게 상호 배타 유지됨 (완화되지 않음).
+
 근본 원인과 상세 분석: [references/known-issues.md](references/known-issues.md) §1
 
 ## 입력 방법
@@ -141,11 +149,13 @@ error: the argument '--base <BRANCH>' cannot be used with '--uncommitted'
 
 | 방법 | 예시 |
 |------|------|
-| 인라인 문자열 | `env CODEX_PROGRAMMATIC=1 codex exec --full-auto "짧은 질의"` |
-| stdin 파이프 | `cat prompt.md \| env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o result.md` |
-| stdin 마커 | `env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto` (stdin에서 읽음) |
-| 파일 리다이렉트 | `env CODEX_PROGRAMMATIC=1 codex exec --full-auto < prompt.md -o result.md` |
-| here-doc | `env CODEX_PROGRAMMATIC=1 codex exec --full-auto <<'EOF' ... EOF` |
+| 인라인 문자열 | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "짧은 질의"` |
+| stdin 파이프 | `cat prompt.md \| env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result.md` |
+| stdin 마커 | `env CODEX_PROGRAMMATIC=1 codex exec review -` (stdin에서 읽음) |
+| 파일 리다이렉트 | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write < prompt.md -o result.md` |
+| here-doc | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write <<'EOF' ... EOF` |
+
+⚠️ PROMPT 인자와 stdin을 동시에 사용하는 경우(0.142.5 신규 동작, `codex exec --help` 기준): stdin이 파이프된 상태에서 PROMPT 인자도 함께 주어지면, stdin 내용이 프롬프트에 `<stdin>` 블록으로 append된다. 이전 버전에서는 이 조합의 동작이 문서화되어 있지 않았다. 위 표의 각 방법은 여전히 단독 사용을 기본으로 하되, 혼용 시 이 append 동작을 인지한다.
 
 ## 표준 실행 절차
 
@@ -163,25 +173,25 @@ PROMPT
 
 ```bash
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
-cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/result.md 2>&1
+cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/result.md 2>&1
 ```
 
 인라인 프롬프트도 가능하다 (짧은 질의에 한해):
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec --full-auto "git diff 기준으로 회귀 가능성 한 줄 요약"
+env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "git diff 기준으로 회귀 가능성 한 줄 요약"
 ```
 
 ### 코드 리뷰 — scope flag만 사용 (커스텀 지시 불필요)
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main --full-auto > /tmp/review.md 2>&1
-env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted --full-auto > /tmp/review.md 2>&1
-env CODEX_PROGRAMMATIC=1 codex exec review --commit <sha> --full-auto > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --commit <sha> > /tmp/review.md 2>&1
 ```
 
-review 결과를 파일 저장하려면 stdout 리다이렉트(`> file 2>&1`)를 사용한다.
-`-o`는 review --help에 표시되지만 upstream bug(#12502)로 빈 파일을 생성한다.
+review 결과 저장에는 `-o`(`--output-last-message`) 또는 stdout 리다이렉트(`> file 2>&1`) 둘 다 사용 가능하다.
+`-o`가 빈 파일을 생성하던 upstream bug(#12502)는 0.142.5에서 해소됨 (재확인: 2026-07-03, known-issues.md §2 참조). 과거 문서/스크립트가 이 회피책으로 stdout 리다이렉트를 쓰고 있다면 그대로 두어도 무방하다 — 대체 필수는 아니다.
 
 ### 코드 리뷰 — 커스텀 지시 필요
 
@@ -212,13 +222,13 @@ env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제�
 
 ## Gotchas
 
-1. `--search`는 exec에서 미동작: `error: unexpected argument '--search' found`. 대안: `-c web_search=live`
-2. `--full-auto`는 `--sandbox`를 묵묵히 override: `-s read-only` 명시해도 `workspace-write`로 강제됨
+1. `--search`는 exec에서 미동작: `error: unexpected argument '--search' found`. 대안: `-c web_search=live` (재확인: 2026-07-03, 0.142.5에서도 동일)
+2. 과거 자동 실행 플래그(승인 자동화 + `--sandbox workspace-write`를 함께 지정하던 단축 플래그)는 0.142.5에서 완전히 제거됨: 그 이름 그대로 호출하면 `error: unexpected argument ... found`. exec에서는 `-s workspace-write`로 명시한다. 재확인 결과 이 조합은 config.toml의 `sandbox_mode`를 조용히 override하지 않는다 — 명시한 `-s` 값이 그대로 적용된다 (2026-07-03 실측: `-s read-only` 지정 시 config.toml이 `danger-full-access`여도 실제로 `read-only`로 실행됨).
 3. CODEX_API_KEY는 exec 전용: interactive TUI와 VS Code extension에서는 무시됨. OPENAI_API_KEY는 auth 체인에 미참여 (TUI prefill 전용). 우선순위: CODEX_API_KEY > ephemeral tokens > auth.json (상세: [known-issues.md](references/known-issues.md) 워크트리 참고)
 4. ephemeral 세션 resume 불가: `--ephemeral`으로 실행한 세션은 파일 미저장되어 `No saved session found` 에러 발생
-5. `codex review` (top-level) vs `codex exec review`: 전자는 `-m`, `--full-auto`, `--json`, `-o` 등 미지원. 비대화형 자동화에는 반드시 `codex exec review` 사용
+5. `codex review` (top-level) vs `codex exec review`: 전자는 `-m`, `--json`, `-o`, `--output-schema`, `--ephemeral`, `-s/--sandbox` 등 미지원 (재확인: 2026-07-03, `codex review --help`). 비대화형 자동화에는 반드시 `codex exec review` 사용
 6. Bash tool sandbox에서 `&` + `$!` 미작동: Claude Code의 Bash tool에서 background process PID 캡처(`$!`)가 리터럴 문자열로 반환됨. shell-level 병렬 대신 여러 병렬 Bash tool 호출 (예: codex exec 경로의 `run-da`/`parallel-audit`) + `cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -` stdin pipe를 사용한다. 이 제약은 Codex 세션의 native subagent 경로에는 적용되지 않는다. 상세: [known-issues.md](references/known-issues.md) §11
-7. stdin pipe로 stdin hang 방지: Claude Code Bash tool에서 병렬 호출 시 codex exec가 background로 자동 전환되면, stdin이 닫히지 않아 `Reading additional input from stdin...`에서 hang이 발생한다. `cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -` stdin pipe를 사용하면 pipe EOF가 stdin을 구조적으로 닫아 hang을 방지한다: `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec --full-auto --ephemeral -o "$DIR/result.md" - 2>"$DIR/stderr.log"`. 인라인 인자 `"$(cat file)"`와 `< /dev/null`은 사용하지 않는다. 상세: [known-issues.md](references/known-issues.md) §14
+7. stdin pipe로 stdin hang 방지: Claude Code Bash tool에서 병렬 호출 시 codex exec가 background로 자동 전환되면, stdin이 닫히지 않아 `Reading additional input from stdin...`에서 hang이 발생한다. `cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -` stdin pipe를 사용하면 pipe EOF가 stdin을 구조적으로 닫아 hang을 방지한다: `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --ephemeral -o "$DIR/result.md" - 2>"$DIR/stderr.log"`. 인라인 인자 `"$(cat file)"`와 `< /dev/null`은 사용하지 않는다. 상세: [known-issues.md](references/known-issues.md) §14
 
 ## 모델 사용 원칙
 
@@ -245,7 +255,6 @@ env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제�
 
 | 금지 패턴 | 발생 에러 | 올바른 대안 |
 |-----------|----------|------------|
-| review에서 `-o` 결과 저장 의존 | 빈 파일 생성 (upstream bug #12502) | stdout 리다이렉트 `> file 2>&1` |
 | review에서 PROMPT + scope flag | `'[PROMPT]' cannot be used with '--base'` | 의사결정 트리의 방법 A 또는 B |
 | exec 전용 플래그를 review에 전달 | `unexpected argument` | exec 전용/공통 매트릭스 확인 |
 | `-m o3` / `-m o4-mini` 등 비Codex 모델 지정 | "Model metadata not found" + "model is not supported" | `-m` 생략, config.toml 기본 모델 사용 |

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -99,14 +99,18 @@ pub commit: Option<String>,
 재검증 방법: 아래 명령이 에러 없이 실행되면 제약이 해소된 것이다:
 
 ```bash
-echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --base main --full-auto 2>&1 | head -5
+echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --base main 2>&1 | head -5
 ```
 
-### 2. review `-o` upstream bug — 빈 파일 생성
+재확인: 2026-07-03, codex-cli 0.142.5 — 위 명령은 여전히 `error: the argument '[PROMPT]' cannot be used with '--base <BRANCH>'`로 실패한다. 4개 변형(PROMPT/--base/--uncommitted/--commit) 모두 clap `conflicts_with_all`로 상호 배타가 유지됨. 제약 미해소.
 
-심각도: 높음
+### 2. review `-o` upstream bug — 빈 파일 생성 (0.142.5에서 해소됨)
 
-관찰된 동작: `-o` 사용 시 `Warning: no last agent message; wrote empty content` 출력, 0바이트 파일 생성 (v0.114.0에서 직접 재현)
+심각도: 높음 (해소 전 기준 — 버전 하한 판단 근거로 보존)
+
+0.142.5에서 해소됨 (재확인: 2026-07-03). 실제 uncommitted diff가 있는 상태에서 `codex exec review --uncommitted -o <file>`을 실행한 결과, `Warning: no last agent message` 경고 없이 파일에 리뷰 내용이 정상 기록됨을 확인했다. 아래는 해소 전(v0.104.0~v0.115.0-alpha) 증상의 기록이다.
+
+관찰된 동작 (해소 전): `-o` 사용 시 `Warning: no last agent message; wrote empty content` 출력, 0바이트 파일 생성 (v0.114.0에서 직접 재현)
 
 참고: `-o`(`--output-last-message`)는 `codex exec review --help`에 표시되므로 CLI 파서는 인자를 수용한다. 문제는 `ReviewTask::run()`이 None을 반환하여 빈 파일이 생성되는 것이다.
 
@@ -117,26 +121,28 @@ echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --base main --full-au
 | [#12502](https://github.com/openai/codex/issues/12502) | OPEN (2026-02-22~) | review `-o` 빈 파일 생성 보고 |
 | [#14335](https://github.com/openai/codex/issues/14335) | OPEN (2026-03-11~) | 동일 증상 재보고 |
 
-영향 범위: v0.104.0 ~ v0.115.0-alpha (직접 검증 기준)
+영향 범위: v0.104.0 ~ v0.115.0-alpha (직접 검증 기준). 0.142.5는 영향 범위 밖 (해소 확인).
 
-재현:
+재현 (해소 전, 역사적 기록):
 
 ```bash
-echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto -o /tmp/test.md 2>&1
-# → 0바이트 파일 + "Warning: no last agent message; wrote empty content"
+echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - -o /tmp/test.md 2>&1
+# v0.114.0 기준: 0바이트 파일 + "Warning: no last agent message; wrote empty content"
 ```
 
-워크어라운드: stdout 리다이렉트로 대체한다:
+워크어라운드 (해소 전 필요했던 방법, 0.142.5에서는 불필요하지만 유지해도 무방): stdout 리다이렉트로 대체한다:
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main --full-auto > /tmp/review-result.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review-result.md 2>&1
 ```
 
 재검증 방법: 아래 명령으로 `-o`가 비어있지 않은 파일을 생성하면 수정된 것이다:
 
 ```bash
-echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto -o /tmp/test.md 2>&1 && [ -s /tmp/test.md ] && echo "FIXED" || echo "STILL BROKEN"
+echo "modified" >> file.txt && echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted -o /tmp/test.md 2>&1 && [ -s /tmp/test.md ] && echo "FIXED" || echo "STILL BROKEN"
 ```
+
+2026-07-03 실측 결과: 실제 uncommitted diff가 있는 저장소에서 위 재검증 명령이 `FIXED`를 반환함 (`codex exec review --uncommitted -o <file>`로 직접 재현, PROMPT 없이 scope flag만 사용). `echo "test" | ... review - -o ...`처럼 PROMPT를 stdin으로 줄 경우 diff가 없으면 "There are no ... changes to review" 메시지가 정상 저장되는 것으로 대체되므로, 리그레션 확인 시 실제 diff가 있는 상태에서 재현해야 한다.
 
 ### 3. review가 working-tree 변경을 잘못 포함
 
@@ -167,9 +173,11 @@ echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto -o /tmp/t
 
 ### 5. `unexpected argument '--approval-mode' found`
 
-원인: `codex exec`는 `--approval-mode` 플래그를 받지 않는다.
+원인: `codex exec`는 `--approval-mode` 플래그를 받지 않는다. exec/review/resume은 headless 실행이라 승인 프롬프트 자체가 없고, 승인 관련 CLI 플래그는 애초에 존재하지 않는다 (승인은 항상 `never`로 고정 — 재확인: 2026-07-03, 0.142.5, `--ignore-user-config`로 CLI 기본값 직접 확인).
 
-해결: 자동 실행이 필요하면 `--full-auto`를 사용한다. 세밀한 승인/샌드박스 조정은 `-c key=value`로 처리한다.
+해결: 세밀한 샌드박스 조정이 필요하면 exec에서 `-s, --sandbox <MODE>`를 사용한다 (review/resume은 `-s` 미지원 — config.toml의 `sandbox_mode`를 따른다). 그 외 조정은 `-c key=value`로 처리한다.
+
+과거 버전에는 승인 자동화 + `--sandbox workspace-write`를 한 번에 지정하는 단축 플래그가 있었으나, 0.142.5 `codex exec --help` / `codex exec review --help` / `codex exec resume --help` 어디에도 나타나지 않는다 (완전히 제거됨). 문서/스크립트에 그 이름이 남아 있으면 `-s workspace-write`로 치환한다.
 
 ### 6. 결과 파일이 비어 있음 (`-o` 사용 시)
 
@@ -200,7 +208,7 @@ echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto -o /tmp/t
    ```
 2. 인라인 프롬프트로 비교 실행한다:
    ```bash
-   codex exec --full-auto "짧은 스모크 테스트"
+   codex exec -s workspace-write "짧은 스모크 테스트"
    ```
 
 ### 8. Git 저장소 체크 실패
@@ -266,7 +274,7 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다 (§11 하위 항목).
 
 ```bash
-cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/smoke-result.md 2>&1
+cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/smoke-result.md 2>&1
 cat /tmp/smoke-result.md
 ```
 
@@ -381,14 +389,14 @@ echo "PID: $!"
 
 관찰된 동작: 특정 Bash tool sandbox 구성에서 heredoc과 codex exec를 같은 호출에 체이닝하면 hang이 발생한다. 정확한 메커니즘은 미확정이나, heredoc이 stdin 상태에 영향을 주어 후속 codex exec가 추가 입력을 기다리는 것으로 추정된다. `run_in_background` 환경에서만 발생하며, 일반 터미널에서는 재현되지 않는다.
 
-재현 (codex-cli v0.118.0, 2026-04-01 확인):
+재현 (codex-cli v0.118.0, 2026-04-01 확인. 원 재현에는 당시 존재하던 자동실행 플래그를 사용했으나 0.142.5에서 제거되어 아래는 `-s workspace-write`로 치환한 등가 명령이다 — 버그는 stdin/heredoc 상호작용이 원인이라 이 치환으로 재현 조건이 바뀌지 않는다):
 
 HANG — heredoc 체이닝 (같은 Bash 호출):
 ```bash
 (umask 077; TDIR=$(mktemp -d /tmp/test-XXXXXX) && cat > "$TDIR/prompt.md" <<'EOF'
 테스트 프롬프트
 EOF
-codex exec --full-auto --ephemeral -o "$TDIR/result.md" "$(cat "$TDIR/prompt.md")")
+codex exec -s workspace-write --ephemeral -o "$TDIR/result.md" "$(cat "$TDIR/prompt.md")")
 # → 무한 대기
 ```
 
@@ -447,9 +455,9 @@ cat "$TDIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
 
 근본 원인: Claude Code Bash tool이 병렬 실행 시 background 전환하면서 stdin이 적절히 닫히지 않음. codex exec는 인자로 프롬프트를 받아도 stdin이 열려있으면 추가 입력을 기다림.
 
-해결: 모든 codex exec 호출에 `< /dev/null`을 추가하여 stdin을 즉시 EOF로 만든다.
+해결: 모든 codex exec 호출에 `< /dev/null`을 추가하여 stdin을 즉시 EOF로 만든다. (아래 명령의 샌드박스 플래그는 §13 최초 기록 당시의 자동실행 플래그를 0.142.5 제거 이후 등가 표기인 `-s workspace-write`로 치환한 것 — stdin EOF 해결 패턴 자체와는 무관하다.)
 ```bash
-codex exec --full-auto --ephemeral -o "$DIR/result.md" "$(cat prompt.md)" < /dev/null
+codex exec -s workspace-write --ephemeral -o "$DIR/result.md" "$(cat prompt.md)" < /dev/null
 ```
 
 참고: Codex 공식 플러그인의 background 작업은 `stdio: "ignore"`로 stdin/stdout/stderr를 모두 /dev/null로 리다이렉트한다 (동일 효과).
@@ -467,7 +475,7 @@ codex exec --full-auto --ephemeral -o "$DIR/result.md" "$(cat prompt.md)" < /dev
 ```bash
 # §13의 < /dev/null 패턴을 대체:
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
-cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec --full-auto --ephemeral \
+cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --ephemeral \
   -o "$DIR/result.md" \
   - \
   2>"$DIR/stderr.log"
@@ -525,7 +533,7 @@ variant legend (issue #593 PoC 8 variant + wrapper 적용 분류):
 | 시나리오 | HOME | CODEX_HOME | hooks 등록 | sandbox | stdin | 결과 (Mac 0.128, supervised wrapper 미적용) | wrapper 적용 후 기대 |
 |----------|------|-----------|-----------|---------|-------|--------|--------|
 | `host_home_no_override_stdin_pipe_pass` | host | host | 없음 (host config inline) | read-only | `</dev/null` 또는 pipe | OK 12s, hook fired, "PONG" | OK (wrapper grace 무관 — 이미 정상) |
-| `raw_override_inline_toml_hang` | host/sandbox | host/sandbox | `-c hooks.<event>` override | full-auto/read-only | host inherited 또는 pipe | HANG (timeout 못 죽임) | wrapper의 setsid+kill-after로 timeout 안에 정리되어 PASS |
+| `raw_override_inline_toml_hang` | host/sandbox | host/sandbox | `-c hooks.<event>` override | workspace-write(당시 자동실행 플래그)/read-only | host inherited 또는 pipe | HANG (timeout 못 죽임) | wrapper의 setsid+kill-after로 timeout 안에 정리되어 PASS |
 | `isolated_codex_home_overrideless_retired_self_injection` | sandbox | sandbox | ephemeral config.toml | read-only | inherited | HANG/marker unset in retired PR #595 self-injection assertion | Retired historical context (#634) — local fixture now validates caller-supplied `CODEX_PROGRAMMATIC=1` inheritance with supervised wrapper + stdin pipe EOF |
 
 Retired historical context (#634): `tests/test-codex-hook-fixtures.sh`의 기존 PR #595 self-injection assertion은 `CODEX_HOME=$sandbox/codex-home` + ephemeral config.toml + inherited stdin + raw `codex exec`에서 mac 0.128 marker unset/hang 계열 실패를 보였다. #634에서 fixture 계약을 local supported path로 정렬했다: programmatic caller가 `CODEX_PROGRAMMATIC=1`을 codex 프로세스에 붙이고, live fixture는 `codex-exec-supervised` + stdin pipe EOF + sandbox `CODEX_HOME` hook config로 이 marker가 hook subprocess까지 상속되는지만 검증한다. managed hook early-exit 자체는 deterministic noise-guard fixture가 검증한다.

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
@@ -19,7 +19,7 @@ PROMPT
 
 ```bash
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
-cat /tmp/codex-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/codex-result.md 2>&1
+cat /tmp/codex-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/codex-result.md 2>&1
 cat /tmp/codex-result.md
 ```
 
@@ -27,7 +27,7 @@ cat /tmp/codex-result.md
 - `-o`: 마지막 에이전트 메시지를 파일로 저장. 루프 연동 시 필수.
 - `2>&1`: stderr도 함께 캡처하여 실패 원인 추적에 활용.
 - stdin pipe 패턴 (`cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -`): pipe EOF가 stdin을 자동으로 닫아, Claude Code Bash tool의 background 전환 시 stdin hang을 구조적으로 방지한다. `< /dev/null`은 pipe가 대체하므로 불필요. 인라인 인자 `"$(cat file)"`는 사용하지 않는다 ([known-issues.md §14](known-issues.md)). marker는 codex 프로세스에 적용한다 (issue #585).
-- 인라인 프롬프트(`codex exec --full-auto "..."`)는 짧은 질의에만 사용.
+- 인라인 프롬프트(`codex exec -s workspace-write "..."`)는 짧은 질의에만 사용.
 
 ## 패턴 2: 코드 리뷰 — scope flag만 사용 (커스텀 지시 불필요)
 
@@ -36,7 +36,7 @@ cat /tmp/codex-result.md
 ### 브랜치 비교
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main --full-auto > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
 ```
 
 현재 브랜치를 `main`과 비교하여 리뷰한다.
@@ -44,7 +44,7 @@ env CODEX_PROGRAMMATIC=1 codex exec review --base main --full-auto > /tmp/review
 ### 미커밋 변경
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted --full-auto > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted > /tmp/review.md 2>&1
 ```
 
 staged/unstaged/untracked 변경을 함께 리뷰한다. 커밋 전 self-review에 적합.
@@ -52,23 +52,23 @@ staged/unstaged/untracked 변경을 함께 리뷰한다. 커밋 전 self-review�
 ### 특정 커밋
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 --full-auto > /tmp/review.md 2>&1
-env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 --title "Fix sandbox leak" --full-auto > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 --title "Fix sandbox leak" > /tmp/review.md 2>&1
 ```
 
 `--title`은 `--commit`과 함께 사용하여 리뷰 요약에 커밋 제목을 표시한다.
 
 ### 주의사항
 
-- `-o` review 미지원: `-o`는 review --help에 표시되지만 빈 파일을 생성한다(`Warning: no last agent message; wrote empty content`). `> file 2>&1`이 유일한 워크어라운드.
+- `-o`도 사용 가능: 0.142.5에서 review의 `-o` 빈 파일 생성 upstream bug(#12502)가 해소되어, `-o`와 stdout 리다이렉트(`> file 2>&1`) 둘 다 사용할 수 있다 (재확인: 2026-07-03, known-issues.md §2).
 - PROMPT 금지: scope flag과 PROMPT은 상호 배타. 자세한 내용은 SKILL.md 호환성 매트릭스 참조.
 
-## 패턴 2b: stdin PROMPT로 review (`-o` 대신 `> redirect` 사용)
+## 패턴 2b: stdin PROMPT로 review
 
 scope flag 없이 PROMPT을 stdin으로 전달하여 review를 실행한다.
 
 ```bash
-cat prompt.md | env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto > /tmp/result.md 2>&1
+cat prompt.md | env CODEX_PROGRAMMATIC=1 codex exec review - > /tmp/result.md 2>&1
 ```
 
 > ⚠️ scope flag 미사용: PROMPT 사용 시 scope flag(`--uncommitted`/`--base`/`--commit`)와
@@ -101,7 +101,7 @@ EOF
 2. scope flag으로 리뷰를 실행한다:
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main --full-auto > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
 ```
 
 ### 전역 정책 (모든 프로젝트에 적용)
@@ -137,7 +137,7 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. diff가 클 수 있으므로 stdin pipe를 사용한다.
 
 ```bash
-cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/review-result.md - 2>&1
+cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/review-result.md - 2>&1
 cat /tmp/review-result.md
 ```
 
@@ -153,12 +153,12 @@ PROMPT
 ```
 
 ```bash
-cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/review-result.md - 2>&1
+cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/review-result.md - 2>&1
 ```
 
 ### 장점
 
-- `-o`로 결과 저장 가능 (review 서브커맨드에서는 빈 파일 생성되므로 exec 전용).
+- `-o`로 결과 저장 가능 (0.142.5부터는 review 서브커맨드에서도 `-o`가 정상 동작하므로, 이 장점은 상대적으로 작아졌다 — patterns.md §패턴 2 주의사항 참조).
 - 프롬프트 내용을 완전히 자유롭게 구성 가능.
 - `--output-schema`와 조합하여 구조화된 JSON 출력도 가능.
 
@@ -192,7 +192,7 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. DA 루프에서는 stdin pipe(`cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -`)를 사용한다.
 
 ```bash
-cat /tmp/da-round1.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/da-round1-result.md \
+cat /tmp/da-round1.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/da-round1-result.md \
   - 2>/tmp/da-round1-stderr.log
 cat /tmp/da-round1-result.md
 ```
@@ -214,7 +214,7 @@ PROMPT
 ```
 
 ```bash
-cat /tmp/da-round2.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/da-round2-result.md \
+cat /tmp/da-round2.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/da-round2-result.md \
   - 2>/tmp/da-round2-stderr.log
 ```
 
@@ -262,18 +262,18 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. diff가 클 수 있으므로 stdin pipe를 사용한다.
 
 ```bash
-cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto --output-schema /tmp/review-schema.json \
+cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --output-schema /tmp/review-schema.json \
   -o /tmp/review-structured.json - 2>&1
 ```
 
-주의: `--output-schema`는 exec 전용. review 서브커맨드에서 사용 불가.
+주의: `--output-schema`는 0.142.5부터 exec뿐 아니라 review/resume에서도 지원된다 (재확인: 2026-07-03, `codex exec review --help`). 이전에는 exec 전용이었다.
 
 ## 패턴 7: JSONL 이벤트 스트림
 
 자동화 파서와 연결하거나 실행 과정을 기록할 때 사용한다.
 
 ```bash
-cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto --json > /tmp/events.jsonl
+cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --json > /tmp/events.jsonl
 ```
 
 주요 이벤트 타입:
@@ -283,7 +283,7 @@ cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto --json > /t
 최종 요약문을 파일로도 보존하려면 `-o`를 별도로 함께 사용한다:
 
 ```bash
-cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto --json -o /tmp/result.md > /tmp/events.jsonl
+cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --json -o /tmp/result.md > /tmp/events.jsonl
 ```
 
 ## 패턴 8: 스모크 테스트
@@ -299,7 +299,7 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다 ([known-issues.md §11](known-issues.md) 하위 항목).
 
 ```bash
-cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o /tmp/smoke-result.md 2>&1
+cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/smoke-result.md 2>&1
 cat /tmp/smoke-result.md
 ```
 
@@ -316,7 +316,7 @@ cat /tmp/smoke-result.md
 | 프롬프트 | 완전 자유 제어 | diff 컨텍스트 내장 |
 | 대상 | 범용 작업 | 코드 리뷰 특화 |
 | diff 스코핑 | 수동 (heredoc 등) | 자동 (--uncommitted/--base/--commit) |
-| `-o` 동작 | 정상 | 빈 파일 생성 (review에서 미지원) |
+| `-o` 동작 | 정상 | 정상 (0.142.5 — upstream bug #12502 해소, 재확인: 2026-07-03) |
 
 ## 빠른 참조 표
 
@@ -324,12 +324,12 @@ cat /tmp/smoke-result.md
 
 | 상황 | 패턴 | 명령 요약 |
 |------|------|-----------|
-| 일반 실행 | 1 | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o result` |
-| 리뷰 (기본) | 2 | `env CODEX_PROGRAMMATIC=1 codex exec review --base main --full-auto > result` |
-| 리뷰 (stdin PROMPT) | 2b | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex exec review - --full-auto > result` |
+| 일반 실행 | 1 | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result` |
+| 리뷰 (기본) | 2 | `env CODEX_PROGRAMMATIC=1 codex exec review --base main > result` |
+| 리뷰 (stdin PROMPT) | 2b | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex exec review - > result` |
 | 리뷰 + 커스텀 지시 (영구) | 3 | AGENTS.md 작성 후 `env CODEX_PROGRAMMATIC=1 codex exec review --base` |
-| 리뷰 + 커스텀 지시 (1회) | 4 | `cat diff+지시 \| env CODEX_PROGRAMMATIC=1 codex exec --full-auto -o result -` |
+| 리뷰 + 커스텀 지시 (1회) | 4 | `cat diff+지시 \| env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result -` |
 | 피드백 루프 | 5 | 라운드별 prompt → `env CODEX_PROGRAMMATIC=1 codex exec -o` → 분석 → 반복 |
 | 구조화 출력 | 6 | `env CODEX_PROGRAMMATIC=1 codex exec --output-schema schema.json -o result` |
-| JSONL 스트림 | 7 | `env CODEX_PROGRAMMATIC=1 codex exec --full-auto --json > events.jsonl` |
+| JSONL 스트림 | 7 | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --json > events.jsonl` |
 | 환경 점검 | 8 | 최소 프롬프트로 `env CODEX_PROGRAMMATIC=1 codex exec` 스모크 테스트 |


### PR DESCRIPTION
## Summary

using-codex-exec 스킬 문서가 codex-cli 0.122.0 (2026-04-21) 기준으로 작성되어 활성 CLI 0.142.5와 어긋나 있었다. 특히 문서가 지시하던 자동 실행 플래그는 현행 CLI에서 완전히 제거된 상태라, 문서를 신뢰한 fan-out 세션이 미지원 플래그 에러를 만나는 구조였다. 전 CLI surface를 실측해 현행화한다.

## Changes

- `SKILL.md`: 작성 기준을 0.142.5/2026-07-03으로 갱신, 제거된 자동 실행 플래그 15곳을 `-s workspace-write`(exec) 또는 플래그 제거(review — `-s` 미지원)로 치환, profile v2(`CONFIG_PROFILE_V2`)·stdin `<stdin>` block append 동작 반영
- `references/known-issues.md`: 단정 주장마다 재확인 날짜/버전 스탬프. review `-o` 빈 파일 버그(upstream #12502)는 0.142.5에서 해소 실측 확인 — 항목은 삭제하지 않고 버전 하한 판단 근거로 보존
- `references/patterns.md`: 예제 명령 전체를 동일 치환 원칙으로 정렬
- 실측 재검증 결과: review의 PROMPT↔scope flag 상호 배타는 여전히 유지, `--search` 미동작도 유지

## Verification

- `grep -rn "full-auto\|0\.122\.0"` 스킬 디렉토리 기준 0건
- `bash tests/run-shell-script-tests.sh` exit 0 (skill-noise 게이트 포함)

Plan: `plans/022-using-codex-exec-doc-refresh.md`

Closes #861

https://claude.ai/code/session_01MLMsqvwrkjvueXzhbrM7vA
