### PR TITLE
fix(karakeep): webhook 브리지 아티팩트의 errexit 주입 제거 — 200 계약 복원

### DIFF
--- a/modules/nixos/programs/docker/karakeep-notify.nix
+++ b/modules/nixos/programs/docker/karakeep-notify.nix
@@ -24,6 +24,13 @@ let
       curl
       gnused
     ];
+    # CIR: 기본 bashOptions는 errexit를 주입해, 비-JSON body에서 jq(exit 5)가
+    # command substitution 할당을 죽여 HTTP 200 응답 전에 핸들러가 종료된다.
+    # 이 핸들러는 "항상 200 + set -e 미사용"이 결정 사항(#919)이므로 errexit를 뺀다.
+    bashOptions = [
+      "nounset"
+      "pipefail"
+    ];
     text = builtins.readFile ./karakeep-notify/files/webhook-bridge.sh;
   };
 in


### PR DESCRIPTION
## Summary

- webhook 브리지의 빌드 아티팩트에서 `writeShellApplication`이 주입하는 `set -o errexit`를 제거해, #919에서 결정된 "항상 HTTP 200 응답" 계약을 실 배포에서 복원한다.
- #971 하드닝 E2E 검증 중 발견된 pre-existing 결함 — 비-JSON body에서 핸들러가 200 응답 전에 죽는다 (배포 초기 세대부터 존재, 하드닝 변경과 무관).

## 기존 문제/배경

`webhook-bridge.sh` 소스는 의도적으로 `set -uo pipefail`만 쓴다 (`set -e` 미사용, 항상 200 응답 — #919 결정). 그러나 이 스크립트를 패키징하는 `writeShellApplication`의 기본 `bashOptions`가 `set -o errexit`를 프리앰블로 주입해, 실 아티팩트에서는 errexit가 활성이었다.

그 결과 비-JSON body가 오면 `operation=$(printf '%s' "$body" | jq -r ...)` 할당에서 jq가 exit 5로 실패하는 순간 핸들러 전체가 종료되고, 마지막 줄의 HTTP 200 응답이 나가지 못한다. #971 E2E 검증에서 실 서비스에 비-JSON POST를 보내 재현했다: 클라이언트는 empty reply(curl exit 52)를 받고 journald에는 `child exited with status 5`가 남는다.

nix store에 남아 있는 이전 5개 세대의 브리지 아티팩트 전부에 동일한 errexit 프리앰블이 있음을 확인했다 — 이번 하드닝(#971)이 도입한 결함이 아니라 배포 초기부터 잠재해 있던 결함이다. Karakeep은 항상 valid JSON을 보내므로 실 트래픽에서는 발현되지 않았다.

## CIR (Change Intent Record)

- **v1** (#919, PR 당시 결정): 핸들러는 `set -e`를 쓰지 않고 항상 200을 응답한다 — 소스에는 반영됐으나 빌드 래퍼의 프리앰블까지는 검토되지 않았다.
- **v2** (이번 변경): `bashOptions = [ "nounset" "pipefail" ]`을 명시해 아티팩트 셸 옵션을 소스 의도와 일치시킨다. 인라인 CIR 주석으로 "errexit를 뺀 이유"를 남겨 미래 세션이 기본값으로 되돌리는 회귀를 방지한다.

**trade-off**: errexit가 없으므로 스크립트 중간 실패가 조용히 지나갈 수 있으나, 이는 #919에서 이미 수용한 설계다(진단은 WARN 로그가 담당). 테스트 suite의 비-JSON 케이스는 소스를 직접 실행하는 방식이라 이 프리앰블 차이를 재현하지 못했는데, 이 수정으로 아티팩트와 소스의 셸 옵션이 같아져 기존 테스트가 실 배포 조건을 그대로 대표하게 된다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `bashOptions` 명시로 errexit 제거 | 빌드 래퍼의 셸 옵션을 소스 의도와 일치 | root-cause 수정, 소스 무변경, 한 곳 선언 | writeShellApplication 파라미터 의존 | ✅ |
| jq 호출마다 `\|\| true` 방어 | 개별 명령 단위로 errexit 우회 | 래퍼 독립적 | 소스가 장황해지고, 새 명령 추가 시마다 같은 방어 필요 — 두더지 잡기 | ❌ |
| `writeShellScriptBin`으로 교체 | 프리앰블 주입 없는 저수준 래퍼 | 프리앰블 제어 완전 | runtimeInputs PATH 구성·shellcheck 검사 등 writeShellApplication의 이점 상실 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/docker/karakeep-notify.nix` | 수정 | `webhookBridgeScript`에 `bashOptions = [ "nounset" "pipefail" ]` + 인라인 CIR 주석 |

### 핵심 코드

```nix
# BEFORE: 기본 bashOptions → 프리앰블에 set -o errexit 주입
webhookBridgeScript = pkgs.writeShellApplication {
  name = "karakeep-webhook-bridge";
  ...
};

# AFTER: 소스의 set -uo pipefail 의도와 일치
webhookBridgeScript = pkgs.writeShellApplication {
  name = "karakeep-webhook-bridge";
  ...
  bashOptions = [ "nounset" "pipefail" ];
  ...
};
```

동일 nixpkgs로 빌드 검증: `bashOptions` 지정 시 아티팩트 프리앰블이 `set -o nounset` + `set -o pipefail`만 포함함을 확인했다.

## 참고 레퍼런스

- Issue #919 — 항상-200 + `set -e` 미사용 계약이 결정된 이슈
- PR #971 — 하드닝 E2E 검증 중 이 결함이 발견된 경위 (후속 코멘트 참조)
- [nixpkgs writeShellApplication](https://nixos.org/manual/nixpkgs/stable/#trivial-builder-writeShellApplication) — `bashOptions` 파라미터 (기본값 errexit/nounset/pipefail)

## Human Test Plan

### 정상 동작 검증

1. 머지 후 `nrs`로 적용하고, 배포된 브리지 아티팩트의 프리앰블을 확인한다.
   - **기대**: `set -o errexit` 없음, `set -o nounset`/`set -o pipefail`만 존재.
   - **실패 시**: `systemctl show karakeep-webhook-bridge -p ExecStart`로 아티팩트 경로를 찾아 head로 직접 확인.
2. 비-JSON body를 POST한다: `curl -si -X POST http://127.0.0.1:9999 -d 'not-json'`.
   - **기대**: `HTTP/1.1 200 OK` 응답 + 알림 미발송.
   - **실패 시**: `journalctl -u karakeep-webhook-bridge -e`에서 자식 프로세스 exit 코드 확인.

### Regression

3. 정상 crawled 페이로드를 POST한다.
   - **기대**: 200 응답 + Pushover 알림 도착 (기존 정상 경로 불변).
   - **실패 시**: journald WARN 로그로 credential/토큰 경로 구분.

---
https://claude.ai/code/session_015mzqhitzrD89p77e1X2EUy
