### PR TITLE
test(codex): remote-control maint sync/알림 상태전이 특성화

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -28,7 +28,7 @@ direction 3건을 plan으로 승격했다(006–018). 각 plan은 epic
 | 006 | gitleaks `.local.md` 전면 예외 제거 → gitignore 대체 | P2 | S | — | #943 | TODO |
 | 007 | codex-remote-control-maint flock 타임아웃 부여 | P2 | S | — | #944 | DONE (PR #979, nrs 적용 + 락 타임아웃 실측 완료 2026-07-05) |
 | 008 | 완료 PRD 상태 정정 + 아카이브 관례 적용 | P3 | S | — | #945 | TODO |
-| 009 | maint sync/알림 상태전이 특성화 테스트 | P3 | S | 007 (soft) | #946 | TODO |
+| 009 | maint sync/알림 상태전이 특성화 테스트 | P3 | S | 007 (soft) | #946 | DONE |
 | 010 | verify-ai-compat lint 엔진 분리 + host-state 테스트 | P2 | M | — | #947 | TODO |
 | 011 | Pushover 전송 플랫폼 공용 헬퍼 통합 | P3 | M | — | #948 | TODO |
 | 012 | claude 훅 hook-runtime 파서 채택 확대 | P3 | M | — | #949 | TODO |

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -83,6 +83,13 @@ if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control repair reaps stale deleted managed app-server" test_codex_remote_control_repair_kills_stale_deleted_managed_app_server
   run_test "codex remote-control repair reaps superseded managed app-server" test_codex_remote_control_repair_kills_stale_superseded_managed_app_server
   run_test "codex remote-control cleans sockets only when no PID after drift" test_codex_remote_control_socket_cleanup_when_no_pid_after_drift
+  run_test "codex remote-control alert recovers after failure" test_codex_remote_control_alert_recovery_after_failure
+  run_test "codex remote-control alert stays quiet on healthy success" test_codex_remote_control_alert_success_without_failure_is_quiet
+  run_test "codex remote-control alert failure cooldown is stateful" test_codex_remote_control_alert_failure_sets_failed_and_cools_down
+  run_test "codex remote-control alert missing token does not mutate state" test_codex_remote_control_alert_without_pushover_token_does_not_mutate_state
+  run_test "codex remote-control sync links current standalone release" test_codex_remote_control_sync_standalone_package_success_links_current_release
+  run_test "codex remote-control sync extract failure propagates status" test_codex_remote_control_sync_extract_failure_propagates_status
+  run_test "codex remote-control sync records login status paths" test_codex_remote_control_sync_records_login_status_success_and_api_key_paths
 else
   echo "==> codex remote-control fixtures: SKIPPED (Linux/NixOS-only service script)" >&2
 fi

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -79,6 +79,39 @@ EOS
   chmod +x "$bin_dir/codex"
 }
 
+_codex_rc_make_alerting() {
+  local sandbox="$1"
+  COD_RC_ALERT_LOG="$sandbox/alerts.log"
+  COD_RC_SERVICE_LIB="$sandbox/service-lib.sh"
+  COD_RC_PUSHOVER_CRED="$sandbox/pushover.env"
+
+  cat > "$COD_RC_SERVICE_LIB" <<'EOS'
+send_notification() {
+  printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$ALERT_LOG"
+}
+EOS
+  printf '%s\n' \
+    'PUSHOVER_TOKEN=test-token' \
+    'PUSHOVER_USER=test-user' \
+    > "$COD_RC_PUSHOVER_CRED"
+}
+
+_codex_rc_assert_alert_count() {
+  local needle="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(
+    if [ -f "$COD_RC_ALERT_LOG" ]; then
+      awk -v needle="$needle" 'index($0, needle) { count++ } END { print count + 0 }' "$COD_RC_ALERT_LOG"
+    else
+      printf '0\n'
+    fi
+  )"
+  [ "$actual" = "$expected" ] \
+    || fail "expected $expected alert(s) containing '$needle' in $COD_RC_ALERT_LOG, got $actual"
+}
+
 _codex_rc_setup() {
   local sandbox="$1"
   COD_RC_HOME="$sandbox/home"
@@ -478,4 +511,162 @@ test_codex_remote_control_socket_cleanup_when_no_pid_after_drift() {
   [ ! -e "$socket_file" ] || fail "socket should be removed when no app-server PID exists during drift restart"
   jq -e '.lastAction == "restarted-version-drift" and .exitCode == 0' <<<"$status" >/dev/null \
     || fail "drift restart status not recorded: $status"
+}
+
+test_codex_remote_control_alert_recovery_after_failure() {
+  local sandbox state
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  _codex_rc_make_alerting "$sandbox"
+  printf 'failed\n' > "$COD_RC_STATE/last-health-state"
+
+  ALERT_LOG="$COD_RC_ALERT_LOG" \
+    SERVICE_LIB="$COD_RC_SERVICE_LIB" \
+    PUSHOVER_CRED_FILE="$COD_RC_PUSHOVER_CRED" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running
+
+  state="$(cat "$COD_RC_STATE/last-health-state")"
+  [ "$state" = "healthy" ] || fail "recovery should update health state to healthy, got: $state"
+  _codex_rc_assert_alert_count "Codex Remote Control Recovered" 1
+  _codex_rc_assert_alert_count "Codex Remote Control Failed" 0
+}
+
+test_codex_remote_control_alert_success_without_failure_is_quiet() {
+  local sandbox state
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  _codex_rc_make_alerting "$sandbox"
+
+  ALERT_LOG="$COD_RC_ALERT_LOG" \
+    SERVICE_LIB="$COD_RC_SERVICE_LIB" \
+    PUSHOVER_CRED_FILE="$COD_RC_PUSHOVER_CRED" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running
+
+  state="$(cat "$COD_RC_STATE/last-health-state")"
+  [ "$state" = "healthy" ] || fail "healthy run should write healthy state, got: $state"
+  _codex_rc_assert_alert_count "Codex Remote Control Recovered" 0
+  _codex_rc_assert_alert_count "Codex Remote Control Failed" 0
+}
+
+test_codex_remote_control_alert_failure_sets_failed_and_cools_down() {
+  local sandbox first_last second_last state
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  _codex_rc_make_alerting "$sandbox"
+  printf 'healthy\n' > "$COD_RC_STATE/last-health-state"
+
+  if FAKE_DAEMON_MALFORMED=1 \
+    ALERT_LOG="$COD_RC_ALERT_LOG" \
+    SERVICE_LIB="$COD_RC_SERVICE_LIB" \
+    PUSHOVER_CRED_FILE="$COD_RC_PUSHOVER_CRED" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running 2>/dev/null; then
+    fail "ensure-running should fail for malformed daemon JSON"
+  fi
+
+  state="$(cat "$COD_RC_STATE/last-health-state")"
+  [ "$state" = "failed" ] || fail "failed run should write failed state, got: $state"
+  [ -s "$COD_RC_STATE/last-failure-alert" ] || fail "failed run should record last failure alert timestamp"
+  first_last="$(cat "$COD_RC_STATE/last-failure-alert")"
+  _codex_rc_assert_alert_count "Codex Remote Control Failed" 1
+
+  if FAKE_DAEMON_MALFORMED=1 \
+    ALERT_LOG="$COD_RC_ALERT_LOG" \
+    SERVICE_LIB="$COD_RC_SERVICE_LIB" \
+    PUSHOVER_CRED_FILE="$COD_RC_PUSHOVER_CRED" \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running 2>/dev/null; then
+    fail "ensure-running should keep failing for malformed daemon JSON"
+  fi
+
+  state="$(cat "$COD_RC_STATE/last-health-state")"
+  second_last="$(cat "$COD_RC_STATE/last-failure-alert")"
+  [ "$state" = "failed" ] || fail "repeated failure should keep failed state, got: $state"
+  [ "$second_last" = "$first_last" ] || fail "cooldown should not rewrite last failure alert timestamp"
+  _codex_rc_assert_alert_count "Codex Remote Control Failed" 1
+  _codex_rc_assert_alert_count "Codex Remote Control Recovered" 0
+}
+
+test_codex_remote_control_alert_without_pushover_token_does_not_mutate_state() {
+  local sandbox state
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  _codex_rc_make_alerting "$sandbox"
+  printf 'healthy\n' > "$COD_RC_STATE/last-health-state"
+
+  if FAKE_DAEMON_MALFORMED=1 \
+    ALERT_LOG="$COD_RC_ALERT_LOG" \
+    SERVICE_LIB="$COD_RC_SERVICE_LIB" \
+    PUSHOVER_CRED_FILE="$sandbox/missing-pushover.env" \
+    CREDENTIALS_DIRECTORY='' \
+    PUSHOVER_TOKEN='' \
+    PUSHOVER_USER='' \
+    _codex_rc_env bash "$(_codex_rc_script)" ensure-running 2>/dev/null; then
+    fail "ensure-running should fail for malformed daemon JSON"
+  fi
+
+  state="$(cat "$COD_RC_STATE/last-health-state")"
+  [ "$state" = "healthy" ] || fail "missing Pushover token should leave health state unchanged, got: $state"
+  [ ! -e "$COD_RC_STATE/last-failure-alert" ] || fail "missing Pushover token should not write failure alert timestamp"
+  _codex_rc_assert_alert_count "Codex Remote Control Failed" 0
+  _codex_rc_assert_alert_count "Codex Remote Control Recovered" 0
+}
+
+test_codex_remote_control_sync_standalone_package_success_links_current_release() {
+  local sandbox release_dir status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  release_dir="$COD_RC_HOME/.codex/packages/standalone/releases/0.142.4-x86_64-unknown-linux-musl"
+
+  _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone
+
+  [ -L "$COD_RC_HOME/.codex/packages/standalone/current" ] \
+    || fail "standalone current should be a symlink"
+  [ "$(readlink "$COD_RC_HOME/.codex/packages/standalone/current")" = "$release_dir" ] \
+    || fail "standalone current should point at desired release"
+  [ -x "$release_dir/bin/codex" ] || fail "synced release should contain executable bin/codex"
+  [ -L "$release_dir/codex" ] || fail "synced release should include compatibility codex symlink"
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.lastAction == "synced-standalone-package" and .standaloneVersion == "0.142.4" and .exitCode == 0' <<<"$status" >/dev/null \
+    || fail "successful standalone sync was not recorded: $status"
+}
+
+test_codex_remote_control_sync_extract_failure_propagates_status() {
+  local sandbox bad_package status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  bad_package="$sandbox/not-a-tarball.tar.gz"
+  printf 'not a tarball\n' > "$bad_package"
+
+  if COD_RC_PKG="$bad_package" _codex_rc_env bash "$(_codex_rc_script)" ensure-standalone 2>/dev/null; then
+    fail "ensure-standalone should fail when package extraction fails"
+  fi
+
+  [ ! -e "$COD_RC_HOME/.codex/packages/standalone/current" ] \
+    || fail "failed standalone sync should not publish current release"
+  status="$(cat "$COD_RC_STATE/status.json")"
+  jq -e '.lastRepairReason == "standalone-sync-failed:extract" and .lastAction != "synced-standalone-package" and .exitCode == 1' <<<"$status" >/dev/null \
+    || fail "standalone extract failure was not propagated: $status"
+}
+
+test_codex_remote_control_sync_records_login_status_success_and_api_key_paths() {
+  local sandbox good_log good_status bad_log bad_status
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+
+  _codex_rc_env bash "$(_codex_rc_script)" ensure-running
+  good_log="$COD_RC_LOG"
+  good_status="$(cat "$COD_RC_STATE/status.json")"
+  assert_file_contains "$good_log" "login status"
+  jq -e '.authMode == "chatgpt" and .loginStatus == "chatgpt" and .exitCode == 0' <<<"$good_status" >/dev/null \
+    || fail "ChatGPT login status was not recorded: $good_status"
+
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  if FAKE_LOGIN_STATUS='Logged in using API key' _codex_rc_env bash "$(_codex_rc_script)" ensure-running; then
+    fail "ensure-running should fail for API-key auth"
+  fi
+  bad_log="$COD_RC_LOG"
+  bad_status="$(cat "$COD_RC_STATE/status.json")"
+  assert_file_contains "$bad_log" "login status"
+  jq -e '.authMode == "api-key" and .loginStatus == "api-key" and .lastRepairReason == "auth-not-chatgpt" and .exitCode == 30' <<<"$bad_status" >/dev/null \
+    || fail "API-key login status was not recorded as unhealthy: $bad_status"
 }


### PR DESCRIPTION
## Summary

- `codex-remote-control-maint.sh`의 미커버 경로 두 곳 — `sync_standalone_package`(패키지 동기화)와 `send_alerts`(실패/복구 알림 상태전이) — 에 현행 동작을 박제하는 특성화 테스트 7건을 추가한다.
- maint 스크립트 본체는 무변경 (특성화 원칙).

Closes #946

## 기존 문제/배경

이 스크립트의 위험도 높은 코어(프로세스 종료 kill-safety)는 기존 suite가 촘촘히 검증하지만, 두 경로가 미커버였다: ① `sync_standalone_package`의 실패 처리에 회귀가 생기면 조용히 패키지 드리프트가 발생하고, ② `send_alerts`의 `last-health-state` 파일 기반 쿨다운·복구 알림 로직이 깨지면 장애를 알리지 못하거나 알림이 스팸이 된다.

## CIR (Change Intent Record)

- **v1** (이번 변경): plans/009-maint-sync-alert-tests.md (Issue #946)의 실행. plan 007(flock 타임아웃, PR #979)이 같은 파일·suite를 만지므로 그 머지 직후에 착수 — soft 의존 순서 준수로 충돌 없음.
- plan은 `sync_standalone_package`가 `nix profile` 호출이라 가정하고 "nix 스텁 주입"을 제안했으나, **실제 구현은 tarball 추출 + 원자적 링크 스왑**이다. plan 자체의 "실패 보고 방식은 코드에서 확인해 박제" 지침에 따라 실제 동작 기준으로 특성화했다 (문서화된 적응 — 리뷰어가 실제 코드로 재확인).
- 기대값은 전부 현행 `send_alerts`/`sync_standalone_package` 코드를 읽고 박제했다. 예: 토큰 미설정 시 조기 return이 state 파일 갱신 **이전**이므로 "상태 무변화"가 기대값이고, 쿨다운 창 내 재실패는 알림도 timestamp 갱신도 없이 state만 failed 유지다.

**trade-off**: 이 테스트들은 현행 동작의 박제다 — 알림 정책이나 sync 전략을 의도적으로 바꾸는 PR은 이 기대값을 함께 바꿔야 하며, 그것이 정상이다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 기존 fixture 재사용 (서브커맨드 구동) | `ensure-running`/`ensure-standalone` 전체 경로로 특성화 | 기존 suite 패턴과 일치, 통합 수준 커버리지 | 함수 단위보다 셋업 큼 | ✅ |
| 함수 단위 source 후 직접 호출 | `send_alerts`만 분리 구동 | 셋업 최소 | 스크립트가 source-safe하지 않고 기존 suite에 선례 없음 (plan STOP 조건 회피) | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `tests/suites/codex-remote-control.sh` | 수정 | 특성화 테스트 7건 + 알림 스텁/카운트 헬퍼 2개 추가 (기존 테스트 무변경) |
| `tests/shell-script-tests.sh` | 수정 | 신규 테스트 7건 `run_test` 등록 (Linux 조건부 블록) |
| `plans/README.md` | 수정 | plan 009 상태 행 DONE 갱신 |

### 테스트 커버리지

| 케이스 | 박제한 동작 |
|---|---|
| 복구 알림 | previous=failed + 성공 → "Recovered" 1회 + state=healthy |
| 정상 무알림 | 이력 없음 + 성공 → 알림 0회 + state=healthy |
| 실패 상태전이 + 쿨다운 | 실패 → "Failed" 1회 + timestamp 기록 + state=failed; 쿨다운 창 내 재실패 → 알림·timestamp 불변 |
| 토큰 미설정 | 조기 return — 알림 0회, state 파일·timestamp 무변화 |
| sync 성공 | 원자적 `current` 링크 스왑, 호환 symlink, `synced-standalone-package` 기록 |
| sync 추출 실패 | `standalone-sync-failed:extract` 사유 전파, `current` 미발행, exitCode 1 |
| login status 두 분기 | chatgpt(정상) / api-key(`auth-not-chatgpt`, exitCode 30) |

## 참고 레퍼런스

- Issue #946 — 이 finding의 원본 (epic #937의 sub-issue)
- PR #979 — 같은 파일을 만진 선행 plan 007 (soft 의존)
- `tests/suites/codex-remote-control.sh`의 기존 테스트 — fixture/구동 패턴 exemplar

## Human Test Plan

테스트 전용 변경이라 배포 영향이 없다.

1. `nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh` 실행.
   - **기대**: codex remote-control alert/sync 신규 테스트들이 로그에 나타나고 전체 통과.
   - **실패 시**: 실패한 테스트명의 assert 메시지와 `send_alerts`/`sync_standalone_package` 현행 코드를 대조 — 동작이 바뀌었다면 그 변경 PR이 기대값도 함께 갱신해야 한다.
2. Regression: 기존 kill-safety·lock 테스트들이 그대로 통과 (이 PR 게이트에서 확인 완료).

---
https://claude.ai/code/session_015mzqhitzrD89p77e1X2EUy
