### PR TITLE
fix(codex-rc): maint lock fd가 spawn된 데몬에 상속되는 leak 차단

### DIFF
--- a/modules/nixos/programs/codex-remote-control.nix
+++ b/modules/nixos/programs/codex-remote-control.nix
@@ -82,7 +82,10 @@ in
         User = username;
         Group = "users";
         WorkingDirectory = homeDir;
-        TimeoutSec = "120";
+        # maint 스크립트의 flock 대기(MAINT_LOCK_TIMEOUT_SECONDS=120)보다 커야
+        # lock-acquire-timeout 실패 경로가 status.json 기록과 Pushover 알림까지
+        # 완주한다. 120으로 동률이면 SIGTERM과 레이스해 알림이 소실될 수 있다.
+        TimeoutSec = "300";
         ExecStart = "${maintenanceCli}/bin/codex-remote-control-maint ensure-running";
         LoadCredential = [ "pushover-system-monitor:${pushoverCredPath}" ];
         KillMode = "process";

--- a/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
+++ b/modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh
@@ -96,7 +96,12 @@ with_lock() {
     LAST_REPAIR_REASON="lock-acquire-timeout"
     return 1
   }
-  "$@"
+  # fd 9는 이 셸이 락을 유지하는 동안만 살아야 한다. 리다이렉트 없이 실행하면
+  # codex remote-control start가 detach하는 app-server 데몬이 fd 9를 상속해
+  # 스크립트 종료 후에도 락을 영구 점유하고, 이후 모든 타이머 실행이
+  # lock-acquire-timeout으로 실패한다. 9>&-는 명령 스코프에서만 fd 9를 닫으므로
+  # (bash가 원본 fd를 CLOEXEC 임시 fd로 보존) 이 셸의 락은 유지된다.
+  "$@" 9>&-
 }
 
 path_under() {

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -75,6 +75,7 @@ if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control sync failure is not marked successful" test_codex_remote_control_sync_failure_is_not_marked_successful
   run_test "codex remote-control lock failure does not run core action" test_codex_remote_control_lock_failure_does_not_run_core_action
   run_test "codex remote-control lock acquisition timeout is recorded" test_codex_remote_control_lock_acquire_timeout_is_recorded
+  run_test "codex remote-control spawned daemon does not inherit lock fd" test_codex_remote_control_spawned_daemon_does_not_inherit_lock_fd
   run_test "codex remote-control repair kills proven stale process" test_codex_remote_control_repair_kills_proven_stale_unmanaged_process
   run_test "codex remote-control repair refuses socket cleanup when PID remains" test_codex_remote_control_repair_refuses_socket_cleanup_when_pid_remains
   run_test "codex remote-control repair refuses unproven stale process" test_codex_remote_control_repair_does_not_kill_without_stale_proof

--- a/tests/suites/codex-remote-control.sh
+++ b/tests/suites/codex-remote-control.sh
@@ -57,6 +57,15 @@ case "$*" in
       echo "${FAKE_START_ERR:-start failed}" >&2
       exit "$FAKE_START_RC"
     fi
+    if [ -n "${FAKE_START_DAEMON_FD_FILE:-}" ]; then
+      # 실제 codex remote-control start처럼 장기 실행 데몬을 detach로 남긴다.
+      # 데몬은 자기 fd 테이블을 기록해 부모(maint 스크립트)의 lock fd 상속 여부를 노출한다.
+      (
+        ls -l "/proc/$BASHPID/fd/" > "$FAKE_START_DAEMON_FD_FILE" 2>&1
+        sleep 5
+      ) &
+      disown
+    fi
     if [ -n "${FAKE_START_JSON:-}" ]; then
       printf '%s\n' "$FAKE_START_JSON"
     else
@@ -348,6 +357,29 @@ test_codex_remote_control_lock_acquire_timeout_is_recorded() {
   jq -e '.lastRepairReason == "lock-acquire-timeout" and .exitCode != 0' <<<"$status" >/dev/null \
     || fail "lock timeout was not recorded as unhealthy: $status"
   assert_not_contains "$(cat "$COD_RC_LOG" 2>/dev/null || true)" 'remote-control start --json'
+}
+
+test_codex_remote_control_spawned_daemon_does_not_inherit_lock_fd() {
+  local sandbox fd_file
+  sandbox="$(new_sandbox)"
+  _codex_rc_setup "$sandbox"
+  fd_file="$sandbox/daemon-fds.txt"
+
+  FAKE_START_DAEMON_FD_FILE="$fd_file" _codex_rc_env bash "$(_codex_rc_script)" ensure-running >/dev/null 2>&1 \
+    || fail "ensure-running should succeed on the healthy fixture path"
+
+  local _i
+  for _i in {1..50}; do
+    [ ! -s "$fd_file" ] || break
+    sleep 0.1
+  done
+  [ -s "$fd_file" ] || fail "fake daemon did not record its fd table"
+
+  # 데몬이 lock fd를 상속하면 maint 스크립트 종료 후에도 flock이 유지되어
+  # 이후 모든 타이머 실행이 lock-acquire-timeout으로 실패한다 (2026-07 실장애).
+  assert_not_contains "$(cat "$fd_file")" 'maintenance.lock'
+  flock --timeout 1 --exclusive "$COD_RC_STATE/maintenance.lock" -c true \
+    || fail "maintenance lock still held after ensure-running exited (fd leaked to spawned daemon)"
 }
 
 test_codex_remote_control_repair_kills_proven_stale_unmanaged_process() {


### PR DESCRIPTION
## Summary
- `codex-remote-control-maint.sh`의 `with_lock`이 잠금 fd 9를 쥔 채 코어 로직을 실행하여, `codex remote-control start`가 detach하는 app-server 데몬이 fd 9를 상속 → 스크립트 종료 후에도 `maintenance.lock`을 영구 점유하는 leak을 차단한다 (`"$@" 9>&-`).
- ensure 유닛 `TimeoutSec` 120→300: flock 대기(120s)와 동률이라 실패 경로의 상태 기록·알림 발송이 SIGTERM과 레이스하던 문제를 해소한다.
- 실장애를 재현하는 회귀 테스트 추가 (fake codex가 실제처럼 detach 데몬을 남기고, 데몬의 fd 테이블과 락 재획득 가능 여부를 검증).

## 기존 문제/배경

2026-07-01 21:55부터 매 30분 `codex-remote-control-ensure.service`가 실패하며 Pushover 긴급 알림("Codex Remote Control Failed — exit=1, reason=lock-acquire-timeout, auth=chatgpt")이 반복 발송됐다 (수일간 지속, 사용자 체감 알림 폭탄).

실측으로 확인한 원인 체인:

1. 7/1 21:22 — codex 0.142.5 갱신 복구 과정에서 ensure 실행이 잠금(fd 9)을 쥔 채 `codex remote-control start`를 실행, detach된 app-server 데몬(`app-server --remote-control --listen unix://`, PPID 1)이 **fd 9를 상속**.
2. ensure 스크립트는 정상 종료했지만 flock은 open file description이 살아있는 한 유지되므로, 데몬이 `maintenance.lock`을 영구 점유 (`lslocks`에서 codex PID가 유일한 WRITE 보유자, `/proc/<pid>/fd/9 → maintenance.lock` 직접 확인).
3. 이후 모든 타이머 실행이 `flock --timeout 120` 대기 → `lock-acquire-timeout` 실패 → 알림. 서비스 `TimeoutSec=120`과 동률 레이스로 일부 실행은 알림 없이 systemd 'timeout'으로 종료.
4. 부수 피해: `KillMode=process`(spawn된 데몬 보호용 의도된 설정)라 대기자 flock 프로세스가 정리되지 않고 서비스 cgroup에 수백 개 누적 (journal의 "Found left-over process (flock) … Ignoring" 다수).

#944 (merged #949)가 flock **대기의 무한 블록**에 타임아웃을 부여했지만, **락 자체가 영구 점유되는 근본 원인(fd 상속 leak)**은 남아 있었다 — 타임아웃 덕에 hang 대신 "30분마다 실패+알림"으로 증상이 바뀐 것.

## CIR (Change Intent Record)

- **발견 경위**: 반복 알림의 원인 조사에서 `lslocks`로 잠금 보유자를 추적 — 대기자 flock 다수(`WRITE*`)와 별개로 실제 보유자가 codex app-server 데몬임을 확인했고, `/proc/<daemon>/fd/9`가 `maintenance.lock`을 가리키는 것으로 fd 상속을 실증했다.
- **수정 위치 결정**: 자식으로 spawn되는 모든 codex 호출 지점(6곳)에 개별 `9>&-`를 다는 대신, `with_lock`이 코어 로직을 실행하는 단일 지점에 `"$@" 9>&-`를 적용했다. bash는 명령 스코프 리다이렉트 시 원본 fd를 CLOEXEC 임시 fd로 보존하므로 셸 자신의 락은 유지되고, 코어 로직 아래 모든 자식이 일괄 차단된다. buggy/fixed 두 시나리오를 로컬 재현 스크립트로 실증했다 (buggy: 데몬 fd 테이블에 락 존재 + 종료 후 락 획득 불가 / fixed: 락 없음 + 즉시 획득 가능).
- **TimeoutSec 동률 레이스**: flock 대기 상한(120s)과 서비스 타임아웃(120s)이 같아, 대기를 다 쓴 실행은 상태 기록(`status.json`)·알림 쿨다운 관리를 완주하지 못하고 SIGTERM을 받을 수 있다. 실패 관측성이 스크립트 소유가 되도록 유닛 타임아웃을 300s로 올렸다.
- **KillMode=process 유지**: spawn된 데몬이 서비스 cgroup에 남기 때문에 control-group kill이면 데몬까지 죽는다. 의도된 설정으로 판단해 유지했다. flock 대기자 누적은 근본 수정 + #944의 `--timeout`으로 재발하지 않는다 (현존 잔재는 배포 후 일회성 정리).

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `with_lock`에서 `"$@" 9>&-` | 코어 로직 전체를 fd 9 없는 스코프로 실행 | 단일 지점, 모든 자식 일괄 차단, 락은 유지 | bash 리다이렉트 의미론 이해 필요 (주석으로 보완) | ✅ |
| 각 codex 호출에 `9>&-` | 데몬을 spawn할 수 있는 호출마다 개별 차단 | 지점별 명시적 | 6곳+ 산재, 새 호출 추가 시 누락 위험 | ❌ |
| fd에 FD_CLOEXEC 설정 | 락 fd를 exec 시 자동 닫힘으로 표시 | 가장 정석 | bash에 fd cloexec 설정 프리미티브가 없음 | ❌ |
| flock을 lock-wrapper 프로세스로 전환 (`flock cmd` 형태 + `--close`) | util-linux가 실행 전 fd를 닫아줌 | 도구 내장 기능 | `with_lock` 구조(획득 실패 사유 기록, 셸 함수 실행) 전면 재작성 필요 | ❌ |
| `TimeoutSec` 300으로 상향 | 실패 경로가 상태 기록·알림까지 완주 | 관측성 확보, 알림 소실 제거 | 진짜 hang 시 감지가 최대 180s 늦어짐 (타이머 주기 30분 대비 무시 가능) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/codex-remote-control/files/codex-remote-control-maint.sh` | 수정 | `with_lock`: `"$@"` → `"$@" 9>&-` + 제약 설명 주석 |
| `modules/nixos/programs/codex-remote-control.nix` | 수정 | `TimeoutSec` 120→300 + 근거 주석 |
| `tests/suites/codex-remote-control.sh` | 수정 | fake codex `remote-control start`에 detach 데몬 fixture(`FAKE_START_DAEMON_FD_FILE`) 추가 + 회귀 테스트 |
| `tests/shell-script-tests.sh` | 수정 | 신규 테스트 등록 |

### 핵심 코드

```bash
flock --timeout "$MAINT_LOCK_TIMEOUT_SECONDS" 9 || {
  LAST_REPAIR_REASON="lock-acquire-timeout"
  return 1
}
# fd 9는 이 셸이 락을 유지하는 동안만 살아야 한다. 리다이렉트 없이 실행하면
# codex remote-control start가 detach하는 app-server 데몬이 fd 9를 상속해
# 스크립트 종료 후에도 락을 영구 점유하고, 이후 모든 타이머 실행이
# lock-acquire-timeout으로 실패한다. 9>&-는 명령 스코프에서만 fd 9를 닫으므로
# (bash가 원본 fd를 CLOEXEC 임시 fd로 보존) 이 셸의 락은 유지된다.
"$@" 9>&-
```

## 참고 레퍼런스

- #944 — flock 대기 무한 블록에 타임아웃 부여 (본 PR이 다루는 근본 원인의 선행 완화)
- 실장애 관측: `journalctl -u codex-remote-control-ensure` 2026-07-01 21:55 이후 매 30분 실패, `lslocks` 기준 잠금 보유자 = detach된 codex app-server 데몬

## Human Test Plan

### 자동 검증

1. `bash tests/shell-script-tests.sh`
   - **기대**: 전체 통과 (신규 "codex remote-control spawned daemon does not inherit lock fd" 포함).
   - **실패 시**: 신규 테스트가 FAIL이면 `with_lock`의 `9>&-` 적용 여부를 확인한다.

2. 테스트 유효성 (선택): maint 스크립트의 `"$@" 9>&-`를 `"$@"`로 되돌리고 1을 재실행.
   - **기대**: 신규 테스트만 FAIL ("expected output to not contain: maintenance.lock") — 실장애 재현 확인 후 원복.

### 배포 후 복구 런북 (머지 + MiniPC `nrs` 이후)

3. 잔재 정리 및 복구:
   ```bash
   sudo systemctl stop codex-remote-control-ensure.timer
   pkill -u "$USER" -x flock              # 누적된 대기자 정리
   codex remote-control stop              # 락 fd를 보유한 구 데몬 정상 종료 → 락 해제
   sudo systemctl start codex-remote-control-ensure.service
   sudo systemctl start codex-remote-control-ensure.timer
   ```
   - **기대**: 서비스가 `Finished`로 성공, "Codex Remote Control Recovered" Pushover 알림 1회 수신, 이후 실패 알림 중단.
   - **실패 시**: `lslocks | grep maintenance.lock`으로 잔여 보유자를 확인하고, `journalctl -u codex-remote-control-ensure -n 50`으로 실패 사유를 본다.

4. 재발 방지 확인 (다음 데몬 재시작 이후):
   ```bash
   lslocks | grep maintenance.lock
   ```
   - **기대**: ensure 실행 중이 아닐 때 보유자 없음 (새로 spawn된 데몬의 fd 테이블에 lock fd 부재).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the remote-control maintenance workflow by preventing a spawned process from holding the lock open.
  * Increased the wait time before the maintenance action times out, reducing false timeout failures.
* **Tests**
  * Added coverage to verify a spawned daemon does not inherit the lock file descriptor.
  * Expanded the remote-control test suite to check that the lock can be acquired again after the workflow completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->