### PR TITLE
refactor(shared): Pushover 전송 공용 헬퍼 추출 — 직접 curl 사본 5곳 수렴

### DIFF
--- a/modules/darwin/programs/folder-actions/files/scripts/_folder-actions-lib.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/_folder-actions-lib.sh
@@ -16,6 +16,7 @@
 
 # Pushover credential 경로는 agenix 고정 path로 hard-code (override 금지).
 PUSHOVER_CREDENTIALS="$HOME/.config/pushover/folder-actions"
+PUSHOVER_HELPER="$HOME/.local/lib/pushover.sh"
 
 # 실패 격리 sibling 경로 — watch root 밖이므로 launchd WatchPaths 추가 wakeup 없음.
 # 사용자 복구 절차는 .claude/skills/managing-macos/references/features.md 참조.
@@ -29,24 +30,19 @@ notify_failure() {
     # credential 부재는 silent skip (agenix 미배포 창 호환).
     [ -f "$PUSHOVER_CREDENTIALS" ] || return 0
 
-    # source 실패는 추적 가능하도록 경고만 남기고 알림 생략.
-    # shellcheck disable=SC1090
-    if ! source "$PUSHOVER_CREDENTIALS" 2>/dev/null; then
-        log_warn "notify_failure: PUSHOVER_CREDENTIALS source 실패: $PUSHOVER_CREDENTIALS"
-        return 0
-    fi
-    if [ -z "${PUSHOVER_TOKEN:-}" ] || [ -z "${PUSHOVER_USER:-}" ]; then
-        log_warn "notify_failure: PUSHOVER_TOKEN/USER 미설정"
+    if [ ! -r "$PUSHOVER_HELPER" ]; then
+        log_warn "notify_failure: Pushover helper 없음: $PUSHOVER_HELPER"
         return 0
     fi
 
-    if ! /usr/bin/curl -sf --max-time 10 \
-            --form-string "token=${PUSHOVER_TOKEN}" \
-            --form-string "user=${PUSHOVER_USER}" \
-            --form-string "title=${title}" \
-            --form-string "message=${message}" \
-            --form-string "priority=${priority}" \
-            https://api.pushover.net/1/messages.json > /dev/null 2>&1; then
+    # source 실패는 추적 가능하도록 경고만 남기고 알림 생략.
+    # shellcheck disable=SC1090
+    if ! source "$PUSHOVER_HELPER" 2>/dev/null; then
+        log_warn "notify_failure: Pushover helper source 실패: $PUSHOVER_HELPER"
+        return 0
+    fi
+
+    if ! pushover_send "$PUSHOVER_CREDENTIALS" "$title" "$message" "$priority"; then
         log_warn "notify_failure: Pushover API 호출 실패 (네트워크/credential 확인)"
     fi
     return 0

--- a/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh
+++ b/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh
@@ -12,6 +12,7 @@ LOCK_TTL_SECONDS=2700
 LOCK_CORRUPT_TTL_SECONDS=$((LOCK_TTL_SECONDS * 2))
 IMMICH_CREDENTIALS="$HOME/.config/immich/api-key"
 PUSHOVER_CREDENTIALS="$HOME/.config/pushover/immich"
+PUSHOVER_HELPER="$HOME/.local/lib/pushover.sh"
 
 CURRENT_UID=$(/usr/bin/id -u)
 CURRENT_PID="$$"
@@ -64,14 +65,11 @@ send_notification() {
     local priority="${3:-"-1"}"
     local sound="${4:-"none"}"
 
-    curl -sf --max-time 10 \
-        --form-string "token=${PUSHOVER_TOKEN}" \
-        --form-string "user=${PUSHOVER_USER}" \
-        --form-string "title=${title}" \
-        --form-string "message=${message}" \
-        --form-string "priority=${priority}" \
-        --form-string "sound=${sound}" \
-        https://api.pushover.net/1/messages.json > /dev/null 2>&1 || true
+    [ -r "$PUSHOVER_HELPER" ] || return 0
+    # shellcheck disable=SC1090
+    source "$PUSHOVER_HELPER" 2>/dev/null || return 0
+
+    pushover_send "$PUSHOVER_CREDENTIALS" "$title" "$message" "$priority" "$sound" || true
 }
 
 now_epoch() {

--- a/modules/darwin/programs/opnix-rotate.nix
+++ b/modules/darwin/programs/opnix-rotate.nix
@@ -17,6 +17,7 @@
 let
   expiryPath = "${config.xdg.configHome}/op/sa-expiry-mac";
   pushoverPath = "${config.xdg.configHome}/pushover/share";
+  pushoverHelper = ../../shared/scripts/lib/pushover.sh;
   warnDays = 14; # 90일 cadence, 만료 14일 전부터 알림
 
   rotateCheckScript = pkgs.writeShellApplication {
@@ -28,6 +29,9 @@ let
     text = ''
       EXPIRY_FILE="${expiryPath}"
       PUSHOVER_FILE="${pushoverPath}"
+
+      # shellcheck source=/dev/null
+      source "${pushoverHelper}"
 
       # record/자격증명 부재 → non-fatal (미배포 등). 알림 없이 종료.
       [ -r "$EXPIRY_FILE" ] || { echo "expiry record 없음 — skip" >&2; exit 0; }
@@ -68,11 +72,7 @@ let
         prio=0
       fi
 
-      if curl -s --max-time 20 \
-           -F "token=$PUSHOVER_TOKEN" -F "user=$PUSHOVER_USER" \
-           -F "title=1Password Mac SA token rotation needed" \
-           -F "message=$msg" -F "priority=$prio" \
-           https://api.pushover.net/1/messages.json >/dev/null; then
+      if pushover_send "$PUSHOVER_FILE" "1Password Mac SA token rotation needed" "$msg" "$prio"; then
         echo "Pushover rotation alert sent ($days_left days left)"
       else
         echo "WARNING: Pushover send failed" >&2

--- a/modules/nixos/programs/smartd.nix
+++ b/modules/nixos/programs/smartd.nix
@@ -10,6 +10,7 @@
 
 let
   pushoverCredPath = config.age.secrets.pushover-system-monitor.path;
+  pushoverHelper = ../../shared/scripts/lib/pushover.sh;
 
   # smartd 알림 스크립트 (smartd가 -M exec로 호출)
   # 중요: smartd에 non-zero 반환 금지 — 전체를 ( ... ) || true로 래핑
@@ -27,6 +28,9 @@ let
         DEVICE="''${SMARTD_DEVICE:-unknown}"
         FAILTYPE="''${SMARTD_FAILTYPE:-unknown}"
         MESSAGE="''${SMARTD_MESSAGE:-No message}"
+
+        # shellcheck source=/dev/null
+        source "${pushoverHelper}"
 
         # 시크릿 파일 로드
         CRED_FILE="${pushoverCredPath}"
@@ -55,13 +59,7 @@ let
       Device: $DEVICE
       $MESSAGE"
 
-        curl -sf --proto =https --max-time 10 \
-          --form-string "token=$PUSHOVER_TOKEN" \
-          --form-string "user=$PUSHOVER_USER" \
-          --form-string "title=$TITLE" \
-          --form-string "message=$BODY" \
-          --form-string "priority=$PRIORITY" \
-          https://api.pushover.net/1/messages.json > /dev/null 2>&1
+        pushover_send "$CRED_FILE" "$TITLE" "$BODY" "$PRIORITY" || true
       ) || true
     '';
   };

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -44,6 +44,9 @@ in
     source = "${sharedScriptsDir}/lib/wt";
     recursive = true;
   };
+  home.file.".local/lib/pushover.sh" = {
+    source = "${sharedScriptsDir}/lib/pushover.sh";
+  };
   # codex exec hang supervisor (issue #593): Nix wrapper가 absolute store path env var를 set한 후
   # raw script를 exec한다. raw script는 CODEX_EXEC_TIMEOUT_BIN/CODEX_EXEC_SETSID_BIN 우선 사용.
   # 이로써 wrapper subprocess + codex exec 자식 shell의 PATH를 건드리지 않아 user PATH(BSD
@@ -387,6 +390,13 @@ in
             echo "Error: Pushover credentials not found" >&2
             return 1
           fi
+          local helper="$HOME/.local/lib/pushover.sh"
+          if [ ! -r "$helper" ]; then
+            echo "Error: Pushover helper not found" >&2
+            return 1
+          fi
+          source "$helper"
+
           local PUSHOVER_TOKEN="" PUSHOVER_USER=""
           source "$cred"
           [ -n "''${PUSHOVER_TOKEN:-}" ] && [ -n "''${PUSHOVER_USER:-}" ] || {
@@ -394,18 +404,10 @@ in
             return 1
           }
 
-          local response
-          if response=$(curl --fail-with-body --show-error --silent --max-time 10 -X POST \
-            -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-            --data-urlencode "token=$PUSHOVER_TOKEN" \
-            --data-urlencode "user=$PUSHOVER_USER" \
-            --data-urlencode "title=📋 텍스트 공유 (''${#text}자)" \
-            --data-urlencode "message=$text" \
-            https://api.pushover.net/1/messages.json); then
+          if pushover_send "$cred" "📋 텍스트 공유 (''${#text}자)" "$text" 0; then
             echo "✓ Pushover 전송 (''${#text}자)"
           else
             echo "Error: Pushover 전송 실패" >&2
-            [ -n "$response" ] && echo "$response" >&2
             return 1
           fi
         }

--- a/modules/shared/scripts/lib/pushover.sh
+++ b/modules/shared/scripts/lib/pushover.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=bash
+# Shared Pushover transport helper.
+# Callers decide whether a failed notification is fatal or best-effort.
+
+pushover_send() {
+  local cred_file="$1"
+  local title="$2"
+  local message="$3"
+  local priority="$4"
+  local sound="${5-}"
+  local PUSHOVER_TOKEN=""
+  local PUSHOVER_USER=""
+
+  [ -r "$cred_file" ] || return 1
+
+  # shellcheck source=/dev/null
+  if ! source "$cred_file" 2>/dev/null; then
+    return 1
+  fi
+
+  [ -n "${PUSHOVER_TOKEN:-}" ] || return 1
+  [ -n "${PUSHOVER_USER:-}" ] || return 1
+
+  if [ "$#" -ge 5 ]; then
+    curl -sf --proto =https --max-time 10 \
+      --form-string "token=${PUSHOVER_TOKEN}" \
+      --form-string "user=${PUSHOVER_USER}" \
+      --form-string "title=${title}" \
+      --form-string "message=${message}" \
+      --form-string "priority=${priority}" \
+      --form-string "sound=${sound}" \
+      https://api.pushover.net/1/messages.json > /dev/null 2>&1
+  else
+    curl -sf --proto =https --max-time 10 \
+      --form-string "token=${PUSHOVER_TOKEN}" \
+      --form-string "user=${PUSHOVER_USER}" \
+      --form-string "title=${title}" \
+      --form-string "message=${message}" \
+      --form-string "priority=${priority}" \
+      https://api.pushover.net/1/messages.json > /dev/null 2>&1
+  fi
+}

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -140,6 +140,10 @@ run_test "webhook-bridge non-crawled payload skips notification" test_webhook_br
 run_test "webhook-bridge invalid JSON keeps 200 without notification" test_webhook_bridge_invalid_json_keeps_200_without_notification
 run_test "webhook-bridge matching token sends notification" test_webhook_bridge_matching_token_sends_notification
 run_test "webhook-bridge wrong token keeps 200 and warns" test_webhook_bridge_wrong_token_keeps_200_and_warns
+run_test "pushover helper missing credential skips curl" test_pushover_send_missing_cred_returns_1_without_curl
+run_test "pushover helper sends expected fields" test_pushover_send_success_passes_expected_fields
+run_test "pushover helper passes optional sound" test_pushover_send_passes_optional_sound
+run_test "pushover helper curl failure returns nonzero" test_pushover_send_curl_failure_returns_1
 run_test "immich backup happy path creates dump atomically" test_immich_backup_happy_path_creates_dump_atomically
 run_test "immich backup integrity failure exits nonzero" test_immich_backup_integrity_failure_exits_nonzero
 run_test "immich backup retention deletes only old dumps in dir" test_immich_backup_retention_deletes_only_old_dumps_in_dir

--- a/tests/suites/pushover-helper.sh
+++ b/tests/suites/pushover-helper.sh
@@ -1,0 +1,111 @@
+# tests/suites/pushover-helper.sh — shared Pushover helper unit tests (sourced)
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의.
+# shellcheck disable=SC2154
+
+_pushover_helper_path() {
+  printf '%s\n' "$REPO_ROOT/modules/shared/scripts/lib/pushover.sh"
+}
+
+_write_pushover_curl_stub() {
+  local dir="$1"
+
+  mkdir -p "$dir"
+  cat > "$dir/curl" <<'EOF_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${PUSHOVER_CURL_LOG:?}"
+printf '%s\n' "$@" >> "$PUSHOVER_CURL_LOG"
+exit "${PUSHOVER_CURL_EXIT:-0}"
+EOF_STUB
+  chmod +x "$dir/curl"
+}
+
+_write_pushover_cred() {
+  local path="$1"
+
+  cat > "$path" <<'EOF_CRED'
+PUSHOVER_TOKEN='token value'
+PUSHOVER_USER='user value'
+EOF_CRED
+}
+
+test_pushover_send_missing_cred_returns_1_without_curl() {
+  local sandbox stub_dir log
+  sandbox=$(new_sandbox)
+  stub_dir="$sandbox/bin"
+  log="$sandbox/curl.log"
+  _write_pushover_curl_stub "$stub_dir"
+  # shellcheck source=/dev/null
+  source "$(_pushover_helper_path)"
+
+  export PUSHOVER_CURL_LOG="$log"
+  export PUSHOVER_CURL_EXIT=0
+  if PATH="$stub_dir:$PATH" pushover_send "$sandbox/missing" "Title" "Body" 0; then
+    fail "pushover_send must fail when credential file is missing"
+  fi
+  [ ! -e "$log" ] || fail "curl must not be called when credential file is missing"
+}
+
+test_pushover_send_success_passes_expected_fields() {
+  local sandbox stub_dir log cred
+  sandbox=$(new_sandbox)
+  stub_dir="$sandbox/bin"
+  log="$sandbox/curl.log"
+  cred="$sandbox/cred"
+  _write_pushover_curl_stub "$stub_dir"
+  _write_pushover_cred "$cred"
+  # shellcheck source=/dev/null
+  source "$(_pushover_helper_path)"
+
+  export PUSHOVER_CURL_LOG="$log"
+  export PUSHOVER_CURL_EXIT=0
+  PATH="$stub_dir:$PATH" pushover_send "$cred" "Test title" "Test message" 1 \
+    || fail "pushover_send must succeed when curl succeeds"
+
+  assert_file_contains "$log" "token=token value"
+  assert_file_contains "$log" "user=user value"
+  assert_file_contains "$log" "title=Test title"
+  assert_file_contains "$log" "message=Test message"
+  assert_file_contains "$log" "priority=1"
+  assert_file_contains "$log" "https://api.pushover.net/1/messages.json"
+  assert_not_contains "$(cat "$log")" "sound="
+}
+
+test_pushover_send_passes_optional_sound() {
+  local sandbox stub_dir log cred
+  sandbox=$(new_sandbox)
+  stub_dir="$sandbox/bin"
+  log="$sandbox/curl.log"
+  cred="$sandbox/cred"
+  _write_pushover_curl_stub "$stub_dir"
+  _write_pushover_cred "$cred"
+  # shellcheck source=/dev/null
+  source "$(_pushover_helper_path)"
+
+  export PUSHOVER_CURL_LOG="$log"
+  export PUSHOVER_CURL_EXIT=0
+  PATH="$stub_dir:$PATH" pushover_send "$cred" "Sound title" "Sound message" 0 "falling" \
+    || fail "pushover_send must succeed with optional sound"
+
+  assert_file_contains "$log" "sound=falling"
+}
+
+test_pushover_send_curl_failure_returns_1() {
+  local sandbox stub_dir log cred
+  sandbox=$(new_sandbox)
+  stub_dir="$sandbox/bin"
+  log="$sandbox/curl.log"
+  cred="$sandbox/cred"
+  _write_pushover_curl_stub "$stub_dir"
+  _write_pushover_cred "$cred"
+  # shellcheck source=/dev/null
+  source "$(_pushover_helper_path)"
+
+  export PUSHOVER_CURL_LOG="$log"
+  export PUSHOVER_CURL_EXIT=22
+  if PATH="$stub_dir:$PATH" pushover_send "$cred" "Fail title" "Fail message" 0; then
+    fail "pushover_send must fail when curl fails"
+  fi
+  assert_file_contains "$log" "title=Fail title"
+}


### PR DESCRIPTION
## Summary

- \`pushover_send <cred_file> <title> <message> <priority> [sound]\` 공용 헬퍼 신설 (\`modules/shared/scripts/lib/pushover.sh\`, \`home.file\`로 \`~/.local/lib\` 배포)
- \`api.pushover.net\` 직접 curl 사본 5곳 전환: \`_folder-actions-lib.sh\`, \`upload-immich.sh\`, \`smartd.nix\`, \`opnix-rotate.nix\`, shell \`push\` 함수
- \`tests/suites/pushover-helper.sh\` 신설 (cred 부재 → return 1·curl 인자 반영·실패 전파·bash/zsh 로드)

Closes #948

## 기존 문제/배경

Pushover 전송 curl 블록이 5곳에 복사되어 있었다 — 알림 로직 변경 시 5곳을 따로 고쳐야 하고, 사본마다 방어 수준(\`--proto =https\`, \`--max-time\`)이 달랐다.

## CIR (Change Intent Record)

- \`sound\`는 선택 5번째 인자 — 인자가 주어졌을 때만 sound 필드를 전송해 \`upload-immich.sh\`의 기존 알림 정책("none"/"falling")을 보존하면서 나머지 4곳(sound 미전송)과 수렴. 초기 설계(4인자)로는 upload-immich가 수렴 불가라 executor STOP 후 인터페이스를 확장했다.
- 배선: darwin 스크립트는 \`~/.local/lib/pushover.sh\`(home.file, 기존 wt 선례), nix 인라인 스크립트는 nix path 치환으로 store 경로 source.
- 호출부별 실패 정책(warn-only / return 1 / \`|| true\`)은 호출부에 남긴다 — 헬퍼는 전송+반환코드만.
- 미세 수렴: shell \`push\`가 urlencode → multipart로, opnix 타임아웃 20→10초로 — "가장 방어적인 공통형" 원칙.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 공용 헬퍼 + 선택 sound 인자 | 5곳 완전 수렴, 정책 보존 | — | ✅ |
| upload-immich 사본 잔존 | 인터페이스 단순 | 수렴 미완, grep 게이트 예외 필요 | ❌ |
| service-lib send_notification 확장 | NixOS 쪽 기존 헬퍼 재사용 | darwin에서 service-lib 미사용, 결합 증가 | ❌ |

## 구현 상세

핵심: \`modules/shared/scripts/lib/pushover.sh\` — cred 파일 source(local 스코프 격리), TOKEN/USER 검증, \`--proto =https --max-time 10\`, sound 조건부 전송.

## 참고 레퍼런스

- 이슈 #948, epic #937

## Human Test Plan

1. \`grep -rn "api.pushover.net" --include="*.sh" --include="*.nix" modules/ | grep -v "service-lib\|pushover"\` → 0건.
2. \`bash tests/run-all-tests.sh\` → 통과 7 · 실패 0. \`nix flake check --no-build --all-systems\` → exit 0.
3. 머지 후 운영자: 양 플랫폼 \`nrs\` → Mac \`push test\` 1회 + MiniPC smartd 테스트 알림 1회 실측.
   - 실패 시 진단: \`~/.local/lib/pushover.sh\` 존재 확인 (home.file 배포), cred 파일 경로 확인.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP