### PR TITLE
refactor(hooks): claude 훅 stdin 파싱을 hook-runtime으로 수렴

### DIFF
--- a/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh
@@ -5,6 +5,11 @@
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 # [WHY] fence strip을 document 모드의 SCAN_INPUT과 delta 검사의 OLD_STRIPPED
 # 양쪽에서 사용하므로 함수로 추출. Markdown spec 기준 0-3칸 들여쓰기 + 3개 이상 backtick.
 _strip_fences() {
@@ -23,11 +28,11 @@ _strip_fences() {
 }
 
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+TOOL_NAME=$(printf '%s' "$INPUT" | hook_parse_tool_name)
 
 case "$TOOL_NAME" in Edit|Write) ;; *) exit 0 ;; esac
 
-FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
+FILE_PATH=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.file_path // empty')
 [ -z "$FILE_PATH" ] && exit 0
 
 # [WHY] SKILL.md body와 references/는 LLM이 생성/수정하는 스킬 콘텐츠.
@@ -45,10 +50,10 @@ esac
 # SCAN_MODE: document=전체 문서(fence strip 가능), fragment=조각(fence strip 불가).
 SCAN_MODE="document"
 if [ "$TOOL_NAME" = "Write" ]; then
-  CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
+  CONTENT=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.content // empty')
 else
-  OLD_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.old_string // empty' 2>/dev/null)
-  NEW_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
+  OLD_STR=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.old_string // empty')
+  NEW_STR=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.new_string // empty')
   if [ -n "$OLD_STR" ] && [ -f "$FILE_PATH" ]; then
     # [WHY] awk ENVIRON + index() + substr()로 순수 문자열 치환.
     # -v 대신 ENVIRON을 사용하여 C-style escape 변환을 방지.

--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -7,17 +7,22 @@
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 INPUT=$(cat)
 
 # 서브에이전트 내부 호출은 제외
-AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
+AGENT_ID=$(printf '%s' "$INPUT" | hook_parse_json_path '.agent_id // empty')
 [ -n "$AGENT_ID" ] && exit 0
 
-SKILL=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null)
+SKILL=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.skill // empty')
 [ -z "$SKILL" ] && exit 0
 
-ARGS=$(printf '%s' "$INPUT" | jq -r '.tool_input.args // ""' 2>/dev/null)
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)
+ARGS=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.args // ""')
+SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
 REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || true)
 
 # 로그 파일 owner-only 권한 (민감 args 보호)

--- a/modules/shared/programs/claude/files/hooks/nrs-session-cleanup.sh
+++ b/modules/shared/programs/claude/files/hooks/nrs-session-cleanup.sh
@@ -10,8 +10,13 @@
 NRS_LOCK_FILE="/tmp/nrs-state"
 [[ ! -f "$NRS_LOCK_FILE" ]] && exit 0
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 INPUT=$(cat)
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=$(printf '%s' "$INPUT" | hook_parse_json_path '.cwd // empty')
 [[ -z "$CWD" ]] && exit 0
 
 # CWD에서 git toplevel 추출 → lock worktree와 비교

--- a/modules/shared/programs/claude/files/hooks/plans-gc.sh
+++ b/modules/shared/programs/claude/files/hooks/plans-gc.sh
@@ -25,8 +25,13 @@ GC_AGE_DAYS=7
 # 정의한 SSOT 기준). unquoted 변수로 bash regex 매칭 (quote 시 literal 매칭됨).
 HEX_RE='-[0-9a-f]{8}\.md$'
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 INPUT=$(cat)
-CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+CWD=$(printf '%s' "$INPUT" | hook_parse_json_path '.cwd // empty')
 [[ -z "$CWD" ]] && exit 0
 
 GIT_TOPLEVEL=$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null) || exit 0

--- a/modules/shared/programs/claude/files/hooks/record-last-session.sh
+++ b/modules/shared/programs/claude/files/hooks/record-last-session.sh
@@ -23,6 +23,11 @@ fi
 # shellcheck source=../lib/session-state.sh disable=SC1091
 . "$SESSION_STATE_LIB"
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
@@ -37,11 +42,11 @@ if [ -z "$INPUT" ]; then
 fi
 
 # subagent 내부 Stop은 무시 (메인 턴만 추적)
-AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null) || true
+AGENT_ID=$(printf '%s' "$INPUT" | hook_parse_json_path '.agent_id // empty')
 [ -n "$AGENT_ID" ] && exit 0
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || true
-CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || true
+SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
+CWD=$(printf '%s' "$INPUT" | hook_parse_json_path '.cwd // empty')
 
 if [ -z "$SESSION_ID" ] || [ -z "$CWD" ]; then
   exit 0

--- a/modules/shared/programs/claude/files/hooks/session-init-icons.sh
+++ b/modules/shared/programs/claude/files/hooks/session-init-icons.sh
@@ -29,6 +29,11 @@ fi
 # shellcheck source=../lib/session-state.sh disable=SC1091
 . "$SESSION_STATE_LIB"
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 # jq 필수 — 없으면 graceful skip
 if ! command -v jq >/dev/null 2>&1; then
   exit 0
@@ -44,10 +49,10 @@ if [ -z "$INPUT" ]; then
   exit 0
 fi
 
-SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || true
-TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null) || true
-SOURCE=$(printf '%s' "$INPUT" | jq -r '.source // empty' 2>/dev/null) || true
-CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || true
+SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
+TRANSCRIPT=$(printf '%s' "$INPUT" | hook_parse_json_path '.transcript_path // empty')
+SOURCE=$(printf '%s' "$INPUT" | hook_parse_json_path '.source // empty')
+CWD=$(printf '%s' "$INPUT" | hook_parse_json_path '.cwd // empty')
 
 # session_id resolution — statusline.sh와 동일 fallback (D-8)
 # stdin.session_id 우선, 비어있으면 transcript basename — 단, transcript는

--- a/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/system-bash-guard.sh
@@ -7,8 +7,13 @@
 
 command -v jq >/dev/null 2>&1 || exit 0
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 INPUT=$(cat)
-TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+TOOL_NAME=$(printf '%s' "$INPUT" | hook_parse_tool_name)
 
 _deny() {
   # [WHY] 공식 최신 PreToolUse 스펙: hookSpecificOutput.permissionDecision
@@ -21,7 +26,7 @@ _deny() {
 
 case "$TOOL_NAME" in
   Bash)
-    CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+    CMD=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.command // empty')
     # [WHY] 명령 세그먼트 시작(라인 시작, `;`, `&&`, `||`, `|`, `(`) 뒤에서
     # `/bin/bash`가 실행되는 케이스만 매치. `grep /bin/bash README`나
     # `test -x /bin/bash` 같은 문자열 언급은 통과.
@@ -32,15 +37,15 @@ case "$TOOL_NAME" in
     fi
     ;;
   Write)
-    CONTENT=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
+    CONTENT=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.content // empty')
     if printf '%s' "$CONTENT" | grep -Eq '^#!/bin/bash([[:space:]]|$)'; then
       _deny "[system-bash-guard] Write content의 shebang이 #!/bin/bash입니다. macOS /bin/bash는 3.2 (GPLv3 legacy)로 bash 4+ 기능이 실패합니다. 대안: #!/usr/bin/env bash (호출 환경 PATH를 통해 bash가 해석됨; launchd/systemd처럼 PATH가 통제된 컨텍스트에서는 해당 agent의 PATH에 Nix bash 경로가 포함되는지 별도 확인 필요)."
     fi
     ;;
   Edit)
-    FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
-    OLD_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.old_string // empty' 2>/dev/null)
-    NEW_STR=$(printf '%s' "$INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null)
+    FILE_PATH=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.file_path // empty')
+    OLD_STR=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.old_string // empty')
+    NEW_STR=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.new_string // empty')
     # [WHY] new_string만 검사하면 partial 치환(예: old="/usr/bin/env bash",
     # new="/bin/bash")이 post-edit shebang을 #!/bin/bash로 만들어도 우회된다.
     # old_string을 new_string으로 치환한 전체 결과에서 검사하여 bypass를 차단.

--- a/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
+++ b/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh
@@ -2,8 +2,13 @@
 # Claude Code PreToolUse hook: worktree path guard
 # worktree에서 실행 중일 때 main repo 파일을 Edit/Write하면 차단하고 worktree 경로를 안내
 
+HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
+[ -f "$HOOK_RUNTIME_LIB" ] || exit 0
+# shellcheck source=../lib/hook-runtime.sh
+. "$HOOK_RUNTIME_LIB"
+
 INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name')
+TOOL_NAME=$(printf '%s' "$INPUT" | hook_parse_tool_name)
 
 # Edit, Write만 감시
 case "$TOOL_NAME" in
@@ -11,7 +16,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+FILE_PATH=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.file_path // empty')
 [[ -z "$FILE_PATH" ]] && exit 0
 
 # worktree 감지: git-dir ≠ git-common-dir

--- a/modules/shared/programs/claude/files/lib/hook-runtime.sh
+++ b/modules/shared/programs/claude/files/lib/hook-runtime.sh
@@ -2,13 +2,9 @@
 # hook-runtime.sh — claude/codex hook 공통 helper 라이브러리.
 # 정책 출처: https://github.com/greenheadHQ/nixos-config/issues/759
 #
-# 본 라이브러리는 pinning-alert, pinning-guard (claude/codex 양 트리) 와 record-last-stop,
-# record-prompt-submit (codex 트리) 의 구현 use-site 에서 사용한다. 런타임별
-# 전용 로직 (CLAUDECODE/CODEX_PROGRAMMATIC 가드, agent_id 가드, apply_patch envelope
-# dispatch) 은 각 hook 본문에 inline 유지한다.
-#
-# 비대상: nrs-session-cleanup (claude/codex 양쪽) — 자체 NRS_LOCK_FILE cleanup 로직만
-# 사용하며 lib 의존성 없음.
+# 본 라이브러리는 claude/codex hook 구현 use-site 에서 사용한다. 런타임별 전용 로직
+# (CLAUDECODE/CODEX_PROGRAMMATIC 가드, agent_id 가드, apply_patch envelope dispatch) 은
+# 각 hook 본문에 inline 유지한다.
 #
 # 호출자는 본 lib 의 실패 정책 (fail-closed / warn-only / inline fallback) 을 결정한다.
 # `hook_load_lib` 는 정책 결정권 없이 stdout 으로 path 또는 빈 문자열을 반환한다.
@@ -16,6 +12,14 @@
 # USED-BY:
 #   claude/files/hooks/pinning-alert.sh         # via $HOOK_RUNTIME_LIB
 #   claude/files/hooks/pinning-guard.sh         # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/fragile-hardcoding-guard.sh # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/log-skill.sh             # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/nrs-session-cleanup.sh   # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/plans-gc.sh              # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/record-last-session.sh   # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/session-init-icons.sh    # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/system-bash-guard.sh     # via $HOOK_RUNTIME_LIB
+#   claude/files/hooks/worktree-path-guard.sh   # via $HOOK_RUNTIME_LIB
 #   codex/files/hooks/pinning-alert.sh          # via $HOOK_RUNTIME_LIB
 #   codex/files/hooks/pinning-guard.sh          # via $HOOK_RUNTIME_LIB
 #   codex/files/hooks/record-last-stop.sh       # via $HOOK_RUNTIME_LIB
@@ -106,6 +110,19 @@ hook_init_scan_dir() {
   return 1
 }
 
+# hook_parse_json_path <jq_filter>
+#
+# stdin 으로 받은 JSON 에서 caller 가 지정한 jq filter 를 추출. 기존 hook inline
+# parsing 의 jq filter 를 그대로 전달해 기본값/fallback 의미를 보존한다.
+#
+# stdin: hook stdin JSON
+# stdout: 추출 값 또는 filter 가 정한 기본값. jq 파싱 실패 시 빈 문자열.
+# exit code: 항상 0.
+hook_parse_json_path() {
+  local jq_filter="$1"
+  jq -r "$jq_filter" 2>/dev/null || true
+}
+
 # hook_parse_tool_name
 #
 # stdin 으로 받은 JSON 에서 .tool_name 추출. jq 사용.
@@ -114,7 +131,7 @@ hook_init_scan_dir() {
 # stdout: tool_name 값 또는 빈 문자열.
 # exit code: 항상 0 (jq 파싱 실패 시에도 빈 문자열 + 0).
 hook_parse_tool_name() {
-  jq -r '.tool_name // empty' 2>/dev/null || true
+  hook_parse_json_path '.tool_name // empty'
 }
 
 # hook_parse_session_id
@@ -125,5 +142,5 @@ hook_parse_tool_name() {
 # stdout: session_id 값 또는 빈 문자열.
 # exit code: 항상 0.
 hook_parse_session_id() {
-  jq -r '.session_id // empty' 2>/dev/null || true
+  hook_parse_json_path '.session_id // empty'
 }

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -148,11 +148,25 @@ run_test "karakeep backup missing db exits nonzero" test_karakeep_backup_missing
 run_test "karakeep backup retention scopes to backup dir" test_karakeep_backup_retention_scopes_to_backup_dir
 run_test "fragile-hardcoding-guard line count word order independent" test_fragile_hardcoding_guard_line_count_word_order_independent
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
+run_test "fragile-hardcoding-guard edit true positive preserved" test_fragile_hardcoding_guard_edit_true_positive_preserved
+run_test "fragile-hardcoding-guard empty and malformed input noop" test_fragile_hardcoding_guard_empty_and_malformed_input_noop
+run_test "log-skill normal input logs usage" test_log_skill_hook_normal_input_logs_usage
+run_test "log-skill empty malformed and subagent noop" test_log_skill_hook_empty_malformed_and_subagent_noop
+run_test "nrs-session-cleanup empty malformed and nonrepo noop" test_nrs_session_cleanup_hook_empty_malformed_and_nonrepo_input_noop
+run_test "plans-gc removes old transient buffer" test_plans_gc_hook_removes_old_transient_buffer
+run_test "plans-gc empty and malformed input noop" test_plans_gc_hook_empty_and_malformed_input_noop
+run_test "record-last-session normal input writes marker" test_record_last_session_hook_normal_input_writes_marker
+run_test "record-last-session empty malformed and subagent noop" test_record_last_session_hook_empty_malformed_and_subagent_noop
+run_test "session-init-icons startup creates state and context" test_session_init_icons_hook_startup_creates_state_and_context
+run_test "session-init-icons empty and malformed input noop" test_session_init_icons_hook_empty_and_malformed_input_noop
+run_test "system-bash-guard denies bash write and edit patterns" test_system_bash_guard_hook_denies_bash_write_and_edit_patterns
+run_test "system-bash-guard empty and malformed input noop" test_system_bash_guard_hook_empty_and_malformed_input_noop
 run_test "worktree-path-guard main repo session always allows" test_worktree_path_guard_main_repo_session_always_allows
 run_test "worktree-path-guard denies main repo file from worktree" test_worktree_path_guard_denies_main_repo_file_from_worktree
 run_test "worktree-path-guard allows own worktree file" test_worktree_path_guard_allows_own_worktree_file
 run_test "worktree-path-guard allows sibling worktree file" test_worktree_path_guard_allows_sibling_worktree_file
 run_test "worktree-path-guard allows main repo plan path exception" test_worktree_path_guard_allows_main_repo_plan_path_exception
+run_test "worktree-path-guard empty and malformed input noop" test_worktree_path_guard_empty_and_malformed_input_noop
 run_test "immich originals mirror skips rsync on empty source" test_immich_originals_mirror_empty_source_skips_rsync
 run_test "immich cleanup paginates v3 nextPage string" test_immich_cleanup_v3_paginates_next_page_string
 run_test "immich cleanup preserves empty album notification" test_immich_cleanup_v3_empty_album_preserves_notification
@@ -162,6 +176,8 @@ run_test "hook_init_scan_dir falls back when TMPDIR missing" test_hook_init_scan
 run_test "hook_init_scan_dir falls back when TMPDIR unwritable" test_hook_init_scan_dir_falls_back_when_tmpdir_unwritable
 run_test "hook_init_scan_dir falls back when system tmp unusable" test_hook_init_scan_dir_falls_back_to_user_cache_when_system_tmp_unusable
 run_test "hook_init_scan_dir uses valid TMPDIR" test_hook_init_scan_dir_uses_valid_tmpdir
+run_test "hook_parse_json_path preserves filter defaults" test_hook_parse_json_path_preserves_filter_defaults
+run_test "hook_parse_json_path malformed input returns empty success" test_hook_parse_json_path_malformed_input_returns_empty_success
 run_test "pinning-guard survives set-but-unusable TMPDIR (e2e)" test_pinning_guard_survives_unusable_tmpdir
 
 # codex-config fixture는 tomlkit이 필요하다. lefthook pre-push는 `nix shell` wrap으로

--- a/tests/suites/claude-hook-runtime-adoption.sh
+++ b/tests/suites/claude-hook-runtime-adoption.sh
@@ -1,0 +1,238 @@
+# tests/suites/claude-hook-runtime-adoption.sh — hook-runtime parser adoption fixtures
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2164
+
+_chra_hook_runtime_lib() {
+  printf '%s' "$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh"
+}
+
+_chra_session_state_lib() {
+  printf '%s' "$REPO_ROOT/modules/shared/programs/claude/files/lib/session-state.sh"
+}
+
+_chra_hook_path() {
+  printf '%s' "$REPO_ROOT/modules/shared/programs/claude/files/hooks/$1"
+}
+
+_chra_run_hook() {
+  local hook_name="$1" input="$2"
+  shift 2
+  printf '%s' "$input" | \
+    env HOOK_RUNTIME_LIB="$(_chra_hook_runtime_lib)" "$@" bash "$(_chra_hook_path "$hook_name")" 2>&1
+}
+
+_chra_git_init() {
+  local repo="$1"
+  GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_NOSYSTEM=1 \
+    git -C "$repo" -c init.templateDir= init -b main >/dev/null 2>&1
+}
+
+_chra_make_old_file() {
+  local path="$1"
+  printf '%s\n' "old transient buffer" > "$path"
+  touch -d '10 days ago' "$path" 2>/dev/null || touch -t 200001010000 "$path"
+}
+
+_chra_marker_path() {
+  local home="$1" cwd="$2"
+  HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)" CWD_FOR_MARKER="$cwd" \
+    bash -c '. "$SESSION_STATE_LIB"; marker_path_for_cwd "$CWD_FOR_MARKER"'
+}
+
+test_log_skill_hook_normal_input_logs_usage() {
+  local sandbox home input out log line
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  input=$(jq -n \
+    --arg sid "sid-1" \
+    --arg skill "managing-minipc" \
+    --arg args "arg value" \
+    '{session_id:$sid,tool_input:{skill:$skill,args:$args}}')
+  out=$(_chra_run_hook "log-skill.sh" "$input" HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "expected log-skill normal input to produce no stdout, got: $out"
+  log="$home/.claude/skill-usage.log"
+  [ -f "$log" ] || fail "expected log-skill to create usage log"
+  line=$(cat "$log")
+  assert_contains "$line" $'tester\tsid-1'
+  assert_contains "$line" $'\tmanaging-minipc\targ value'
+}
+
+test_log_skill_hook_empty_malformed_and_subagent_noop() {
+  local sandbox home input out log
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  log="$home/.claude/skill-usage.log"
+
+  out=$(_chra_run_hook "log-skill.sh" "" HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "expected log-skill empty stdin to noop, got: $out"
+  [ ! -e "$log" ] || fail "expected log-skill empty stdin not to create log"
+
+  out=$(_chra_run_hook "log-skill.sh" '{"tool_input":' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "expected log-skill malformed JSON to noop, got: $out"
+  [ ! -e "$log" ] || fail "expected log-skill malformed JSON not to create log"
+
+  input=$(jq -n '{agent_id:"agent-1",session_id:"sid-1",tool_input:{skill:"demo"}}')
+  out=$(_chra_run_hook "log-skill.sh" "$input" HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "expected log-skill subagent input to noop, got: $out"
+  [ ! -e "$log" ] || fail "expected log-skill subagent input not to create log"
+}
+
+test_nrs_session_cleanup_hook_empty_malformed_and_nonrepo_input_noop() {
+  local sandbox home input out
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home"
+
+  out=$(_chra_run_hook "nrs-session-cleanup.sh" "" HOME="$home")
+  [[ -z "$out" ]] || fail "expected nrs cleanup empty stdin to noop, got: $out"
+
+  out=$(_chra_run_hook "nrs-session-cleanup.sh" '{"cwd":' HOME="$home")
+  [[ -z "$out" ]] || fail "expected nrs cleanup malformed JSON to noop, got: $out"
+
+  input=$(jq -n --arg cwd "$sandbox/not-a-git-repo" '{cwd:$cwd}')
+  out=$(_chra_run_hook "nrs-session-cleanup.sh" "$input" HOME="$home")
+  [[ -z "$out" ]] || fail "expected nrs cleanup non-repo cwd to noop, got: $out"
+}
+
+test_plans_gc_hook_removes_old_transient_buffer() {
+  local sandbox home repo old input out
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  repo="$sandbox/repo"
+  mkdir -p "$home" "$repo/.claude/plans"
+  _chra_git_init "$repo"
+  old="$repo/.claude/plans/demo-1a2b3c4d.md"
+  _chra_make_old_file "$old"
+
+  input=$(jq -n --arg cwd "$repo" '{cwd:$cwd}')
+  out=$(_chra_run_hook "plans-gc.sh" "$input" HOME="$home")
+  [[ -z "$out" ]] || fail "expected plans-gc normal input to produce no stdout, got: $out"
+  [ ! -e "$old" ] || fail "expected plans-gc to remove old transient buffer"
+}
+
+test_plans_gc_hook_empty_and_malformed_input_noop() {
+  local sandbox home repo keep out
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  repo="$sandbox/repo"
+  mkdir -p "$home" "$repo/.claude/plans"
+  _chra_git_init "$repo"
+  keep="$repo/.claude/plans/demo-1a2b3c4d.md"
+  _chra_make_old_file "$keep"
+
+  out=$(_chra_run_hook "plans-gc.sh" "" HOME="$home")
+  [[ -z "$out" ]] || fail "expected plans-gc empty stdin to noop, got: $out"
+  [ -f "$keep" ] || fail "expected plans-gc empty stdin not to remove files"
+
+  out=$(_chra_run_hook "plans-gc.sh" '{"cwd":' HOME="$home")
+  [[ -z "$out" ]] || fail "expected plans-gc malformed JSON to noop, got: $out"
+  [ -f "$keep" ] || fail "expected plans-gc malformed JSON not to remove files"
+}
+
+test_record_last_session_hook_normal_input_writes_marker() {
+  local sandbox home cwd sid input out marker
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  cwd="$sandbox/project"
+  sid="sid-abc_1"
+  mkdir -p "$home" "$cwd"
+  input=$(jq -n --arg sid "$sid" --arg cwd "$cwd" '{session_id:$sid,cwd:$cwd}')
+
+  out=$(_chra_run_hook "record-last-session.sh" "$input" \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  [[ -z "$out" ]] || fail "expected record-last-session normal input to produce no stdout, got: $out"
+  marker=$(_chra_marker_path "$home" "$cwd")
+  assert_file_contains "$marker" "$sid"
+}
+
+test_record_last_session_hook_empty_malformed_and_subagent_noop() {
+  local sandbox home cwd sid input out marker
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  cwd="$sandbox/project"
+  sid="sid-abc_1"
+  mkdir -p "$home" "$cwd"
+  marker=$(_chra_marker_path "$home" "$cwd")
+
+  out=$(_chra_run_hook "record-last-session.sh" "" \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  [[ -z "$out" ]] || fail "expected record-last-session empty stdin to noop, got: $out"
+  [ ! -e "$marker" ] || fail "expected record-last-session empty stdin not to create marker"
+
+  out=$(_chra_run_hook "record-last-session.sh" '{"session_id":' \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  [[ -z "$out" ]] || fail "expected record-last-session malformed JSON to noop, got: $out"
+  [ ! -e "$marker" ] || fail "expected record-last-session malformed JSON not to create marker"
+
+  input=$(jq -n --arg sid "$sid" --arg cwd "$cwd" '{agent_id:"agent-1",session_id:$sid,cwd:$cwd}')
+  out=$(_chra_run_hook "record-last-session.sh" "$input" \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  [[ -z "$out" ]] || fail "expected record-last-session subagent input to noop, got: $out"
+  [ ! -e "$marker" ] || fail "expected record-last-session subagent input not to create marker"
+}
+
+test_session_init_icons_hook_startup_creates_state_and_context() {
+  local sandbox home cwd sid input out
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  cwd="$sandbox/project"
+  sid="sid-start_1"
+  mkdir -p "$home" "$cwd"
+  input=$(jq -n --arg sid "$sid" --arg cwd "$cwd" \
+    '{session_id:$sid,source:"startup",cwd:$cwd,transcript_path:""}')
+
+  out=$(_chra_run_hook "session-init-icons.sh" "$input" \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  assert_contains "$out" '"hookEventName": "SessionStart"'
+  [ -f "$home/.claude/status-icons/$sid.json" ] || fail "expected session-init-icons to create state file"
+  [ -f "$home/.claude/memos/$sid.md" ] || fail "expected session-init-icons to create memo file"
+}
+
+test_session_init_icons_hook_empty_and_malformed_input_noop() {
+  local sandbox home out
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home"
+
+  out=$(_chra_run_hook "session-init-icons.sh" "" \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  [[ -z "$out" ]] || fail "expected session-init-icons empty stdin to noop, got: $out"
+
+  out=$(_chra_run_hook "session-init-icons.sh" '{"session_id":' \
+    HOME="$home" SESSION_STATE_LIB="$(_chra_session_state_lib)")
+  [[ -z "$out" ]] || fail "expected session-init-icons malformed JSON to noop, got: $out"
+}
+
+test_system_bash_guard_hook_denies_bash_write_and_edit_patterns() {
+  local sandbox file input out
+  sandbox=$(new_sandbox)
+
+  input=$(jq -n --arg cmd "/bin/bash -lc true" '{tool_name:"Bash",tool_input:{command:$cmd}}')
+  out=$(_chra_run_hook "system-bash-guard.sh" "$input")
+  assert_contains "$out" '"permissionDecision": "deny"'
+
+  input=$(jq -n --arg content $'#!/bin/bash\nprintf ok\n' '{tool_name:"Write",tool_input:{content:$content}}')
+  out=$(_chra_run_hook "system-bash-guard.sh" "$input")
+  assert_contains "$out" '"permissionDecision": "deny"'
+
+  file="$sandbox/script.sh"
+  printf '%s\n' '#!/usr/bin/env bash' 'printf ok' > "$file"
+  input=$(jq -n \
+    --arg path "$file" \
+    --arg old "#!/usr/bin/env bash" \
+    --arg new "#!/bin/bash" \
+    '{tool_name:"Edit",tool_input:{file_path:$path,old_string:$old,new_string:$new}}')
+  out=$(_chra_run_hook "system-bash-guard.sh" "$input")
+  assert_contains "$out" '"permissionDecision": "deny"'
+}
+
+test_system_bash_guard_hook_empty_and_malformed_input_noop() {
+  local out
+  out=$(_chra_run_hook "system-bash-guard.sh" "")
+  [[ -z "$out" ]] || fail "expected system-bash-guard empty stdin to noop, got: $out"
+  out=$(_chra_run_hook "system-bash-guard.sh" '{"tool_name":')
+  [[ -z "$out" ]] || fail "expected system-bash-guard malformed JSON to noop, got: $out"
+}

--- a/tests/suites/fragile-hardcoding-guard.sh
+++ b/tests/suites/fragile-hardcoding-guard.sh
@@ -11,7 +11,15 @@ _fragile_guard_decision() {
   # $1 = SKILL.md content. 가드의 stdout(+stderr)을 반환한다(deny JSON 또는 빈 출력).
   local content="$1"
   printf '{"tool_name":"Write","tool_input":{"file_path":"repo/modules/x/claude/files/skills/demo/SKILL.md","content":"%s"}}' "$content" | \
-    bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh" 2>&1
+    env HOOK_RUNTIME_LIB="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" \
+      bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh" 2>&1
+}
+
+_fragile_guard_raw() {
+  local input="$1"
+  printf '%s' "$input" | \
+    env HOOK_RUNTIME_LIB="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" \
+      bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/fragile-hardcoding-guard.sh" 2>&1
 }
 
 test_fragile_hardcoding_guard_line_count_word_order_independent() {
@@ -32,4 +40,27 @@ test_fragile_hardcoding_guard_line_count_true_positive_preserved() {
   # 정탐 보존: 제외 키워드가 전혀 없는 순수 "N줄" 하드코딩은 어순 무관화 이후에도 deny된다.
   out=$(_fragile_guard_decision "이 문서는 120줄로 구성된다")
   assert_contains "$out" '"permissionDecision": "deny"'
+}
+
+test_fragile_hardcoding_guard_edit_true_positive_preserved() {
+  local sandbox file input out
+  sandbox=$(new_sandbox)
+  file="$sandbox/repo/modules/x/claude/files/skills/demo/SKILL.md"
+  mkdir -p "$(dirname "$file")"
+  printf '%s\n' "기존 본문" > "$file"
+  input=$(jq -n \
+    --arg path "$file" \
+    --arg old "기존 본문" \
+    --arg new "이 문서는 120줄로 구성된다" \
+    '{tool_name:"Edit",tool_input:{file_path:$path,old_string:$old,new_string:$new}}')
+  out=$(_fragile_guard_raw "$input")
+  assert_contains "$out" '"permissionDecision": "deny"'
+}
+
+test_fragile_hardcoding_guard_empty_and_malformed_input_noop() {
+  local out
+  out=$(_fragile_guard_raw "")
+  [[ -z "$out" ]] || fail "expected empty stdin to noop, got: $out"
+  out=$(_fragile_guard_raw '{"tool_name":')
+  [[ -z "$out" ]] || fail "expected malformed JSON to noop, got: $out"
 }

--- a/tests/suites/hook-runtime.sh
+++ b/tests/suites/hook-runtime.sh
@@ -16,6 +16,29 @@ _hook_runtime_lib_path() {
   printf '%s' "$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh"
 }
 
+test_hook_parse_json_path_preserves_filter_defaults() {
+  local lib out
+  lib="$(_hook_runtime_lib_path)"
+  out=$(printf '%s' '{"tool_input":{"args":null,"file_path":"demo.txt"}}' \
+    | HOOK_RT_LIB="$lib" bash -c '. "$HOOK_RT_LIB"; hook_parse_json_path ".tool_input.args // \"fallback\""') \
+    || fail "hook_parse_json_path must exit 0 for valid JSON"
+  [[ "$out" == "fallback" ]] || fail "expected jq filter default to be preserved, got: $out"
+
+  out=$(printf '%s' '{"tool_input":{"file_path":"demo.txt"}}' \
+    | HOOK_RT_LIB="$lib" bash -c '. "$HOOK_RT_LIB"; hook_parse_json_path ".tool_input.file_path // empty"') \
+    || fail "hook_parse_json_path must extract nested field"
+  [[ "$out" == "demo.txt" ]] || fail "expected nested field extraction, got: $out"
+}
+
+test_hook_parse_json_path_malformed_input_returns_empty_success() {
+  local lib out
+  lib="$(_hook_runtime_lib_path)"
+  out=$(printf '%s' '{"tool_name":' \
+    | HOOK_RT_LIB="$lib" bash -c '. "$HOOK_RT_LIB"; hook_parse_tool_name') \
+    || fail "hook_parse_tool_name must exit 0 for malformed JSON"
+  [[ -z "$out" ]] || fail "expected malformed JSON to parse as empty, got: $out"
+}
+
 # 존재하지 않는 TMPDIR (codex dangling ~/.codex/tmp/... 재현) → fallback + 성공.
 test_hook_init_scan_dir_falls_back_when_tmpdir_missing() {
   local sandbox out lib

--- a/tests/suites/worktree-path-guard.sh
+++ b/tests/suites/worktree-path-guard.sh
@@ -47,10 +47,18 @@ _wpg_setup_fixture() {
 _wpg_decision() {
   # $1 = 훅을 실행할 cwd, $2 = tool_input.file_path, $3 = tool_name(기본 Edit).
   local cwd="$1" file_path="$2" tool_name="${3:-Edit}"
+  local input
+  input=$(printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool_name" "$file_path")
+  _wpg_raw "$cwd" "$input"
+}
+
+_wpg_raw() {
+  local cwd="$1" input="$2"
   (
     cd "$cwd" && \
-    printf '{"tool_name":"%s","tool_input":{"file_path":"%s"}}' "$tool_name" "$file_path" | \
-      bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh" 2>&1
+    printf '%s' "$input" | \
+      env HOOK_RUNTIME_LIB="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" \
+        bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/worktree-path-guard.sh" 2>&1
   )
 }
 
@@ -97,4 +105,14 @@ test_worktree_path_guard_allows_main_repo_plan_path_exception() {
   main_root=$(_wpg_setup_fixture "$sandbox")
   out=$(_wpg_decision "$main_root/.claude/worktrees/a" "$main_root/.claude/plans/x.md")
   [[ -z "$out" ]] || fail "expected main repo plan path exception to allow, got: $out"
+}
+
+test_worktree_path_guard_empty_and_malformed_input_noop() {
+  local sandbox main_root out
+  sandbox=$(new_sandbox)
+  main_root=$(_wpg_setup_fixture "$sandbox")
+  out=$(_wpg_raw "$main_root/.claude/worktrees/a" "")
+  [[ -z "$out" ]] || fail "expected empty stdin to noop, got: $out"
+  out=$(_wpg_raw "$main_root/.claude/worktrees/a" '{"tool_name":')
+  [[ -z "$out" ]] || fail "expected malformed JSON to noop, got: $out"
 }


### PR DESCRIPTION
## Summary

- stdin JSON을 자체 `jq` 인라인으로 파싱하던 claude 훅 8개를 `hook-runtime.sh` 공용 파서로 전환 (판정 로직 불변, 파싱 계층만 교체)
- `hook_parse_json_path <jq_filter>` 헬퍼 1개를 추가해 훅별 다양한 필드를 기존 jq filter 그대로 위임 — 기본값/fallback 의미 보존
- 신규 suite `claude-hook-runtime-adoption` + 기존 가드 suite에 empty/malformed stdin noop 특성화 추가

Closes #949

## 기존 문제/배경

claude 훅 10개 중 2개(pinning-guard, pinning-alert)만 hook-runtime.sh를 채택했고, 나머지 8개는 각자 `jq -r` 인라인 파싱을 반복하고 있었다. 파싱 오류 처리(빈 stdin, malformed JSON)의 동작이 훅마다 암묵적으로 달라질 수 있고, stdin 스키마가 바뀌면 10곳을 따로 고쳐야 했다.

## CIR (Change Intent Record)

- improve 감사(epic #937)의 tech-debt finding에서 승격된 plan을 executor가 수행하고 supervisor가 리뷰했다.
- 필드별 전용 헬퍼(`hook_parse_file_path` 등) 여러 개 대신 **jq filter를 인자로 받는 범용 헬퍼 1개**를 선택 — 각 훅의 기존 filter 문자열(`.tool_input.file_path // empty` 등)을 그대로 전달해 의미 변화를 구조적으로 차단.
- lib 부재 시 실패 정책: 전환 훅 8개는 fail-open(`exit 0`)으로 통일했다. hook-runtime.sh 헤더의 "호출자가 실패 정책을 결정한다" 설계를 따르며, **보안 경계인 pinning-guard만 fail-closed(deny)**를 유지한다 — 편의성 가드가 비정상 설치 상황에서 세션 전체를 마비시키지 않게 하는 위험도 기반 선택.
- 기존 suite 2건(fragile-hardcoding-guard, worktree-path-guard)의 헬퍼에 `HOOK_RUNTIME_LIB` env 주입을 추가했다 — 리포 체크아웃 기준 테스트가 배포 경로(`$HOME/.claude/lib`) 대신 리포의 lib를 사용하게 하는 필수 부수 수정. 기존 테스트 기대값은 불변.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 범용 `hook_parse_json_path` 1개 | jq filter를 인자로 위임 | 기존 filter 보존, 헬퍼 증식 방지 | filter 문자열이 훅에 남음 | ✅ |
| 필드별 전용 헬퍼 다수 | `hook_parse_file_path` 등 | 호출부가 짧아짐 | 훅마다 다른 기본값 조합을 헬퍼 폭발 없이 못 담음 | ❌ |
| 파싱 1회 + 변수 일괄 추출 | stdin을 한 번 파싱해 모든 필드 추출 | jq 호출 수 감소 | 훅별 필드 집합이 달라 공용화 어려움, 동작 변화 위험 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `lib/hook-runtime.sh` | `hook_parse_json_path` 추가, 기존 `hook_parse_tool_name`/`hook_parse_session_id`가 이를 사용, USED-BY 갱신 |
| `hooks/{fragile-hardcoding-guard, log-skill, nrs-session-cleanup, plans-gc, record-last-session, session-init-icons, system-bash-guard, worktree-path-guard}.sh` | 인라인 `jq -r` → hook-runtime 파서. 판정 로직·deny 조건·스캔 패턴 불변 |
| `tests/suites/claude-hook-runtime-adoption.sh` (신규) | 전환 훅들의 채택 상태·파싱 동작 특성화 |
| `tests/suites/hook-runtime.sh` | `hook_parse_json_path` 단위 케이스 추가 |
| `tests/suites/{fragile-hardcoding-guard, worktree-path-guard}.sh` | env 주입 + Edit true-positive·empty/malformed noop 케이스 추가 |
| `tests/shell-script-tests.sh` | 신규 suite 등록 |

## 참고 레퍼런스

- 이슈 #949, epic #937
- hook-runtime.sh 도입 정책: 이슈 #759
- 전환 전 채택 선례: pinning-guard/pinning-alert (fail-closed 정책 주석 포함)

## Human Test Plan

1. `nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh` → 전부 통과 (신규 suite 포함).
2. `bash tests/run-all-tests.sh` → 통과 7 · 실패 0.
3. `grep -rln "hook-runtime.sh" modules/shared/programs/claude/files/hooks/` → 10개 훅 전부.
4. 전환 훅에 stdin 필드용 인라인 `jq -r` 잔존 없음: `grep -n "jq -r" modules/shared/programs/claude/files/hooks/*.sh` 결과가 판정 로직/출력용 jq뿐이다.
5. 머지 + `nrs` 후 실제 세션에서 worktree 내 main repo 파일 Edit 시도 → 기존과 동일하게 차단 메시지.
   - 실패 시 진단: `~/.claude/lib/hook-runtime.sh` 존재 확인, 훅이 fail-open이므로 lib 부재면 가드가 조용히 비활성화된다.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP
