### PR TITLE
test(ai): verify-ai-compat host-state 검증부 lib 추출 + fixture 테스트

### DIFF
--- a/scripts/ai/lib/host-state-checks.sh
+++ b/scripts/ai/lib/host-state-checks.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# scripts/ai/lib/host-state-checks.sh
+#
+# verify-ai-compat.sh의 host-state 검사 함수 모음.
+# source한 caller가 REPO_ROOT, REPO_ROOT_REAL, MAIN_REPO_ROOT, HOME, pass/fail 전역을 제공한다.
+
+# shellcheck disable=SC2154
+
+resolved_target_matches_repo_suffix() {
+  local resolved="$1"
+  local expected="$2"
+  local expected_suffix="$3"
+
+  [ -n "$resolved" ] || return 1
+  [ -n "$expected" ] || return 1
+
+  if [ "$resolved" = "$expected" ]; then
+    return 0
+  fi
+
+  case "$resolved" in
+    */"$expected_suffix") ;;
+    *) return 1 ;;
+  esac
+
+  case "$resolved" in
+    /nix/store/*/"$expected_suffix")
+      return 0
+      ;;
+  esac
+
+  if [ -n "$MAIN_REPO_ROOT" ]; then
+    case "$resolved" in
+      "$MAIN_REPO_ROOT/$expected_suffix"|"$MAIN_REPO_ROOT/.claude/worktrees/"*/"$expected_suffix")
+        return 0
+        ;;
+    esac
+  fi
+
+  if [ -n "$REPO_ROOT_REAL" ]; then
+    case "$resolved" in
+      "$REPO_ROOT_REAL/$expected_suffix")
+        return 0
+        ;;
+    esac
+  fi
+
+  return 1
+}
+
+_check_hook_executable() {
+  local relpath="$1" abspath="$HOME/$1" hook_name
+  hook_name="$(basename "$relpath")"
+  local expected_suffix="modules/shared/programs/codex/files/hooks/$hook_name"
+  if [ ! -e "$abspath" ]; then
+    fail "hook 사본 없음: $abspath"
+    return
+  fi
+  if [ ! -x "$abspath" ]; then
+    fail "hook 실행 권한 없음: $abspath"
+    return
+  fi
+  local resolved
+  resolved="$(readlink -f "$abspath" 2>/dev/null || true)"
+  if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+    fail "hook 사본 readlink 실패 또는 target 부재: $relpath (resolved=$resolved)"
+    return
+  fi
+  case "$resolved" in
+    */"$expected_suffix")
+      pass "hook 사본 OK: $relpath"
+      ;;
+    *)
+      fail "hook 사본 대상 path suffix 불일치: $relpath (resolved=$resolved expected_suffix=*/$expected_suffix)"
+      ;;
+  esac
+}
+
+_check_executable_symlink_suffix() {
+  local relpath="$1" expected_suffix="$2"
+  local abspath="$HOME/$relpath"
+  if [ ! -e "$abspath" ]; then
+    fail "프로비저닝 실행 파일 없음: $abspath"
+    return
+  fi
+  if [ ! -x "$abspath" ]; then
+    fail "프로비저닝 실행 권한 없음: $abspath"
+    return
+  fi
+  local resolved
+  resolved="$(readlink -f "$abspath" 2>/dev/null || true)"
+  if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
+    fail "프로비저닝 실행 파일 readlink 실패 또는 target 부재: $relpath (resolved=$resolved)"
+    return
+  fi
+  case "$resolved" in
+    */"$expected_suffix")
+      pass "프로비저닝 실행 파일 OK: $relpath"
+      ;;
+    *)
+      fail "프로비저닝 실행 파일 target suffix 불일치: $relpath (resolved=$resolved expected_suffix=*/$expected_suffix)"
+      ;;
+  esac
+}
+
+verify_used_by_oracle() {
+  local _lib_path="$1"
+  local _lib_label="$2"
+  local _lib_basename _lib_basename_re
+  _lib_basename=$(basename "$_lib_path")
+  _lib_basename_re=${_lib_basename//./\\.}
+  if [ ! -f "$_lib_path" ]; then
+    fail "USED-BY oracle: lib 파일 없음 ($_lib_label) — $_lib_path"
+    return
+  fi
+
+  # 헤더에서 USED-BY 블록 파싱. `^#[[:space:]]+` 로 시작하는 모든 indented 주석 라인을 후보로
+  # 처리하고, 라인 형식이 정확히 `<path>.sh   # via $VAR_NAME` 인지 strict 검증한다.
+  # 위반은 `BAD\t<line>` sentinel 로 emit 하여 shell loop 가 명시 fail. 정상은 `OK\t<path>\t<var>`.
+  # 빈 주석 (`^#$`) 또는 비-주석 라인 (`!/^#/`) 에서만 블록 종료.
+  #
+  # strict 형식 (고정 위치):
+  #   - arr[1] = path (`.sh` 로 끝나는 형태)
+  #   - arr[2] = `#` (구분자)
+  #   - arr[3] = `via` (literal)
+  #   - arr[4] = `$VAR_NAME` ($ prefix + `[A-Z_][A-Z0-9_]*` 형태)
+  #   - arr[5+] = 선택적 trailing 주석/설명 (검증 안 함)
+  local _used_by_entries
+  _used_by_entries=$(awk '
+    /^# USED-BY:/ { in_block=1; next }
+    in_block {
+      if (/^#$/ || !/^#/) {
+        in_block=0
+        next
+      }
+      if (/^#[[:space:]]+/) {
+        line = $0
+        sub(/^#[[:space:]]+/, "", line)
+        if (line == "") next
+        n = split(line, arr, /[[:space:]]+/)
+        if (n < 4) {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        path = arr[1]
+        if (path !~ "^[a-zA-Z][a-zA-Z0-9_./-]+\\.sh$") {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        if (arr[2] != "#" || arr[3] != "via") {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        var_raw = arr[4]
+        if (var_raw !~ "^\\$[A-Z_][A-Z0-9_]*$") {
+          printf "BAD\t%s\n", $0
+          next
+        }
+        var = var_raw
+        sub(/^\$/, "", var)
+        printf "OK\t%s\t%s\n", path, var
+      }
+    }
+  ' "$_lib_path")
+
+  if [ -z "$_used_by_entries" ]; then
+    fail "USED-BY oracle: lib 헤더에 USED-BY 블록 없음 ($_lib_label)"
+    return
+  fi
+
+  local _ok=1
+  local _count=0
+  # Forward check: 선언된 각 use-site 가 실제 source 패턴을 가지는지 확인.
+  # Declared list: backward check 시 비교용. newline-delimited 정규화된 path 를 모아 두고
+  # grep -Fxq 로 set membership 검사. `declare -A` (Bash 4+) 회피하여 macOS /bin/bash 3.2 호환.
+  local _declared_list=""
+  while IFS=$'\t' read -r _tag _arg1 _arg2; do
+    [ -n "$_tag" ] || continue
+    if [ "$_tag" = "BAD" ]; then
+      fail "USED-BY oracle: $_lib_label 헤더의 USED-BY 라인 형식 위반 ($_arg1) — \`<path>.sh   # via \$VAR_NAME\` 형식 필요"
+      _ok=0
+      continue
+    fi
+    local _use_site="$_arg1" _expected_var="$_arg2"
+    [ -n "$_use_site" ] || continue
+    _count=$((_count + 1))
+    _declared_list="${_declared_list}${_use_site}"$'\n'
+    local _use_full_path
+    case "$_use_site" in
+      claude/*|codex/*)
+        _use_full_path="$REPO_ROOT/modules/shared/programs/$_use_site"
+        ;;
+      *)
+        _use_full_path="$REPO_ROOT/$_use_site"
+        ;;
+    esac
+    if [ ! -f "$_use_full_path" ]; then
+      fail "USED-BY oracle: 선언된 use-site 미존재 ($_lib_label → $_use_site)"
+      _ok=0
+      continue
+    fi
+    # 주석 라인 제외 (특히 `# shellcheck source=`).
+    local _non_comment
+    _non_comment=$(grep -vE '^[[:space:]]*#' "$_use_full_path")
+
+    # 단일 매칭 규칙: expected_var (use-site source local 변수) 의 할당 RHS 가 lib_basename 포함
+    # + 동일 var 의 source 호출. hook_load_lib helper 호출은 변수 할당 RHS 의 일부이므로 같은 매칭 적용.
+    if printf '%s\n' "$_non_comment" | grep -qE "^[[:space:]]*${_expected_var}=.*${_lib_basename_re}" \
+      && printf '%s\n' "$_non_comment" | grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$${_expected_var}\""; then
+      continue
+    fi
+    fail "USED-BY oracle: $_lib_label → $_use_site 에서 실제 source 패턴 미발견 (\$${_expected_var} 변수 할당 RHS 에 ${_lib_basename} 포함 + 동일 var source 필요)"
+    _ok=0
+  done <<< "$_used_by_entries"
+
+  # Backward check: repo 내에서 lib_basename 을 변수 할당 RHS 로 사용 + 동일 var source 호출이
+  # 있는 .sh 파일을 후보로 수집한 뒤, _declared_list 에 없는 후보는 fail.
+  # 이는 `실제 source 하지만 USED-BY 헤더에 미선언` 인 drift 를 잡는다 (양방향 검증).
+  # 검색 범위: modules/shared/programs/ + scripts/. 자기 자신 lib path 는 제외.
+  local _candidate _candidate_rel _candidate_abs_rel
+  while IFS= read -r _candidate; do
+    [ -n "$_candidate" ] || continue
+    # 자기 자신 (lib 정의 파일) 제외.
+    [ "$_candidate" = "$_lib_path" ] && continue
+    # lib 자체 디렉토리 내 다른 lib 파일은 제외 (예: hook-runtime 검증 시 pinning-patterns 본문 매치).
+    case "$_candidate" in
+      */modules/shared/programs/claude/files/lib/*) continue ;;
+      */modules/shared/programs/codex/files/lib/*) continue ;;
+    esac
+    # 변수 할당 + source 호출 패턴 둘 다 있어야 진짜 후보.
+    if grep -qE "^[[:space:]]*[A-Z_]+_LIB=.*${_lib_basename_re}" "$_candidate" \
+      && grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$[A-Z_]+_LIB\"" "$_candidate"; then
+      _candidate_abs_rel="${_candidate#"$REPO_ROOT"/}"
+      _candidate_rel="${_candidate_abs_rel#modules/shared/programs/}"
+      if ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_rel" \
+        && ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_abs_rel"; then
+        fail "USED-BY oracle: $_lib_label backward check 실패 — $_candidate_rel 가 lib 을 source 하지만 USED-BY 헤더에 미선언"
+        _ok=0
+      fi
+    fi
+  done < <(grep -rlE "${_lib_basename_re}" \
+    --include='*.sh' \
+    "$REPO_ROOT/modules/shared/programs/" "$REPO_ROOT/scripts/" 2>/dev/null)
+
+  if [ "$_ok" = "1" ]; then
+    pass "USED-BY oracle 통과: $_lib_label ($_count use-site, backward check OK)"
+  fi
+}

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -93,47 +93,9 @@ in_list() {
   return 1
 }
 
-resolved_target_matches_repo_suffix() {
-  local resolved="$1"
-  local expected="$2"
-  local expected_suffix="$3"
+# shellcheck disable=SC1091  # source file은 repo 내부 고정 경로
+. "$REPO_ROOT/scripts/ai/lib/host-state-checks.sh"
 
-  [ -n "$resolved" ] || return 1
-  [ -n "$expected" ] || return 1
-
-  if [ "$resolved" = "$expected" ]; then
-    return 0
-  fi
-
-  case "$resolved" in
-    */"$expected_suffix") ;;
-    *) return 1 ;;
-  esac
-
-  case "$resolved" in
-    /nix/store/*/"$expected_suffix")
-      return 0
-      ;;
-  esac
-
-  if [ -n "$MAIN_REPO_ROOT" ]; then
-    case "$resolved" in
-      "$MAIN_REPO_ROOT/$expected_suffix"|"$MAIN_REPO_ROOT/.claude/worktrees/"*/"$expected_suffix")
-        return 0
-        ;;
-    esac
-  fi
-
-  if [ -n "$REPO_ROOT_REAL" ]; then
-    case "$resolved" in
-      "$REPO_ROOT_REAL/$expected_suffix")
-        return 0
-        ;;
-    esac
-  fi
-
-  return 1
-}
 
 RUN_GUARDRAIL_FIXTURES=0
 case "${1:-}" in
@@ -955,34 +917,6 @@ fi
 # 두지만 verifier는 worktree REPO_ROOT에서 실행되므로 두 경로가 다를 수 있다. 따라서 path suffix
 # 매칭(.../modules/shared/programs/codex/files/hooks/<name>)과 readlink target 실재만 검사하여
 # main checkout / worktree 양쪽에서 false fail이 나지 않도록 한다.
-_check_hook_executable() {
-  local relpath="$1" abspath="$HOME/$1" hook_name
-  hook_name="$(basename "$relpath")"
-  local expected_suffix="modules/shared/programs/codex/files/hooks/$hook_name"
-  if [ ! -e "$abspath" ]; then
-    fail "hook 사본 없음: $abspath"
-    return
-  fi
-  if [ ! -x "$abspath" ]; then
-    fail "hook 실행 권한 없음: $abspath"
-    return
-  fi
-  local resolved
-  resolved="$(readlink -f "$abspath" 2>/dev/null || true)"
-  if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
-    fail "hook 사본 readlink 실패 또는 target 부재: $relpath (resolved=$resolved)"
-    return
-  fi
-  case "$resolved" in
-    */"$expected_suffix")
-      pass "hook 사본 OK: $relpath"
-      ;;
-    *)
-      fail "hook 사본 대상 path suffix 불일치: $relpath (resolved=$resolved expected_suffix=*/$expected_suffix)"
-      ;;
-  esac
-}
-
 _check_hook_executable ".codex/hooks/record-prompt-submit.sh"
 _check_hook_executable ".codex/hooks/_stop-dispatcher.sh"
 for _sub in "${EXPECTED_DISPATCHER_SUB_SCRIPTS[@]}"; do
@@ -990,33 +924,6 @@ for _sub in "${EXPECTED_DISPATCHER_SUB_SCRIPTS[@]}"; do
 done
 _check_hook_executable ".codex/hooks/pinning-alert.sh"
 _check_hook_executable ".codex/hooks/pinning-guard.sh"
-
-_check_executable_symlink_suffix() {
-  local relpath="$1" expected_suffix="$2"
-  local abspath="$HOME/$relpath"
-  if [ ! -e "$abspath" ]; then
-    fail "프로비저닝 실행 파일 없음: $abspath"
-    return
-  fi
-  if [ ! -x "$abspath" ]; then
-    fail "프로비저닝 실행 권한 없음: $abspath"
-    return
-  fi
-  local resolved
-  resolved="$(readlink -f "$abspath" 2>/dev/null || true)"
-  if [ -z "$resolved" ] || [ ! -f "$resolved" ]; then
-    fail "프로비저닝 실행 파일 readlink 실패 또는 target 부재: $relpath (resolved=$resolved)"
-    return
-  fi
-  case "$resolved" in
-    */"$expected_suffix")
-      pass "프로비저닝 실행 파일 OK: $relpath"
-      ;;
-    *)
-      fail "프로비저닝 실행 파일 target suffix 불일치: $relpath (resolved=$resolved expected_suffix=*/$expected_suffix)"
-      ;;
-  esac
-}
 
 _check_executable_symlink_suffix ".claude/hooks/pinning-guard.sh" \
   "modules/shared/programs/claude/files/hooks/pinning-guard.sh"
@@ -1107,150 +1014,6 @@ done
 # 매칭 조건: 같은 파일에 `<expected_var>=...<lib_basename>...` 변수 할당 + `. "$<expected_var>"`
 # 또는 `source "$<expected_var>"` 호출. helper 호출도 변수 할당 RHS 의 일부이므로 같은 매칭이 적용된다.
 # `# shellcheck source=` 주석 라인은 oracle 대상에서 제외 (실제 source 호출이 아니므로).
-verify_used_by_oracle() {
-  local _lib_path="$1"
-  local _lib_label="$2"
-  local _lib_basename _lib_basename_re
-  _lib_basename=$(basename "$_lib_path")
-  _lib_basename_re=${_lib_basename//./\\.}
-  if [ ! -f "$_lib_path" ]; then
-    fail "USED-BY oracle: lib 파일 없음 ($_lib_label) — $_lib_path"
-    return
-  fi
-
-  # 헤더에서 USED-BY 블록 파싱. `^#[[:space:]]+` 로 시작하는 모든 indented 주석 라인을 후보로
-  # 처리하고, 라인 형식이 정확히 `<path>.sh   # via $VAR_NAME` 인지 strict 검증한다.
-  # 위반은 `BAD\t<line>` sentinel 로 emit 하여 shell loop 가 명시 fail. 정상은 `OK\t<path>\t<var>`.
-  # 빈 주석 (`^#$`) 또는 비-주석 라인 (`!/^#/`) 에서만 블록 종료.
-  #
-  # strict 형식 (고정 위치):
-  #   - arr[1] = path (`.sh` 로 끝나는 형태)
-  #   - arr[2] = `#` (구분자)
-  #   - arr[3] = `via` (literal)
-  #   - arr[4] = `$VAR_NAME` ($ prefix + `[A-Z_][A-Z0-9_]*` 형태)
-  #   - arr[5+] = 선택적 trailing 주석/설명 (검증 안 함)
-  local _used_by_entries
-  _used_by_entries=$(awk '
-    /^# USED-BY:/ { in_block=1; next }
-    in_block {
-      if (/^#$/ || !/^#/) {
-        in_block=0
-        next
-      }
-      if (/^#[[:space:]]+/) {
-        line = $0
-        sub(/^#[[:space:]]+/, "", line)
-        if (line == "") next
-        n = split(line, arr, /[[:space:]]+/)
-        if (n < 4) {
-          printf "BAD\t%s\n", $0
-          next
-        }
-        path = arr[1]
-        if (path !~ "^[a-zA-Z][a-zA-Z0-9_./-]+\\.sh$") {
-          printf "BAD\t%s\n", $0
-          next
-        }
-        if (arr[2] != "#" || arr[3] != "via") {
-          printf "BAD\t%s\n", $0
-          next
-        }
-        var_raw = arr[4]
-        if (var_raw !~ "^\\$[A-Z_][A-Z0-9_]*$") {
-          printf "BAD\t%s\n", $0
-          next
-        }
-        var = var_raw
-        sub(/^\$/, "", var)
-        printf "OK\t%s\t%s\n", path, var
-      }
-    }
-  ' "$_lib_path")
-
-  if [ -z "$_used_by_entries" ]; then
-    fail "USED-BY oracle: lib 헤더에 USED-BY 블록 없음 ($_lib_label)"
-    return
-  fi
-
-  local _ok=1
-  local _count=0
-  # Forward check: 선언된 각 use-site 가 실제 source 패턴을 가지는지 확인.
-  # Declared list: backward check 시 비교용. newline-delimited 정규화된 path 를 모아 두고
-  # grep -Fxq 로 set membership 검사. `declare -A` (Bash 4+) 회피하여 macOS /bin/bash 3.2 호환.
-  local _declared_list=""
-  while IFS=$'\t' read -r _tag _arg1 _arg2; do
-    [ -n "$_tag" ] || continue
-    if [ "$_tag" = "BAD" ]; then
-      fail "USED-BY oracle: $_lib_label 헤더의 USED-BY 라인 형식 위반 ($_arg1) — \`<path>.sh   # via \$VAR_NAME\` 형식 필요"
-      _ok=0
-      continue
-    fi
-    local _use_site="$_arg1" _expected_var="$_arg2"
-    [ -n "$_use_site" ] || continue
-    _count=$((_count + 1))
-    _declared_list="${_declared_list}${_use_site}"$'\n'
-    local _use_full_path
-    case "$_use_site" in
-      claude/*|codex/*)
-        _use_full_path="$REPO_ROOT/modules/shared/programs/$_use_site"
-        ;;
-      *)
-        _use_full_path="$REPO_ROOT/$_use_site"
-        ;;
-    esac
-    if [ ! -f "$_use_full_path" ]; then
-      fail "USED-BY oracle: 선언된 use-site 미존재 ($_lib_label → $_use_site)"
-      _ok=0
-      continue
-    fi
-    # 주석 라인 제외 (특히 `# shellcheck source=`).
-    local _non_comment
-    _non_comment=$(grep -vE '^[[:space:]]*#' "$_use_full_path")
-
-    # 단일 매칭 규칙: expected_var (use-site source local 변수) 의 할당 RHS 가 lib_basename 포함
-    # + 동일 var 의 source 호출. hook_load_lib helper 호출은 변수 할당 RHS 의 일부이므로 같은 매칭 적용.
-    if printf '%s\n' "$_non_comment" | grep -qE "^[[:space:]]*${_expected_var}=.*${_lib_basename_re}" \
-      && printf '%s\n' "$_non_comment" | grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$${_expected_var}\""; then
-      continue
-    fi
-    fail "USED-BY oracle: $_lib_label → $_use_site 에서 실제 source 패턴 미발견 (\$${_expected_var} 변수 할당 RHS 에 ${_lib_basename} 포함 + 동일 var source 필요)"
-    _ok=0
-  done <<< "$_used_by_entries"
-
-  # Backward check: repo 내에서 lib_basename 을 변수 할당 RHS 로 사용 + 동일 var source 호출이
-  # 있는 .sh 파일을 후보로 수집한 뒤, _declared_list 에 없는 후보는 fail.
-  # 이는 `실제 source 하지만 USED-BY 헤더에 미선언` 인 drift 를 잡는다 (양방향 검증).
-  # 검색 범위: modules/shared/programs/ + scripts/. 자기 자신 lib path 는 제외.
-  local _candidate _candidate_rel _candidate_abs_rel
-  while IFS= read -r _candidate; do
-    [ -n "$_candidate" ] || continue
-    # 자기 자신 (lib 정의 파일) 제외.
-    [ "$_candidate" = "$_lib_path" ] && continue
-    # lib 자체 디렉토리 내 다른 lib 파일은 제외 (예: hook-runtime 검증 시 pinning-patterns 본문 매치).
-    case "$_candidate" in
-      */modules/shared/programs/claude/files/lib/*) continue ;;
-      */modules/shared/programs/codex/files/lib/*) continue ;;
-    esac
-    # 변수 할당 + source 호출 패턴 둘 다 있어야 진짜 후보.
-    if grep -qE "^[[:space:]]*[A-Z_]+_LIB=.*${_lib_basename_re}" "$_candidate" \
-      && grep -qE "(\.[[:space:]]+|source[[:space:]]+)\"\\\$[A-Z_]+_LIB\"" "$_candidate"; then
-      _candidate_abs_rel="${_candidate#"$REPO_ROOT"/}"
-      _candidate_rel="${_candidate_abs_rel#modules/shared/programs/}"
-      if ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_rel" \
-        && ! printf '%s' "$_declared_list" | grep -Fxq "$_candidate_abs_rel"; then
-        fail "USED-BY oracle: $_lib_label backward check 실패 — $_candidate_rel 가 lib 을 source 하지만 USED-BY 헤더에 미선언"
-        _ok=0
-      fi
-    fi
-  done < <(grep -rlE "${_lib_basename_re}" \
-    --include='*.sh' \
-    "$REPO_ROOT/modules/shared/programs/" "$REPO_ROOT/scripts/" 2>/dev/null)
-
-  if [ "$_ok" = "1" ]; then
-    pass "USED-BY oracle 통과: $_lib_label ($_count use-site, backward check OK)"
-  fi
-}
-
 verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/pinning-patterns.sh" "pinning-patterns.sh"
 verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/session-state.sh" "session-state.sh"
 verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" "hook-runtime.sh"

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -116,6 +116,10 @@ run_test "extract_oos_entries filesystem input" test_extract_oos_entries_filesys
 run_test "extract_oos_entries git show input" test_extract_oos_entries_git_show_input
 run_test "extract_oos_entries empty and absent exit zero" test_extract_oos_entries_empty_and_absent_exit_zero
 run_test "verify-ai-compat Codex artifact contract static" test_verify_ai_compat_codex_artifact_contract_static
+run_test "verify-ai-compat host-state positive fixture" test_verify_ai_compat_host_state_positive_fixture
+run_test "verify-ai-compat host-state detects non-executable hook" test_verify_ai_compat_host_state_detects_non_executable_hook
+run_test "verify-ai-compat host-state detects bad symlink targets" test_verify_ai_compat_host_state_detects_bad_symlink_targets
+run_test "verify-ai-compat host-state detects removed oracle reference" test_verify_ai_compat_host_state_detects_removed_oracle_reference
 run_test "stale filter supports clean symlinked user hooks" test_user_hooks_stale_filter_supports_clean_symlink_target
 run_test "stale filter detects symlinked stale user hooks" test_user_hooks_stale_filter_detects_symlink_target_stale_entries
 run_test "stale filter ignores stale path mentions" test_user_hooks_stale_filter_ignores_stale_path_mentions

--- a/tests/suites/verify-ai-compat.sh
+++ b/tests/suites/verify-ai-compat.sh
@@ -1,0 +1,196 @@
+# tests/suites/verify-ai-compat.sh — verify-ai-compat host-state lib fixture tests
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC1091: repo-local lib source.
+# shellcheck disable=SC2154,SC1091
+
+source "$REPO_ROOT/scripts/ai/lib/host-state-checks.sh"
+
+_verify_ai_compat_write_script() {
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' '#!/usr/bin/env bash' ':' > "$path"
+}
+
+_verify_ai_compat_make_oracle_fixture() {
+  local repo_root="$1"
+  local source_state="$2"
+  local lib_path="$repo_root/modules/shared/programs/claude/files/lib/demo-lib.sh"
+  local hook_path="$repo_root/modules/shared/programs/claude/files/hooks/demo-hook.sh"
+
+  mkdir -p "$(dirname "$lib_path")" "$(dirname "$hook_path")" "$repo_root/scripts"
+  cat > "$lib_path" <<'EOF'
+#!/usr/bin/env bash
+# demo lib
+# USED-BY:
+# claude/files/hooks/demo-hook.sh   # via $DEMO_LIB
+#
+demo_lib_function() { :; }
+EOF
+
+  if [[ "$source_state" == "present" ]]; then
+    cat > "$hook_path" <<'EOF'
+#!/usr/bin/env bash
+DEMO_LIB="${DEMO_LIB:-demo-lib.sh}"
+. "$DEMO_LIB"
+EOF
+  else
+    cat > "$hook_path" <<'EOF'
+#!/usr/bin/env bash
+DEMO_LIB="${DEMO_LIB:-demo-lib.sh}"
+:
+EOF
+  fi
+}
+
+_verify_ai_compat_make_positive_fixture() {
+  local sandbox="$1"
+  local home_dir="$sandbox/home"
+  local repo_root="$sandbox/repo"
+  local codex_hook="$repo_root/modules/shared/programs/codex/files/hooks/pinning-guard.sh"
+  local claude_hook="$repo_root/modules/shared/programs/claude/files/hooks/pinning-guard.sh"
+
+  _verify_ai_compat_write_script "$codex_hook"
+  _verify_ai_compat_write_script "$claude_hook"
+  chmod +x "$codex_hook" "$claude_hook"
+  mkdir -p "$home_dir/.codex/hooks" "$home_dir/.claude/hooks"
+  ln -s "$codex_hook" "$home_dir/.codex/hooks/pinning-guard.sh"
+  ln -s "$claude_hook" "$home_dir/.claude/hooks/pinning-guard.sh"
+  _verify_ai_compat_make_oracle_fixture "$repo_root" present
+}
+
+_verify_ai_compat_with_stubbed_gate() (
+  set -euo pipefail
+  local home_dir="$1"
+  local repo_root="$2"
+  shift 2
+
+  mkdir -p "$home_dir" "$repo_root"
+  HOME="$home_dir"
+  REPO_ROOT="$repo_root"
+  REPO_ROOT_REAL="$(cd "$repo_root" && pwd -P)"
+  MAIN_REPO_ROOT="$REPO_ROOT_REAL"
+  errors=0
+  pass_count=0
+
+  pass() {
+    pass_count=$((pass_count + 1))
+    printf 'PASS\t%s\n' "$1"
+  }
+
+  fail() {
+    errors=$((errors + 1))
+    printf 'FAIL\t%s\n' "$1"
+  }
+
+  "$@"
+  printf 'ERRORS\t%s\n' "$errors"
+  printf 'PASSES\t%s\n' "$pass_count"
+)
+
+_verify_ai_compat_assert_error_count() {
+  local output="$1"
+  local expected="$2"
+  local marker
+  marker="$(printf 'ERRORS\t%s' "$expected")"
+  assert_contains "$output" "$marker"
+}
+
+_verify_ai_compat_positive_checks() {
+  local expected_suffix="modules/shared/programs/claude/files/hooks/pinning-guard.sh"
+  local expected="$REPO_ROOT_REAL/$expected_suffix"
+
+  _check_hook_executable ".codex/hooks/pinning-guard.sh"
+  _check_executable_symlink_suffix ".claude/hooks/pinning-guard.sh" "$expected_suffix"
+  if resolved_target_matches_repo_suffix "$expected" "$expected" "$expected_suffix"; then
+    pass "resolved target accepts expected repo suffix"
+  else
+    fail "resolved target rejected expected repo suffix"
+  fi
+  verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/demo-lib.sh" "demo-lib.sh"
+}
+
+test_verify_ai_compat_host_state_positive_fixture() {
+  local sandbox home_dir repo_root output
+  sandbox="$(new_sandbox)"
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  _verify_ai_compat_make_positive_fixture "$sandbox"
+
+  output="$(_verify_ai_compat_with_stubbed_gate "$home_dir" "$repo_root" _verify_ai_compat_positive_checks)"
+  _verify_ai_compat_assert_error_count "$output" 0
+  assert_contains "$output" "hook 사본 OK: .codex/hooks/pinning-guard.sh"
+  assert_contains "$output" "프로비저닝 실행 파일 OK: .claude/hooks/pinning-guard.sh"
+  assert_contains "$output" "USED-BY oracle 통과: demo-lib.sh"
+}
+
+_verify_ai_compat_non_executable_hook_check() {
+  _check_hook_executable ".codex/hooks/pinning-guard.sh"
+}
+
+test_verify_ai_compat_host_state_detects_non_executable_hook() {
+  local sandbox home_dir repo_root hook_path output
+  sandbox="$(new_sandbox)"
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  hook_path="$repo_root/modules/shared/programs/codex/files/hooks/pinning-guard.sh"
+  _verify_ai_compat_write_script "$hook_path"
+  chmod 0644 "$hook_path"
+  mkdir -p "$home_dir/.codex/hooks"
+  ln -s "$hook_path" "$home_dir/.codex/hooks/pinning-guard.sh"
+
+  output="$(_verify_ai_compat_with_stubbed_gate "$home_dir" "$repo_root" _verify_ai_compat_non_executable_hook_check)"
+  _verify_ai_compat_assert_error_count "$output" 1
+  assert_contains "$output" "hook 실행 권한 없음"
+}
+
+_verify_ai_compat_bad_symlink_checks() {
+  local expected_suffix="modules/shared/programs/claude/files/hooks/pinning-guard.sh"
+  local expected="$REPO_ROOT_REAL/$expected_suffix"
+  local foreign="$REPO_ROOT_REAL/../foreign/$expected_suffix"
+
+  _check_executable_symlink_suffix ".claude/hooks/pinning-guard.sh" "$expected_suffix"
+  _check_executable_symlink_suffix ".claude/hooks/broken.sh" "$expected_suffix"
+
+  if resolved_target_matches_repo_suffix "$foreign" "$expected" "$expected_suffix"; then
+    fail "resolved target accepted foreign prefix"
+  else
+    pass "resolved target rejects foreign prefix"
+  fi
+}
+
+test_verify_ai_compat_host_state_detects_bad_symlink_targets() {
+  local sandbox home_dir repo_root wrong_target output
+  sandbox="$(new_sandbox)"
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  wrong_target="$sandbox/foreign/pinning-guard.sh"
+  _verify_ai_compat_write_script "$wrong_target"
+  chmod +x "$wrong_target"
+  mkdir -p "$home_dir/.claude/hooks"
+  ln -s "$wrong_target" "$home_dir/.claude/hooks/pinning-guard.sh"
+  ln -s "$sandbox/missing/pinning-guard.sh" "$home_dir/.claude/hooks/broken.sh"
+
+  output="$(_verify_ai_compat_with_stubbed_gate "$home_dir" "$repo_root" _verify_ai_compat_bad_symlink_checks)"
+  _verify_ai_compat_assert_error_count "$output" 2
+  assert_contains "$output" "프로비저닝 실행 파일 target suffix 불일치"
+  assert_contains "$output" "프로비저닝 실행 파일 없음"
+  assert_contains "$output" "resolved target rejects foreign prefix"
+}
+
+_verify_ai_compat_removed_oracle_reference_check() {
+  verify_used_by_oracle "$REPO_ROOT/modules/shared/programs/claude/files/lib/demo-lib.sh" "demo-lib.sh"
+}
+
+test_verify_ai_compat_host_state_detects_removed_oracle_reference() {
+  local sandbox home_dir repo_root output
+  sandbox="$(new_sandbox)"
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  mkdir -p "$home_dir"
+  _verify_ai_compat_make_oracle_fixture "$repo_root" removed
+
+  output="$(_verify_ai_compat_with_stubbed_gate "$home_dir" "$repo_root" _verify_ai_compat_removed_oracle_reference_check)"
+  _verify_ai_compat_assert_error_count "$output" 1
+  assert_contains "$output" "USED-BY oracle: demo-lib.sh"
+  assert_contains "$output" "실제 source 패턴 미발견"
+}


### PR DESCRIPTION
## Summary

- host-state 검증부 함수 4개를 \`scripts/ai/lib/host-state-checks.sh\`(source-safe lib)로 추출 — 호출문은 게이트 본체 원위치 유지, **전후 출력 diff 0** (일반 실행 + \`--run-fixture-tests\` 양쪽)
- \`tests/suites/verify-ai-compat.sh\` 신설 — pass/fail 양방향 fixture 4케이스로 게이트의 조용한 약화를 감지

Closes #994

## 기존 문제/배경

host-state 검증부는 실제 리포 상태에 대해서만 실행되고 로직 회귀 테스트가 없었다 — 검증 조건이 항상 pass가 되도록 망가져도 통합 테스트가 통과한다. plan 010(#947)에서 실행문 인터리브 구조 때문에 강등됐던 범위다.

## CIR (Change Intent Record)

- epic #1000의 4번(마지막) 작업. PR #987(lint 엔진 추출)과 같은 패턴: 함수 정의만 lib로, 실행 문장은 원위치 — plan 010이 STOP했던 "BASH_SOURCE 가드 불가(실행문 6곳+ 인터리브)" 문제를 재배열 없이 우회한다.
- oracle: 추출 전후 출력 byte 동일(diff 0). 이 파일은 pre-commit 커밋 차단 게이트라 diff-0 없이는 어떤 재배열도 금지 조건이었다.
- suite의 \`pass\`/\`fail\`은 카운터 스텁으로 대체해 부모 test harness 오염을 차단. bad-symlink 케이스는 #993 판정 로직(\`resolved_target_matches_repo_suffix\`)의 음성 특성화(suffix 불일치·foreign prefix)를 겸한다.
- suite는 정의 전용 + aggregator 명시 등록 (저장소 컨벤션).

## ADR

| 대안 | 장점 | 단점 | 결정 |
|------|------|------|------|
| 함수만 lib 추출 (호출 원위치) | diff-0 보장, 테스트 가능 | 파일 2개로 분리 | ✅ |
| BASH_SOURCE 가드 | 파일 1개 유지 | 실행문 인터리브로 불가 (plan 010 실측) | ❌ |
| 실행부 재배열 | 구조 개선 | 게이트 동작 불변 훼손 위험 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| \`scripts/ai/lib/host-state-checks.sh\` (신규) | 함수 4개 (정의 전용, source-safe) |
| \`scripts/ai/verify-ai-compat.sh\` | 해당 구간 −239줄 → source 1줄 |
| \`tests/suites/verify-ai-compat.sh\` (신규) | fixture 4케이스 (positive / non-executable / bad symlink / removed oracle) |
| \`tests/shell-script-tests.sh\` | 등록 4라인 |

## 참고 레퍼런스

- epic #1000, 이슈 #994 · 선례: PR #987 (lint 추출) · 음성 판정 대상: PR #1001 (#993)

## Human Test Plan

1. \`bash scripts/ai/verify-ai-compat.sh\` → 추출 전과 출력 동일, exit 0. \`--run-fixture-tests\` → exit 0.
2. \`nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash tests/run-shell-script-tests.sh\` → 신규 4케이스 통과.
3. 게이트 약화 감지 확인: \`host-state-checks.sh\`의 판정 하나를 임시로 \`return 0\` 처리 → suite의 해당 fail-감지 케이스가 실패 (실험 후 원복).

https://claude.ai/code/session_01AZvWWrjUWJneLCN9zDUfdP