### PR TITLE
fix(ai): verify-ai-compat host-state 검사의 git worktree 오탐 해소

### DIFF
--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -11,6 +11,12 @@ TARGET_SKILLS_DIR="$REPO_ROOT/.agents/skills"
 SHARED_SKILLS_DIR="$REPO_ROOT/modules/shared/programs/claude/files/skills"
 CODEX_GLOBAL_SKILLS_DIR="$HOME/.codex/skills"
 CLAUDE_GLOBAL_SKILLS_DIR="$HOME/.claude/skills"
+REPO_ROOT_REAL="$(readlink -f "$REPO_ROOT" 2>/dev/null || printf '%s' "$REPO_ROOT")"
+GIT_COMMON_DIR="$(git -C "$REPO_ROOT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+MAIN_REPO_ROOT=""
+if [ -n "$GIT_COMMON_DIR" ]; then
+  MAIN_REPO_ROOT="$(cd "$GIT_COMMON_DIR/.." 2>/dev/null && pwd -P || true)"
+fi
 
 # shellcheck source=/dev/null
 . "$REPO_ROOT/modules/shared/scripts/lib/rebuild/codex-legacy-hooks.sh"
@@ -84,6 +90,48 @@ in_list() {
   for item in "$@"; do
     [ "$item" = "$needle" ] && return 0
   done
+  return 1
+}
+
+resolved_target_matches_repo_suffix() {
+  local resolved="$1"
+  local expected="$2"
+  local expected_suffix="$3"
+
+  [ -n "$resolved" ] || return 1
+  [ -n "$expected" ] || return 1
+
+  if [ "$resolved" = "$expected" ]; then
+    return 0
+  fi
+
+  case "$resolved" in
+    */"$expected_suffix") ;;
+    *) return 1 ;;
+  esac
+
+  case "$resolved" in
+    /nix/store/*/"$expected_suffix")
+      return 0
+      ;;
+  esac
+
+  if [ -n "$MAIN_REPO_ROOT" ]; then
+    case "$resolved" in
+      "$MAIN_REPO_ROOT/$expected_suffix"|"$MAIN_REPO_ROOT/.claude/worktrees/"*/"$expected_suffix")
+        return 0
+        ;;
+    esac
+  fi
+
+  if [ -n "$REPO_ROOT_REAL" ]; then
+    case "$resolved" in
+      "$REPO_ROOT_REAL/$expected_suffix")
+        return 0
+        ;;
+    esac
+  fi
+
   return 1
 }
 
@@ -605,8 +653,9 @@ else
       # Canonical target 검증: readlink -f 결과가 shared source에 도달해야 함
       resolved="$(readlink -f "$exposed_path" 2>/dev/null || true)"
       expected_real="$(readlink -f "$skill_dir" 2>/dev/null || true)"
-      if [ -z "$resolved" ] || [ "$resolved" != "$expected_real" ]; then
-        fail "노출 대상 불일치: $skill_name (actual=$resolved expected=$expected_real)"
+      expected_suffix="modules/shared/programs/claude/files/skills/$skill_name"
+      if ! resolved_target_matches_repo_suffix "$resolved" "$expected_real" "$expected_suffix"; then
+        fail "노출 대상 불일치: $skill_name (actual=$resolved expected=$expected_real expected_suffix=*/$expected_suffix)"
         continue
       fi
       pass "shared 노출 정상: $skill_name"
@@ -676,8 +725,9 @@ verify_codex_helper() {
   local resolved expected
   resolved="$(readlink -f "$helper_path" 2>/dev/null || true)"
   expected="$(readlink -f "$helper_source" 2>/dev/null || true)"
-  if [ -z "$resolved" ] || [ "$resolved" != "$expected" ]; then
-    fail "$helper_path 대상 불일치: actual=$resolved expected=$expected"
+  local expected_suffix="modules/shared/programs/claude/files/scripts/$helper"
+  if ! resolved_target_matches_repo_suffix "$resolved" "$expected" "$expected_suffix"; then
+    fail "$helper_path 대상 불일치: actual=$resolved expected=$expected expected_suffix=*/$expected_suffix"
   else
     pass "Codex helper 정상: $helper"
   fi
@@ -697,8 +747,9 @@ verify_claude_helper() {
   local resolved expected
   resolved="$(readlink -f "$helper_path" 2>/dev/null || true)"
   expected="$(readlink -f "$helper_source" 2>/dev/null || true)"
-  if [ -z "$resolved" ] || [ "$resolved" != "$expected" ]; then
-    fail "$helper_path 대상 불일치: actual=$resolved expected=$expected"
+  local expected_suffix="modules/shared/programs/claude/files/scripts/$helper"
+  if ! resolved_target_matches_repo_suffix "$resolved" "$expected" "$expected_suffix"; then
+    fail "$helper_path 대상 불일치: actual=$resolved expected=$expected expected_suffix=*/$expected_suffix"
   else
     pass "Claude helper 정상: $helper"
   fi


### PR DESCRIPTION
## Summary

- git worktree에서 \`verify-ai-compat.sh\` 실행 시 발생하던 "노출/대상 불일치" 오탐 11건 해소 — expected를 현재 REPO_ROOT 완전일치로만 보던 검사를 \`저장소-상대 suffix 일치 + 허용 prefix 가드\`로 확장
- 검증력 보존: suffix가 다르면(잘못된 파일을 가리킴) 기존대로 FAIL, 허용 밖 prefix(외부 저장소의 동일 suffix)도 FAIL

Closes #993

## 기존 문제/배경

\`$HOME\` 심링크가 main repo(또는 nix store 체인)를 가리키는 것이 정상인데, 검사의 expected가 현재 REPO_ROOT(워크트리) 기준이라 워크트리 실행이 항상 실패했다. 이 오탐이 executor STOP을 유발했고 plans/010에 예외 문구가 필요했으며, 한 executor가 이를 "고치려" nrs를 실행해 심링크 오염 사고(#996)로 이어졌다.

## CIR (Change Intent Record)

- epic #1000의 1번 작업. 설계 3안 중 supervisor 지정 (c) 변형 채택: 완전일치 우선 → suffix 비교 → prefix 가드. (a) SKIP은 검증력 손실, (b) main-기준 expected는 nrs-relink로 워크트리를 가리키는 정상 상태를 오탐.
- prefix 가드 4종: main repo(git-common-dir 부모), \`main/.claude/worktrees/*\`, \`/nix/store/*\`, 현재 REPO_ROOT realpath — "전혀 다른 저장소의 같은 상대 경로" 통과를 차단.
- 적용 범위 한정: 오탐이 실측된 host-state 3개 검사만. repo-local \`.agents/skills\` 상대 심링크 검사는 워크트리 오탐이 없어 불변.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| suffix 비교 + prefix 가드 | 모든 정상 상태 수용, 검증력 보존 | 판정 함수 1개 추가 | ✅ |
| worktree 감지 시 SKIP | 단순 | 워크트리에서 게이트 무력화 | ❌ |
| expected를 main 기준으로 | main 검증력 유지 | relink된 워크트리 상태 오탐 | ❌ |

## 구현 상세

\`scripts/ai/verify-ai-compat.sh\` 1개 파일 — \`resolved_target_matches_repo_suffix()\` 신설 + 3개 검사 호출 전환, 실패 메시지에 expected_suffix 병기.

## 참고 레퍼런스

- epic #1000, 이슈 #993 · 사고 체인: #996 · 오탐 실측 기록: plans/010 (2026-07-06)

## Human Test Plan

1. 아무 워크트리에서 \`bash scripts/ai/verify-ai-compat.sh\` → 대상 불일치 0건, exit 0.
2. main repo에서 동일 실행 → 기존과 동일 exit 0.
3. 음성: \`~/.claude/skills/<이름>\`을 다른 상대 경로로 임시 변경 후 실행 → FAIL 재현 (실험 후 원복).
4. \`--run-fixture-tests\` → exit 0, pre-commit \`ai-skills-consistency\` 통과.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP