### PR TITLE
fix(karakeep): webhook 브리지 비특권 유저 + systemd sandbox 하드닝

### DIFF
--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -134,6 +134,11 @@
         default = 9999;
         description = "Local port for webhook receiver";
       };
+      webhookTokenFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Optional file containing the expected Karakeep webhook bearer token";
+      };
     };
 
     karakeepLogMonitor = {

--- a/modules/nixos/programs/docker/karakeep-notify.nix
+++ b/modules/nixos/programs/docker/karakeep-notify.nix
@@ -63,15 +63,37 @@ in
       serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.socat}/bin/socat TCP-LISTEN:${toString cfg.webhookPort},reuseaddr,fork EXEC:${webhookBridgeScript}/bin/karakeep-webhook-bridge";
+        DynamicUser = true;
+        LoadCredential = [
+          "pushover:${pushoverCredPath}"
+        ]
+        ++ lib.optionals (cfg.webhookTokenFile != null) [
+          "webhook-token:${cfg.webhookTokenFile}"
+        ];
         Restart = "on-failure";
         RestartSec = "5s";
+        ProtectSystem = "strict";
+        ProtectHome = true;
         PrivateTmp = true;
+        PrivateDevices = true;
         NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
       };
 
       environment = {
-        PUSHOVER_CRED_FILE = pushoverCredPath;
+        PUSHOVER_CRED_FILE = "%d/pushover";
         SERVICE_LIB = "${serviceLib}";
+      }
+      // lib.optionalAttrs (cfg.webhookTokenFile != null) {
+        WEBHOOK_TOKEN_FILE = "%d/webhook-token";
       };
     };
   };

--- a/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh
+++ b/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh
@@ -5,12 +5,15 @@ set -uo pipefail
 
 # HTTP 헤더 읽기 (빈 줄까지 스킵)
 content_length=0
+authorization=""
 while IFS= read -r line; do
   line="${line%%$'\r'}"
   [ -z "$line" ] && break
   if [[ "${line,,}" == content-length:* ]]; then
     content_length="${line#*:}"
     content_length="${content_length// /}"
+  elif [[ "${line,,}" == authorization:* ]]; then
+    authorization=$(printf '%s' "${line#*:}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
   fi
 done
 
@@ -24,8 +27,20 @@ fi
 operation=$(printf '%s' "$body" | jq -r '.operation // empty' 2>/dev/null)
 url=$(printf '%s' "$body" | jq -r '.url // empty' 2>/dev/null)
 
+notification_allowed=true
+if [ -n "${WEBHOOK_TOKEN_FILE:-}" ]; then
+  expected_token=$({ tr -d '\r\n' < "$WEBHOOK_TOKEN_FILE"; } 2>/dev/null || true)
+  if [ -z "$expected_token" ]; then
+    echo "WARN: webhook-bridge: WEBHOOK_TOKEN_FILE token unavailable (notification skipped)" >&2
+    notification_allowed=false
+  elif [ "$authorization" != "Bearer $expected_token" ]; then
+    echo "WARN: webhook-bridge: Authorization bearer token mismatch (notification skipped)" >&2
+    notification_allowed=false
+  fi
+fi
+
 # crawled 이벤트만 처리
-if [ "$operation" = "crawled" ] && [ -n "$url" ]; then
+if [ "$notification_allowed" = true ] && [ "$operation" = "crawled" ] && [ -n "$url" ]; then
   # 프로토콜 제거 (도메인+경로 유지, 쿼리스트링/트레일링 슬래시 제거)
   short_url=$(printf '%s' "$url" | sed -E 's|^https?://||; s|\?.*||; s|/$||')
   # shellcheck source=/dev/null

--- a/plans/README.md
+++ b/plans/README.md
@@ -21,7 +21,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 | Plan | Title | Priority | Effort | Depends on | Issue | Status |
 |------|-------|----------|--------|------------|-------|--------|
 | 001 | Immich DB 재해복구 문서를 백업 이원 구조에 맞게 정정 | P1 | S | — | #938 | DONE |
-| 002 | karakeep webhook 브리지 비특권·sandbox·인증 하드닝 | P1 | M | — | #939 | TODO |
+| 002 | karakeep webhook 브리지 비특권·sandbox·인증 하드닝 | P1 | M | — | #939 | DONE (실 배포 `nrs`·알림 왕복 확인은 운영자 후속) |
 | 003 | log-monitor 상태/큐 재작성 same-fs 원자적 교체 | P1 | S | — | #940 | DONE |
 | 004 | 백업 스크립트 추출 + 특성화 테스트 | P2 | M | — | #941 | TODO |
 | 005 | Immich DB(pgvecto-rs) 마이그레이션 spike (조사 전용) | P2 | M | — | #942 | DONE |

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -129,6 +129,7 @@ run_test "install-lefthook pins worktree-local hooks path in worktree mode" test
 run_test "webhook-bridge crawled payload sends notification" test_webhook_bridge_crawled_payload_sends_notification
 run_test "webhook-bridge non-crawled payload skips notification" test_webhook_bridge_non_crawled_payload_skips_notification
 run_test "webhook-bridge invalid JSON keeps 200 without notification" test_webhook_bridge_invalid_json_keeps_200_without_notification
+run_test "webhook-bridge matching token sends notification" test_webhook_bridge_matching_token_sends_notification
 run_test "webhook-bridge wrong token keeps 200 and warns" test_webhook_bridge_wrong_token_keeps_200_and_warns
 run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -126,6 +126,10 @@ run_test "install-lefthook preserves custom local core.hooksPath" test_install_l
 run_test "install-lefthook is silent on clean state" test_install_lefthook_silent_on_clean_state
 run_test "install-lefthook serializes concurrent invocations" test_install_lefthook_concurrent_install_serializes
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
+run_test "webhook-bridge crawled payload sends notification" test_webhook_bridge_crawled_payload_sends_notification
+run_test "webhook-bridge non-crawled payload skips notification" test_webhook_bridge_non_crawled_payload_skips_notification
+run_test "webhook-bridge invalid JSON keeps 200 without notification" test_webhook_bridge_invalid_json_keeps_200_without_notification
+run_test "webhook-bridge wrong token keeps 200 and warns" test_webhook_bridge_wrong_token_keeps_200_and_warns
 run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
 run_test "worktree-path-guard main repo session always allows" test_worktree_path_guard_main_repo_session_always_allows

--- a/tests/suites/webhook-bridge.sh
+++ b/tests/suites/webhook-bridge.sh
@@ -1,0 +1,115 @@
+# tests/suites/webhook-bridge.sh — Karakeep webhook bridge fixture tests (sourced)
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+_webhook_bridge_script="$REPO_ROOT/modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh"
+
+_webhook_bridge_prepare_sandbox() {
+  local sandbox="$1"
+  printf '# stub pushover credentials\n' > "$sandbox/pushover"
+  cat > "$sandbox/service-lib" <<'STUB'
+send_notification() {
+  printf '%s\n' "$*" > "$WEBHOOK_TEST_MARKER"
+}
+STUB
+}
+
+_webhook_bridge_run() {
+  local sandbox="$1"
+  local headers="$2"
+  local body="$3"
+  local token_file="$4"
+  local stdout_path="$5"
+  local stderr_path="$6"
+  local content_length
+
+  content_length=${#body}
+
+  if [ -n "$token_file" ]; then
+    {
+      printf 'POST / HTTP/1.1\r\n'
+      printf '%s' "$headers"
+      printf 'Content-Length: %s\r\n\r\n' "$content_length"
+      printf '%s' "$body"
+    } | PUSHOVER_CRED_FILE="$sandbox/pushover" \
+      SERVICE_LIB="$sandbox/service-lib" \
+      WEBHOOK_TEST_MARKER="$sandbox/notification-marker" \
+      WEBHOOK_TOKEN_FILE="$token_file" \
+      bash "$_webhook_bridge_script" > "$stdout_path" 2> "$stderr_path"
+  else
+    {
+      printf 'POST / HTTP/1.1\r\n'
+      printf '%s' "$headers"
+      printf 'Content-Length: %s\r\n\r\n' "$content_length"
+      printf '%s' "$body"
+    } | PUSHOVER_CRED_FILE="$sandbox/pushover" \
+      SERVICE_LIB="$sandbox/service-lib" \
+      WEBHOOK_TEST_MARKER="$sandbox/notification-marker" \
+      bash "$_webhook_bridge_script" > "$stdout_path" 2> "$stderr_path"
+  fi
+}
+
+test_webhook_bridge_crawled_payload_sends_notification() {
+  local sandbox stdout_path stderr_path marker output
+  sandbox=$(new_sandbox)
+  _webhook_bridge_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  marker="$sandbox/notification-marker"
+
+  _webhook_bridge_run "$sandbox" "" '{"operation":"crawled","url":"https://example.com/path?x=1"}' "" "$stdout_path" "$stderr_path"
+
+  output=$(cat "$stdout_path")
+  assert_contains "$output" "HTTP/1.1 200 OK"
+  [ -f "$marker" ] || fail "expected webhook bridge to call send_notification"
+}
+
+test_webhook_bridge_non_crawled_payload_skips_notification() {
+  local sandbox stdout_path stderr_path marker output
+  sandbox=$(new_sandbox)
+  _webhook_bridge_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  marker="$sandbox/notification-marker"
+
+  _webhook_bridge_run "$sandbox" "" '{"operation":"created","url":"https://example.com/path"}' "" "$stdout_path" "$stderr_path"
+
+  output=$(cat "$stdout_path")
+  assert_contains "$output" "HTTP/1.1 200 OK"
+  [ ! -e "$marker" ] || fail "expected webhook bridge to skip non-crawled notification"
+}
+
+test_webhook_bridge_invalid_json_keeps_200_without_notification() {
+  local sandbox stdout_path stderr_path marker output
+  sandbox=$(new_sandbox)
+  _webhook_bridge_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  marker="$sandbox/notification-marker"
+
+  _webhook_bridge_run "$sandbox" "" 'not-json' "" "$stdout_path" "$stderr_path"
+
+  output=$(cat "$stdout_path")
+  assert_contains "$output" "HTTP/1.1 200 OK"
+  [ ! -e "$marker" ] || fail "expected webhook bridge to skip invalid JSON notification"
+}
+
+test_webhook_bridge_wrong_token_keeps_200_and_warns() {
+  local sandbox stdout_path stderr_path marker output stderr_output token_file
+  sandbox=$(new_sandbox)
+  _webhook_bridge_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  marker="$sandbox/notification-marker"
+  token_file="$sandbox/webhook-token"
+  printf 'expected-token\n' > "$token_file"
+
+  _webhook_bridge_run "$sandbox" $'Authorization: Bearer wrong-token\r\n' '{"operation":"crawled","url":"https://example.com/path"}' "$token_file" "$stdout_path" "$stderr_path"
+
+  output=$(cat "$stdout_path")
+  stderr_output=$(cat "$stderr_path")
+  assert_contains "$output" "HTTP/1.1 200 OK"
+  assert_contains "$stderr_output" "WARN"
+  [ ! -e "$marker" ] || fail "expected webhook bridge to skip wrong-token notification"
+}

--- a/tests/suites/webhook-bridge.sh
+++ b/tests/suites/webhook-bridge.sh
@@ -26,28 +26,21 @@ _webhook_bridge_run() {
 
   content_length=${#body}
 
+  local -a env_vars=(
+    PUSHOVER_CRED_FILE="$sandbox/pushover"
+    SERVICE_LIB="$sandbox/service-lib"
+    WEBHOOK_TEST_MARKER="$sandbox/notification-marker"
+  )
   if [ -n "$token_file" ]; then
-    {
-      printf 'POST / HTTP/1.1\r\n'
-      printf '%s' "$headers"
-      printf 'Content-Length: %s\r\n\r\n' "$content_length"
-      printf '%s' "$body"
-    } | PUSHOVER_CRED_FILE="$sandbox/pushover" \
-      SERVICE_LIB="$sandbox/service-lib" \
-      WEBHOOK_TEST_MARKER="$sandbox/notification-marker" \
-      WEBHOOK_TOKEN_FILE="$token_file" \
-      bash "$_webhook_bridge_script" > "$stdout_path" 2> "$stderr_path"
-  else
-    {
-      printf 'POST / HTTP/1.1\r\n'
-      printf '%s' "$headers"
-      printf 'Content-Length: %s\r\n\r\n' "$content_length"
-      printf '%s' "$body"
-    } | PUSHOVER_CRED_FILE="$sandbox/pushover" \
-      SERVICE_LIB="$sandbox/service-lib" \
-      WEBHOOK_TEST_MARKER="$sandbox/notification-marker" \
-      bash "$_webhook_bridge_script" > "$stdout_path" 2> "$stderr_path"
+    env_vars+=(WEBHOOK_TOKEN_FILE="$token_file")
   fi
+
+  {
+    printf 'POST / HTTP/1.1\r\n'
+    printf '%s' "$headers"
+    printf 'Content-Length: %s\r\n\r\n' "$content_length"
+    printf '%s' "$body"
+  } | env "${env_vars[@]}" bash "$_webhook_bridge_script" > "$stdout_path" 2> "$stderr_path"
 }
 
 test_webhook_bridge_crawled_payload_sends_notification() {
@@ -93,6 +86,24 @@ test_webhook_bridge_invalid_json_keeps_200_without_notification() {
   output=$(cat "$stdout_path")
   assert_contains "$output" "HTTP/1.1 200 OK"
   [ ! -e "$marker" ] || fail "expected webhook bridge to skip invalid JSON notification"
+}
+
+test_webhook_bridge_matching_token_sends_notification() {
+  local sandbox stdout_path stderr_path marker output token_file
+  sandbox=$(new_sandbox)
+  _webhook_bridge_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  marker="$sandbox/notification-marker"
+  token_file="$sandbox/webhook-token"
+  # 트레일링 뉴라인 포함 — 브리지의 토큰 정규화(tr -d '\r\n') 경로까지 검증한다.
+  printf 'expected-token\n' > "$token_file"
+
+  _webhook_bridge_run "$sandbox" $'Authorization: Bearer expected-token\r\n' '{"operation":"crawled","url":"https://example.com/path"}' "$token_file" "$stdout_path" "$stderr_path"
+
+  output=$(cat "$stdout_path")
+  assert_contains "$output" "HTTP/1.1 200 OK"
+  [ -f "$marker" ] || fail "expected webhook bridge to send notification for matching token"
 }
 
 test_webhook_bridge_wrong_token_keeps_200_and_warns() {


### PR DESCRIPTION
## Summary

- 이 호스트의 유일한 미인증 네트워크 리스너인 karakeep-webhook-bridge에서 root 권한 증폭 경로를 제거한다: `DynamicUser` 전환 + agenix 시크릿의 `LoadCredential` 전달 + systemd sandbox 강화.
- Karakeep이 webhook에 `Authorization: Bearer` 토큰을 지원함을 확인하고, 선택적 `webhookTokenFile` 옵션으로 위조 요청 억제층을 추가한다 (미설정 시 현행 무인증 동작 유지 — 하위 호환).
- 인증 실패 시에도 알림만 억제하고 항상 HTTP 200을 응답한다 — #919에서 결정된 응답 계약은 그대로 유지.

Closes #939

## 기존 문제/배경

`karakeep-webhook-bridge`는 socat이 바인드 주소 없이 리슨하고, 방화벽이 `podman+` 인터페이스를 허용하며 `tailscale0`이 trusted interface라 **컨테이너망과 tailnet 전역 양쪽에서 도달 가능한 미인증 엔드포인트**다. 그런데 서비스는 root로 실행되고 sandbox는 `PrivateTmp`/`NoNewPrivileges`뿐이었다.

신뢰 불가 웹 콘텐츠를 렌더링하는 headless Chrome이 같은 컨테이너망에 있으므로, 컨테이너 침해 시 이 엔드포인트로 알림 위조/스팸이 가능하고, root로 도는 bash/jq 파서의 어떤 결함도 root 권한으로 증폭된다. 같은 저장소의 codex-remote-control 서비스는 이미 강한 systemd hardening을 적용하고 있어 이 서비스만 예외로 남아 있었다.

## CIR (Change Intent Record)

- **v1** (이번 변경): plans/002-webhook-bridge-hardening.md (Issue #939)의 실행. 두 개의 독립 방어층을 도입 — (1) 침해 시 증폭 제거: `DynamicUser` + `LoadCredential` + sandbox, (2) 위조 요청 억제: Bearer 토큰 검증.
- 토큰 검증은 조사 우선으로 진행: Karakeep 공식 문서에서 webhook 토큰이 `Authorization: Bearer <token>` 헤더로 전달됨을 확인한 뒤 구현했다. 토큰 `.age` 시크릿의 암호화 생성은 운영자 키가 필요하므로 이 PR은 옵션/코드 자리만 만들고, 실제 활성화는 운영자 절차로 남긴다 (Human Test Plan 참조).
- `RestrictAddressFamilies`는 plan 명세대로 `AF_INET`/`AF_INET6`만 허용했다. NixOS에서 DNS 조회(nscd 소켓)나 socat 내부 동작이 `AF_UNIX`를 요구할 가능성은 eval로는 드러나지 않는다 — 배포 후 알림이 조용히 죽으면 `AF_UNIX` 추가가 1차 용의자다 (Human Test Plan의 진단 항목).

**trade-off**: 토큰을 필수화하지 않아 기본 배포는 여전히 무인증이지만, 옵션 미설정 시 동작 불변이라 이 PR 머지·배포가 기존 알림 흐름을 깨지 않는다. 토큰 활성화는 운영자가 시크릿 준비 후 독립적으로 켤 수 있다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 토큰 검증 필수화 | `webhookTokenFile`을 required로 강제 | 무인증 창 즉시 제거 | `.age` 생성은 운영자 키 필요 — 머지 즉시 서비스 기동 불가, 배포 순서 결합 | ❌ |
| 선택적 `webhookTokenFile` + 미설정 시 무인증 유지 | null 기본값, 설정 시에만 검증 활성 | 하위 호환, 운영자가 독립적으로 활성화, 코드 경로는 지금 검증됨 | 기본 배포는 여전히 무인증 (단 sandbox 층은 즉시 적용) | ✅ |
| 인증 실패 시 401 응답 | HTTP 표준 준수 | 시맨틱 명확 | #919에서 확정된 항상-200 계약 위반 — Karakeep 쪽 재시도/에러 플로우 교란 위험 | ❌ |
| 고정 시스템 유저(`User=`) | 전용 유저 선언 | 유저 수명 명시적 | 상태 없는 서비스에 유저 관리 부담, `DynamicUser`가 UID 재사용 공격면도 줄임 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/docker/karakeep-notify.nix` | 수정 | `DynamicUser`, `LoadCredential`(pushover + 조건부 webhook-token), sandbox 옵션 11종, `%d` credentials 경로 전환 |
| `modules/nixos/programs/docker/karakeep-notify/files/webhook-bridge.sh` | 수정 | `authorization` 헤더 파싱 + `WEBHOOK_TOKEN_FILE` 설정 시 Bearer 비교, 불일치 시 WARN + 알림 억제 + 200 유지 |
| `modules/nixos/options/homeserver.nix` | 수정 | `karakeepNotify.webhookTokenFile` 옵션 (nullOr str, 기본 null) |
| `tests/suites/webhook-bridge.sh` | 신규 | 브리지 fixture 테스트 4건 (아래 참조) |
| `tests/shell-script-tests.sh` | 수정 | 신규 suite 테스트 4건 `run_test` 등록 |
| `plans/README.md` | 수정 | plan 002 상태 행 DONE 갱신 |

### 핵심 코드

```nix
# BEFORE: root 실행, 시크릿 경로 직접 참조
serviceConfig = { PrivateTmp = true; NoNewPrivileges = true; ... };
environment.PUSHOVER_CRED_FILE = pushoverCredPath;

# AFTER: 비특권 + credentials 디렉토리 경유 + sandbox
serviceConfig = {
  DynamicUser = true;
  LoadCredential = [ "pushover:${pushoverCredPath}" ]
    ++ lib.optionals (cfg.webhookTokenFile != null) [ "webhook-token:${cfg.webhookTokenFile}" ];
  ProtectSystem = "strict"; ProtectHome = true; PrivateDevices = true;
  RestrictAddressFamilies = [ "AF_INET" "AF_INET6" ]; # AF_UNIX 필요 여부는 배포 후 확인
  ...
};
environment.PUSHOVER_CRED_FILE = "%d/pushover";
```

```bash
# 브리지: 토큰 파일이 설정된 경우에만 검증 — 불일치는 알림 억제, 200 계약 유지
if [ -n "${WEBHOOK_TOKEN_FILE:-}" ]; then
  expected_token=$({ tr -d '\r\n' < "$WEBHOOK_TOKEN_FILE"; } 2>/dev/null || true)
  ...
  elif [ "$authorization" != "Bearer $expected_token" ]; then
    echo "WARN: webhook-bridge: Authorization bearer token mismatch (notification skipped)" >&2
    notification_allowed=false
  fi
fi
```

신규 테스트는 실제 HTTP 요청(CRLF + Content-Length)을 스크립트 stdin에 흘리고 스텁 `send_notification`의 마커 파일로 알림 호출 여부를 검증한다: 정상 crawled(알림 호출), 비-crawled(미호출), 비-JSON(미호출), 오토큰(미호출 + WARN) — 4건 모두 200 응답 계약을 assert.

## 참고 레퍼런스

- Issue #939 — 이 하드닝 finding의 원본 (epic #937의 sub-issue)
- Issue #919 — 항상-200 응답 + `set -uo pipefail` 계약이 결정된 이슈
- [Karakeep 환경변수 문서](https://docs.karakeep.app/configuration/environment-variables/) — webhook 토큰이 `Authorization: Bearer`로 전달됨을 확인한 출처
- `modules/nixos/programs/codex-remote-control.nix` — 이 저장소의 systemd hardening exemplar

## Human Test Plan

### 정상 동작 검증 (배포 필수 — 이 PR의 게이트는 eval/flake-check/테스트까지)

1. 머지 후 `nrs`로 적용한다.
   - **기대**: `karakeep-webhook-bridge` 서비스가 기동하고 `systemctl show karakeep-webhook-bridge -p User`가 root가 아닌 동적 유저를 보인다.
   - **실패 시**: `journalctl -u karakeep-webhook-bridge -e`에서 LoadCredential/DynamicUser 관련 에러 확인.
2. Karakeep UI에서 페이지 1건을 아카이브한다.
   - **기대**: Pushover로 "아카이브 완료: <url>" 알림 도착.
   - **실패 시**: `journalctl -u karakeep-webhook-bridge -f`로 요청 수신 여부와 WARN 로그 확인. 알림이 조용히 죽으면 sandbox 과잉이 1차 용의자 — 특히 `RestrictAddressFamilies`에 `AF_UNIX` 누락 (NixOS nscd DNS 소켓 요구 가능). `AF_UNIX` 추가 후 재시도.

### 토큰 활성화 (선택 — 운영자 후속)

3. 토큰 시크릿 생성 → `webhookTokenFile` 설정 → Karakeep UI의 webhook 설정에 같은 토큰 등록 → `nrs`.
   - **기대**: 정상 토큰으로 알림 도착. Karakeep UI에서 토큰을 틀리게 바꾸면 알림이 오지 않고 journald에 "bearer token mismatch" WARN.
   - **실패 시**: `systemd-creds`가 `%d/webhook-token`을 전달했는지 `journalctl`의 WARN 종류(token unavailable vs mismatch)로 구분.

### Regression

4. `webhookTokenFile` 미설정 상태(현행 기본)에서 아카이브 이벤트를 발생시킨다.
   - **기대**: 이전과 동일하게 무인증으로 알림 도착 — 이 PR 적용만으로 알림 흐름이 깨지지 않는다.
   - **실패 시**: 위 2번의 sandbox 진단 절차와 동일.

---
https://claude.ai/code/session_015mzqhitzrD89p77e1X2EUy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional webhook token support for the Karakeep notification bridge.
  * Strengthened the bridge’s runtime isolation and credential handling.

* **Bug Fixes**
  * Webhook notifications now only send for valid “crawled” events with the expected token when configured.
  * Invalid JSON and token mismatches now return success without sending notifications, while logging warnings.

* **Tests**
  * Added end-to-end coverage for valid, invalid, and unauthorized webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->