### PR TITLE
feat(nixos): bubblewrap 설치로 codex sandbox tier 활성화 + 문서 실측

### DIFF
--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -76,6 +76,7 @@
     git
     curl
     nvd
+    bubblewrap # Codex CLI Linux sandbox (read-only/workspace-write)
   ];
 
   # Zsh 활성화

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -159,6 +159,9 @@ error: the argument '--base <BRANCH>' cannot be used with '--uncommitted'
 
 ## 표준 실행 절차
 
+NixOS에서 `-s read-only` / `-s workspace-write`를 구조적으로 강제하려면 `bubblewrap`이
+PATH에 있어야 한다. bwrap 의존성, 임시 우회, tier별 실측은 [known-issues.md §16](references/known-issues.md#16-nixos-bwrap-의존)을 참조한다.
+
 ### 일반 exec
 
 프롬프트를 파일로 작성하고, stdin 파이프로 전달하며, `-o`로 결과를 저장한다:

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -543,3 +543,46 @@ Retired historical context (#634): `tests/test-codex-hook-fixtures.sh`의 기존
 실증 (Mac codex 0.128): `read_prompt_from_stdin(StdinPromptBehavior::OptionalAppend)` source line + npm wrapper spawn 시 detach 부재 직접 검증. 외부 보고 4종(gstack #1034/#1045, codex_sdk, oh-my-codex #1449)이 stdin EOF fix path를 일관되게 제시.
 
 발견 세션: PR #588 Phase 4 머지 후 retry hang (issue #593, 2026-04-29 발생).
+
+### 16. NixOS bwrap 의존
+
+심각도: 높음 — Linux `read-only` / `workspace-write` sandbox의 구조적 강제 전제
+
+증상:
+
+NixOS에서 system `bwrap`이 PATH에 없으면 `codex exec -s read-only` / `-s workspace-write`가
+bubblewrap 의존 경로를 밟는다. 보고된 즉시 panic 문구:
+
+```
+bubblewrap is unavailable: no system bwrap was found on PATH
+```
+
+재확인: 2026-07-06, codex-cli 0.142.5, 현재 MiniPC PATH에 system `bwrap` 없음.
+이 환경에서는 위 panic 대신 다음 warning 후 bundled bubblewrap fallback으로 진행됨을 확인했다:
+
+```
+warning: Codex could not find bubblewrap on PATH. Install bubblewrap with your OS package manager. See the sandbox prerequisites: https://developers.openai.com/codex/concepts/sandboxing#prerequisites. Codex will use the bundled bubblewrap in the meantime.
+```
+
+해결: NixOS 공통 시스템 패키지에 `bubblewrap`을 설치한다. 배포 전 임시 실측은 아래처럼
+`nix shell`로 PATH에 bwrap을 주입해 수행한다:
+
+```bash
+nix shell nixpkgs#bubblewrap --command env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "짧은 sandbox smoke test"
+```
+
+배포 전 실측 매트릭스 (2026-07-06, codex-cli 0.142.5, `nixpkgs#bubblewrap` = 0.11.2):
+
+| tier | 읽기 (`modules/nixos/configuration.nix`) | 워크트리 쓰기 | 워크트리 밖 `/tmp` 쓰기 | 네트워크 (`curl -I --max-time 5 https://example.com`) | stderr sandbox 표기 |
+|------|------|------|------|------|------|
+| `read-only` | OK | BLOCKED | BLOCKED | BLOCKED | `sandbox: read-only` |
+| `workspace-write` | OK | OK | OK | BLOCKED | `sandbox: workspace-write [workdir, /tmp, $TMPDIR]` |
+| `danger-full-access` | OK | OK | OK | OK | `sandbox: danger-full-access` |
+| config 기본값 (`-s` 생략) | OK | OK | OK | OK | `sandbox: danger-full-access` |
+
+주의:
+- `workspace-write`는 이름과 달리 `/tmp`와 `$TMPDIR`도 writable root로 열었다. 일반 `$HOME` 경로
+  쓰기 차단은 이 세션의 "워크트리 밖 쓰기 시도는 `/tmp` 또는 워크트리 내부만 사용" 제한 때문에
+  직접 시도하지 않았다.
+- `read-only` / `workspace-write`에서는 네트워크가 차단되었고, `danger-full-access` 및 config 기본값에서는 허용되었다.
+- `~/.codex/config.toml`의 `sandbox_mode = "danger-full-access"` 기본값은 이 이슈에서 변경하지 않는다.


### PR DESCRIPTION
## Summary

- NixOS 시스템 패키지에 \`bubblewrap\` 추가 — codex CLI의 \`read-only\`/\`workspace-write\` sandbox tier를 구조적으로 사용 가능하게 함
- \`using-codex-exec\` known-issues §16 신설: bwrap 의존 증상·해결·\`nix shell\` 임시 우회·**3-tier 실측 매트릭스** (2026-07-06, codex-cli 0.142.5 + bubblewrap 0.11.2)

Closes #995

## 기존 문제/배경

2026-07-06 plans 배치에서 \`-s workspace-write\`로 dispatch한 executor 5개 전원이 bwrap 관련 오류로 STOPPED — 이 호스트의 모든 codex 실행이 config 기본값 \`danger-full-access\` 하나로 강제되고 있었다. run-da hardening-contract가 요구하는 reviewer read-only sandbox도 이 전제가 없으면 이 호스트에서 무의미했다.

## CIR (Change Intent Record)

- epic #1000의 3번 작업. 실측 반전을 정직하게 기록: 아침 배치에서는 "bubblewrap is unavailable" 즉시 panic이 보고됐으나, 같은 날 재확인에서는 bundled bubblewrap fallback warning 후 진행됐다 — §16에 두 관찰을 분리 기록했다. 어느 경로든 시스템 bwrap 설치가 공식 해법(upstream prerequisites)이다.
- 배포 전 실측은 \`nix shell nixpkgs#bubblewrap\` PATH 주입으로 수행 — nrs 없이 tier 매트릭스 확정.
- 주목할 실측: \`workspace-write\`는 workdir 외에 \`/tmp\`·\`$TMPDIR\`도 writable root로 연다 (stderr 표기 그대로 기록). read-only/workspace-write 모두 네트워크 차단.
- \`~/.codex/config.toml\`의 \`sandbox_mode\` 기본값 변경과 run-da hardening-contract 갱신은 범위 밖 (epic 후속 판정).

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 시스템 패키지 설치 + 문서 실측 | 구조적 격리 가능, upstream 공식 경로 | 패키지 1개 추가 | ✅ |
| bundled fallback 신뢰 | 변경 없음 | 재확인에서만 관찰된 경로, 아침 배치에서는 실패 — 신뢰 불가 | ❌ |
| devShell에만 추가 | 시스템 오염 없음 | nrs·cron 등 devShell 밖 실행 경로 미커버 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`modules/nixos/configuration.nix\` | systemPackages에 bubblewrap 1줄 (+용도 주석) |
| \`using-codex-exec/references/known-issues.md\` | §16 신설 (증상 2종·해결·우회·매트릭스) |
| \`using-codex-exec/SKILL.md\` | 표준 실행 절차에 NixOS 캐비앗 2줄 |

## 참고 레퍼런스

- epic #1000, 이슈 #995 · 실측 기원: 2026-07-06 plans 배치 (executor 5개 STOPPED)

## Human Test Plan

1. 머지 후 \`nrs\` → \`which bwrap\` → \`/run/current-system/sw/bin/bwrap\`.
2. \`env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "pwd 출력"\` → 패닉/warning 없이 완료, stderr에 \`sandbox: workspace-write\` 표기.
3. \`-s read-only\`로 파일 쓰기 시도 → 차단.
4. \`bash tests/run-eval-tests.sh\` + \`nix flake check --no-build --all-systems\` → 통과.

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bubblewrap` to the default NixOS package set.
  * Expanded guidance for running Codex exec on NixOS with sandboxed modes.
* **Documentation**
  * Added notes about required system setup for read-only and workspace-write execution.
  * Documented a known NixOS issue, including a workaround and a quick verification command.
  * Added a summary table showing expected sandbox, network, and write access behavior across modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->