### PR TITLE
fix(security): gitleaks .local.md 전면 예외 제거 — gitignore로 대체

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ oauth-state.json
 
 # anchoring-bias baseline measurements (스크립트로 동적 산출, repo에 수치 저장 안 함)
 .claude/metrics/
+
+# 로컬 전용 메모 (시크릿 포함 가능 — 추적 금지. gitleaks 스캔 예외는 두지 않는다)
+*.local.md

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,5 +6,4 @@ useDefault = true
 [allowlist]
 paths = [
   '''flake\.lock''',
-  '''\.local\.md''',
 ]

--- a/plans/README.md
+++ b/plans/README.md
@@ -25,7 +25,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 | 003 | log-monitor 상태/큐 재작성 same-fs 원자적 교체 | P1 | S | — | #940 | DONE |
 | 004 | 백업 스크립트 추출 + 특성화 테스트 | P2 | M | — | #941 | DONE (PR #980, nrs 적용 + 실 백업 2종 E2E 완료 2026-07-05) |
 | 005 | Immich DB(pgvecto-rs) 마이그레이션 spike (조사 전용) | P2 | M | — | #942 | DONE |
-| 006 | gitleaks `.local.md` 전면 예외 제거 → gitignore 대체 | P2 | S | — | #943 | TODO |
+| 006 | gitleaks `.local.md` 전면 예외 제거 → gitignore 대체 | P2 | S | — | #943 | DONE |
 | 007 | codex-remote-control-maint flock 타임아웃 부여 | P2 | S | — | #944 | DONE (PR #979, nrs 적용 + 락 타임아웃 실측 완료 2026-07-05) |
 | 008 | 완료 PRD 상태 정정 + 아카이브 관례 적용 | P3 | S | — | #945 | TODO |
 | 009 | maint sync/알림 상태전이 특성화 테스트 | P3 | S | 007 (soft) | #946 | TODO |


### PR DESCRIPTION
## Summary

- `.gitleaks.toml`의 `.local.md` 경로 전면 예외를 제거하고 `.gitignore`의 `*.local.md`로 대체한다 — "추적 금지 + 스캔 유지" 조합으로 시크릿 스캐너의 blind spot을 닫는다.
- 변경 전후 전체 히스토리 스캔의 fingerprint 차집합 0건 — 이 예외 제거가 새로 만드는 탐지는 없다.

Closes #943

## 기존 문제/배경

allowlist의 `'''\.local\.md'''`가 해당 패턴에 매칭되는 **모든 파일을 시크릿 스캔에서 통째로 제외**하고 있었다. 그런데 `.gitignore`에는 `*.local.md`가 없어서, 로컬 메모를 `something.local.md`로 실수 커밋하면 그 안의 실토큰/비밀번호를 pre-commit gitleaks가 전혀 잡지 못한다. 경로 단위 전면 예외는 라인 단위 억제(`.gitleaksignore`)보다 은폐 표면이 훨씬 넓다. 현재 추적 중인 `*.local.md`는 0건(실측)이라 예방적 예외였고, 지금 제거해도 깨지는 것이 없다.

## CIR (Change Intent Record)

- **v1** (이번 변경): plans/006-gitleaks-local-md-allowlist.md (Issue #943)의 실행. Step 1 실측 결과 기존 로컬/글로벌 ignore가 `*.local.md`를 매칭하지 않아 `.gitignore` 추가가 필요했다. `flake\.lock` 예외는 lock 해시 오탐 방지용으로 정당해 유지.
- 리뷰 검증: staged-only 훅으로는 잡히지 않는 회귀 가능성(히스토리·기존 파일에서의 신규 탐지)을 확인하기 위해 변경 전/후 config로 전체 히스토리 스캔을 각각 실행 — 두 결과 모두 동일 건수였고 fingerprint 차집합 0건. 스캔에서 나온 기존 탐지들은 이 변경과 무관한 pre-existing으로, pre-commit staged 정책 운영에는 영향이 없다 (필요 시 별도 검토 사안).

**trade-off**: 향후 정당한 `.local.md` 오탐이 생기면 경로 예외 복원이 아니라 `.gitleaksignore` 라인 단위 예외로 좁혀 추가해야 한다 (저장소 기존 패턴).

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| gitignore 추가 + gitleaks 예외 제거 | 추적 금지 + 스캔 유지 | 실수 커밋을 원천 차단하면서, 강제 추가된 파일도 스캔됨 | 로컬 파일을 의도적으로 커밋하려면 `-f` 필요 | ✅ |
| gitleaks 예외만 제거 | 스캔만 복원 | 최소 변경 | 실수 `git add`는 여전히 가능 — 스캔이 마지막 방어선이 되어버림 | ❌ |
| 현상 유지 | 변경 없음 | 없음 | 유일한 스캐너 blind spot 존치 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `.gitleaks.toml` | 수정 | allowlist paths에서 `'''\.local\.md'''` 한 줄 제거 |
| `.gitignore` | 수정 | 주석 + `*.local.md` 추가 |
| `plans/README.md` | 수정 | plan 006 상태 행 DONE 갱신 |

## 참고 레퍼런스

- Issue #943 — 이 finding의 원본 (epic #937의 sub-issue)
- `.gitleaksignore` — 라인 단위 예외의 기존 패턴 (문서 예시 키 억제)

## Human Test Plan

1. `touch memo.local.md && git status` — **기대**: untracked에 나타나지 않음 (ignored). 확인 후 `rm memo.local.md`.
2. 시크릿 형태 문자열이 든 `.local.md`를 강제로 스테이징(`git add -f`)하고 커밋을 시도한다 — **기대**: pre-commit gitleaks가 차단. 확인 후 `git reset`으로 되돌리고 파일 삭제. (**주의**: 실토큰이 아닌 테스트용 더미 패턴 사용.)
3. Regression: 일반 커밋이 기존처럼 훅을 통과한다 (이 PR 커밋 자체가 새 config로 gitleaks 훅을 통과했음).

---
https://claude.ai/code/session_015mzqhitzrD89p77e1X2EUy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local file handling so secret-capable memo files are no longer tracked by version control.
  * Removed a previous broad exception, keeping only the necessary lockfile allowance.
* **Documentation**
  * Marked the related plan item as completed in the project notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->