### PR TITLE
fix(nrs): 비대화형(에이전트) 컨텍스트의 worktree relink 가드

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Environment 섹션의 `Platform` 값으로 현재 환경을 판별한다.
 
 ## 빌드
 
-`nrs`를 사용. `darwin-rebuild`/`nixos-rebuild` 직접 실행 금지. `nrs`는 preview를 포함하며, macOS에서는 launchd 정리와 Hammerspoon 재시작도 처리한다. 워크트리에서 `nrs` 완료 시 `$HOME` 아래 out-of-store symlink의 워크트리 relink을 시도한다 (`nrs-relink`, non-fatal). main repo에서 `nrs` 실행 시 nix store 체인으로 복원을 시도한다.
+`nrs`를 사용. `darwin-rebuild`/`nixos-rebuild` 직접 실행 금지. `nrs`는 preview를 포함하며, macOS에서는 launchd 정리와 Hammerspoon 재시작도 처리한다. 워크트리에서 `nrs` 완료 시 `$HOME` 아래 out-of-store symlink의 워크트리 relink을 시도한다 (`nrs-relink`, non-fatal). 비TTY/에이전트 컨텍스트에서는 이 worktree relink만 스킵하며, 필요 시 `NRS_ALLOW_WORKTREE_RELINK=1`로 opt-in한다. main repo에서 `nrs` 실행 시 nix store 체인으로 복원을 시도한다.
 
 home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이 외부 프로세스의 atomic rename으로 일반 파일이 되면 `home-manager.backupCommand`가 자가 치유한다 (regular file은 unlink + 콘솔 한 줄 echo, directory는 timestamped backup). 사이드이펙트로, symlink가 깨진 시간 동안 사용자가 home 쪽에서 의도 변경한 내용도 silent 손실될 수 있다 (예: VSCode UI에서 keybinding 추가 후 settings.json이 깨진 상태에서 한 후속 변경). 정상 symlink 흐름에서는 source 직접 수정 = git 추적이 정상 동작한다. 본 정책은 사용자 명시 동의 범위 내. 정책 본체는 `modules/darwin/home.nix`.
 

--- a/modules/shared/scripts/lib/rebuild/relink.sh
+++ b/modules/shared/scripts/lib/rebuild/relink.sh
@@ -25,6 +25,14 @@ rebuild_is_main_flake() {
     [[ "$FLAKE_PATH" == "$MAIN_FLAKE_PATH" ]]
 }
 
+_nrs_should_skip_worktree_relink() {
+    [[ "${NRS_ALLOW_WORKTREE_RELINK:-}" == "1" ]] && return 1
+    [[ ! -t 0 ]] && return 0
+    [[ "${CODEX_PROGRAMMATIC:-}" == "1" ]] && return 0
+    [[ "${CLAUDECODE:-}" == "1" ]] && return 0
+    return 1
+}
+
 prepare_worktree_symlinks_for_rebuild() {
     log_info "🔗 Removing worktree symlinks before rebuild..."
     _remove_worktree_symlinks "$FLAKE_PATH/" "worktree" || true
@@ -38,6 +46,19 @@ prepare_worktree_symlinks_for_rebuild() {
 #───────────────────────────────────────────────────────────────────────────────
 maybe_relink_or_restore() {
     if ! rebuild_is_main_flake; then
+        # === Change Intent Record ===
+        # v6 (#996): 비대화형/에이전트 worktree nrs에서 post-switch relink가
+        #    $HOME의 OOS 심링크를 리뷰 전 worktree로 전환해 host 활성본과 tracked file을
+        #    교차 오염시키는 사고가 실측됨(2026-07-06).
+        #    채택: stdin 비TTY 또는 기존 에이전트 신호(CODEX_PROGRAMMATIC/CLAUDECODE)면
+        #    relink만 skip하고 nrs 흐름은 계속 진행. 명시 opt-in
+        #    NRS_ALLOW_WORKTREE_RELINK=1은 기존 동작을 유지한다.
+        #    trade-off: 파이프/자동화에서 의도적 worktree relink가 필요하면 env opt-in이
+        #              필요하지만, 대화형 TTY 사용자의 기존 워크플로는 변경하지 않는다.
+        if _nrs_should_skip_worktree_relink; then
+            log_info "🔗 Skipping worktree relink in non-interactive/agent context (set NRS_ALLOW_WORKTREE_RELINK=1 to allow)."
+            return 0
+        fi
         log_info "🔗 Relinking symlinks to worktree..."
         "$HOME/.local/bin/nrs-relink" relink || log_warn "⚠️  nrs-relink failed (non-fatal)"
     else

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -27,6 +27,9 @@ run_test "wt wrapper ignores runtime HOME for real script" test_wt_wrapper_ignor
 run_test "managed plugin skill helper rejects duplicate matches" test_managed_plugin_skill_link_requires_single_match
 run_test "rebuild-common exports public API" test_rebuild_common_exports_public_api
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
+run_test "worktree relink skips non-TTY without opt-in" test_worktree_relink_skips_non_tty_without_opt_in
+run_test "worktree relink opt-in allows non-TTY" test_worktree_relink_opt_in_allows_non_tty
+run_test "main relink restore ignores non-TTY guard" test_main_relink_restore_ignores_non_tty_guard
 run_test "wt cd returns target path by name" test_wt_cd_by_name_returns_target_path
 run_test "wt ls lists deployed worktrees" test_wt_ls_from_deployed_layout_lists_worktrees
 run_test "wt ls --json outputs parseable array" test_wt_ls_json_outputs_parseable_array

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -132,6 +132,18 @@ install_platform_nrs_entrypoint() {
     *) fail "unknown platform for nrs entrypoint: $platform" ;;
   esac
 }
+
+install_recording_nrs_relink() {
+  local home_dir="$1"
+  mkdir -p "$home_dir/.local/bin"
+  cat > "$home_dir/.local/bin/nrs-relink" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${NRS_RELINK_LOG:?}"
+EOF
+  chmod +x "$home_dir/.local/bin/nrs-relink"
+}
+
 test_rebuild_common_exports_public_api() {
   local sandbox output
   sandbox=$(new_sandbox)
@@ -226,6 +238,104 @@ test_detect_worktree_uses_current_worktree_path() {
   assert_contains "$output" "flake=$worktree_root"
   assert_contains "$output" "is_main=false"
 }
+
+test_worktree_relink_skips_non_tty_without_opt_in() {
+  local sandbox home_dir repo_root worktree_root output relink_log
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  relink_log="$sandbox/nrs-relink.log"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  worktree_root="$repo_root/.claude/worktrees/feature_one"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_recording_nrs_relink "$home_dir"
+
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    NRS_RELINK_LOG="$relink_log" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$worktree_root"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      maybe_relink_or_restore
+    ' </dev/null 2>&1
+  )
+
+  assert_contains "$output" "Skipping worktree relink in non-interactive/agent context"
+  assert_not_contains "$output" "Relinking symlinks to worktree"
+  [[ ! -s "$relink_log" ]] || fail "expected non-TTY worktree relink to skip nrs-relink"
+}
+
+test_worktree_relink_opt_in_allows_non_tty() {
+  local sandbox home_dir repo_root worktree_root output relink_log
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  relink_log="$sandbox/nrs-relink.log"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  worktree_root="$repo_root/.claude/worktrees/feature_one"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_recording_nrs_relink "$home_dir"
+
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    NRS_RELINK_LOG="$relink_log" \
+    NRS_ALLOW_WORKTREE_RELINK=1 \
+    bash -c '
+      set -euo pipefail
+      cd "'"$worktree_root"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      maybe_relink_or_restore
+    ' </dev/null 2>&1
+  )
+
+  assert_contains "$output" "Relinking symlinks to worktree"
+  assert_not_contains "$output" "Skipping worktree relink"
+  assert_file_contains "$relink_log" "relink"
+}
+
+test_main_relink_restore_ignores_non_tty_guard() {
+  local sandbox home_dir repo_root worktree_root output relink_log
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  relink_log="$sandbox/nrs-relink.log"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  worktree_root="$repo_root/.claude/worktrees/feature_one"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_recording_nrs_relink "$home_dir"
+
+  mkdir -p "$home_dir/.claude" "$worktree_root"
+  ln -sf "$worktree_root/CLAUDE.md" "$home_dir/.claude/CLAUDE.md"
+
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    NRS_RELINK_LOG="$relink_log" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$home_dir/.local/lib/rebuild-common.sh"'"
+      maybe_relink_or_restore
+    ' </dev/null 2>&1
+  )
+
+  assert_contains "$output" "Restoring symlinks to nix store chain"
+  assert_not_contains "$output" "Skipping worktree relink"
+  assert_file_contains "$relink_log" "restore"
+}
+
 test_nixos_nrs_offline_force_smoke() {
   local sandbox home_dir repo_root stub_dir output result_target
   sandbox=$(new_sandbox)


### PR DESCRIPTION
## Summary

- 워크트리 \`nrs\`의 post-switch relink에 비대화형/에이전트 컨텍스트 가드 추가 — 감지 시 relink만 스킵하고 nrs 흐름은 정상 진행
- \`NRS_ALLOW_WORKTREE_RELINK=1\` opt-in으로 기존 동작 허용. 대화형(TTY) 사용자 워크플로는 무변경

Closes #996

## 기존 문제/배경

2026-07-06 실측 사고: codex executor가 워크트리에서 nrs를 실행 → relink가 \`$HOME\` OOS 심링크 50개를 리뷰 전 워크트리로 전환 → 미리뷰 스킬 문서가 호스트 활성본이 되고, 사용자의 \`/model\` 설정 저장이 다른 워크트리 tracked 파일에 기록되는 교차 오염 발생. 프롬프트 규율(nrs 금지 명시)로 임시 완화했으나 구조적 가드가 아니었다.

## CIR (Change Intent Record)

- epic #1000의 2번 작업. 가드 위치는 relink의 유일한 진입 분기(\`maybe_relink_or_restore()\` worktree 경로) — main 분기의 restore는 오염 "복원"이므로 가드 대상에서 제외.
- 감지 신호는 3종으로 제한: stdin 비TTY(기본 방어선 — 에이전트 Bash tool은 전부 비TTY), \`CODEX_PROGRAMMATIC=1\`(이번 사고의 실측 신호), \`CLAUDECODE=1\`(기존 hook guard 관례). 광범위한 \`CLAUDE_CODE_*\` 변수는 오탐 위험으로 제외.
- 파일 내 CIR 관례(v1~v5)에 v6으로 사고·채택·트레이드오프를 기록.

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 비TTY+에이전트 신호 가드 + env opt-in | 대화형 무변경, 자동화는 명시 opt-in | 파이프 기반 의도적 relink에 env 필요 | ✅ |
| 프롬프트 규율만 유지 | 코드 변경 없음 | 규율은 가드가 아님 — 재발 가능 | ❌ |
| worktree relink 기능 제거 | 오염 원천 차단 | 대화형 워크플로(워크트리 개발 즉시 반영) 파괴 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`modules/shared/scripts/lib/rebuild/relink.sh\` | \`_nrs_should_skip_worktree_relink()\` + worktree 분기 가드 + CIR v6 |
| \`tests/suites/rebuild-nrs.sh\` | 비TTY 스킵 / opt-in 허용 / main restore 무영향 3케이스 |
| \`tests/shell-script-tests.sh\` | 등록 3라인 |
| \`CLAUDE.md\` | 빌드 절에 가드 동작 1줄 |

## 참고 레퍼런스

- epic #1000, 이슈 #996 · 사고 트리거: #993 (게이트 오탐 — PR #1001로 해소)

## Human Test Plan

1. \`nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh\` → 신규 3케이스 포함 통과.
2. 실환경: 워크트리에서 에이전트가 nrs 실행 → "Skipping worktree relink in non-interactive/agent context" 로그 + \`~/.claude/skills/*\` 대상 불변.
3. 같은 명령에 \`NRS_ALLOW_WORKTREE_RELINK=1\` → 기존 relink 수행.
4. 대화형 터미널에서 워크트리 nrs → 기존과 동일하게 relink.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP