### PR TITLE
fix(skills): run-da 세션 간 기각 이력 영속성 — dismissal ledger 설계

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -76,14 +76,16 @@ Review Intensity 판단을 건너뛰고 exhaustive override를 실행한다.
 |------|----------|-------------|
 | DA 프롬프트 | 이전 라운드 결과 요약 포함 가능 | 코드/계획 + 프로젝트 컨텍스트만 전달. 이전 라운드 언급 금지 |
 | 편향 | 이전 발견에 anchoring 가능 | 매 라운드 완전 독립 리뷰 |
-| 무한 루프 위험 | 낮음 (이전 맥락으로 중복 감소) | 높음 (동일 지적 반복 가능 → 반복 감지 규칙으로 대응) |
+| 무한 루프 위험 | 낮음 (이전 맥락으로 중복 감소) | 높음 (동일 지적 반복 가능 → 반복 감지 + dismissal ledger exact match로 대응) |
 
 `fresh` 사용 시 메인 에이전트는 DA 에이전트 프롬프트에 다음을 포함하지 않는다:
 - 이전 라운드의 발견 사항
 - 이전 라운드에서 수용/기각된 지적 내역
 - "이번에는 다른 관점에서 봐주세요" 등 이전 라운드를 암시하는 표현
 
-메인 에이전트는 finding의 세부 관점 + 위치(파일:줄 또는 계획 항목 번호) 조합으로 라운드 간 반복 감지를 수행한다.
+예외: current changeset에 대해 valid dismissal ledger가 있으면 메인 에이전트는 [`references/dismissal-ledger.md`](references/dismissal-ledger.md)의 exact match 절차로 동일 지적을 suppress할 수 있다. 이때도 DA reviewer에게 이전 finding 본문, Arbiter reasoning, 이전 라운드 transcript를 전달하지 않는다. 런타임상 주입이 필요한 정보는 ledger key, scope, `dismissed: NOT_AN_ISSUE|USER_EXCLUDED` 결론뿐이다.
+
+메인 에이전트는 finding의 세부 관점 + 위치(파일:줄 또는 계획 항목 번호) 조합으로 라운드 간 반복 감지를 수행하고, `fresh` 반복 세션에서는 dismissal ledger key가 모두 일치하는 동일 지적만 새 finding에서 제외한다.
 
 ## 빠른 참조와 lazy loading
 
@@ -102,7 +104,7 @@ Preflight에서 아래 lazy reference를 미리 열지 않는다. mode가 비어
 | `for_plan` | [`modes/for_plan.md`](modes/for_plan.md), [`references/intensity-procedure.md`](references/intensity-procedure.md) | mode 확정 후 Step 0 실행 시 |
 | `for_pr` | [`modes/for_pr.md`](modes/for_pr.md), [`modes/for_plan.md`](modes/for_plan.md), [`references/intensity-procedure.md`](references/intensity-procedure.md) | mode 확정 후 Step 0 실행 시. `for_pr`은 delta 문서이므로 `for_plan` 공통 절차도 함께 읽는다 |
 | `both` | [`modes/for_plan.md`](modes/for_plan.md) → 사용자 계획 승인 후 [`modes/for_pr.md`](modes/for_pr.md) + [`modes/for_plan.md`](modes/for_plan.md) | 각 phase 진입 직전에만 해당 mode 문서를 읽는다 |
-| `fresh` modifier | 이 `SKILL.md`; 후속 라운드 propagation 조립 시 [`references/protocol.md`](references/protocol.md) | preflight에서는 추가 reference 없음. 이전 라운드 맥락과 selective propagation을 모두 끊어야 하는 시점에만 protocol을 확인한다 |
+| `fresh` modifier | 이 `SKILL.md`; 후속 라운드 propagation 조립 시 [`references/protocol.md`](references/protocol.md), ledger suppression이 필요하면 [`references/dismissal-ledger.md`](references/dismissal-ledger.md) | preflight에서는 추가 reference 없음. 이전 라운드 맥락과 selective propagation을 모두 끊어야 하는 시점에만 protocol을 확인한다. current changeset에 valid ledger가 있을 때만 dismissal-ledger를 확인한다 |
 | `MAX` modifier | 선택 mode 문서, [`references/da-domains.md`](references/da-domains.md) | Review Intensity를 건너뛰고 exhaustive 6-domain fan-out 조립 직전. `intensity-procedure.md`는 읽지 않는다 |
 | LITE/FULL reviewer fan-out | [`references/da-domains.md`](references/da-domains.md), [`references/runtime-mapping.md`](references/runtime-mapping.md), [`references/hardening-contract.md`](references/hardening-contract.md) | Step 2에서 실제 reviewer prompt/런타임을 조립할 때 |
 | codex exec fallback 또는 literal 재사용 위험 | [`../using-codex-exec/references/known-issues.md`](../using-codex-exec/references/known-issues.md#literal-재사용-시-random-suffix-환각-금지-issue-632), [`references/arbiter-scaling.md`](references/arbiter-scaling.md) | native delegation이 거부되거나 codex exec 경로를 실제로 사용할 때 |
@@ -152,6 +154,7 @@ Preflight에서 아래 lazy reference를 미리 열지 않는다. mode가 비어
 6. 사용자 전건 보고 + 질문 도구 의무 — 모든 Arbiter 판정 결과를 사용자에게 보고. NEEDS_MORE_INFO/`split` 항목은 [`references/main-agent-obligations.md`](references/main-agent-obligations.md#사용자-질문-시-맥락-설명-의무)의 5요소 맥락(현재 상황 / 문제 / 비유법 / 선택지 장단점 / 질문)으로 질문 도구 호출.
 7. Fresh perspective 보장 — 매 라운드마다 새 reviewer/Arbiter 실행 단위 (Codex: 새 native subagent thread, codex exec: 새 `codex exec` 프로세스).
 8. 의사결정·회귀 컨텍스트 조사 — 제거/단순화/되돌림/리팩터 변경이거나 git상 왕복 핫스팟 파일이면 Review Intensity와 무관하게 fail-closed로 과거 의사결정(commit/PR/issue + 있으면 CIR/ADR·로컬 세션 로그)을 조사해 회귀 재도입을 점검한다. 메인이 "의사결정 컨텍스트 팩"을 수집·주입하고 reviewer/Arbiter가 read-only 보강한다. git으로 버전관리되는 모든 저장소에서 동작하며 기록 관습에 의존하지 않는다 ([`references/decision-regression-audit.md`](references/decision-regression-audit.md)).
+9. Dismissal ledger는 exact match만 suppress — `fresh` anti-anchoring을 위해 이전 finding 본문/이전 transcript는 주입하지 않는다. Arbiter `NOT_AN_ISSUE` 또는 사용자 명시 제외 중 eligible 항목만 ignored local ledger에 기록하고, `NEEDS_MORE_INFO`는 자동 기각으로 저장하지 않는다 ([`references/dismissal-ledger.md`](references/dismissal-ledger.md)).
 
 ## 주의사항
 

--- a/modules/shared/programs/claude/files/skills/run-da/modes/for_plan.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/for_plan.md
@@ -17,11 +17,13 @@
 
 계획이 제거·단순화·되돌림·리팩터 방향이거나 변경 대상이 git상 왕복 핫스팟이면, [`../references/decision-regression-audit.md`](../references/decision-regression-audit.md)의 발동 조건에 따라 "의사결정 컨텍스트 팩"(해당 문서 Step A)을 수집한다 — 메인이 commit/PR/issue(+있으면 CIR/ADR·로컬 세션 로그)에서 과거 결정·되돌림 이력을 추려, Step 2의 reviewer 프롬프트와 Step 5의 Arbiter 프롬프트에 selective propagation으로 주입한다. 그 외 변경은 Review Intensity에 연동한다(FULL=전체 조사, LITE=경량, SKIP=생략).
 
+`fresh` 반복 세션에서 local dismissal ledger가 있으면, changeset freeze 직후 current changeset key와 일치하는 valid entry만 읽는다. ledger entry는 Step 2 reviewer prompt에 넣지 않고, Step 3 결과 수집 후 Arbiter 진입 전 exact match suppression에만 사용한다. 세부 key/schema/invalidation 규칙은 [`../references/dismissal-ledger.md`](../references/dismissal-ledger.md)를 따른다.
+
 ## Outer round phase model: changeset 동결 + read/write 분리
 
 각 outer round는 `changeset 동결 → review phase → write phase` 순서로 진행한다.
 
-- changeset 동결: Step 2 진입 전에 이번 라운드의 검토 표면을 고정한다. for_plan은 계획 원문과 관련 파일/맥락, for_pr은 `git diff main...HEAD`와 현재 workspace 상태가 frozen changeset이다.
+- changeset 동결: Step 2 진입 전에 이번 라운드의 검토 표면을 고정한다. for_plan은 계획 원문과 관련 파일/맥락, for_pr은 `git diff main...HEAD`와 현재 workspace 상태가 frozen changeset이다. dismissal ledger를 사용할 때도 이 frozen changeset key와 exact match하는 entry만 valid하다.
 - review phase: Step 2 reviewer fan-out부터 Step 5e 상태 전이와 사용자 전건 보고까지다. 이 구간에는 메인 에이전트와 delegated reviewer/Arbiter 모두 active changeset을 바꾸지 않는다. patch/edit/apply_patch, write-mode formatter, codegen/regeneration으로 생기는 generated output 변경, lockfile 재생성, commit/push를 금지한다. formatter/generator는 check/diff-only 모드처럼 파일 변경이 없을 때만 허용한다.
 - write phase: 한 라운드의 Arbiter 판정과 필요한 사용자 판단이 끝난 뒤에만 시작한다. CONFIRMED_ISSUE와 사용자가 수용한 NEEDS_MORE_INFO/`split` 항목을 queue에 모아 메인 에이전트가 batch로 반영한다.
 - CRITICAL 기본값: CRITICAL도 review phase 중 즉시 patch하지 않는다. 해당 라운드의 Arbiter 판정이 닫힌 뒤 write phase 첫 항목으로 반영하며, 해결 전에는 다음 outer round로 진행하지 않는다.
@@ -75,6 +77,7 @@
 - Codex 세션 경로: `VIOLATION` 처리 규칙은 [`../references/hardening-contract.md`](../references/hardening-contract.md)의 공통 처리 정의를 따른다. offending unit은 rerun 또는 `BLOCKED` 해소 전까지 `CLEAR` 계산에 포함하지 않는다.
 - codex exec 경로: 선택된 review unit(FULL 기본 4개, LITE는 선택한 수, explicit exhaustive는 6개) 전부 실행(Claude Code는 병렬, headless는 serial) 완료 후, 각 `$DA_DIR/$UNIT-result.md` 패턴의 결과 파일을 파일 읽기 도구로 명시적으로 읽어 수집한다. 결과 파일이 없거나 빈 경우, 또는 exit code가 0이 아니면 실패로 판정한다.
 - 실패한 review unit만 재실행한다. codex exec 경로는 라운드마다 새 `DA_DIR`을 생성하여 이전 라운드 산출물과 분리한다.
+- `fresh` 반복 세션에서 valid dismissal ledger가 있으면, reviewer finding별 dismissal key를 계산해 exact match 항목만 `dismissed_suppressed`로 분류한다. suppress된 항목은 Arbiter 입력, 신규 finding 계산, pending write queue에 포함하지 않는다. match하지 않는 항목은 평소처럼 Step 5 Arbiter로 보낸다.
 
 ## Step 4: ALL CLEAR 또는 Arbiter 진입
 
@@ -94,7 +97,7 @@ findings 0건이고 `VIOLATION`/`BLOCKED` review unit이 없으면 → ALL CLEAR
 
 - CONFIRMED_ISSUE + CRITICAL + (N/A 또는 stable) + `low_confidence_warning=false`: 진행 차단. review phase 중 patch 금지 원칙을 유지하고, Arbiter 판정이 닫힌 뒤 write phase의 첫 batch 항목으로 계획에 반영한다. 해결 전에는 다음 outer round로 진행하지 않는다.
 - CONFIRMED_ISSUE + HIGH/MEDIUM/LOW + (N/A 또는 stable) + `low_confidence_warning=false`: pending write queue에 추가하고, Step 6 write phase에서 계획에 일괄 수정한다.
-- NOT_AN_ISSUE + (N/A 또는 stable) + `low_confidence_warning=false`: 보고만 (반영 불필요).
+- NOT_AN_ISSUE + (N/A 또는 stable) + `low_confidence_warning=false`: 보고만 (반영 불필요). eligible 항목은 사용자 전건 보고 후 local ignored dismissal ledger에 기록한다.
 - NEEDS_MORE_INFO 또는 `stability_status=split`: 질문 도구로 사용자 판단을 요청한다 (vote-shape와 minority verdict도 함께 보고). 사용자가 수용한 항목만 pending write queue에 추가한다.
 - 임의 verdict + (N/A 또는 stable) + `low_confidence_warning=true`: fail-closed 승격 — 질문 도구로 사용자 판단 요청 (unanimous/단일 Arbiter라도 LOW confidence 이력이 있으면 기존 LOW-confidence NOT_AN_ISSUE 자동 NEEDS_MORE_INFO 계약을 유지).
 - `stability_status=fragmented` 또는 `partial_failure=true`: BLOCKED — 질문 도구 지원 런타임에서는 판단 요청, 미지원 런타임에서는 자동 승격 금지(중단 보고).

--- a/modules/shared/programs/claude/files/skills/run-da/modes/for_pr.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/for_pr.md
@@ -15,7 +15,7 @@
 | Step 3 | 동일 | 동일 ([`./for_plan.md`](./for_plan.md#step-3-reviewer-결과-수신--종합-리포트)) |
 | Step 4 | 동일 (ALL CLEAR) | 동일 |
 | Step 5 (Arbiter) | for_plan 조립 (계획 원문 포함) | for_pr 조립 (diff 컨텍스트 포함) — [`../references/arbiter-prompt.md`](../references/arbiter-prompt.md)의 "프롬프트 조립 > for_pr 모드" 참조. for_pr에서는 계획 원문 대신 diff 또는 변경 컨텍스트를 포함 |
-| Step 5 상태 전이 | CONFIRMED_ISSUE를 pending write queue에 추가 | 동일. review phase 중 patch 금지, formatter write 금지, generated output 변경 금지. 코드 수정/commit은 Step 6 write phase 전까지 금지 |
+| Step 5 상태 전이 | CONFIRMED_ISSUE를 pending write queue에 추가, eligible NOT_AN_ISSUE/사용자 제외는 dismissal ledger에 기록 | 동일. review phase 중 patch 금지, formatter write 금지, generated output 변경 금지. 코드 수정/commit은 Step 6 write phase 전까지 금지. dismissal ledger 기록은 tracked diff가 아닌 local ignored review metadata로만 허용 |
 | Step 6 write phase | 계획/관련 파일을 batch로 수정하고 새 changeset 선언 | 코드 변경을 batch로 반영하고 커밋한다. 메인 에이전트가 single-writer로 코드 수정 + commit ([`../references/hardening-contract.md`](../references/hardening-contract.md)의 single-writer 정의). 반영 후 새 changeset(diff/commit range)을 선언하고 변경 범위를 round summary에 기록 |
 | Step 7 | CLEAR까지 반복 (protocol.md "최대 라운드 수" 적용: 상한 + 추세 기반 조기 중단 + read/write 분리) | 동일 |
 | Step 8 | (없음) | push — 최종 승인 후 push한다 (네트워크/auth 정책 의존 — [`../SKILL.md#non-goals`](../SKILL.md#non-goals) 참조) |
@@ -25,10 +25,10 @@
 다음은 `for_plan`과 100% 동일하다. 본문은 [`./for_plan.md`](./for_plan.md)를 SSOT로 한다:
 
 - Step 0 본문: Review Intensity 판단 절차 ([`../references/intensity-procedure.md`](../references/intensity-procedure.md)).
-- Step 1 본문 (의사결정 컨텍스트 팩 수집): 제거·단순화·되돌림·리팩터 또는 왕복 핫스팟이면 [`../references/decision-regression-audit.md`](../references/decision-regression-audit.md) Step A를 for_plan Step 1과 동일하게 수행한다 (입력만 계획 대신 `git diff main...HEAD`). 수집한 팩은 Step 2 reviewer·Step 5 Arbiter 프롬프트에 selective propagation으로 주입.
+- Step 1 본문 (의사결정 컨텍스트 팩 수집 + dismissal ledger load): 제거·단순화·되돌림·리팩터 또는 왕복 핫스팟이면 [`../references/decision-regression-audit.md`](../references/decision-regression-audit.md) Step A를 for_plan Step 1과 동일하게 수행한다 (입력만 계획 대신 `git diff main...HEAD`). 수집한 팩은 Step 2 reviewer·Step 5 Arbiter 프롬프트에 selective propagation으로 주입. `fresh` 반복 세션의 dismissal ledger load는 frozen `git diff main...HEAD` + workspace review surface hash와 exact match할 때만 유효하다.
 - Step 2 본문 (Codex 세션 경로): `spawn_agent`/`wait_agent`/`close_agent` lifecycle, batch 규칙, conservative wait, fresh modifier, selective propagation.
 - Step 2 본문 (codex exec 경로): 임시 디렉토리, stdout `DA_DIR` 리터럴 재설정, prompt 파일 guard, `cat | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral ... -` stdin pipe (Layer 1, [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md) role별 명령 표가 SSOT), `&+wait` 금지, Claude Code 병렬 / headless serial foreground 구분, [`../references/runtime-mapping.md`](../references/runtime-mapping.md) 공통 주의(셸 호출 간 변수 유실).
-- Step 3 본문: VIOLATION 처리, 결과 파일 검증, 실패 unit 재실행.
+- Step 3 본문: VIOLATION 처리, 결과 파일 검증, 실패 unit 재실행, `fresh` dismissal ledger exact match suppression.
 - Step 5 (5a~5e): Arbiter 호출, selective consistency trigger 검사, N=3 재판정, vote-shape 집계, 상태 전이 적용. 상태 전이 구조(N/A·stable·split·fragmented 분기, NEEDS_MORE_INFO 사용자 판단 요청, fragmented BLOCKED)는 for_plan과 동일하다. CONFIRMED_ISSUE는 review phase 중 수정하지 않고 pending write queue로만 이동한다.
 - Step 6: write phase batch 반영, 새 reviewer 실행 단위, 새 `DA_DIR`. for_pr은 batch 코드 수정 후 commit까지 수행하고, 다음 라운드를 새 changeset으로 선언한다.
 - Step 7: CLEAR 탈출 조건. CLEAR까지 반복은 상한/조기중단/read-write 분리 규칙을 함께 적용한다.

--- a/modules/shared/programs/claude/files/skills/run-da/references/dismissal-ledger.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/dismissal-ledger.md
@@ -1,0 +1,135 @@
+# DA dismissal ledger
+
+`fresh` 모드의 anti-anchoring을 유지하면서 세션을 넘는 동일 false positive 재제기를 막기 위한 local ledger 규칙을 정의한다.
+
+이 문서는 ledger의 저장 위치, key, schema, 기록 시점, `fresh` 모드 suppression, invalidation 규칙의 SSOT다. DA reviewer/Arbiter prompt 본문, Arbiter 판정 기준, pending write queue 규칙은 각각 [`da-domains.md`](da-domains.md), [`arbiter-prompt.md`](arbiter-prompt.md), [`protocol.md`](protocol.md)가 정본이다.
+
+## 저장소 위치 결정
+
+| 후보 | 장점 | 단점 | 판정 |
+|------|------|------|------|
+| repo tracked 파일 | 세션/머신 간 공유 가능, 리뷰어가 근거를 볼 수 있음 | PR 노이즈와 merge conflict가 잦고, false positive 근거가 장기 박제되며, 변경셋별 stale 판단 비용이 큼 | 기본값 아님 |
+| ignored local ledger | 같은 worktree의 반복 `fresh` 세션에서 재사용 가능, PR diff를 더럽히지 않음, 네트워크/auth 불필요 | 다른 clone/runner에는 전파되지 않음, 로컬 cleanup 정책이 필요함 | 기본값 |
+| PR comment ledger | PR 타임라인에 이력이 남고 clone 간 공유 가능 | GitHub auth/network 의존, PR comment update 권한 필요, 외부 서비스 장애와 정보 노출 위험, 로컬 plan DA에는 부적합 | 기본값 아님 |
+
+기본 저장 위치는 repo-local ignored ledger다:
+
+```text
+.claude/da-ledger/<changeset-key>/<dismissal-key>.local.md
+```
+
+현재 repo root `.gitignore`는 `*.local.md`를 ignore하므로 위 파일명 suffix를 유지하면 ledger 파일은 tracked diff에 들어가지 않는다. 해당 ignore가 없는 clone에서는 ledger를 쓰기 전에 `.git/info/exclude` 같은 local-only ignore에 `.claude/da-ledger/` 또는 `*.local.md`를 추가한다. tracked 파일로 생성될 상황이면 ledger write를 생략하고 round summary의 NOTES에 남긴다.
+
+## 기록 대상
+
+ledger에 저장할 수 있는 항목은 아래뿐이다.
+
+- Arbiter가 `NOT_AN_ISSUE`로 판정했고, `confidence`가 `HIGH` 또는 `MEDIUM`이며, `stability_status`가 `N/A` 또는 `stable`이고, 기술적 반증 근거가 있는 항목.
+- 3회 반복 규칙 또는 사용자 판단 경로에서 사용자가 명시적으로 `제외 + 근거 기록`을 선택했고, 적용 범위와 기술적 근거가 있는 항목.
+
+저장하지 않는 항목:
+
+- `NEEDS_MORE_INFO` 자체. 사용자 판단이 필요한 상태를 자동 기각으로 저장하지 않는다.
+- LOW confidence `NOT_AN_ISSUE`가 fail-closed로 `NEEDS_MORE_INFO` 경로에 들어간 항목.
+- `split`, `fragmented`, `partial_failure`, `unknown` 상태.
+- "사용자 지시"만 있고 기술적 근거가 없는 제외.
+
+## Changeset key
+
+`changeset-key`는 frozen changeset이 바뀌면 달라져야 한다. 기본 구성:
+
+| 필드 | 내용 |
+|------|------|
+| `mode` | `for_plan` 또는 `for_pr` |
+| `base_commit` | `for_pr`: target branch와 `HEAD`의 merge-base. `for_plan`: 계획이 특정 diff/branch에 묶인 경우 그 base commit, 아니면 현재 `HEAD` |
+| `surface_hash` | frozen changeset 전체의 hash. `for_pr`는 `git diff main...HEAD`와 review surface에 포함된 dirty/untracked content의 canonical hash. `for_plan`은 계획 원문과 Step 1에서 수집한 관련 context pack의 canonical hash |
+| `target` | PR 번호/branch/계획 파일 경로처럼 사람이 scope를 식별할 수 있는 값 |
+
+`surface_hash`는 ledger match의 핵심이다. hash를 계산할 수 없으면 ledger suppression을 사용하지 않는다.
+
+## Dismissal key
+
+`dismissal-key`는 같은 changeset 안에서도 같은 지적만 suppress하도록 좁게 잡는다. 아래 필드가 모두 일치해야 match다.
+
+| 필드 | 내용 |
+|------|------|
+| `changeset_key` | 위 changeset key |
+| `review_unit` | `Correctness`/`Design`/`Regression`/`Maintainability` 또는 `MAX` 세부 도메인 |
+| `perspective` | `HALLUCINATION`, `SECURITY`, `YAGNI`, `SIDE_EFFECT`, `CONSISTENCY`, `READABILITY`, `NGMI`, `CLEAN_CODE` 등 |
+| `location_identity` | `path:line` 또는 `plan item` 기준 위치. 가능하면 symbol/heading anchor와 해당 위치의 content hash를 함께 기록하되, line이 불명확하게 이동하면 stale로 본다 |
+| `finding_fingerprint` | finding 요약을 정규화한 한 줄 요약의 hash. 같은 관점+위치라도 다른 failure mode면 match하지 않는다 |
+| `scope` | 기본 `same_changeset`. 사용자가 명시한 경우에만 `current_loop` 같은 좁은 확장 scope 허용 |
+
+동일성은 "같은 관점 + 같은 위치 + 같은 요약 fingerprint + 같은 changeset"이다. 관점과 위치만 같아도 요약 fingerprint가 다르면 새 finding으로 Arbiter에 보낸다.
+
+## Ledger schema
+
+ledger 파일은 사람이 읽을 수 있는 markdown에 아래 필드를 빠짐없이 기록한다. JSON/YAML front matter를 써도 되지만 실행 코드는 전제하지 않는다.
+
+```yaml
+schema_version: 1
+created_at: "2026-07-06T00:00:00Z"
+mode: for_pr
+round: R1
+changeset:
+  base_commit: "<sha>"
+  surface_hash: "<hash>"
+  target: "PR #123 or branch"
+review:
+  review_unit: Regression
+  perspective: SIDE_EFFECT
+finding:
+  location_identity: "modules/foo.nix:42"
+  location_anchor: "option homeserver.foo.enable"
+  finding_summary: "Changing the default enable path was claimed to break existing disabled installs."
+  finding_fingerprint: "<hash>"
+dismissal:
+  verdict: NOT_AN_ISSUE
+  source: arbiter
+  confidence: HIGH
+  stability_status: N/A
+  rationale: "The option default remains false and the changed branch is only reached when explicitly enabled."
+scope: same_changeset
+```
+
+사용자 제외 항목은 `dismissal.verdict: USER_EXCLUDED`, `dismissal.source: user`, `dismissal.user_decision: exclude_with_rationale`를 사용한다. `rationale`는 사용자가 승인한 기술적 근거를 적는다.
+
+## 기록 시점과 phase 정합
+
+ledger write는 active changeset을 수정하는 write phase 산출물이 아니다. local ignored review metadata다.
+
+1. Step 1 changeset freeze 직후 current changeset key를 계산하고, 같은 key의 valid ledger entry만 load한다.
+2. Step 2-5 review phase 중 reviewer/Arbiter는 active changeset을 바꾸지 않는다. ledger는 reviewer/Arbiter가 직접 쓰지 않는다.
+3. Step 5e 상태 전이와 사용자 전건 보고가 끝난 직후, `NOT_AN_ISSUE` 또는 사용자가 명시 제외한 eligible 항목을 메인 에이전트가 ledger에 기록한다.
+4. 이 기록은 pending write queue에 들어가지 않으며, Step 6 write phase batch 수정 범위나 generated output 범위에 포함하지 않는다.
+5. ledger write가 tracked diff를 만들거나 local-only ignore를 보장할 수 없으면 기록하지 않고 NOTES에 "ledger write skipped"를 남긴다.
+
+## `fresh` suppression 절차
+
+`fresh` 모드는 이전 round/session transcript를 DA reviewer에게 전달하지 않는다. ledger 사용 시에도 finding 본문, Arbiter reasoning, 이전 round 요약은 reviewer prompt에 넣지 않는다.
+
+절차:
+
+1. Step 1에서 valid ledger entries를 읽는다. `fresh`가 아니어도 읽을 수 있지만, suppression은 `fresh` 반복 세션에서만 사용한다.
+2. Step 2 reviewer prompt는 기존 `fresh` 규칙을 유지한다. 이전 발견, 수용/기각 내역, 이전 라운드를 암시하는 문구를 넣지 않는다.
+3. Step 3 reviewer 결과 수집 후 Arbiter 진입 전에 메인 에이전트가 각 finding의 dismissal key를 계산한다.
+4. valid ledger entry와 exact match하면 해당 finding을 `dismissed_suppressed`로 분류하고 Arbiter 입력 및 "new finding" 계산에서 제외한다.
+5. match하지 않으면 평소처럼 Arbiter로 보낸다. 같은 위치라도 fingerprint, perspective, review unit, changeset 중 하나라도 다르면 suppress하지 않는다.
+6. 사용자 보고와 round summary에는 `dismissed_suppressed` count와 key만 남긴다. finding 본문과 이전 reasoning은 재서술하지 않는다.
+
+프롬프트에 ledger 정보를 넣어야 하는 예외적 런타임에서는 key, scope, `dismissed: NOT_AN_ISSUE|USER_EXCLUDED` 결론만 넣는다. finding 본문, 원 Arbiter reasoning, 이전 round transcript는 넣지 않는다.
+
+## Invalidation
+
+아래 조건 중 하나라도 맞으면 ledger entry는 stale로 보고 무시한다. 자동 삭제는 필요하지 않다.
+
+- `base_commit` 또는 `surface_hash`가 current changeset과 다름.
+- 대상 파일/계획 항목의 `location_identity`가 사라졌거나 line/anchor가 현재 content와 단일하게 대응되지 않음.
+- `finding_fingerprint`가 현재 finding과 다름.
+- `review_unit` 또는 `perspective`가 다름.
+- `scope`가 현재 실행 범위를 포함하지 않음.
+- schema 필수 필드, 기술적 `rationale`, Arbiter confidence/stability 정보가 누락됨.
+- ledger 파일이 tracked 상태거나 tracked diff에 잡힘.
+- verdict가 `NEEDS_MORE_INFO`, `split`, `fragmented`, `partial_failure`, `unknown` 중 하나임.
+
+stale entry를 무시하면 기존 `fresh` 동작으로 돌아간다. ledger 디렉토리를 제거해도 suppression 없이 기존 `fresh` 리뷰가 실행되어야 한다.

--- a/modules/shared/programs/claude/files/skills/run-da/references/main-agent-obligations.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/main-agent-obligations.md
@@ -12,6 +12,7 @@
 | `wt`, `nrs`, rebuild 계열 실행 | main-agent-only command를 direct fan-out subagent에 넘기기 |
 | 질문 도구 호출 (SKIP/NEEDS_MORE_INFO) | "사용자 지시"로 DA 기각 |
 | Arbiter 결과 수신 및 보고 | 프롬프트 조향 |
+| ignored dismissal ledger read/write (메인 에이전트만) | ledger를 tracked diff로 만들기 |
 | 결과 파일 파싱 | — |
 
 ## 메인 에이전트 직접 수행 행동
@@ -21,11 +22,12 @@
 - Review Intensity 인라인 체크리스트: 직접 `/run-da` 호출 진입 시 메인 에이전트는 [`intensity-rules.md`](intensity-rules.md)의 모든 룰을 평가한 표를 plan/대화에 남기고(short-circuit 금지) first-match 룰 단계를 채택해 SKIP/LITE/FULL 판정을 결정한다. 문서화된 자동 호출자의 preflight handoff를 수신한 경우에는 freshness를 검증해 유효하면 재사용하고, 누락/형식 오류/stale이면 현재 입력으로 체크리스트를 다시 적용한다. 자유 추론 금지. fail-closed rule group 매치/불확실 또는 룰 ID+근거 미명시 시 강한 검토 fail-closed. 절차 SSOT는 [`intensity-procedure.md`](intensity-procedure.md).
 - Arbiter 독립 판정 보존: DA findings는 독립 Arbiter 에이전트가 판정한다. 메인 에이전트는 Arbiter 판정을 대체하지 않는다. 메인 에이전트는 CONFIRMED_ISSUE 항목의 수정만 담당한다.
 - CONFIRMED_ISSUE 자동 반영: Arbiter가 CONFIRMED_ISSUE로 판정한 항목은 자동으로 반영하되, review phase 중에는 patch/edit/apply_patch, write-mode formatter, generated output 변경을 금지한다. 항목은 pending write queue에 모아 write phase에서 batch로 반영한다. CRITICAL 심각도는 다음 outer round 진행을 차단하고 write phase 첫 항목으로 수정한다. 상태 전이별 행동의 정본은 [`protocol.md`](protocol.md)의 "DA → Arbiter → Main Agent 상태 흐름"이다.
+- Dismissal ledger 관리: `NOT_AN_ISSUE` 또는 사용자가 명시 제외한 eligible 항목만 [`dismissal-ledger.md`](dismissal-ledger.md)에 따라 local ignored ledger에 기록한다. `NEEDS_MORE_INFO`는 자동 기각으로 저장하지 않는다. `fresh` 반복 세션에서는 exact match 항목만 새 finding에서 제외한다.
 - 사용자 전건 보고: 모든 Arbiter 판정 결과(CONFIRMED_ISSUE, NOT_AN_ISSUE, NEEDS_MORE_INFO)를 사용자에게 보고한다. NEEDS_MORE_INFO·`split` 항목은 아래 "사용자 질문 시 맥락 설명 의무"의 5요소를 갖춘 질문 도구 호출로 처리한다.
 - Conservative wait: Codex 세션 경로에서 `wait_agent` timeout이나 단순 지연만으로 reviewer/Arbiter를 kill하지 않는다. explicit failure signal, documented violation, 최종 응답 파싱 실패가 없는 한 self-auditing으로 대체하지 않는다. (Review Intensity는 인라인 체크리스트라 wait 대상 아님.)
-- Fresh perspective 보장: 매 라운드마다 새 reviewer/Arbiter 실행 단위를 사용한다 (Codex 세션: 새 native subagent thread, codex exec 경로: 새 `codex exec` 프로세스). `fresh` modifier 사용 시 이전 라운드 맥락도 완전히 차단한다.
+- Fresh perspective 보장: 매 라운드마다 새 reviewer/Arbiter 실행 단위를 사용한다 (Codex 세션: 새 native subagent thread, codex exec 경로: 새 `codex exec` 프로세스). `fresh` modifier 사용 시 이전 라운드 맥락을 차단한다. dismissal ledger 예외도 이전 finding 본문/이전 reasoning/transcript는 주입하지 않고, 메인 에이전트의 exact match suppression에만 사용한다.
 - Selective propagation 기본값: Arbiter/후속 reviewer에게는 unique findings, conflicting findings, high-severity findings, user decision required findings만 전달한다. raw transcript 전체, CLEAR 결과, 중복 low-signal finding의 all-to-all broadcast는 금지한다. `MAX` modifier는 propagation이 아니라 fan-out만 확장한다.
-- 프롬프트 조향 금지: 후속 라운드 DA/Arbiter 프롬프트에 이전 라운드의 판정 결과를 포함하지 않는다. 이전 라운드 결과를 "이미 해결된 사안"으로 프레이밍하는 것도 금지한다.
+- 프롬프트 조향 금지: 후속 라운드 DA/Arbiter 프롬프트에 이전 라운드의 판정 결과를 포함하지 않는다. 이전 라운드 결과를 "이미 해결된 사안"으로 프레이밍하는 것도 금지한다. dismissal ledger를 주입해야 하는 예외적 런타임에서도 key, scope, `dismissed` 결론만 허용하고 finding 본문은 금지한다.
 
 ## 정책 / 계약 / 상태 흐름 (link only)
 
@@ -33,6 +35,7 @@
 
 - Single-writer / main-agent-only / 역할별 경계 / VIOLATION 처리 / Delegation fallback: [`hardening-contract.md`](hardening-contract.md) (`Codex 세션 하드닝 계약` SSOT).
 - PoC 의무화 / Arbiter 판정 프로토콜 / DA → Arbiter 상태 흐름 / read-write 분리 / 무한 루프 방지(3회 반복) / 탈출 조건(전 unit CLEAR) / PR 코멘트 형식: [`protocol.md`](protocol.md) (protocol SSOT).
+- Dismissal ledger key/schema/storage/invalidation: [`dismissal-ledger.md`](dismissal-ledger.md) SSOT.
 - Selective consistency trigger / vote-shape / threshold: [`stability-measurement.md`](stability-measurement.md) SSOT, 상태 전이는 [`protocol.md`](protocol.md), 실행 계약은 [`arbiter-scaling.md`](arbiter-scaling.md).
 
 ## 사용자 질문 시 맥락 설명 의무

--- a/modules/shared/programs/claude/files/skills/run-da/references/protocol.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/protocol.md
@@ -7,7 +7,7 @@ DA → Arbiter → Main Agent 상태 흐름, Arbiter 판정 프로토콜, 무한
 | DA 결과 | Arbiter 판정 | stability_status | 메인 에이전트 행동 | 사용자 보고 |
 |---------|-------------|------------------|-------------------|-----------|
 | finding 있음 | CONFIRMED_ISSUE | N/A / stable (+ low_confidence_warning=false) | pending write queue에 추가. write phase에서 일괄 수정 (CRITICAL은 다음 round 진행 차단) | 수정 필요 테이블 |
-| finding 있음 | NOT_AN_ISSUE | N/A / stable (+ low_confidence_warning=false) | 반영 불필요 | 무해 테이블 |
+| finding 있음 | NOT_AN_ISSUE | N/A / stable (+ low_confidence_warning=false) | 반영 불필요. eligible 항목은 dismissal ledger에 기록 | 무해 테이블 |
 | finding 있음 | NEEDS_MORE_INFO | N/A / stable | 사용자 판단 대기 | 질문 도구 |
 | finding 있음 | 임의 | N/A / stable + low_confidence_warning=true | fail-closed 승격 (질문 도구 호출) | 질문 도구 + LOW confidence 이력 |
 | finding 있음 | (majority verdict) | split | 사용자 판단 대기 (NEEDS_MORE_INFO 경로) | 질문 도구 + vote-shape |
@@ -37,7 +37,8 @@ stability_status 의미, selective consistency 트리거, `unknown` sentinel 정
 6. CONFIRMED_ISSUE + (stability_status=N/A 또는 stable) 항목을 pending write queue에 추가한다. CRITICAL은 진행 차단 항목으로 표시하되 review phase 중 즉시 patch하지 않는다.
 7. NEEDS_MORE_INFO 또는 stability_status=split 항목은 사용자 판단을 요청한다. 사용자가 수용한 항목만 pending write queue에 추가한다.
 8. stability_status=fragmented 항목은 BLOCKED 상태로 기록하고 자동 수정하지 않는다 (아래 섹션 참조).
-9. Arbiter 상태 전이와 필요한 사용자 판단이 끝난 뒤 write phase로 넘어가 pending write queue를 batch로 반영한다.
+9. NOT_AN_ISSUE 또는 사용자가 명시적으로 제외한 eligible 항목은 [`dismissal-ledger.md`](dismissal-ledger.md)에 따라 local ignored dismissal ledger에 기록한다. 이 기록은 active changeset 수정이나 pending write queue가 아니다.
+10. Arbiter 상태 전이와 필요한 사용자 판단이 끝난 뒤 write phase로 넘어가 pending write queue를 batch로 반영한다.
 
 ### 라운드 read/write 분리
 
@@ -46,6 +47,7 @@ stability_status 의미, selective consistency 트리거, `unknown` sentinel 정
 - changeset 동결: outer round 시작 시 검토 표면을 고정한다. for_plan은 계획 원문과 관련 파일/맥락, for_pr은 `git diff main...HEAD`와 현재 workspace 상태가 frozen changeset이다.
 - review phase 범위: reviewer 실행, reviewer 결과 수집, Arbiter 실행, selective consistency N=3, vote-shape 집계, 전건 보고, 질문 도구 판단 수집까지다.
 - review phase 중 patch 금지: 이 구간에는 active changeset을 바꾸는 patch/edit/apply_patch, write-mode formatter, codegen/regeneration으로 생기는 generated output 변경, lockfile 재생성, commit/push를 금지한다. check-only formatter나 diff-only generator처럼 파일 변경이 없으면 허용한다. delegated reviewer/Arbiter의 read-only/no-write 경계는 [`hardening-contract.md`](hardening-contract.md)가 정본이다.
+- dismissal ledger 기록: Arbiter 상태 전이와 사용자 전건 보고가 끝난 직후 메인 에이전트가 쓰는 local ignored review metadata다. write phase 산출물이 아니며 pending write queue에 넣지 않는다. ledger write가 tracked diff를 만들면 기록하지 않고 NOTES에 남긴다. 세부 규칙은 [`dismissal-ledger.md`](dismissal-ledger.md)가 정본이다.
 - 일괄 수정: CONFIRMED_ISSUE와 사용자가 수용한 NEEDS_MORE_INFO/`split` 항목은 pending write queue에 모아 write phase에서 메인 에이전트가 batch로 반영한다. 정상 confirmed finding 반영을 막는 규칙이 아니라 반영 시점을 라운드 밖으로 옮기는 규칙이다.
 - CRITICAL 기본값: CRITICAL finding만 즉시 중단/수정하는 예외는 기본 절차에 두지 않는다. CRITICAL은 다음 outer round 진입을 차단하고, 현재 round의 Arbiter 판정이 닫힌 뒤 write phase 첫 batch 항목으로 반영한다.
 - 새 changeset: write phase 후 다음 outer round를 시작하면 "새 changeset" 리뷰로 명시한다. 이전 round의 frozen changeset과 write phase batch delta를 round summary에 기록해 추세 기반 조기 중단의 신규 confirmed finding 계산 기준을 분리한다.
@@ -98,7 +100,7 @@ Threshold 숫자는 이 문서에서 재서술하지 않는다. `STABLE_MIN`/`ES
 - Arbiter 입력: reviewer 원문 전체가 아니라, 위 규칙으로 추린 escalated finding set만 전달한다.
 - 후속 reviewer 입력: 다음 라운드에서도 raw transcript 전체를 브로드캐스트하지 않는다.
   열려 있는 finding 중 해당 bundle에 실질적으로 관련된 항목만 전달한다.
-- `fresh` modifier: selective propagation조차 끊는다. 이전 라운드 맥락을 전달하지 않는다.
+- `fresh` modifier: selective propagation조차 끊는다. 이전 라운드 맥락을 전달하지 않는다. 단, current changeset에 valid dismissal ledger가 있으면 메인 에이전트가 reviewer 결과 수집 후 Arbiter 입력 전 exact match suppression을 수행할 수 있다. 이때도 reviewer prompt에는 이전 finding 본문/이전 reasoning/transcript를 전달하지 않는다.
 - `MAX` modifier: reviewer fan-out만 exhaustive로 확장할 뿐, propagation 기본값은 여전히 selective다.
 
 ## 합리화 방지 (Rationalization Prevention)
@@ -155,6 +157,7 @@ write phase에서 Arbiter가 CONFIRMED_ISSUE로 판정한 항목을 수정할 �
    - 수용: 지적대로 수정한다.
    - 제외 + 근거 기록: 기술적 근거를 CIR로 남기고 현재 루프에서 제외한다.
    - 보류: 별도 이슈로 등록하고 현재 루프에서 제외한다.
+3. 사용자가 "제외 + 근거 기록"을 선택하면 dismissal ledger에 `USER_EXCLUDED`로 기록할 수 있다. 단 `NEEDS_MORE_INFO`를 자동 기각으로 저장하지 말고, 사용자의 명시 결정과 기술적 근거, 적용 scope가 있을 때만 기록한다.
 
 Selective consistency 서브런 카운팅: selective consistency의 N=3 재판정은 동일 outer round 내부의 서브런이다. 3회 반복 규칙과 최대 라운드 카운트에 포함하지 않는다. 즉, outer round 1에서 N=3 재판정을 수행해도 outer round 카운트는 1에 머문다.
 
@@ -173,6 +176,7 @@ Selective consistency 서브런 카운팅: selective consistency의 N=3 재판�
 Round N 요약: DA 발견 X건 → Arbiter: CONFIRMED Y건(신규 Y'건 — 직전 라운드에 없던 관점+위치), NOT_AN_ISSUE Z건, NEEDS_MORE_INFO W건
 bundle별: Correctness 2건(SECURITY 1, HALLUCINATION 1), Regression CLEAR, ...
 changeset: frozen=<계획 원문/commit range/diff 기준>, write_phase=<수정 파일/계획 항목/diffstat/generated output 유무>, next=<R(N+1) 새 changeset 여부>
+dismissal_ledger: recorded=<NOT_AN_ISSUE/USER_EXCLUDED 기록 수>, suppressed=<fresh exact match로 새 finding에서 제외한 수>, stale_ignored=<stale ledger로 무시한 수>
 ```
 
 selective consistency가 발동한 라운드는 추가 라인으로 stability_status 분포를 명시한다:


### PR DESCRIPTION
## Summary

- \`references/dismissal-ledger.md\` 신설 — 세션을 넘는 동일 false positive 재제기를 막는 local ledger 규칙의 SSOT (저장 위치·key·schema·기록 시점·suppression·invalidation)
- \`fresh\` 모드의 anti-anchoring은 유지: reviewer prompt에는 아무것도 주입하지 않고, Step 3 결과 수집 후 Arbiter 진입 전에 메인 에이전트가 exact match만 suppress

Closes #904

## 기존 문제/배경

\`fresh\` 모드는 독립 검토를 강화하지만 세션을 넘는 기각 이력이 없어, 이미 기각된 지적이 다음 fresh 세션에서 다시 올라올 수 있었다. 사용자가 수동 blocklist를 반복 제공하는 방식은 지속 불가능했다.

## CIR (Change Intent Record)

- epic #903의 마지막 child. #911·#907·#905가 머지된 구조 위에서 설계 — ledger 기록은 #905의 write phase 산출물이 아니라 Step 5e 이후의 local ignored review metadata로 정의해 phase 정합을 유지했다.
- 저장 위치는 supervisor 지정 기본안(ignored local ledger)을 채택: \`.claude/da-ledger/<changeset-key>/<dismissal-key>.local.md\` — 기존 \`.gitignore\`의 \`*.local.md\` 규칙(PR #981) 재사용을 실측 확인(\`git check-ignore -v\`). repo tracked는 PR 노이즈·충돌, PR comment는 GitHub/auth 의존이라 기본값에서 제외 (3안 트레이드오프 표를 문서에 박제).
- 기록 화이트리스트가 좁다: NOT_AN_ISSUE(HIGH/MEDIUM confidence + stable + 기술 반증) 또는 사용자 명시 제외만. NEEDS_MORE_INFO 자동 기각 저장 금지(이슈 Boundaries).
- fail-safe 다층: surface_hash 계산 불가 시 suppression 미사용, tracked diff 위험 시 write 생략, stale 조건 8종 중 하나면 무시 → ledger 부재/제거 시 기존 fresh 동작 그대로.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| ignored local ledger | fresh 반복 세션 재사용, PR diff 오염 없음, 무의존 | clone 간 비공유 | ✅ |
| repo tracked 파일 | 공유·리뷰 가능 | PR 노이즈, merge conflict, stale 박제 | ❌ |
| PR comment ledger | 타임라인 이력 | GitHub/auth/network 의존, plan DA 부적합 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`references/dismissal-ledger.md\` (신규, SSOT) | 위치 결정 표, changeset/dismissal key, YAML schema 예시, 기록 시점 5규칙, fresh suppression 6절차, invalidation 8조건 |
| \`SKILL.md\` | fresh 절 예외 명시(주입 허용 정보 = key·scope·결론뿐), lazy-load 표 조건부 행, 의무 9번 |
| \`modes/for_plan.md\`·\`for_pr.md\` | freeze 직후 load·Step 3 후 suppression 시점 연결 |
| \`references/protocol.md\` | NOT_AN_ISSUE 처리에 eligible 기록, round summary에 \`dismissal_ledger: recorded/suppressed/stale_ignored\` 카운트 |
| \`references/main-agent-obligations.md\` | 사용자 "제외+근거 기록" 경로의 USER_EXCLUDED 기록 규칙 |

## 참고 레퍼런스

- epic #903, 이슈 #904 · PR #997(#905 read/write 분리 — phase 정합 전제), PR #981(#943 — \`*.local.md\` gitignore)

## Human Test Plan

1. \`rg -n "dismiss|ledger|fresh" modules/shared/programs/claude/files/skills/run-da\` → 저장/주입/무효화 규칙 명시 확인.
2. \`git check-ignore -v .claude/da-ledger/example.local.md\` → \`.gitignore:*.local.md\` 매치.
3. 같은 changeset에서 1차 세션 기각 후 2차 \`fresh\` 세션 → ledger exact match 항목이 새 finding으로 재제기되지 않고 round summary에 \`suppressed\` 카운트로 보고된다.
4. \`.claude/da-ledger/\` 삭제 후 재실행 → 기존 fresh 동작(suppression 없음)으로 복귀.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP