### PR TITLE
fix(caddy): Karakeep CSP 제거를 아카이브 자산 경로로 한정

### DIFF
--- a/modules/nixos/programs/caddy.nix
+++ b/modules/nixos/programs/caddy.nix
@@ -99,28 +99,29 @@ in
         listenAddresses = [ minipcTailscaleIP ];
         extraConfig = ''
           ${securityHeaders}
-          # CSP 헤더 제거: Karakeep iframe 내 SingleFile HTML의 CSS 렌더링 차단 방지
-          # Tailscale VPN 전용이므로 XSS 위험 무시 가능
-          # ref: https://github.com/karakeep-app/karakeep/issues/1977
-          header -Content-Security-Policy
-          header -Content-Security-Policy-Report-Only
-          ${
-            if singlefileBridgeCfg.enable then
-              ''
-                route {
+          route {
+            @karakeepArchiveAssets path /api/assets/*
+            handle @karakeepArchiveAssets {
+              # CSP는 아카이브 자산 경로에서만 제거 (렌더링 호환) -- 앱 셸은 표준 CSP 유지.
+              # 이전에는 vhost 전체 제거였음. ref: https://github.com/karakeep-app/karakeep/issues/1977
+              header -Content-Security-Policy
+              header -Content-Security-Policy-Report-Only
+              reverse_proxy localhost:${toString constants.network.ports.karakeep}
+            }
+            ${
+              if singlefileBridgeCfg.enable then
+                ''
                   @singlefile path /api/v1/bookmarks/singlefile*
                   handle @singlefile {
                     reverse_proxy localhost:${toString singlefileBridgeCfg.port}
                   }
-                  handle {
-                    reverse_proxy localhost:${toString constants.network.ports.karakeep}
-                  }
-                }
-              ''
-            else
-              ''
-                reverse_proxy localhost:${toString constants.network.ports.karakeep}
-              ''
+                ''
+              else
+                ""
+            }
+            handle {
+              reverse_proxy localhost:${toString constants.network.ports.karakeep}
+            }
           }
         '';
       };


### PR DESCRIPTION
## Summary

- Karakeep vhost 전체에 적용되던 CSP 헤더 제거를 \`/api/assets/*\`(아카이브 자산) 경로 handle 내로 한정
- 앱 셸/API는 표준 CSP를 유지하고, SingleFile 아카이브 iframe 렌더링 호환은 보존

Closes #951

## 기존 문제/배경

SingleFile HTML의 CSS 렌더링을 위해 vhost 전체에서 CSP를 제거하고 있었다 — Tailscale 전용이라 위험은 낮지만, 렌더링에 필요한 범위(아카이브 자산)보다 훨씬 넓은 완화였다.

## CIR (Change Intent Record)

- 최소 렌더 경로를 upstream 실측으로 확정: Karakeep \`LinkContentSection.tsx\`가 \`/api/assets/\${archiveAssetId}\`로 아카이브를 로드하고 \`serveAsset\`이 CSP를 설정한다 (karakeep #1977, #2621).
- Caddy route 내 handle 순서: assets → singlefile bridge → 기본 (경로 겹침 없음).
- 기존 vhost 전체 제거는 의도적 도입이었다 (#1977 렌더링 이슈 대응) — 이 PR은 그 목적을 유지하면서 범위만 축소한다.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| /api/assets/* handle 스코핑 | 최소 완화, 렌더링 보존 | 경로 실측 필요 (완료) | ✅ |
| 전체 제거 유지 | 변경 없음 | 불필요하게 넓은 완화 | ❌ |
| CSP 재작성(허용 지시어 추가) | 제거보다 정밀 | upstream CSP 값 추적 부담 | ❌ |

## 구현 상세

\`modules/nixos/programs/caddy.nix\` 1개 파일 — Karakeep vhost의 extraConfig 재구성.

## 참고 레퍼런스

- 이슈 #951, epic #937 · upstream: karakeep-app/karakeep #1977, #2621

## Human Test Plan

1. \`bash tests/run-eval-tests.sh\` + \`nix flake check --no-build --all-systems\` → 통과.
2. 머지 후 운영자 \`nrs\`, 그 다음:
   - 기존 SingleFile 아카이브 열어 CSS 렌더링 확인.
   - \`curl -sI https://archive.greenhead.dev/ | grep -i content-security\` → 앱 셸에 CSP 존재.
   - 아카이브 자산 URL에 같은 curl → CSP 부재.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP