### PR TITLE
test(karakeep): fallback-sync·singlefile-bridge 특성화 테스트

### DIFF
--- a/modules/nixos/programs/docker/karakeep-singlefile-bridge/tests/conftest.py
+++ b/modules/nixos/programs/docker/karakeep-singlefile-bridge/tests/conftest.py
@@ -1,0 +1,19 @@
+"""pytest loader for karakeep-singlefile-bridge tests."""
+import importlib.util
+import os
+
+import pytest
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SOURCE_PATH = os.path.join(os.path.dirname(HERE), "files", "singlefile-bridge.py")
+
+
+@pytest.fixture(scope="session")
+def bridge_module():
+    spec = importlib.util.spec_from_file_location("karakeep_singlefile_bridge", SOURCE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load module spec from {SOURCE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/modules/nixos/programs/docker/karakeep-singlefile-bridge/tests/test_singlefile_bridge.py
+++ b/modules/nixos/programs/docker/karakeep-singlefile-bridge/tests/test_singlefile_bridge.py
@@ -1,0 +1,104 @@
+"""Characterization tests for pure singlefile-bridge helpers.
+
+run_curl and send_pushover are subprocess/network boundaries and are intentionally
+left outside this pure-helper suite.
+"""
+
+
+def test_sanitize_filename_preserves_current_cleanup_rules(bridge_module):
+    cases = [
+        ("folder/Report: 2026?.html", "Report_2026_.html"),
+        ("../../", "archive.html"),
+        ("weird<>name", "weird_name.html"),
+        (".hidden.", "hidden.html"),
+        ("snapshot.xhtml", "snapshot.xhtml"),
+    ]
+
+    for raw, expected in cases:
+        assert bridge_module.sanitize_filename(raw) == expected
+
+
+def test_extract_boundary_handles_quoted_and_missing_boundary(bridge_module):
+    assert (
+        bridge_module.extract_boundary('multipart/form-data; boundary="abc123"')
+        == "abc123"
+    )
+    assert bridge_module.extract_boundary("MULTIPART/FORM-DATA; BOUNDARY=plain") == "plain"
+    assert bridge_module.extract_boundary("text/plain") is None
+
+
+def test_parse_content_disposition_current_attribute_rules(bridge_module):
+    parsed = bridge_module.parse_content_disposition(
+        'form-data; name="file"; filename="archive.html"; ignored'
+    )
+
+    assert parsed == {
+        "type": "form-data",
+        "name": "file",
+        "filename": "archive.html",
+    }
+
+
+def test_parse_multipart_body_returns_text_fields_and_file_part(bridge_module):
+    boundary = "----fixture"
+    body = (
+        b"------fixture\r\n"
+        b'Content-Disposition: form-data; name="url"\r\n'
+        b"\r\n"
+        b"https://example.com/article\r\n"
+        b"------fixture\r\n"
+        b'Content-Disposition: form-data; name="file"; filename="archive.html"\r\n'
+        b"Content-Type: text/html\r\n"
+        b"\r\n"
+        b"<html>saved</html>\r\n"
+        b"------fixture--\r\n"
+    )
+
+    text_fields, file_part = bridge_module.parse_multipart_body(body, boundary)
+
+    assert text_fields == [("url", "https://example.com/article")]
+    assert file_part == {
+        "name": "file",
+        "filename": "archive.html",
+        "content": b"<html>saved</html>",
+        "content_type": "text/html",
+    }
+
+
+def test_parse_multipart_body_missing_boundary_or_field_name_is_ignored(bridge_module):
+    missing_boundary_body = (
+        b"--actual\r\n"
+        b'Content-Disposition: form-data; name="url"\r\n'
+        b"\r\n"
+        b"https://example.com/article\r\n"
+        b"--actual--\r\n"
+    )
+    nameless_body = (
+        b"--fixture\r\n"
+        b"Content-Disposition: form-data\r\n"
+        b"\r\n"
+        b"value\r\n"
+        b"--fixture--\r\n"
+    )
+
+    assert bridge_module.parse_multipart_body(missing_boundary_body, "other") == ([], None)
+    assert bridge_module.parse_multipart_body(nameless_body, "fixture") == ([], None)
+
+
+def test_parse_json_body_returns_dict_only(bridge_module):
+    assert bridge_module.parse_json_body(b'{"assetId":"asset-1"}') == {
+        "assetId": "asset-1"
+    }
+    assert bridge_module.parse_json_body(b'["not", "a", "dict"]') == {}
+    assert bridge_module.parse_json_body(b"not-json") == {}
+    assert bridge_module.parse_json_body(b"") == {}
+
+
+def test_parse_ifexists_mode_normalizes_query_values(bridge_module):
+    assert bridge_module.parse_ifexists_mode("") == "skip"
+    assert bridge_module.parse_ifexists_mode("ifexists=overwrite") == "overwrite"
+    assert (
+        bridge_module.parse_ifexists_mode("url=x&ifexists=APPEND-RECRAWL")
+        == "append-recrawl"
+    )
+    assert bridge_module.parse_ifexists_mode("ifexists=invalid") == "skip"

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -144,6 +144,10 @@ run_test "pushover helper missing credential skips curl" test_pushover_send_miss
 run_test "pushover helper sends expected fields" test_pushover_send_success_passes_expected_fields
 run_test "pushover helper passes optional sound" test_pushover_send_passes_optional_sound
 run_test "pushover helper curl failure returns nonzero" test_pushover_send_curl_failure_returns_1
+run_test "karakeep fallback-sync success removes only matched queue URL" test_karakeep_fallback_sync_success_removes_only_matched_queue_url
+run_test "karakeep fallback-sync upload failure preserves queue" test_karakeep_fallback_sync_upload_failure_preserves_queue_and_records_notify_state
+run_test "karakeep fallback-sync GC removes expired state" test_karakeep_fallback_sync_gc_removes_only_expired_state_entries
+run_test "karakeep fallback-sync unmatched notification is deduplicated" test_karakeep_fallback_sync_unmatched_notification_is_deduplicated
 run_test "immich backup happy path creates dump atomically" test_immich_backup_happy_path_creates_dump_atomically
 run_test "immich backup integrity failure exits nonzero" test_immich_backup_integrity_failure_exits_nonzero
 run_test "immich backup retention deletes only old dumps in dir" test_immich_backup_retention_deletes_only_old_dumps_in_dir

--- a/tests/suites/karakeep-fallback-sync.sh
+++ b/tests/suites/karakeep-fallback-sync.sh
@@ -1,0 +1,189 @@
+# tests/suites/karakeep-fallback-sync.sh - Karakeep fallback sync fixture tests (sourced)
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2164
+
+_karakeep_fallback_sync_script="$REPO_ROOT/modules/nixos/programs/docker/karakeep-fallback-sync/files/fallback-sync.sh"
+
+_karakeep_fallback_sync_install_curl_stub() {
+  local path="$1"
+  cat > "$path" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output_path="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+printf '%s\n' "$*" >> "$FALLBACK_SYNC_TEST_CURL_LOG"
+if [ -n "$output_path" ]; then
+  printf '%s\n' "${FALLBACK_SYNC_TEST_CURL_BODY:-{\"ok\":true}}" > "$output_path"
+fi
+printf '%s' "${FALLBACK_SYNC_TEST_HTTP_CODE:-200}"
+exit "${FALLBACK_SYNC_TEST_CURL_EXIT:-0}"
+STUB
+  chmod +x "$path"
+}
+
+_karakeep_fallback_sync_prepare_sandbox() {
+  local sandbox="$1"
+  mkdir -p "$sandbox/fallback" "$sandbox/state" "$sandbox/stub-bin"
+  printf 'KARAKEEP_API_KEY=fixture-api-key\n' > "$sandbox/pushover"
+  : > "$sandbox/notifications.log"
+  : > "$sandbox/curl.log"
+  cat > "$sandbox/service-lib" <<'STUB'
+send_notification() {
+  printf 'send_notification\t%s\n' "$*" >> "$FALLBACK_SYNC_TEST_NOTIFICATIONS"
+}
+
+send_notification_strict() {
+  printf 'send_notification_strict\t%s\n' "$*" >> "$FALLBACK_SYNC_TEST_NOTIFICATIONS"
+}
+STUB
+  _karakeep_fallback_sync_install_curl_stub "$sandbox/stub-bin/curl"
+}
+
+_karakeep_fallback_sync_run() {
+  local sandbox="$1"
+  local stdout_path="$2"
+  local stderr_path="$3"
+
+  env \
+    PATH="$sandbox/stub-bin:$PATH" \
+    PUSHOVER_CRED_FILE="$sandbox/pushover" \
+    SERVICE_LIB="$sandbox/service-lib" \
+    FALLBACK_DIR="$sandbox/fallback" \
+    FAILED_URL_QUEUE_FILE="$sandbox/state/failed-urls.txt" \
+    KARAKEEP_BASE_URL="http://karakeep.local" \
+    FALLBACK_SYNC_TEST_CURL_LOG="$sandbox/curl.log" \
+    FALLBACK_SYNC_TEST_NOTIFICATIONS="$sandbox/notifications.log" \
+    FALLBACK_SYNC_TEST_HTTP_CODE="${FALLBACK_SYNC_TEST_HTTP_CODE:-200}" \
+    FALLBACK_SYNC_TEST_CURL_EXIT="${FALLBACK_SYNC_TEST_CURL_EXIT:-0}" \
+    bash -eu -o pipefail "$_karakeep_fallback_sync_script" > "$stdout_path" 2> "$stderr_path"
+}
+
+test_karakeep_fallback_sync_success_removes_only_matched_queue_url() {
+  local sandbox stdout_path stderr_path matched_url remaining_url output
+  sandbox=$(new_sandbox)
+  _karakeep_fallback_sync_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  matched_url="https://example.com/articles/one?from=queue"
+  remaining_url="https://example.com/articles/two"
+  printf '%s\n%s\n' "$matched_url" "$remaining_url" > "$sandbox/state/failed-urls.txt"
+  cat > "$sandbox/fallback/archive.html" <<'HTML'
+<!doctype html>
+<link rel="canonical" href="https://example.com/articles/one?from=singlefile">
+HTML
+
+  _karakeep_fallback_sync_run "$sandbox" "$stdout_path" "$stderr_path" \
+    || fail "expected fallback sync success case to exit 0"
+
+  assert_file_contains "$sandbox/state/failed-urls.txt" "$remaining_url"
+  ! grep -Fqx "$matched_url" "$sandbox/state/failed-urls.txt" \
+    || fail "expected matched queue URL to be removed"
+  grep -Fq "$matched_url" "$sandbox/state/fallback-processed.tsv" \
+    || fail "expected processed state to record matched URL"
+  output=$(cat "$stdout_path")
+  assert_contains "$output" "Auto relink succeeded: $matched_url <- $sandbox/fallback/archive.html"
+}
+
+test_karakeep_fallback_sync_upload_failure_preserves_queue_and_records_notify_state() {
+  local sandbox stdout_path stderr_path failed_url output notify_state
+  sandbox=$(new_sandbox)
+  _karakeep_fallback_sync_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  failed_url="https://example.com/articles/fail"
+  printf '%s\n' "$failed_url" > "$sandbox/state/failed-urls.txt"
+  cat > "$sandbox/fallback/archive.html" <<'HTML'
+<!doctype html>
+<meta property="og:url" content="https://example.com/articles/fail/">
+HTML
+
+  FALLBACK_SYNC_TEST_CURL_EXIT=7 FALLBACK_SYNC_TEST_HTTP_CODE=000 \
+    _karakeep_fallback_sync_run "$sandbox" "$stdout_path" "$stderr_path" \
+    || fail "expected upload failure case to preserve current script-level exit 0"
+
+  assert_file_contains "$sandbox/state/failed-urls.txt" "$failed_url"
+  [ ! -s "$sandbox/state/fallback-processed.tsv" ] \
+    || fail "expected upload failure not to record processed state"
+  notify_state=$(cat "$sandbox/state/fallback-notify-state.tsv")
+  assert_contains "$notify_state" "upload-failed:example.com/articles/fail"
+  output=$(cat "$stdout_path")
+  assert_contains "$output" "Fallback sync failure count: 1/3"
+}
+
+test_karakeep_fallback_sync_gc_removes_only_expired_state_entries() {
+  local sandbox stdout_path stderr_path now
+  sandbox=$(new_sandbox)
+  _karakeep_fallback_sync_prepare_sandbox "$sandbox"
+  stdout_path="$sandbox/stdout"
+  stderr_path="$sandbox/stderr"
+  now=$(date +%s)
+  : > "$sandbox/state/failed-urls.txt"
+  printf 'old\n' > "$sandbox/fallback/old.html"
+  printf 'new\n' > "$sandbox/fallback/new.html"
+  cat > "$sandbox/state/fallback-processed.tsv" <<EOF
+old-hash	https://example.com/old	$sandbox/fallback/old.html	946684800
+new-hash	https://example.com/new	$sandbox/fallback/new.html	$now
+EOF
+  cat > "$sandbox/state/fallback-unmatched-notified.tsv" <<EOF
+old-unmatched	946684800	$sandbox/fallback/old.html
+new-unmatched	$now	$sandbox/fallback/new.html
+EOF
+  cat > "$sandbox/state/fallback-notify-state.tsv" <<EOF
+old-notify	946684800
+new-notify	$now
+EOF
+
+  _karakeep_fallback_sync_run "$sandbox" "$stdout_path" "$stderr_path" \
+    || fail "expected GC-only case with empty queue to exit 0"
+
+  ! grep -Fq "old-hash" "$sandbox/state/fallback-processed.tsv" \
+    || fail "expected expired processed state to be removed"
+  grep -Fq "new-hash" "$sandbox/state/fallback-processed.tsv" \
+    || fail "expected fresh processed state to remain"
+  ! grep -Fq "old-unmatched" "$sandbox/state/fallback-unmatched-notified.tsv" \
+    || fail "expected expired unmatched state to be removed"
+  grep -Fq "new-unmatched" "$sandbox/state/fallback-unmatched-notified.tsv" \
+    || fail "expected fresh unmatched state to remain"
+  ! grep -Fq "old-notify" "$sandbox/state/fallback-notify-state.tsv" \
+    || fail "expected expired notify state to be removed"
+  grep -Fq "new-notify" "$sandbox/state/fallback-notify-state.tsv" \
+    || fail "expected fresh notify state to remain"
+}
+
+test_karakeep_fallback_sync_unmatched_notification_is_deduplicated() {
+  local sandbox stdout_one stderr_one stdout_two stderr_two notification_count
+  sandbox=$(new_sandbox)
+  _karakeep_fallback_sync_prepare_sandbox "$sandbox"
+  stdout_one="$sandbox/stdout-one"
+  stderr_one="$sandbox/stderr-one"
+  stdout_two="$sandbox/stdout-two"
+  stderr_two="$sandbox/stderr-two"
+  printf '%s\n' "https://example.com/queued-only" > "$sandbox/state/failed-urls.txt"
+  cat > "$sandbox/fallback/unmatched.html" <<'HTML'
+<!doctype html>
+<title>No source URL in this SingleFile document</title>
+HTML
+
+  _karakeep_fallback_sync_run "$sandbox" "$stdout_one" "$stderr_one" \
+    || fail "expected first unmatched run to exit 0"
+  _karakeep_fallback_sync_run "$sandbox" "$stdout_two" "$stderr_two" \
+    || fail "expected second unmatched run to exit 0"
+
+  notification_count=$(grep -Fc "send_notification_strict" "$sandbox/notifications.log")
+  [ "$notification_count" = "1" ] \
+    || fail "expected exactly one unmatched notification, got $notification_count"
+  grep -Fq "Unmatched fallback already notified once" "$stdout_two" \
+    || fail "expected second run to hit unmatched notification dedup path"
+}


### PR DESCRIPTION
## Summary

- \`tests/suites/karakeep-fallback-sync.sh\` 신설 — 스크립트 전체 실행 + stub fixture 방식으로 4 시나리오 박제 (매칭 큐 제거·실패 보존·gc 만료·알림 dedup)
- singlefile-bridge pytest 신설 — 소스 옆 \`tests/\` + importlib conftest, 순수 함수 7케이스
- 대상 스크립트 2개는 동작 변경 0 (테스트만 추가)

Closes #950

## 기존 문제/배경

Karakeep 파이프라인의 두 헬퍼(fallback-sync.sh 385줄, singlefile-bridge.py 688줄)는 tests/ 참조 0건이었다 — URL 정규화·gc·dedup·multipart 파싱 회귀를 잡을 수단이 없었다.

## CIR (Change Intent Record)

- fallback-sync.sh는 source-unsafe(상단 즉시 초기화 + 하단 main 블록 무가드) — 함수 단위 source 대신 저장소의 확립된 선례인 \`tests/suites/backup-scripts.sh\` 방식(전체 실행 + curl stub + SERVICE_LIB 스텁)을 채택했다. 대상 수정 없이 테스트 가능.
- pytest는 저장소 게이트에 미배선이 현 관례 — analyzing-da-sessions 스킬-로컬 선례(소스 옆 tests/ + ad-hoc \`pytest <dir>\` 실행)를 그대로 따랐고 게이트 배선을 발명하지 않았다.
- \`run_curl\`/\`send_pushover\`는 subprocess/network 경계라 의도적으로 제외 (파일 주석에 명시 — silent cap 금지 원칙).
- 특성화는 현행 동작의 박제다 — 예: 업로드 실패 시 큐 보존 + exit 0은 관찰된 현행 동작 그대로 assert.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 전체 실행 + stub (backup-scripts 선례) | 대상 무수정, 실전적 시나리오 커버 | 함수 단위 입출력 박제는 간접적 | ✅ |
| 대상에 BASH_SOURCE 가드 추가 후 함수 source | 함수 단위 정밀 박제 | 상단 초기화 재배열 필요 — 동작 변경 위험 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`tests/suites/karakeep-fallback-sync.sh\` (신규) | curl stub + cred/SERVICE_LIB fixture + 4 시나리오 |
| \`modules/nixos/programs/docker/karakeep-singlefile-bridge/tests/\` (신규) | conftest.py (importlib 로드 — 하이픈 파일명) + test 7케이스 |
| \`tests/shell-script-tests.sh\` | suite 등록 |

## 참고 레퍼런스

- 이슈 #950, epic #937 · 방식 선례: PR #980 (backup-scripts 특성화)

## Human Test Plan

1. \`nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh\` → 신규 4케이스 포함 전부 통과.
2. \`nix run nixpkgs#python3Packages.pytest -- modules/nixos/programs/docker/karakeep-singlefile-bridge/tests/\` → 7 passed.
3. \`git diff --stat\`에 대상 스크립트 2개 없음 (테스트만).

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP