### PR TITLE
fix(codex): remote-control maint 락 획득에 타임아웃 부여

### DIFF
--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -16,6 +16,7 @@ STANDALONE_CURRENT="${STANDALONE_CURRENT:-$STANDALONE_ROOT/current}"
 STANDALONE_BIN="$STANDALONE_CURRENT/bin/codex"
 STATUS_FILE="$STATE_DIR/status.json"
 LOCK_FILE="$STATE_DIR/maintenance.lock"
+MAINT_LOCK_TIMEOUT_SECONDS="${MAINT_LOCK_TIMEOUT_SECONDS:-120}"
 ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
 PUSHOVER_CRED_FILE="${PUSHOVER_CRED_FILE:-}"
 SERVICE_LIB="${SERVICE_LIB:-}"
@@ -91,8 +92,8 @@ with_lock() {
     LAST_REPAIR_REASON="lock-open-failed"
     return 1
   }
-  flock 9 || {
-    LAST_REPAIR_REASON="lock-acquire-failed"
+  flock --timeout "$MAINT_LOCK_TIMEOUT_SECONDS" 9 || {
+    LAST_REPAIR_REASON="lock-acquire-timeout"
     return 1
   }
   "$@"

--- a/plans/README.md
+++ b/plans/README.md
@@ -26,7 +26,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 | 004 | 백업 스크립트 추출 + 특성화 테스트 | P2 | M | — | #941 | TODO |
 | 005 | Immich DB(pgvecto-rs) 마이그레이션 spike (조사 전용) | P2 | M | — | #942 | DONE |
 | 006 | gitleaks `.local.md` 전면 예외 제거 → gitignore 대체 | P2 | S | — | #943 | TODO |
-| 007 | codex-remote-control-maint flock 타임아웃 부여 | P2 | S | — | #944 | TODO |
+| 007 | codex-remote-control-maint flock 타임아웃 부여 | P2 | S | — | #944 | DONE (실 배포 `nrs`는 운영자 후속) |
 | 008 | 완료 PRD 상태 정정 + 아카이브 관례 적용 | P3 | S | — | #945 | TODO |
 | 009 | maint sync/알림 상태전이 특성화 테스트 | P3 | S | 007 (soft) | #946 | TODO |
 | 010 | verify-ai-compat lint 엔진 분리 + host-state 테스트 | P2 | M | — | #947 | TODO |

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -74,6 +74,7 @@ if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control rejects non-Nix PATH shadow" test_codex_remote_control_rejects_non_nix_path_shadow
   run_test "codex remote-control sync failure is not marked successful" test_codex_remote_control_sync_failure_is_not_marked_successful
   run_test "codex remote-control lock failure does not run core action" test_codex_remote_control_lock_failure_does_not_run_core_action
+  run_test "codex remote-control lock acquisition timeout is recorded" test_codex_remote_control_lock_acquire_timeout_is_recorded
   run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
   run_test "codex remote-control repair refuses socket cleanup when PID remains" test_codex_remote_control_repair_refuses_socket_cleanup_when_pid_remains
   run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -288,6 +288,35 @@ test_codex_remote_control_lock_failure_does_not_run_core_action() {
   assert_not_contains "$(cat "$COD_RC_LOG" 2>/dev/null || true)" 'remote-control start --json'
 }
 
+test_codex_remote_control_lock_acquire_timeout_is_recorded() {
+  local sandbox ready lock_holder status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  ready="$sandbox/lock-ready"
+
+  flock "$COD_RC_STATE/maintenance.lock" bash -c 'touch "$1"; sleep 5' _ "$ready" &
+  lock_holder=$!
+  for _ in {1..50}; do
+    [ ! -e "$ready" ] || break
+    kill -0 "$lock_holder" 2>/dev/null || fail "lock holder exited before acquiring lock"
+    sleep 0.1
+  done
+  [ -e "$ready" ] || fail "lock holder did not acquire lock"
+
+  if MAINT_LOCK_TIMEOUT_SECONDS=1 _codex_rc_env bash "$(_codex_rc_script)" ensure-running 2>/dev/null; then
+    kill "$lock_holder" 2>/dev/null || true
+    wait "$lock_holder" 2>/dev/null || true
+    fail "ensure-running should fail when maintenance lock acquisition times out"
+  fi
+  kill "$lock_holder" 2>/dev/null || true
+  wait "$lock_holder" 2>/dev/null || true
+
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.lastRepairReason == "lock-acquire-timeout" and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "lock timeout was not recorded as unhealthy: $status"
+  assert_not_contains "$(cat "$COD_RC_LOG" 2>/dev/null || true)" 'remote-control start --json'
+}
+
 test_codex_remote_control_repair_kills_proven_stale_unmanaged_process() {
   local sandbox ps_file kill_log socket_file user
   sandbox="$(new_sandbox)"


### PR DESCRIPTION
## Summary

- `codex-remote-control-maint.sh`의 무한 blocking `flock 9`에 타임아웃(기본 120초, env 오버라이드 가능)을 부여해, 선행 실행이 락을 쥔 채 hang하면 후속 타이머 인보케이션이 무기한 블록되는 stuck 유닛 누적 경로를 제거한다.
- 실제 락 선점 상태에서 타임아웃 실패와 사유 기록을 검증하는 회귀 테스트를 추가한다.

Closes #944

## 기존 문제/배경

`with_lock`이 옵션 없는 `flock 9`(무한 대기)를 쓴다. 이 스크립트는 systemd 타이머로 반복 실행되고 내부에서 codex CLI를 여러 번 호출하므로, 선행 실행이 CLI hang으로 락을 쥔 채 멈추면 후속 인보케이션들이 락 대기에 무기한 갇힌다. 서비스가 `Type = "oneshot"`이라 systemd 기본 타임아웃도 적용되지 않고 `RuntimeMaxSec`도 미설정이다. 같은 저장소의 다른 락 인프라 두 곳(`scripts/ai/install-lefthook-hooks.sh`, `modules/shared/scripts/lib/rebuild/locks.sh`)은 이미 `flock --timeout`을 쓰고 있어 이 파일만 컨벤션에서 벗어나 있었다.

## CIR (Change Intent Record)

- **v1** (이번 변경): plans/007-maint-flock-timeout.md (Issue #944)의 실행. 저장소의 기존 flock 타임아웃 컨벤션을 이 파일에도 적용. 기본 120초는 정상 실행(수 초)과 타이머 주기 사이의 값으로, 테스트에서 짧게 줄일 수 있게 env 오버라이드 형태로 뒀다.
- 실패 사유는 기존 `LAST_REPAIR_REASON` 보고 경로에 `lock-acquire-timeout`으로 실린다 — 알림/로그에서 이 문자열로 검색 가능.

**trade-off**: 사유 문자열이 `lock-acquire-failed`에서 `lock-acquire-timeout`으로 바뀌므로, 타임아웃 외의 드문 flock 실패(fd 문제 등)도 같은 사유로 보고된다. fd는 직전 `exec 9>`로 방금 열리므로 실질적으로 타임아웃이 유일한 실패 모드다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `flock --timeout` (스크립트 레벨) | 락 획득에 유한 대기 | 저장소 기존 컨벤션과 일치, 사유 보고 경로 재사용 | 값 선택 필요 | ✅ |
| systemd `RuntimeMaxSec` (유닛 레벨) | 유닛 전체 실행 시간 제한 | 스크립트 무변경 | codex CLI 정상 호출(패키지 sync 포함) 소요의 운영 데이터 없이 값을 정하면 정상 실행을 죽일 수 있음 | ❌ (기록만, 별도 판단) |
| `flock -n` (즉시 실패) | 대기 없이 즉시 반환 | 가장 단순 | 정상적인 짧은 경합(직전 실행이 수 초 내 끝나는 경우)까지 실패로 처리 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh` | 수정 | `MAINT_LOCK_TIMEOUT_SECONDS` 상수 + `flock --timeout` 교체 (with_lock만, 다른 함수 무변경) |
| `tests/suites/codex-remote-control.sh` | 수정 | 타임아웃 회귀 테스트 1건 추가 |
| `tests/shell-script-tests.sh` | 수정 | 신규 테스트 `run_test` 등록 |
| `plans/README.md` | 수정 | plan 007 상태 행 DONE 갱신 |

### 핵심 코드

```bash
# BEFORE
flock 9 || {
  LAST_REPAIR_REASON="lock-acquire-failed"
  return 1
}

# AFTER
flock --timeout "$MAINT_LOCK_TIMEOUT_SECONDS" 9 || {
  LAST_REPAIR_REASON="lock-acquire-timeout"
  return 1
}
```

신규 테스트는 실제 `flock`으로 maintenance.lock을 선점한 뒤 `MAINT_LOCK_TIMEOUT_SECONDS=1`로 `ensure-running`을 구동해, (1) 무한 대기 없이 실패 반환, (2) status.json에 `lastRepairReason == "lock-acquire-timeout"` + 비정상 exitCode 기록, (3) core action 미실행을 assert한다.

## 참고 레퍼런스

- Issue #944 — 이 finding의 원본 (epic #937의 sub-issue)
- `scripts/ai/install-lefthook-hooks.sh`, `modules/shared/scripts/lib/rebuild/locks.sh` — 저장소의 기존 flock 타임아웃 컨벤션 exemplar

## Human Test Plan

### 정상 동작 검증

1. 머지 후 `nrs`로 적용하고 타이머 주기의 정상 실행을 관찰한다.
   - **기대**: `systemctl status codex-remote-control-maint`가 기존과 동일하게 성공 (경합 없는 정상 경로는 타임아웃 무영향).
   - **실패 시**: `journalctl -u codex-remote-control-maint -e`에서 lock 관련 로그 확인.

### 엣지 케이스

2. 수동으로 락을 선점(`flock <state-dir>/maintenance.lock sleep 300` 백그라운드)한 뒤 유닛을 시작한다.
   - **기대**: 약 120초 후 유닛이 실패로 종료하고 status.json의 `lastRepairReason`이 `lock-acquire-timeout`.
   - **실패 시**: `MAINT_LOCK_TIMEOUT_SECONDS` env가 유닛에 오버라이드돼 있지 않은지 확인.

### Regression

3. 기존 lock 실패 테스트(`lock failure does not run core action`) 포함 shell 테스트 전체가 통과한다 (이 PR 게이트에서 검증 완료 — 재확인용).

---
https://claude.ai/code/session_015mzqhitzrD89p77e1X2EUy
