### PR TITLE
fix(hooks): worktree-path-guard sibling worktree 오탐 제거 (#935)

### DIFF
--- a/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
@@ -21,6 +21,9 @@ COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
 
 WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 MAIN_REPO=$(cd "$COMMON_DIR/.." 2>/dev/null && pwd) || exit 0
+# 저장소 관례상 worktree는 모두 $MAIN_REPO/.claude/worktrees/ 아래에 생성된다(wt 스크립트).
+# 이 컨테이너 밖에 수동으로 만든 worktree는 관례를 벗어난 것이므로 아래 예외의 보호 대상이 아니다.
+WORKTREES_CONTAINER="$MAIN_REPO/.claude/worktrees"
 
 # 대상 파일의 실제 경로 확인 (심링크 해석)
 RESOLVED=$(readlink -f "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
@@ -47,6 +50,7 @@ _is_main_repo_path() {
   local p="$1"
   [[ "$p" != "$MAIN_REPO"/* ]] && return 1
   [[ "$p" == "$WORKTREE_ROOT"/* ]] && return 1
+  [[ "$p" == "$WORKTREES_CONTAINER"/* ]] && return 1
   return 0
 }
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -125,6 +125,11 @@ run_test "install-lefthook serializes concurrent invocations" test_install_lefth
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
 run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
+run_test "worktree-path-guard main repo session always allows" test_worktree_path_guard_main_repo_session_always_allows
+run_test "worktree-path-guard denies main repo file from worktree" test_worktree_path_guard_denies_main_repo_file_from_worktree
+run_test "worktree-path-guard allows own worktree file" test_worktree_path_guard_allows_own_worktree_file
+run_test "worktree-path-guard allows sibling worktree file" test_worktree_path_guard_allows_sibling_worktree_file
+run_test "worktree-path-guard allows main repo plan path exception" test_worktree_path_guard_allows_main_repo_plan_path_exception
 run_test "immich originals mirror skips rsync on empty source" test_immich_originals_mirror_empty_source_skips_rsync
 run_test "immich cleanup paginates v3 nextPage string" test_immich_cleanup_v3_paginates_next_page_string
 run_test "immich cleanup preserves empty album notification" test_immich_cleanup_v3_empty_album_preserves_notification

--- a/tests/suites/worktree-path-guard.sh
+++ b/tests/suites/worktree-path-guard.sh
@@ -1,0 +1,100 @@
+# tests/suites/worktree-path-guard.sh — 도메인 테스트 정의 (sourced; aggregator가 lib/test-common.sh 후 source)
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+# worktree-path-guard.sh PreToolUse 가드에 JSON stdin을 흘려, main repo 보호와 sibling worktree
+# 오탐 제거(이슈 #935)를 함께 박제한다. 가드는 Edit/Write tool_input.file_path만 검사하며,
+# main repo 세션(git-dir == git-common-dir)에서는 조기 종료로 항상 통과한다.
+# 임시 bare-minimum git repo + `git worktree add` 2개(a, b)로 fixture를 구성해
+# 실제 $HOME이나 이 저장소의 worktree는 건드리지 않는다.
+
+_wpg_isolated_git() {
+  # fixture repo 전용 git 실행기. HOME/XDG를 격리해 실제 사용자 git 설정과 무관하게 동작시킨다.
+  local repo_root="$1"
+  shift
+  local home_dir
+  home_dir="$(dirname "$repo_root")/home"
+  mkdir -p "$home_dir/.config"
+  HOME="$home_dir" \
+    XDG_CONFIG_HOME="$home_dir/.config" \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_NOSYSTEM=1 \
+    git -C "$repo_root" \
+    -c commit.gpgSign=false \
+    -c init.templateDir= \
+    "$@"
+}
+
+_wpg_setup_fixture() {
+  # $1 = sandbox 디렉토리(new_sandbox로 이미 생성됨). main repo + worktree a/b를 만들고
+  # main repo 절대경로를 stdout으로 반환한다.
+  local sandbox="$1"
+  local main_root="$sandbox/main"
+  mkdir -p "$main_root"
+  _wpg_isolated_git "$main_root" init -b main >/dev/null 2>&1
+  _wpg_isolated_git "$main_root" config user.name "Test User"
+  _wpg_isolated_git "$main_root" config user.email "test@example.com"
+  echo "main" > "$main_root/flake.nix"
+  mkdir -p "$main_root/.claude/plans"
+  _wpg_isolated_git "$main_root" add flake.nix
+  _wpg_isolated_git "$main_root" commit -m "initial" >/dev/null 2>&1
+  _wpg_isolated_git "$main_root" worktree add ".claude/worktrees/a" -b wt-a >/dev/null 2>&1
+  _wpg_isolated_git "$main_root" worktree add ".claude/worktrees/b" -b wt-b >/dev/null 2>&1
+  printf '%s\n' "$main_root"
+}
+
+_wpg_decision() {
+  # $1 = 훅을 실행할 cwd, $2 = tool_input.file_path, $3 = tool_name(기본 Edit).
+  local cwd="$1" file_path="$2" tool_name="${3:-Edit}"
+  (
+    cd "$cwd" && \
+    printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool_name" "$file_path" | \
+      bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh" 2>&1
+  )
+}
+
+test_worktree_path_guard_main_repo_session_always_allows() {
+  local sandbox main_root out
+  sandbox=$(new_sandbox)
+  main_root=$(_wpg_setup_fixture "$sandbox")
+  # main repo 세션(git-dir == git-common-dir)은 조기 종료 — repo 밖 임의 경로도 통과해야 한다.
+  out=$(_wpg_decision "$main_root" "/etc/hosts")
+  [[ -z "$out" ]] || fail "expected main repo session to allow unconditionally, got: $out"
+}
+
+test_worktree_path_guard_denies_main_repo_file_from_worktree() {
+  local sandbox main_root out
+  sandbox=$(new_sandbox)
+  main_root=$(_wpg_setup_fixture "$sandbox")
+  out=$(_wpg_decision "$main_root/.claude/worktrees/a" "$main_root/flake.nix")
+  assert_contains "$out" '"permissionDecision": "deny"'
+}
+
+test_worktree_path_guard_allows_own_worktree_file() {
+  local sandbox main_root out
+  sandbox=$(new_sandbox)
+  main_root=$(_wpg_setup_fixture "$sandbox")
+  out=$(_wpg_decision "$main_root/.claude/worktrees/a" "$main_root/.claude/worktrees/a/flake.nix")
+  [[ -z "$out" ]] || fail "expected own worktree file to be allowed, got: $out"
+}
+
+test_worktree_path_guard_allows_sibling_worktree_file() {
+  # 이슈 #935 회귀 테스트: worktree A에서 sibling worktree B 파일 편집은 main repo 파일이
+  # 아니므로 허용되어야 한다. 이번 plan의 존재 이유.
+  local sandbox main_root out
+  sandbox=$(new_sandbox)
+  main_root=$(_wpg_setup_fixture "$sandbox")
+  out=$(_wpg_decision "$main_root/.claude/worktrees/a" "$main_root/.claude/worktrees/b/flake.nix")
+  [[ -z "$out" ]] || fail "expected sibling worktree file to be allowed, got: $out"
+}
+
+test_worktree_path_guard_allows_main_repo_plan_path_exception() {
+  # 기존 예외(29-43행 상당, 이번 plan 범위 밖) 회귀 확인: main repo .claude/plans/*.md는
+  # worktree 세션에서도 계속 허용되어야 한다.
+  local sandbox main_root out
+  sandbox=$(new_sandbox)
+  main_root=$(_wpg_setup_fixture "$sandbox")
+  out=$(_wpg_decision "$main_root/.claude/worktrees/a" "$main_root/.claude/plans/x.md")
+  [[ -z "$out" ]] || fail "expected main repo plan path exception to allow, got: $out"
+}


### PR DESCRIPTION
## Summary

worktree-path-guard가 sibling worktree 경로(`<main>/.claude/worktrees/<other>/...`)를 "main repo 하위 + 현재 worktree 밖"으로 판정해 정당한 편집을 오탐 차단했다 (이 저장소의 worktree는 관례상 main repo 하위에 생성되기 때문). worktree 컨테이너 프리픽스 예외를 추가해 해소한다 — git 호출 추가 없이 프리픽스 검사만 사용.

## Changes

- `modules/shared/programs/claude/files/hooks/worktree-path-guard.sh`: `WORKTREES_CONTAINER` 변수 + `_is_main_repo_path` 예외 조건 (+4줄). 컨테이너 밖 수동 worktree는 관례 밖이므로 허용 오차로 주석 명시
- `tests/suites/worktree-path-guard.sh` 신설: HOME/XDG 격리 git fixture로 5케이스 — main 세션 통과 / main repo 파일 deny (가드 비약화 증거) / 자기 worktree allow / sibling worktree allow (#935 회귀) / `.claude/plans` 예외 회귀
- `tests/shell-script-tests.sh`: 신규 suite 5케이스 등록

## Verification

- `bash tests/run-shell-script-tests.sh` exit 0 (신규 5케이스 포함)
- `bash tests/run-all-tests.sh` 통과 7 · 실패 0
- shellcheck 경고 0

Plan: `plans/023-worktree-path-guard-sibling.md`

Closes #935

https://claude.ai/code/session_01MLMsqvwrkjvueXzhbrM7vA
