### PR TITLE
test(darwin): folder-actions 공유 lib 특성화 테스트 (1단계)

### DIFF
--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -144,6 +144,12 @@ run_test "pushover helper missing credential skips curl" test_pushover_send_miss
 run_test "pushover helper sends expected fields" test_pushover_send_success_passes_expected_fields
 run_test "pushover helper passes optional sound" test_pushover_send_passes_optional_sound
 run_test "pushover helper curl failure returns nonzero" test_pushover_send_curl_failure_returns_1
+run_test "folder-actions lib source has no side effects" test_folder_actions_lib_source_is_side_effect_free
+run_test "folder-actions notify_failure uses Pushover helper boundary" test_folder_actions_notify_failure_uses_pushover_helper_boundary
+run_test "folder-actions drain_queue processes rescanned files in order" test_folder_actions_drain_queue_processes_rescanned_files_in_order
+run_test "folder-actions drain_queue defers unstable files" test_folder_actions_drain_queue_defers_unstable_files
+run_test "folder-actions quarantine_or_abort branches" test_folder_actions_quarantine_or_abort_branches
+run_test "upload-immich missing credential branch is quiet" test_upload_immich_missing_credential_branch_is_quiet_or_skipped
 run_test "karakeep fallback-sync success removes only matched queue URL" test_karakeep_fallback_sync_success_removes_only_matched_queue_url
 run_test "karakeep fallback-sync upload failure preserves queue" test_karakeep_fallback_sync_upload_failure_preserves_queue_and_records_notify_state
 run_test "karakeep fallback-sync GC removes expired state" test_karakeep_fallback_sync_gc_removes_only_expired_state_entries

--- a/tests/suites/folder-actions-lib.sh
+++ b/tests/suites/folder-actions-lib.sh
@@ -1,0 +1,271 @@
+# tests/suites/folder-actions-lib.sh — Folder Actions shared lib characterization (sourced)
+# shellcheck shell=bash
+# SC2154: REPO_ROOT/new_sandbox/run_test/assert_* are provided by tests/lib/test-common.sh.
+# shellcheck disable=SC2154
+
+# Source-safety/dependency audit, current as of this characterization:
+# - source side effects: variable assignments only
+#   (PUSHOVER_CREDENTIALS, PUSHOVER_HELPER, _FA_LIB_FAILED_ROOT) plus function
+#   definitions. No file, process, or network side effect was observed.
+# - notify_failure: sources $HOME/.local/lib/pushover.sh and calls pushover_send
+#   only when $HOME/.config/pushover/folder-actions exists.
+# - ensure_failed_dir: basename, /bin/mkdir, /bin/chmod, caller-provided
+#   verify_path_security.
+# - move_to_failed: ensure_failed_dir, basename, /bin/date, /bin/mv,
+#   notify_failure.
+# - wait_file_stable: /usr/bin/stat -f '%z:%m', sleep.
+# - drain_queue: find_candidates/process_one callbacks, wait_file_stable,
+#   basename in the deferred warning path.
+# - quarantine_or_abort: move_to_failed, log_error, exit 1 on quarantine failure.
+#
+# Linux/NixOS exclusion list:
+# - ensure_failed_dir, move_to_failed, and wait_file_stable are not exercised
+#   directly here because the implementation hard-codes macOS absolute command
+#   paths that are absent on the Linux/NixOS runner (/bin/mkdir, /bin/chmod,
+#   /bin/date, /bin/mv, /usr/bin/stat). drain_queue and quarantine_or_abort are
+#   still covered by overriding those callback boundaries after sourcing.
+# - upload-immich.sh missing-credential e2e is skipped when those macOS absolute
+#   commands are absent before the credential branch.
+#
+# This suite is definition-only; tests/shell-script-tests.sh owns run_test registration.
+
+_folder_actions_lib_path() {
+  printf '%s\n' "$REPO_ROOT/modules/darwin/programs/folder-actions/files/scripts/_folder-actions-lib.sh"
+}
+
+_upload_immich_script_path() {
+  printf '%s\n' "$REPO_ROOT/modules/darwin/programs/folder-actions/files/scripts/upload-immich.sh"
+}
+
+_folder_actions_define_logger_stubs() {
+  _FOLDER_ACTIONS_TEST_LOG_FILE="$1"
+
+  log_info() { printf 'INFO:%s\n' "$*" >> "$_FOLDER_ACTIONS_TEST_LOG_FILE"; }
+  log_warn() { printf 'WARN:%s\n' "$*" >> "$_FOLDER_ACTIONS_TEST_LOG_FILE"; }
+  log_error() { printf 'ERROR:%s\n' "$*" >> "$_FOLDER_ACTIONS_TEST_LOG_FILE"; }
+  verify_path_security() { return 0; }
+}
+
+test_folder_actions_lib_source_is_side_effect_free() (
+  local sandbox home out
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home"
+
+  out=$(
+    HOME="$home" bash -c '
+      set -euo pipefail
+      WATCH_DIR="$HOME/FolderActions/compress-video"
+      CURRENT_PID="12345"
+      log_info() { :; }
+      log_warn() { :; }
+      log_error() { :; }
+      verify_path_security() { :; }
+      # shellcheck source=/dev/null
+      source "$1"
+    ' _ "$(_folder_actions_lib_path)" 2>&1
+  )
+
+  [[ -z "$out" ]] || fail "source must not emit output, got: $out"
+  [[ ! -e "$home/FolderActions" ]] || fail "source must not create FolderActions paths"
+  [[ ! -e "$home/.config" ]] || fail "source must not create credential paths"
+  [[ ! -e "$home/.local" ]] || fail "source must not create helper paths"
+)
+
+test_folder_actions_notify_failure_uses_pushover_helper_boundary() (
+  local sandbox home helper cred log_file
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  helper="$home/.local/lib/pushover.sh"
+  cred="$home/.config/pushover/folder-actions"
+  log_file="$sandbox/pushover-send.log"
+
+  mkdir -p "$(dirname "$helper")" "$(dirname "$cred")"
+  : > "$cred"
+  cat > "$helper" <<'EOF_HELPER'
+pushover_send() {
+  : "${PUSHOVER_SEND_LOG:?}"
+  printf '%s\n' "$@" > "$PUSHOVER_SEND_LOG"
+}
+EOF_HELPER
+
+  export HOME="$home"
+  export WATCH_DIR="$home/FolderActions/compress-video"
+  export CURRENT_PID="12345"
+  export PUSHOVER_SEND_LOG="$log_file"
+  _folder_actions_define_logger_stubs "$sandbox/events.log"
+  # shellcheck source=/dev/null
+  source "$(_folder_actions_lib_path)"
+
+  notify_failure "FolderActions 실패" "처리 실패 격리: input.mov" 1
+
+  assert_file_contains "$log_file" "$cred"
+  assert_file_contains "$log_file" "FolderActions 실패"
+  assert_file_contains "$log_file" "처리 실패 격리: input.mov"
+  assert_file_contains "$log_file" "1"
+)
+
+test_folder_actions_drain_queue_processes_rescanned_files_in_order() (
+  local sandbox home watch processed
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  watch="$home/FolderActions/compress-video"
+  processed="$sandbox/processed.log"
+  mkdir -p "$watch"
+  printf '%s\n' "first" > "$watch/first.txt"
+
+  export HOME="$home"
+  export WATCH_DIR="$watch"
+  export CURRENT_PID="12345"
+  _folder_actions_define_logger_stubs "$sandbox/events.log"
+  # shellcheck source=/dev/null
+  source "$(_folder_actions_lib_path)"
+
+  wait_file_stable() { return 0; }
+  find_candidates() { find "$watch" -maxdepth 1 -type f | sort; }
+  process_one() {
+    local file="$1"
+    local name
+    name=$(basename "$file")
+    printf '%s\n' "$name" >> "$processed"
+    rm -f "$file"
+    if [ "$name" = "first.txt" ]; then
+      printf '%s\n' "second" > "$watch/second.txt"
+    fi
+  }
+
+  drain_queue process_one
+
+  assert_file_contains "$processed" "first.txt"
+  assert_file_contains "$processed" "second.txt"
+  [[ "$(cat "$processed")" = $'first.txt\nsecond.txt' ]] \
+    || fail "expected FIFO processing with rescan, got: $(cat "$processed")"
+  [[ -z "$(find "$watch" -maxdepth 1 -type f -print)" ]] \
+    || fail "expected queue to be empty after stable processing"
+)
+
+test_folder_actions_drain_queue_defers_unstable_files() (
+  local sandbox home watch processed events
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  watch="$home/FolderActions/rename-asset"
+  processed="$sandbox/processed.log"
+  events="$sandbox/events.log"
+  mkdir -p "$watch"
+  printf '%s\n' "stable" > "$watch/stable.txt"
+  printf '%s\n' "unstable" > "$watch/unstable.txt"
+
+  export HOME="$home"
+  export WATCH_DIR="$watch"
+  export CURRENT_PID="12345"
+  _folder_actions_define_logger_stubs "$events"
+  # shellcheck source=/dev/null
+  source "$(_folder_actions_lib_path)"
+
+  wait_file_stable() {
+    [ "$(basename "$1")" != "unstable.txt" ]
+  }
+  find_candidates() { find "$watch" -maxdepth 1 -type f | sort; }
+  process_one() {
+    printf '%s\n' "$(basename "$1")" >> "$processed"
+    rm -f "$1"
+  }
+
+  drain_queue process_one
+
+  assert_file_contains "$processed" "stable.txt"
+  [[ ! -e "$watch/stable.txt" ]] || fail "stable file must be processed"
+  [[ -e "$watch/unstable.txt" ]] || fail "unstable file must remain for a later wakeup"
+  assert_contains "$(cat "$events")" "WARN:unstable; deferred to next wakeup: unstable.txt"
+  assert_contains "$(cat "$events")" "INFO:unstable 파일 1개 잔존; run 종료"
+)
+
+test_folder_actions_quarantine_or_abort_branches() (
+  local sandbox home success_log fail_log rc
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  success_log="$sandbox/quarantine-success.log"
+  fail_log="$sandbox/quarantine-fail.log"
+
+  export HOME="$home"
+  export WATCH_DIR="$home/FolderActions/compress-rar"
+  export CURRENT_PID="12345"
+  _folder_actions_define_logger_stubs "$sandbox/events.log"
+  # shellcheck source=/dev/null
+  source "$(_folder_actions_lib_path)"
+
+  move_to_failed() {
+    printf '%s\n' "$1" >> "$success_log"
+    return 0
+  }
+  quarantine_or_abort "$sandbox/input.rar"
+  assert_file_contains "$success_log" "$sandbox/input.rar"
+
+  set +e
+  (
+    set -euo pipefail
+    export HOME="$home"
+    export WATCH_DIR="$home/FolderActions/compress-rar"
+    export CURRENT_PID="12345"
+    log_info() { :; }
+    log_warn() { :; }
+    log_error() { printf 'ERROR:%s\n' "$*" >> "$fail_log"; }
+    verify_path_security() { return 0; }
+    # shellcheck source=/dev/null
+    source "$(_folder_actions_lib_path)"
+    move_to_failed() { return 1; }
+    quarantine_or_abort "$sandbox/input.rar"
+  )
+  rc=$?
+  set -e
+
+  [[ "$rc" -eq 1 ]] || fail "quarantine_or_abort must exit 1 when move_to_failed fails (got $rc)"
+  assert_contains "$(cat "$fail_log")" "ERROR:quarantine 실패; run 중단"
+)
+
+test_upload_immich_missing_credential_branch_is_quiet_or_skipped() (
+  local required path sandbox home watch out rc
+  required=(
+    /usr/bin/id
+    /usr/bin/stat
+    /usr/bin/sed
+    /usr/bin/grep
+    /usr/bin/tr
+    /bin/date
+    /bin/ps
+    /bin/mkdir
+    /bin/rm
+  )
+
+  if [ "$(uname -s)" != "Darwin" ]; then
+    echo "==> upload-immich missing credentials: SKIPPED (macOS absolute command contract; runner=$(uname -s))" >&2
+    return 0
+  fi
+
+  for path in "${required[@]}"; do
+    if [ ! -x "$path" ]; then
+      echo "==> upload-immich missing credentials: SKIPPED (missing $path before credential branch)" >&2
+      return 0
+    fi
+  done
+
+  if [ -e /tmp/upload-immich.lock.d ] || [ -e /tmp/upload-immich.lock ]; then
+    echo "==> upload-immich missing credentials: SKIPPED (real lock path already exists)" >&2
+    return 0
+  fi
+
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  watch="$home/FolderActions/upload-immich"
+  mkdir -p "$watch"
+  printf '%s\n' "image" > "$watch/photo.jpg"
+
+  set +e
+  out=$(HOME="$home" WATCH_DIR="$watch" bash "$(_upload_immich_script_path)" 2>&1)
+  rc=$?
+  set -e
+
+  [[ "$rc" -eq 0 ]] || fail "upload-immich missing credential branch must exit 0 (got $rc): $out"
+  assert_contains "$out" "자격증명 없음: $home/.config/immich/api-key"
+  [[ -e "$watch/photo.jpg" ]] || fail "missing credentials must not delete media"
+)


### PR DESCRIPTION
## Summary

- \`tests/suites/folder-actions-lib.sh\` 신설 — \`_folder-actions-lib.sh\`의 현행 동작 특성화 (source 부작용 없음, notify_failure의 Pushover 헬퍼 경계, drain_queue 순서·불안정 파일 유예, quarantine_or_abort 분기)
- macOS 절대경로 계약(/bin/mkdir, /usr/bin/stat 등)에 묶인 함수는 Darwin 전용 케이스로 작성하고 Linux 러너에서는 명시 SKIP

Closes #952

## 기존 문제/배경

darwin folder-actions 공유 lib는 launchd 자동화의 공통 기반인데 tests/ 참조가 0건이었다 — Pushover 헬퍼 전환(PR #988) 같은 변경이 회귀를 만들어도 잡을 수단이 없었다.

## CIR (Change Intent Record)

- PR #988 머지로 soft 의존(011 선행)이 풀린 직후 착수 — notify_failure 특성화는 전환 후 코드(pushover_send 헬퍼 경계) 기준.
- 초기 산출물이 suite self-register 방식이었으나 supervisor 리뷰에서 컨벤션(정의 전용 suite + aggregator 명시 등록) 위반으로 REVISE — scope를 확장해 \`tests/shell-script-tests.sh\` 등록 라인을 추가했다.
- Linux 러너에서 실행 불가한 macOS 계약은 silent cap 없이 SKIP 라인으로 노출된다.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| Linux 실행 가능 부분 + Darwin SKIP | 게이트에 즉시 편입, 커버리지 명시 | Darwin 케이스는 Mac에서만 실행 | ✅ |
| Darwin 전용 suite 분리 | 러너 분리 명확 | 게이트 편입 복잡, 1단계 범위 초과 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`tests/suites/folder-actions-lib.sh\` (신규) | 정의 전용 특성화 suite (6 케이스) |
| \`tests/shell-script-tests.sh\` | run_test 등록 6라인 |

## 참고 레퍼런스

- 이슈 #952, epic #937 · PR #988 (notify_failure 전환 — 특성화 기준)

## Human Test Plan

1. \`nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh\` → folder-actions 라인 6개 통과(+1 Linux SKIP 표시).
2. \`git diff --stat -- modules/darwin/programs/folder-actions/\` → 0 (프로덕션 무수정).
3. (선택, Mac) 같은 suite 실행 시 upload-immich Darwin 케이스가 SKIP 대신 실행된다.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader end-to-end shell test coverage for folder actions, including source side effects, notification handling, queue ordering, unstable-file deferral, and quarantine/abort paths.
  * Added coverage for upload behavior when required credentials are missing, verifying the command stays quiet or skips as expected.
  * Introduced a new shared test suite to support these scenarios with reusable logging and script-location helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->