### PR TITLE
fix(skills): run-da read/write 분리로 피드백 루프 수렴성 보강

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -148,7 +148,7 @@ Preflight에서 아래 lazy reference를 미리 열지 않는다. mode가 비어
 2. Single-writer / main-agent-only — tracked workspace write, branch mutation, commit/push, GitHub write, `wt`/`nrs`/rebuild 계열은 메인 에이전트 소유. DA reviewer/Arbiter는 위임 금지 ([`references/hardening-contract.md`](references/hardening-contract.md) 역할별 경계). Review Intensity 인라인 판정은 메인 에이전트의 정상 경로다.
 3. Conservative wait — `wait_agent` timeout이나 단순 지연만으로 reviewer/Arbiter를 kill하지 않는다. explicit failure signal, documented violation, 최종 응답 파싱 실패가 없는 한 self-auditing으로 대체하지 않는다. (Review Intensity는 인라인 체크리스트라 wait 대상 아님.)
 4. PoC 의무화 — DA가 위반을 지적하면 구체적 파일:줄 또는 계획 항목 번호를 제시. 증거 없는 추상적 우려는 Arbiter가 NOT_AN_ISSUE로 판정한다.
-5. CONFIRMED_ISSUE 자동 반영 — Arbiter가 CONFIRMED_ISSUE로 판정한 항목은 자동 반영. CRITICAL 심각도는 진행 차단.
+5. CONFIRMED_ISSUE 자동 반영 — Arbiter가 CONFIRMED_ISSUE로 판정한 항목은 자동 반영하되, review phase 중 patch/edit/apply_patch, write-mode formatter, generated output 변경은 금지한다. confirmed 항목은 write phase에서 batch로 반영하며, CRITICAL 심각도는 다음 outer round 진행 차단 후 write phase 첫 항목으로 처리한다.
 6. 사용자 전건 보고 + 질문 도구 의무 — 모든 Arbiter 판정 결과를 사용자에게 보고. NEEDS_MORE_INFO/`split` 항목은 [`references/main-agent-obligations.md`](references/main-agent-obligations.md#사용자-질문-시-맥락-설명-의무)의 5요소 맥락(현재 상황 / 문제 / 비유법 / 선택지 장단점 / 질문)으로 질문 도구 호출.
 7. Fresh perspective 보장 — 매 라운드마다 새 reviewer/Arbiter 실행 단위 (Codex: 새 native subagent thread, codex exec: 새 `codex exec` 프로세스).
 8. 의사결정·회귀 컨텍스트 조사 — 제거/단순화/되돌림/리팩터 변경이거나 git상 왕복 핫스팟 파일이면 Review Intensity와 무관하게 fail-closed로 과거 의사결정(commit/PR/issue + 있으면 CIR/ADR·로컬 세션 로그)을 조사해 회귀 재도입을 점검한다. 메인이 "의사결정 컨텍스트 팩"을 수집·주입하고 reviewer/Arbiter가 read-only 보강한다. git으로 버전관리되는 모든 저장소에서 동작하며 기록 관습에 의존하지 않는다 ([`references/decision-regression-audit.md`](references/decision-regression-audit.md)).

--- a/modules/shared/programs/claude/files/skills/run-da/modes/for_plan.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/for_plan.md
@@ -17,6 +17,16 @@
 
 계획이 제거·단순화·되돌림·리팩터 방향이거나 변경 대상이 git상 왕복 핫스팟이면, [`../references/decision-regression-audit.md`](../references/decision-regression-audit.md)의 발동 조건에 따라 "의사결정 컨텍스트 팩"(해당 문서 Step A)을 수집한다 — 메인이 commit/PR/issue(+있으면 CIR/ADR·로컬 세션 로그)에서 과거 결정·되돌림 이력을 추려, Step 2의 reviewer 프롬프트와 Step 5의 Arbiter 프롬프트에 selective propagation으로 주입한다. 그 외 변경은 Review Intensity에 연동한다(FULL=전체 조사, LITE=경량, SKIP=생략).
 
+## Outer round phase model: changeset 동결 + read/write 분리
+
+각 outer round는 `changeset 동결 → review phase → write phase` 순서로 진행한다.
+
+- changeset 동결: Step 2 진입 전에 이번 라운드의 검토 표면을 고정한다. for_plan은 계획 원문과 관련 파일/맥락, for_pr은 `git diff main...HEAD`와 현재 workspace 상태가 frozen changeset이다.
+- review phase: Step 2 reviewer fan-out부터 Step 5e 상태 전이와 사용자 전건 보고까지다. 이 구간에는 메인 에이전트와 delegated reviewer/Arbiter 모두 active changeset을 바꾸지 않는다. patch/edit/apply_patch, write-mode formatter, codegen/regeneration으로 생기는 generated output 변경, lockfile 재생성, commit/push를 금지한다. formatter/generator는 check/diff-only 모드처럼 파일 변경이 없을 때만 허용한다.
+- write phase: 한 라운드의 Arbiter 판정과 필요한 사용자 판단이 끝난 뒤에만 시작한다. CONFIRMED_ISSUE와 사용자가 수용한 NEEDS_MORE_INFO/`split` 항목을 queue에 모아 메인 에이전트가 batch로 반영한다.
+- CRITICAL 기본값: CRITICAL도 review phase 중 즉시 patch하지 않는다. 해당 라운드의 Arbiter 판정이 닫힌 뒤 write phase 첫 항목으로 반영하며, 해결 전에는 다음 outer round로 진행하지 않는다.
+- 새 changeset 선언: write phase가 끝나면 다음 라운드는 "새 changeset" 리뷰로 명시하고, round summary에 batch 변경 범위(수정한 계획/파일, generated output 유무, diffstat)를 기록한다.
+
 ## Step 2: reviewer bundle 병렬 실행
 
 선택된 reviewer bundle 또는 explicit exhaustive override의 세부 도메인별 DA 에이전트를 병렬 실행한다. 런타임별 도구 매핑은 [`../references/runtime-mapping.md`](../references/runtime-mapping.md) 참조.
@@ -82,14 +92,22 @@ findings 0건이고 `VIOLATION`/`BLOCKED` review unit이 없으면 → ALL CLEAR
 
 결과를 수집하여 사용자에게 전건 보고한다 (vote-shape/low_confidence_warning이 있으면 함께 보고):
 
-- CONFIRMED_ISSUE + CRITICAL + (N/A 또는 stable) + `low_confidence_warning=false`: 진행 차단 (현재 라운드 중단 → 즉시 수정 → 수정 확인 후 다음 라운드 진행).
-- CONFIRMED_ISSUE + HIGH/MEDIUM/LOW + (N/A 또는 stable) + `low_confidence_warning=false`: 자동으로 계획에 반영한다.
+- CONFIRMED_ISSUE + CRITICAL + (N/A 또는 stable) + `low_confidence_warning=false`: 진행 차단. review phase 중 patch 금지 원칙을 유지하고, Arbiter 판정이 닫힌 뒤 write phase의 첫 batch 항목으로 계획에 반영한다. 해결 전에는 다음 outer round로 진행하지 않는다.
+- CONFIRMED_ISSUE + HIGH/MEDIUM/LOW + (N/A 또는 stable) + `low_confidence_warning=false`: pending write queue에 추가하고, Step 6 write phase에서 계획에 일괄 수정한다.
 - NOT_AN_ISSUE + (N/A 또는 stable) + `low_confidence_warning=false`: 보고만 (반영 불필요).
-- NEEDS_MORE_INFO 또는 `stability_status=split`: 질문 도구로 사용자 판단을 요청한다 (vote-shape와 minority verdict도 함께 보고).
+- NEEDS_MORE_INFO 또는 `stability_status=split`: 질문 도구로 사용자 판단을 요청한다 (vote-shape와 minority verdict도 함께 보고). 사용자가 수용한 항목만 pending write queue에 추가한다.
 - 임의 verdict + (N/A 또는 stable) + `low_confidence_warning=true`: fail-closed 승격 — 질문 도구로 사용자 판단 요청 (unanimous/단일 Arbiter라도 LOW confidence 이력이 있으면 기존 LOW-confidence NOT_AN_ISSUE 자동 NEEDS_MORE_INFO 계약을 유지).
 - `stability_status=fragmented` 또는 `partial_failure=true`: BLOCKED — 질문 도구 지원 런타임에서는 판단 요청, 미지원 런타임에서는 자동 승격 금지(중단 보고).
 
-## Step 6: 반영 후 새 라운드
+## Step 6: write phase — 일괄 수정 후 새 changeset 선언
+
+pending write queue가 있으면 메인 에이전트가 single-writer로 일괄 수정한다.
+
+- 수정 전 해당 위치(for_plan: 관련 파일 또는 계획 항목)를 직접 확인한다.
+- CONFIRMED_ISSUE와 사용자가 수용한 항목을 batch로 반영한다. CRITICAL은 batch 첫 순서로 처리하되, review phase 중 즉시 patch하는 예외는 두지 않는다.
+- 수정한 계획/관련 파일의 diff를 명시하고, 각 finding이 해결됐는지 확인한다.
+- formatter/generator가 필요하면 write phase에서만 실행하고, generated output 변경 범위를 summary에 기록한다.
+- batch가 끝나면 다음 outer round의 검토 대상이 되는 새 changeset을 선언한다.
 
 반영 후 동일 선택 review unit을 새 reviewer 실행 단위로 재실행한다.
 
@@ -98,4 +116,4 @@ findings 0건이고 `VIOLATION`/`BLOCKED` review unit이 없으면 → ALL CLEAR
 
 ## Step 7: CLEAR까지 반복
 
-선택된 review unit 전부 CLEAR를 반환할 때까지 Step 2-6을 반복한다. 단 [`../references/protocol.md`](../references/protocol.md)의 "최대 라운드 수"(상한 + 추세 기반 조기 중단)를 적용한다 — CLEAR 도달 전에 상한 또는 추세 기반 조기 중단 조건이 충족되면 사용자에게 보고하고 종료/계속을 결정한다(질문 도구 미지원 런타임은 [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md)의 자동 전이를 따른다).
+선택된 review unit 전부 CLEAR를 반환할 때까지 Step 2-6을 반복한다. CLEAR까지 반복 규칙은 [`../references/protocol.md`](../references/protocol.md)의 "최대 라운드 수"(상한 + 추세 기반 조기 중단)와 read/write 분리를 함께 적용한다. 각 반복에서 Step 2-5는 frozen changeset에 대한 read-only review phase이고, Step 6만 batch write phase다. CLEAR 도달 전에 상한 또는 추세 기반 조기 중단 조건이 충족되면 사용자에게 보고하고 종료/계속을 결정한다(질문 도구 미지원 런타임은 [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md)의 자동 전이를 따른다).

--- a/modules/shared/programs/claude/files/skills/run-da/modes/for_pr.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/for_pr.md
@@ -2,7 +2,7 @@
 
 구현 후 코드 DA 1회 — git diff 대상.
 
-`for_pr`은 `for_plan`과 7-step 구조가 동일하다. 입력(diff vs 계획), 임시 디렉토리 prefix, 5단계 자동 반영의 코드 수정+커밋 방식, Step 8 push만 다르다. 동일 절차는 [`./for_plan.md`](./for_plan.md)를 참조하고, 본 파일은 차이점만 step 번호별로 명시한다.
+`for_pr`은 `for_plan`과 7-step 구조가 동일하다. 입력(diff vs 계획), 임시 디렉토리 prefix, write phase의 코드 수정+커밋 방식, Step 8 push만 다르다. 동일 절차는 [`./for_plan.md`](./for_plan.md)를 참조하고, 본 파일은 차이점만 step 번호별로 명시한다.
 
 ## Step 번호별 delta (vs for_plan)
 
@@ -15,9 +15,9 @@
 | Step 3 | 동일 | 동일 ([`./for_plan.md`](./for_plan.md#step-3-reviewer-결과-수신--종합-리포트)) |
 | Step 4 | 동일 (ALL CLEAR) | 동일 |
 | Step 5 (Arbiter) | for_plan 조립 (계획 원문 포함) | for_pr 조립 (diff 컨텍스트 포함) — [`../references/arbiter-prompt.md`](../references/arbiter-prompt.md)의 "프롬프트 조립 > for_pr 모드" 참조. for_pr에서는 계획 원문 대신 diff 또는 변경 컨텍스트를 포함 |
-| Step 5 자동 반영 | "자동으로 계획에 반영한다" | "자동으로 코드에 반영하고 커밋한다" (CONFIRMED_ISSUE + HIGH/MEDIUM/LOW). 메인 에이전트가 single-writer로 코드 수정 + commit ([`../references/hardening-contract.md`](../references/hardening-contract.md)의 single-writer 정의) |
-| Step 6 | 동일 (새 라운드, 새 `DA_DIR`) | 동일 |
-| Step 7 | CLEAR까지 반복 (protocol.md "최대 라운드 수" 적용: 상한 + 추세 기반 조기 중단) | 동일 |
+| Step 5 상태 전이 | CONFIRMED_ISSUE를 pending write queue에 추가 | 동일. review phase 중 patch 금지, formatter write 금지, generated output 변경 금지. 코드 수정/commit은 Step 6 write phase 전까지 금지 |
+| Step 6 write phase | 계획/관련 파일을 batch로 수정하고 새 changeset 선언 | 코드 변경을 batch로 반영하고 커밋한다. 메인 에이전트가 single-writer로 코드 수정 + commit ([`../references/hardening-contract.md`](../references/hardening-contract.md)의 single-writer 정의). 반영 후 새 changeset(diff/commit range)을 선언하고 변경 범위를 round summary에 기록 |
+| Step 7 | CLEAR까지 반복 (protocol.md "최대 라운드 수" 적용: 상한 + 추세 기반 조기 중단 + read/write 분리) | 동일 |
 | Step 8 | (없음) | push — 최종 승인 후 push한다 (네트워크/auth 정책 의존 — [`../SKILL.md#non-goals`](../SKILL.md#non-goals) 참조) |
 
 ## 공통 절차 (for_plan과 동일)
@@ -29,9 +29,9 @@
 - Step 2 본문 (Codex 세션 경로): `spawn_agent`/`wait_agent`/`close_agent` lifecycle, batch 규칙, conservative wait, fresh modifier, selective propagation.
 - Step 2 본문 (codex exec 경로): 임시 디렉토리, stdout `DA_DIR` 리터럴 재설정, prompt 파일 guard, `cat | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral ... -` stdin pipe (Layer 1, [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md) role별 명령 표가 SSOT), `&+wait` 금지, Claude Code 병렬 / headless serial foreground 구분, [`../references/runtime-mapping.md`](../references/runtime-mapping.md) 공통 주의(셸 호출 간 변수 유실).
 - Step 3 본문: VIOLATION 처리, 결과 파일 검증, 실패 unit 재실행.
-- Step 5 (5a~5e): Arbiter 호출, selective consistency trigger 검사, N=3 재판정, vote-shape 집계, 상태 전이 적용. 상태 전이 구조(N/A·stable·split·fragmented 분기, NEEDS_MORE_INFO 사용자 판단 요청, fragmented BLOCKED)는 for_plan과 동일하되, CONFIRMED_ISSUE 자동 반영의 적용 대상과 commit 수반 여부는 위 Step 5 자동 반영 delta 행("자동으로 코드에 반영하고 커밋한다")을 따른다 (for_plan은 계획 반영, for_pr은 코드 수정 + commit).
-- Step 6: 새 reviewer 실행 단위, 새 `DA_DIR`.
-- Step 7: CLEAR 탈출 조건.
+- Step 5 (5a~5e): Arbiter 호출, selective consistency trigger 검사, N=3 재판정, vote-shape 집계, 상태 전이 적용. 상태 전이 구조(N/A·stable·split·fragmented 분기, NEEDS_MORE_INFO 사용자 판단 요청, fragmented BLOCKED)는 for_plan과 동일하다. CONFIRMED_ISSUE는 review phase 중 수정하지 않고 pending write queue로만 이동한다.
+- Step 6: write phase batch 반영, 새 reviewer 실행 단위, 새 `DA_DIR`. for_pr은 batch 코드 수정 후 commit까지 수행하고, 다음 라운드를 새 changeset으로 선언한다.
+- Step 7: CLEAR 탈출 조건. CLEAR까지 반복은 상한/조기중단/read-write 분리 규칙을 함께 적용한다.
 
 ## Step 8 상세: push
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-prompt.md
@@ -106,10 +106,10 @@ for_plan 핵심 원칙:
 
 | DA 심각도 | Arbiter CONFIRMED_ISSUE 시 메인 에이전트 행동 |
 |----------|----------------------------------------------|
-| CRITICAL | 진행 차단 — 이 finding이 해결될 때까지 다음 라운드 불가 |
-| HIGH | 수정 필수 — 반드시 수정, 라운드 내 해결 |
-| MEDIUM | 수정 권장 — 자동 수정 |
-| LOW | 선택적 — 자동 수정 |
+| CRITICAL | 진행 차단 — review phase 중 즉시 patch하지 않고 write phase 첫 batch 항목으로 수정. 해결될 때까지 다음 라운드 불가 |
+| HIGH | 수정 필수 — pending write queue에 추가하고 write phase에서 batch 수정 |
+| MEDIUM | 수정 권장 — pending write queue에 추가하고 write phase에서 batch 수정 |
+| LOW | 선택적 — pending write queue에 추가하고 write phase에서 batch 수정 |
 
 ### Few-shot 교정 예시
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/main-agent-obligations.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/main-agent-obligations.md
@@ -20,7 +20,7 @@
 
 - Review Intensity 인라인 체크리스트: 직접 `/run-da` 호출 진입 시 메인 에이전트는 [`intensity-rules.md`](intensity-rules.md)의 모든 룰을 평가한 표를 plan/대화에 남기고(short-circuit 금지) first-match 룰 단계를 채택해 SKIP/LITE/FULL 판정을 결정한다. 문서화된 자동 호출자의 preflight handoff를 수신한 경우에는 freshness를 검증해 유효하면 재사용하고, 누락/형식 오류/stale이면 현재 입력으로 체크리스트를 다시 적용한다. 자유 추론 금지. fail-closed rule group 매치/불확실 또는 룰 ID+근거 미명시 시 강한 검토 fail-closed. 절차 SSOT는 [`intensity-procedure.md`](intensity-procedure.md).
 - Arbiter 독립 판정 보존: DA findings는 독립 Arbiter 에이전트가 판정한다. 메인 에이전트는 Arbiter 판정을 대체하지 않는다. 메인 에이전트는 CONFIRMED_ISSUE 항목의 수정만 담당한다.
-- CONFIRMED_ISSUE 자동 반영: Arbiter가 CONFIRMED_ISSUE로 판정한 항목은 자동으로 반영한다. CRITICAL 심각도는 진행을 차단하고 즉시 수정한다. 상태 전이별 행동의 정본은 [`protocol.md`](protocol.md)의 "DA → Arbiter → Main Agent 상태 흐름"이다.
+- CONFIRMED_ISSUE 자동 반영: Arbiter가 CONFIRMED_ISSUE로 판정한 항목은 자동으로 반영하되, review phase 중에는 patch/edit/apply_patch, write-mode formatter, generated output 변경을 금지한다. 항목은 pending write queue에 모아 write phase에서 batch로 반영한다. CRITICAL 심각도는 다음 outer round 진행을 차단하고 write phase 첫 항목으로 수정한다. 상태 전이별 행동의 정본은 [`protocol.md`](protocol.md)의 "DA → Arbiter → Main Agent 상태 흐름"이다.
 - 사용자 전건 보고: 모든 Arbiter 판정 결과(CONFIRMED_ISSUE, NOT_AN_ISSUE, NEEDS_MORE_INFO)를 사용자에게 보고한다. NEEDS_MORE_INFO·`split` 항목은 아래 "사용자 질문 시 맥락 설명 의무"의 5요소를 갖춘 질문 도구 호출로 처리한다.
 - Conservative wait: Codex 세션 경로에서 `wait_agent` timeout이나 단순 지연만으로 reviewer/Arbiter를 kill하지 않는다. explicit failure signal, documented violation, 최종 응답 파싱 실패가 없는 한 self-auditing으로 대체하지 않는다. (Review Intensity는 인라인 체크리스트라 wait 대상 아님.)
 - Fresh perspective 보장: 매 라운드마다 새 reviewer/Arbiter 실행 단위를 사용한다 (Codex 세션: 새 native subagent thread, codex exec 경로: 새 `codex exec` 프로세스). `fresh` modifier 사용 시 이전 라운드 맥락도 완전히 차단한다.
@@ -32,7 +32,7 @@
 본 파일은 아래 정책의 SSOT가 아니다. 변경은 정본 파일에서 한다.
 
 - Single-writer / main-agent-only / 역할별 경계 / VIOLATION 처리 / Delegation fallback: [`hardening-contract.md`](hardening-contract.md) (`Codex 세션 하드닝 계약` SSOT).
-- PoC 의무화 / Arbiter 판정 프로토콜 / DA → Arbiter 상태 흐름 / 무한 루프 방지(3회 반복) / 탈출 조건(전 unit CLEAR) / PR 코멘트 형식: [`protocol.md`](protocol.md) (protocol SSOT).
+- PoC 의무화 / Arbiter 판정 프로토콜 / DA → Arbiter 상태 흐름 / read-write 분리 / 무한 루프 방지(3회 반복) / 탈출 조건(전 unit CLEAR) / PR 코멘트 형식: [`protocol.md`](protocol.md) (protocol SSOT).
 - Selective consistency trigger / vote-shape / threshold: [`stability-measurement.md`](stability-measurement.md) SSOT, 상태 전이는 [`protocol.md`](protocol.md), 실행 계약은 [`arbiter-scaling.md`](arbiter-scaling.md).
 
 ## 사용자 질문 시 맥락 설명 의무
@@ -60,7 +60,7 @@
 
 본 섹션은 메인 에이전트가 수정 시 직접 수행할 검증만 정의한다.
 
-- CONFIRMED_ISSUE 항목을 수정할 때, 해당 위치(파일:줄 또는 계획 항목)를 확인하는 것은 수정 작업의 일부로 수행한다.
+- CONFIRMED_ISSUE 항목을 write phase에서 batch 수정할 때, 해당 위치(파일:줄 또는 계획 항목)를 확인하는 것은 수정 작업의 일부로 수행한다.
 - 수정 결과가 finding을 해결하는지 확인한다.
 
 DA 에이전트 출력 요건과 Arbiter 검증 의무(5가지 판정 기준 등)는 본 파일이 정본이 아니다:

--- a/modules/shared/programs/claude/files/skills/run-da/references/protocol.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/protocol.md
@@ -6,7 +6,7 @@ DA → Arbiter → Main Agent 상태 흐름, Arbiter 판정 프로토콜, 무한
 
 | DA 결과 | Arbiter 판정 | stability_status | 메인 에이전트 행동 | 사용자 보고 |
 |---------|-------------|------------------|-------------------|-----------|
-| finding 있음 | CONFIRMED_ISSUE | N/A / stable (+ low_confidence_warning=false) | 자동 수정 (CRITICAL은 진행 차단) | 수정 필요 테이블 |
+| finding 있음 | CONFIRMED_ISSUE | N/A / stable (+ low_confidence_warning=false) | pending write queue에 추가. write phase에서 일괄 수정 (CRITICAL은 다음 round 진행 차단) | 수정 필요 테이블 |
 | finding 있음 | NOT_AN_ISSUE | N/A / stable (+ low_confidence_warning=false) | 반영 불필요 | 무해 테이블 |
 | finding 있음 | NEEDS_MORE_INFO | N/A / stable | 사용자 판단 대기 | 질문 도구 |
 | finding 있음 | 임의 | N/A / stable + low_confidence_warning=true | fail-closed 승격 (질문 도구 호출) | 질문 도구 + LOW confidence 이력 |
@@ -34,9 +34,22 @@ stability_status 의미, selective consistency 트리거, `unknown` sentinel 정
 3. Arbiter 에이전트가 각 finding을 5가지 기준으로 독립 검증한다 ([arbiter-prompt.md](arbiter-prompt.md)). Portability는 verdict 결정권 없는 guardrail이다.
 4. first-pass Arbiter 결과가 selective consistency trigger 조건([stability-measurement.md](stability-measurement.md) 참조)에 매치되면 N=3 재판정을 실행하고 vote-shape로 stability_status를 결정한다. 자세한 상태 전이는 아래 "Selective consistency 상태 전이" 참조.
 5. 메인 에이전트는 사용자에게 전건 보고한다 (vote-shape가 있으면 함께 보고).
-6. CONFIRMED_ISSUE + (stability_status=N/A 또는 stable) 항목을 자동 수정한다 (CRITICAL은 즉시, 진행 차단).
-7. NEEDS_MORE_INFO 또는 stability_status=split 항목은 사용자 판단을 요청한다.
+6. CONFIRMED_ISSUE + (stability_status=N/A 또는 stable) 항목을 pending write queue에 추가한다. CRITICAL은 진행 차단 항목으로 표시하되 review phase 중 즉시 patch하지 않는다.
+7. NEEDS_MORE_INFO 또는 stability_status=split 항목은 사용자 판단을 요청한다. 사용자가 수용한 항목만 pending write queue에 추가한다.
 8. stability_status=fragmented 항목은 BLOCKED 상태로 기록하고 자동 수정하지 않는다 (아래 섹션 참조).
+9. Arbiter 상태 전이와 필요한 사용자 판단이 끝난 뒤 write phase로 넘어가 pending write queue를 batch로 반영한다.
+
+### 라운드 read/write 분리
+
+각 outer round는 frozen changeset을 대상으로 한 review phase와, Arbiter 판정 후의 write phase를 분리한다.
+
+- changeset 동결: outer round 시작 시 검토 표면을 고정한다. for_plan은 계획 원문과 관련 파일/맥락, for_pr은 `git diff main...HEAD`와 현재 workspace 상태가 frozen changeset이다.
+- review phase 범위: reviewer 실행, reviewer 결과 수집, Arbiter 실행, selective consistency N=3, vote-shape 집계, 전건 보고, 질문 도구 판단 수집까지다.
+- review phase 중 patch 금지: 이 구간에는 active changeset을 바꾸는 patch/edit/apply_patch, write-mode formatter, codegen/regeneration으로 생기는 generated output 변경, lockfile 재생성, commit/push를 금지한다. check-only formatter나 diff-only generator처럼 파일 변경이 없으면 허용한다. delegated reviewer/Arbiter의 read-only/no-write 경계는 [`hardening-contract.md`](hardening-contract.md)가 정본이다.
+- 일괄 수정: CONFIRMED_ISSUE와 사용자가 수용한 NEEDS_MORE_INFO/`split` 항목은 pending write queue에 모아 write phase에서 메인 에이전트가 batch로 반영한다. 정상 confirmed finding 반영을 막는 규칙이 아니라 반영 시점을 라운드 밖으로 옮기는 규칙이다.
+- CRITICAL 기본값: CRITICAL finding만 즉시 중단/수정하는 예외는 기본 절차에 두지 않는다. CRITICAL은 다음 outer round 진입을 차단하고, 현재 round의 Arbiter 판정이 닫힌 뒤 write phase 첫 batch 항목으로 반영한다.
+- 새 changeset: write phase 후 다음 outer round를 시작하면 "새 changeset" 리뷰로 명시한다. 이전 round의 frozen changeset과 write phase batch delta를 round summary에 기록해 추세 기반 조기 중단의 신규 confirmed finding 계산 기준을 분리한다.
+- `parallel-audit`와의 용어 정합: `run-da`는 read/write phase를 가진 반복 개선 루프이고, `parallel-audit`는 같은 changeset을 일회성 read-only로 검증하는 전수조사다. 전수조사는 "`SAFE`까지" 자동 반복 재발사하지 않는다.
 
 ### Arbiter 출력 요건
 
@@ -54,7 +67,7 @@ first-pass Arbiter 결과가 trigger 조건에 매치되면 동일 입력으로 
 
 | stability_status | majority verdict | low_confidence_warning | 메인 에이전트 행동 |
 |------------------|------------------|------------------------|-------------------|
-| `stable` (3:0) | unanimous verdict | `false` | 기존 경로 (CONFIRMED→수정, NOT_AN_ISSUE→무해, NEEDS_MORE_INFO→질문 도구) |
+| `stable` (3:0) | unanimous verdict | `false` | 기존 경로 (CONFIRMED→pending write queue, NOT_AN_ISSUE→무해, NEEDS_MORE_INFO→질문 도구) |
 | `stable` (3:0) | unanimous verdict | `true` | fail-closed 승격: NEEDS_MORE_INFO 경로로 사용자 판단 요청. unanimous이어도 어떤 Arbiter가 LOW confidence를 보고했으면 기존 "LOW confidence NOT_AN_ISSUE 자동 NEEDS_MORE_INFO 승격" 계약을 유지한다. fleiss-kappa.py 출력의 `low_confidence_warning`/`min_confidence` 필드로 전달된다. |
 | `split` (2:1) | majority verdict (정보 표시) | any | NEEDS_MORE_INFO 경로로 사용자 판단 요청. vote-shape와 minority verdict도 함께 보고. |
 | `fragmented` (1:1:1) | — | any | BLOCKED. 질문 도구 지원 런타임: 사용자에게 판단 요청 (비유법 설명 포함). 질문 도구 미지원 런타임: 자동 승격 금지, 중단 보고 후 명시적 rerun 전에는 재개하지 않음. |
@@ -125,7 +138,7 @@ DA 에이전트가 위반을 지적할 때 반드시 다음 중 하나를 제시
 
 ### Arbiter 검증 후 수정 의무
 
-Arbiter가 CONFIRMED_ISSUE로 판정한 항목을 수정할 때:
+write phase에서 Arbiter가 CONFIRMED_ISSUE로 판정한 항목을 수정할 때:
 
 - 수정 전 해당 위치(for_pr: 파일:줄 / for_plan: 관련 파일 또는 계획 항목)를 직접 확인한다 (수정 작업의 일부).
 - 수정한 코드/계획의 diff를 명시한다.
@@ -150,7 +163,7 @@ Selective consistency 서브런 카운팅: selective consistency의 N=3 재판�
 명시적 상한은 5 outer round다. 5회 이후에도 CLEAR에 도달하지 못하면
 사용자에게 현황을 보고하고 계속 진행 여부를 확인한다(자동 무한 진행 금지). selective consistency 서브런은 outer round 카운트에 포함하지 않는다.
 
-추세 기반 조기 중단: 신규 confirmed finding(직전 outer round에 없던 confirmed — 동일성은 3회 반복 규칙과 같은 "세부 관점 + 위치(파일:줄 또는 계획 항목 번호)" 기준) 수가 직전 대비 감소하지 않는(동수 포함) outer round가 2회 연속이면(따라서 최소 outer round 3부터 평가 가능하며, R1·단일 라운드는 미발동), 5회 상한 전이라도 비수렴으로 간주해 즉시 현황을 사용자에게 보고하고 계속 여부를 확인한다(질문 도구 미지원 런타임은 [`arbiter-scaling.md`](arbiter-scaling.md)의 "질문 도구 미지원 대응" 자동 종료 규칙을 따른다). 매 라운드의 수정이 새 리뷰 표면을 만들어 finding이 수렴하지 않는 경우(활성 changeset에 반복 리뷰)가 대표 사례다 — 이때는 표면을 다듬어 finding을 닫으려 하기보다 changeset 동결 또는 변경 범위 축소를 우선 검토한다. "3회 반복 규칙"이 동일 지적의 반복을 잡는다면, 이 규칙은 매 라운드 다른 새 finding이 끊이지 않는 비수렴을 잡는다.
+추세 기반 조기 중단: 신규 confirmed finding(직전 outer round에 없던 confirmed — 동일성은 3회 반복 규칙과 같은 "세부 관점 + 위치(파일:줄 또는 계획 항목 번호)" 기준) 수가 직전 대비 감소하지 않는(동수 포함) outer round가 2회 연속이면(따라서 최소 outer round 3부터 평가 가능하며, R1·단일 라운드는 미발동), 5회 상한 전이라도 비수렴으로 간주해 즉시 현황을 사용자에게 보고하고 계속 여부를 확인한다(질문 도구 미지원 런타임은 [`arbiter-scaling.md`](arbiter-scaling.md)의 "질문 도구 미지원 대응" 자동 종료 규칙을 따른다). CLEAR까지 반복은 상한/조기중단/read-write 분리 규칙을 함께 적용한다. 매 라운드의 write phase batch가 새 리뷰 표면을 만들어 finding이 수렴하지 않는 경우가 대표 사례다 — 이때는 라운드 중 표면을 계속 다듬어 finding을 닫으려 하기보다 changeset 동결 유지, batch 범위 축소, 또는 변경 범위 축소를 우선 검토한다. "3회 반복 규칙"이 동일 지적의 반복을 잡는다면, 이 규칙은 매 라운드 다른 새 finding이 끊이지 않는 비수렴을 잡는다.
 
 ## 라운드 요약 기록
 
@@ -159,6 +172,7 @@ Selective consistency 서브런 카운팅: selective consistency의 N=3 재판�
 ```text
 Round N 요약: DA 발견 X건 → Arbiter: CONFIRMED Y건(신규 Y'건 — 직전 라운드에 없던 관점+위치), NOT_AN_ISSUE Z건, NEEDS_MORE_INFO W건
 bundle별: Correctness 2건(SECURITY 1, HALLUCINATION 1), Regression CLEAR, ...
+changeset: frozen=<계획 원문/commit range/diff 기준>, write_phase=<수정 파일/계획 항목/diffstat/generated output 유무>, next=<R(N+1) 새 changeset 여부>
 ```
 
 selective consistency가 발동한 라운드는 추가 라인으로 stability_status 분포를 명시한다:
@@ -197,6 +211,7 @@ DA 피드백 루프가 완료되면 결과를 PR 코멘트로 게시한다 (PR �
 <summary>Round details</summary>
 
 ### Round 1
+- changeset: frozen=main...HEAD@abc1234, write_phase=none, next=R2 new changeset after batch fix
 - Correctness: 3건 (`HALLUCINATION` CONFIRMED 1, `SECURITY` CONFIRMED 1, `SECURITY` NOT_AN_ISSUE 1)
 - Design: CLEAR
 - Regression: 1건 (`SIDE_EFFECT` NEEDS_MORE_INFO 1) → 사용자 판단: 수용 → R2에서 fixed


### PR DESCRIPTION
## Summary

- run-da 리뷰 라운드를 \`changeset 동결 → read-only review phase → batch write phase → 새 changeset 선언\`으로 절차화 — 라운드 중 수정이 새 리뷰 표면을 만들어 수렴을 깨는 구조 차단
- CRITICAL 포함 모든 confirmed 반영을 write phase batch로 이동 (CRITICAL은 batch 첫 순서 + 다음 outer round 차단)

Closes #905

## 기존 문제/배경

PR #910이 라운드 상한과 추세 조기중단을 넣었지만 이는 피해 제한이지 수렴성 개선이 아니었다 — \`for_plan\`은 여전히 반영 후 CLEAR까지 반복하는 구조라, 라운드 중 patch가 계속 발생하면 매 라운드가 새 changeset이 되어 finding이 마르지 않는다.

## CIR (Change Intent Record)

- epic #903의 child. #911(MAX 개명)·#907(lazy loading) 머지 후 그 위에서 작업.
- CRITICAL 예외 여부는 executor가 양안을 정리해 보고했고 supervisor가 "예외 없음"을 판정했다: CRITICAL의 진짜 긴급 케이스(secret 노출 등)는 "즉시 수정"이 아니라 기존 중단·보고 경로의 사안이며, 즉시-수정 예외는 read/write 분리 취지를 뚫는 구멍이 된다.
- review phase의 formatter/generator는 check/diff-only 모드(파일 변경 없음)만 허용 — 검증은 허용하되 표면 변경만 차단.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| read/write phase 분리 + batch 반영 | 같은 changeset을 안정 검토, 수렴성 근본 개선 | 반영 지연 (1라운드 내) | ✅ |
| CRITICAL만 즉시 수정 예외 | 긴급 대응 빠름 | frozen changeset 파괴, 예외 경로 남용 위험 | ❌ |
| 현상 유지 (상한만) | 변경 없음 | 비수렴 원인 미해결 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`modes/for_plan.md\` | Step 0에 동결/phase 정의, Step 5 판정별 pending write queue, Step 6을 write phase로 재정의 |
| \`modes/for_pr.md\` | for_plan delta에 동일 절차 반영 |
| \`references/protocol.md\` | 심각도 표·비수렴 설명을 phase 기준으로 갱신, parallel-audit 일회성 용어 정합 |
| \`SKILL.md\`, \`references/main-agent-obligations.md\`, \`references/arbiter-prompt.md\` | CONFIRMED_ISSUE 자동 반영 문구를 batch 기준으로 통일 |

## 참고 레퍼런스

- epic #903, 이슈 #905 · PR #910 (상한·조기중단 — 유지), PR #984(#911)·#986(#907)

## Human Test Plan

1. \`rg -n "라운드 중|patch 금지|일괄 수정|changeset 동결|read/write" modules/shared/programs/claude/files/skills/run-da\` → 절차 명시 확인.
2. \`rg -n "CLEAR까지 반복" ...\` → 상한/조기중단/분리와 함께 설명됨.
3. docs-only 변경으로 \`/run-da for_plan\` dry-run → review phase에서 파일 변경 0 (executor smoke: native subagent CLEAR, git status 불변 실측).
4. 머지+\`nrs\` 후 실제 DA 라운드에서 confirmed 반영이 Arbiter 판정 종료 후 batch로 일어나는지 관찰.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP