### PR TITLE
feat(claude-rc): bridge version-drift 자동 재시작 — maint 엔진 분리 + 운영 스킬

### DIFF
--- a/.agents/skills/managing-claude-rc
+++ b/.agents/skills/managing-claude-rc
@@ -1,0 +1,1 @@
+../../.claude/skills/managing-claude-rc

--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -15,7 +15,7 @@ bridge 서버의 운영 가이드. NixOS(MiniPC) 전용 — macOS/darwin 배포�
 
 ## 기전 (3계층)
 
-```
+```text
 tmux 세션 "claude-rc" (detached 상시 구동)
  └─ claude-rc 래퍼 (modules/nixos/scripts/claude-rc.sh)
      ├─ 재시작 루프: 비정상 종료 시 exponential backoff로 자동 재시작

--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: managing-claude-rc
+description: |
+  Manage Claude Code Remote Control bridge (claude-rc): 기전, 세션 수명주기, 자동 재시작, 트러블슈팅.
+  Trigger: 'claude-rc', 'remote control', '리모트 컨트롤', 'bridge 서버', '모바일 세션',
+  'claude-rc-ensure', 'claude-rc-maint', '세션 tombstone', 'bridge 재시작'.
+  NOT for Codex remote control (use configuring-codex / issuing-codex-pairing-code).
+  NOT for tmux 일반 설정 (use managing-tmux).
+---
+
+# Claude Code Remote Control (claude-rc) 관리
+
+Claude 모바일 앱/claude.ai에서 MiniPC의 Claude Code 세션을 원격 조종하는
+bridge 서버의 운영 가이드. NixOS(MiniPC) 전용 — macOS/darwin 배포는 별도 이슈 범위.
+
+## 기전 (3계층)
+
+```
+tmux 세션 "claude-rc" (detached 상시 구동)
+ └─ claude-rc 래퍼 (modules/nixos/scripts/claude-rc.sh)
+     ├─ 재시작 루프: 비정상 종료 시 exponential backoff로 자동 재시작
+     ├─ stale 감지: tmux 환경변수 CLAUDE_RC_ACTIVE
+     └─ claude remote-control --spawn worktree --no-create-session-in-dir ...
+         └─ 모바일에서 새 세션 요청 시:
+             .claude/worktrees/bridge-cse_<세션ID> git worktree 생성 (locked) 후
+             `claude --print --sdk-url https://api.anthropic.com/v1/code/sessions/cse_...`
+             자식 프로세스 스폰 (outbound 연결만 사용, 인바운드 포트 없음)
+```
+
+- transcript는 `~/.claude/projects/<정규화된 경로>/<uuid>.jsonl`에 기록된다.
+  프로젝트 디렉토리명은 경로의 비영숫자가 하이픈으로 정규화된다
+  (예: `bridge-cse_01AB...` worktree → `...--claude-worktrees-bridge-cse-01AB...`).
+
+## 사용자 래퍼 (claude-rc)
+
+| 명령 | 동작 |
+|------|------|
+| `claude-rc` | 서버 시작 + tmux attach |
+| `claude-rc --detach` | 서버 시작 (백그라운드) |
+| `claude-rc --attach` | 기존 세션 접속 |
+| `claude-rc --stop` | 서버 종료 (활성 세션 tombstone — 아래 수명주기 참조) |
+| `claude-rc --cleanup` | 서버 종료 + worktree prune + orphan 디렉토리 삭제 |
+
+옵션: `--permission-mode <mode>`, `--capacity <N>`, `--name <name>`.
+수동 실행 시에도 **NixOS 선언값(`homeserver.claudeRemoteControl.*`)과 일치시켜야**
+자동 재시작 후 동작이 달라지지 않는다.
+
+## 자동 재시작 (claude-rc-ensure timer)
+
+`homeserver.claudeRemoteControl.enable = true` 시 systemd timer가 부팅 2분 후 +
+30분마다 `claude-rc-maint ensure`를 실행한다
+(`modules/nixos/programs/claude-remote-control.nix`).
+
+판정 흐름:
+1. tmux 세션 부재/stale → bridge 시작 (부팅 후 자동 복구 겸함)
+2. 실행 중 bridge의 `/proc/PID/exe` 버전 vs `readlink -f ~/.local/bin/claude` 비교
+3. drift 없음 → healthy
+4. drift 있음 → idle 게이트:
+   - 최근 `IDLE_THRESHOLD_MINUTES`(기본 30분) 내 활동한 bridge transcript가 있으면 유예
+   - 스폰 세션 프로세스가 있는데 transcript 명명 규칙 매치가 전혀 없으면
+     판정 불가로 보수적 유예 (`deferred-unknown-activity`)
+   - 둘 다 아니면 재시작 (`restarted-version-drift`)
+5. 모든 경로에서 status 기록 + Pushover 알림 (상태 전이 기반, cooldown 30분)
+
+운영 옵션(permissionMode/capacity/name)은 nix 옵션으로 선언되어 재시작 시 보존된다:
+`hosts` 설정은 `modules/nixos/configuration.nix`의 `homeserver.claudeRemoteControl` 블록.
+
+Pushover fallback: 크리덴셜(`pushover-system-monitor.age`, minipcOnly)이 없는 호스트에서
+maint를 수동 실행하면 알림만 스킵되고 ensure 본체는 정상 동작한다.
+systemd 유닛은 `ConditionPathExists`로 credential 부재 시 조용히 skip된다 (agenix 장애 신호).
+
+## 세션 수명주기 (중요)
+
+- disconnect ≠ end session: 모바일 앱 연결을 끊어도 세션 프로세스는 계속 살아
+  capacity 슬롯을 점유한다. upstream에 세션 age-out이 없다 (#60568 — schema에
+  sessionTimeoutSeconds만 있고 미배선; #28917 revoke, #32050 idle timeout 모두
+  미구현 stale 종결). → `--cleanup` workaround가 계속 필요한 근거.
+- bridge 재시작 = 활성 세션 tombstone: 앱에서 기록은 보이지만 프롬프트가
+  조용히 무시된다. 대화 기록은 보존된다:
+  - 로컬 재개: 해당 worktree에서 `claude --resume <uuid>`
+  - 원격 재개 (claude 2.1.200+): `claude remote-control --session-id <cse_...>`
+    (spawn 플래그와 병용 불가 — 세션 전용 프로세스로 떠야 함)
+- 알려진 upstream 버그: 스폰 세션이 UI 선택 모델을 무시할 수 있음 (#74049, OPEN).
+
+## 트러블슈팅
+
+```bash
+# ensure 상태/이력
+cat ~/.local/state/claude-rc/status.json
+journalctl -u claude-rc-ensure --since -2d
+systemctl list-timers claude-rc-ensure
+
+# bridge 실체 확인
+tmux has-session -t claude-rc && tmux attach -t claude-rc   # 래퍼 로그 확인
+pgrep -af 'claude remote-control'
+readlink /proc/<PID>/exe    # 실행 중 바이너리 버전
+
+# 수동 ensure (drift 즉시 확인)
+systemctl start claude-rc-ensure
+```
+
+| 증상 | 원인/조치 |
+|------|----------|
+| status.json `action: deferred-active-sessions` | 활성 세션 존재 — 정상 유예. 다음 주기 재시도 |
+| `action: deferred-unknown-activity` | transcript 명명 규칙 drift 의심 — `claude-rc-maint.sh`의 `BRIDGE_TRANSCRIPT_GLOBS` 갱신 검토 |
+| `action: no-bridge-process` | 래퍼 backoff 루프가 재시작 중 — 지속되면 `tmux attach -t claude-rc`로 루프 로그 확인 |
+| unit이 실행 안 됨 (Condition failed) | `/run/agenix/pushover-system-monitor` 부재 — agenix 상태 확인 |
+| capacity 꽉 참 (앱에서 새 세션 불가) | idle 프로세스가 슬롯 점유 — 앱에서 "세션 종료" 또는 `claude-rc --cleanup` |
+| 모바일 세션이 응답 없음 (기록만 보임) | tombstone — 위 재개 경로 사용 |
+
+## 관련 파일
+
+- 래퍼: `modules/nixos/scripts/claude-rc.sh` (store 패키지: `modules/nixos/lib/claude-rc-package.nix`)
+- maint 엔진: `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh`
+- systemd 모듈: `modules/nixos/programs/claude-remote-control.nix`
+- 옵션: `modules/nixos/options/homeserver.nix` (`claudeRemoteControl.*`)
+- HM 배선: `modules/shared/programs/shell/nixos.nix`

--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -126,4 +126,9 @@
   homeserver.smokeTest.enable = true; # 런타임 스모크 테스트 (헬스체크 + 백업 신선도)
   homeserver.opnix.enable = true; # 1Password SA token materialization + gh 인증
   homeserver.codexRemoteControl.enable = true; # Codex mobile remote-control app-server 회귀 방지
+  homeserver.claudeRemoteControl = {
+    enable = true; # Claude Code RC bridge version-drift 감시 (30분 timer)
+    capacity = 10; # 현행 운영값 — 자동 재시작 시 이 값으로 유지된다
+    name = "미니피시";
+  };
 }

--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -129,6 +129,6 @@
   homeserver.claudeRemoteControl = {
     enable = true; # Claude Code RC bridge version-drift 감시 (30분 timer)
     capacity = 10; # 현행 운영값 — 자동 재시작 시 이 값으로 유지된다
-    name = "미니피시";
+    name = "miniPC";
   };
 }

--- a/modules/nixos/lib/claude-rc-package.nix
+++ b/modules/nixos/lib/claude-rc-package.nix
@@ -1,0 +1,10 @@
+# claude-rc 사용자 래퍼의 store 패키지 표현식.
+#
+# Home Manager(home.file 링크)와 NixOS systemd 모듈(claude-rc-maint의
+# CLAUDE_RC_BIN)이 같은 인자로 이 표현식을 평가하면 동일 store path를 공유한다.
+# systemd ExecStart/env는 절대 store 경로가 필요하므로 (~ 미확장) HM 산출물이
+# 아닌 store 패키지로 경계를 통일한다.
+{ pkgs, flakePath }:
+pkgs.runCommand "claude-rc" { } ''
+  install -Dm755 ${pkgs.replaceVars ../scripts/claude-rc.sh { inherit flakePath; }} $out/bin/claude-rc
+''

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -201,6 +201,42 @@
     codexRemoteControl = {
       enable = lib.mkEnableOption "Codex mobile remote-control app-server regression guard";
     };
+
+    claudeRemoteControl = {
+      enable = lib.mkEnableOption "Claude Code Remote Control bridge version-drift guard";
+
+      # bridge 시작 옵션 — maint의 자동 재시작이 이 값들을 명시 전달한다.
+      # 선언하지 않으면 재시작 시 래퍼 기본값으로 조용히 되돌아가는 회귀가 생긴다.
+      permissionMode = lib.mkOption {
+        type = lib.types.enum [
+          "acceptEdits"
+          "bypassPermissions"
+          "default"
+          "dontAsk"
+          "plan"
+        ];
+        default = "bypassPermissions";
+        description = "Permission mode for bridge-spawned sessions";
+      };
+
+      capacity = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 5;
+        description = "Max concurrent remote sessions";
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "minipc";
+        description = "Bridge name shown in claude.ai / mobile app";
+      };
+
+      idleThresholdMinutes = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 30;
+        description = "Transcript inactivity window before a session counts as idle (restart gate)";
+      };
+    };
   };
 
   # 모든 서비스 모듈을 정적으로 import (Nix 모듈 시스템은 조건부 import 불가)
@@ -228,5 +264,6 @@
     ../programs/opnix # 1Password Service Account 시크릿 materialization
     ../programs/opnix-rotate.nix # SA token 90일 rotation 알림 (opnix.enable 게이팅)
     ../programs/codex-remote-control.nix # Codex mobile remote-control app-server 회귀 방지
+    ../programs/claude-remote-control.nix # Claude Code RC bridge version-drift 감시
   ];
 }

--- a/modules/nixos/programs/claude-remote-control.nix
+++ b/modules/nixos/programs/claude-remote-control.nix
@@ -1,0 +1,127 @@
+# Claude Code Remote Control bridge의 version-drift 감시 (greenhead-minipc).
+#
+# bridge(claude remote-control)는 tmux 안에서 상시 구동되며 시작 시점 바이너리로
+# 고정된다. claude launcher(~/.local/bin/claude)는 자체 업데이터가 최신으로 굴리므로
+# 방치하면 bridge만 구버전에 남는다 (실측: 23개 릴리스 drift). 이 모듈은 30분 timer로
+# claude-rc-maint를 실행해 drift를 감지하고, 활성 원격 세션이 없을 때만 재시작한다.
+{
+  config,
+  pkgs,
+  lib,
+  username,
+  nixosConfigDefaultPath,
+  ...
+}:
+
+let
+  cfg = config.homeserver.claudeRemoteControl;
+
+  homeDir = "/home/${username}";
+  stateDir = "${homeDir}/.local/state/claude-rc";
+  pushoverCredPath = config.age.secrets.pushover-system-monitor.path;
+  serviceLib = import ../lib/service-lib.nix { inherit pkgs; };
+
+  # HM 배선(modules/shared/programs/shell/nixos.nix)과 같은 인자로 평가되어
+  # 동일 store path를 공유한다.
+  claudeRcPkg = import ../lib/claude-rc-package.nix {
+    inherit pkgs;
+    flakePath = nixosConfigDefaultPath;
+  };
+
+  maintenanceCli = pkgs.writeShellApplication {
+    name = "claude-rc-maint";
+    runtimeInputs = with pkgs; [
+      coreutils
+      findutils
+      gawk
+      gnugrep
+      gnused
+      jq
+      procps
+      tmux
+      util-linux # flock
+      curl # service-lib send_notification
+    ];
+    text = builtins.readFile ./claude-remote-control/files/claude-rc-maint.sh;
+  };
+in
+{
+  config = lib.mkIf cfg.enable {
+    # 기존 Pushover 사용 모듈들(temp-monitor, smoke-test 등)과 동일하게 자체 선언.
+    # Nix 모듈 시스템이 동일 정의를 병합하므로 다른 모듈 활성화 여부에 의존하지 않는다.
+    age.secrets.pushover-system-monitor = {
+      file = ../../../secrets/pushover-system-monitor.age;
+      owner = "root";
+      mode = "0400";
+    };
+
+    systemd.services.claude-rc-ensure = {
+      description = "Ensure Claude Code Remote Control bridge runs the current binary";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      unitConfig = {
+        # credential 부재(=agenix 장애) 시 LoadCredential 단계에서
+        # EXIT_CREDENTIALS(243)로 실패하는 대신 unit을 조용히 skip한다
+        # (codex-remote-control.nix와 동일 패턴; Condition 실패는 journal에 남는다).
+        ConditionPathExists = [
+          homeDir
+          pushoverCredPath
+        ];
+      };
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = username;
+        Group = "users";
+        WorkingDirectory = homeDir;
+        # maint 스크립트의 flock 대기(MAINT_LOCK_TIMEOUT_SECONDS=120)보다 커야
+        # lock-acquire-timeout 실패 경로가 status.json 기록과 Pushover 알림까지
+        # 완주한다 (codex-remote-control.nix와 동일 근거).
+        TimeoutSec = "300";
+        ExecStart = "${maintenanceCli}/bin/claude-rc-maint ensure";
+        LoadCredential = [ "pushover-system-monitor:${pushoverCredPath}" ];
+        # oneshot 종료 시 cgroup 정리가 방금 시작한 tmux server/bridge를
+        # 죽이지 않도록 main process만 kill 대상으로 한다.
+        KillMode = "process";
+
+        # tmux 소켓(/tmp/tmux-<uid>/)에 접근해야 하므로 PrivateTmp는 쓸 수 없고,
+        # bridge/state가 홈 아래이므로 ProtectHome도 쓸 수 없다.
+        ProtectSystem = "full";
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+      };
+
+      environment = {
+        HOME = homeDir;
+        STATE_DIR = stateDir;
+        CLAUDE_RC_BIN = "${claudeRcPkg}/bin/claude-rc";
+        SERVICE_LIB = "${serviceLib}";
+        IDLE_THRESHOLD_MINUTES = toString cfg.idleThresholdMinutes;
+        ALERT_COOLDOWN_SECONDS = "1800";
+        # 자동 재시작이 운영 옵션을 래퍼 기본값으로 되돌리지 않도록 명시 주입.
+        CLAUDE_RC_PERMISSION_MODE = cfg.permissionMode;
+        CLAUDE_RC_CAPACITY = toString cfg.capacity;
+        CLAUDE_RC_NAME = cfg.name;
+        # writeShellApplication runtimeInputs가 앞에 붙는다. 이 tail은 자체 업데이터가
+        # 관리하는 claude launcher(~/.local/bin/claude)와 claude-rc 내부의 bare
+        # `claude` 호출을 해석하기 위해 필요하다 (codex 모듈 PATH 주석과 동일 패턴).
+        PATH = lib.mkForce "${homeDir}/.local/bin:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin";
+      };
+    };
+
+    systemd.timers.claude-rc-ensure = {
+      description = "Periodic Claude Code Remote Control bridge ensure";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2m";
+        OnUnitActiveSec = "30m";
+        RandomizedDelaySec = "1m";
+        Persistent = true;
+      };
+    };
+  };
+}

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# claude-rc-maint: Claude Code Remote Control bridge의 version-drift 감시 엔진.
+#
+# 사용자 래퍼(claude-rc)와 책임을 분리한 maintenance 전용 스크립트로,
+# systemd timer(claude-rc-ensure)가 주기 실행한다. codex-remote-control-maint.sh 골격 차용.
+#
+# 동작: 실행 중 bridge 바이너리(/proc/PID/exe)와 claude launcher가 가리키는
+# 최신 버전을 비교해 drift가 있으면 — 활성 원격 세션이 없을 때만 — bridge를 재시작한다.
+# bridge 재시작은 활성 세션을 tombstone시키므로 idle 게이트가 핵심 안전장치다.
+set -euo pipefail
+
+#───────────────────────────────────────────────────────────────────────────────
+# env 파라미터 (systemd unit이 주입, 수동 실행 시 기본값)
+#───────────────────────────────────────────────────────────────────────────────
+CLAUDE_RC_BIN="${CLAUDE_RC_BIN:-$HOME/.local/bin/claude-rc}"
+CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
+TMUX_SESSION="${TMUX_SESSION:-claude-rc}"
+IDLE_THRESHOLD_MINUTES="${IDLE_THRESHOLD_MINUTES:-30}"
+MAINT_LOCK_TIMEOUT_SECONDS="${MAINT_LOCK_TIMEOUT_SECONDS:-120}"
+ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
+PUSHOVER_CRED_FILE="${PUSHOVER_CRED_FILE:-}"
+SERVICE_LIB="${SERVICE_LIB:-}"
+# bridge 시작 옵션 — NixOS 모듈(homeserver.claudeRemoteControl.*)이 주입한다.
+# maint가 명시 전달하지 않으면 자동 재시작 시 래퍼 기본값으로 조용히 되돌아가므로
+# (예: capacity 10 → 5) 반드시 전량 전달한다.
+CLAUDE_RC_PERMISSION_MODE="${CLAUDE_RC_PERMISSION_MODE:-bypassPermissions}"
+CLAUDE_RC_CAPACITY="${CLAUDE_RC_CAPACITY:-5}"
+CLAUDE_RC_NAME="${CLAUDE_RC_NAME:-minipc}"
+
+#───────────────────────────────────────────────────────────────────────────────
+# upstream 의존 selector — Claude Code CLI/spawn process shape 또는 transcript
+# 프로젝트 디렉토리 명명 규칙이 바뀌면 아래 3개를 함께 갱신한다.
+#───────────────────────────────────────────────────────────────────────────────
+BRIDGE_PROCESS_PATTERN='claude remote-control'
+# 스폰 세션의 argv[0]은 versions 디렉토리 절대경로라 "claude "가 나타나지 않는다
+# (실측: /home/.../claude/versions/2.1.169 --print --sdk-url ...). --sdk-url 자체로
+# 식별하되, ERE [-]로 시작해 pgrep이 패턴을 옵션으로 오해하지 않게 한다.
+BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
+# transcript 프로젝트 디렉토리 glob. 경로의 비영숫자([._/])는 하이픈으로
+# 정규화되어 저장되므로 underscore 변형은 나타나지 않는다 (실측 확인).
+BRIDGE_TRANSCRIPT_GLOBS=('*bridge-cse-*' '*bridge-session-*')
+
+VERSIONS_DIR="$HOME/.local/share/claude/versions"
+PROJECTS_DIR="$HOME/.claude/projects"
+
+ACTION="none"
+RUNNING_VERSION=""
+DESIRED_VERSION=""
+RECENT_TRANSCRIPT_COUNT=0
+
+log_info()  { echo "[claude-rc-maint] $*"; }
+log_error() { echo "[claude-rc-maint] ERROR: $*" >&2; }
+
+#───────────────────────────────────────────────────────────────────────────────
+# flock 직렬화 (수동 실행과 timer의 동시 실행 방지)
+#───────────────────────────────────────────────────────────────────────────────
+with_lock() {
+    mkdir -p "$STATE_DIR"
+    exec 9>"$STATE_DIR/ensure.lock"
+    if ! flock --timeout "$MAINT_LOCK_TIMEOUT_SECONDS" 9; then
+        ACTION="lock-acquire-timeout"
+        return 1
+    fi
+    # fd 9는 이 셸이 락을 유지하는 동안만 살아야 한다. 9>&- 없이 실행하면
+    # detach되는 tmux server/bridge가 fd 9를 상속해 락을 영구 점유하고
+    # 이후 모든 타이머 실행이 lock-acquire-timeout으로 실패한다
+    # (codex-remote-control-maint.sh의 PR #983과 동일 근거).
+    "$@" 9>&-
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# bridge 세션/프로세스 판정
+#───────────────────────────────────────────────────────────────────────────────
+bridge_session_alive() {
+    tmux has-session -t "$TMUX_SESSION" 2>/dev/null || return 1
+    # 조회 실패(변수 없음 포함) = stale — 래퍼 is_session_stale과 동일 판정.
+    # systemd oneshot은 tmux 클라이언트 밖에서 실행되므로 -t 타깃 명시가 필수다.
+    local rc_active
+    rc_active=$(tmux show-environment -t "$TMUX_SESSION" CLAUDE_RC_ACTIVE 2>/dev/null) || return 1
+    [ "$rc_active" = "CLAUDE_RC_ACTIVE=1" ]
+}
+
+# 첫 번째 유효 bridge PID를 출력. 유효 = exe가 claude versions 디렉토리 아래.
+find_bridge_pid() {
+    local pid exe
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || continue
+        case "${exe% (deleted)}" in
+            "$VERSIONS_DIR"/*) echo "$pid"; return 0 ;;
+        esac
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
+    return 1
+}
+
+# /proc/PID/exe 기준 실행 중 버전. 바이너리가 삭제된 구버전이면 "deleted"를 붙여
+# 호출측이 drift로 취급하게 한다.
+pid_exe_version() {
+    local pid="$1" exe
+    exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || return 1
+    case "$exe" in
+        *" (deleted)") echo "$(basename "${exe% (deleted)}") (deleted)" ;;
+        *) basename "$exe" ;;
+    esac
+}
+
+desired_claude_version() {
+    basename "$(readlink -f "$CLAUDE_BIN")"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# 활성 세션 판정 (restart 게이트)
+#───────────────────────────────────────────────────────────────────────────────
+# 허용 glob에 매치되는 transcript 프로젝트 디렉토리 수 (명명 규칙 유효성 신호)
+count_matching_transcript_dirs() {
+    local total=0 glob
+    [ -d "$PROJECTS_DIR" ] || { echo 0; return; }
+    for glob in "${BRIDGE_TRANSCRIPT_GLOBS[@]}"; do
+        total=$((total + $(find "$PROJECTS_DIR" -maxdepth 1 -type d -name "$glob" 2>/dev/null | wc -l)))
+    done
+    echo "$total"
+}
+
+# 최근 활동한 bridge transcript 파일 수. transcript file은 세션의 proxy이며
+# 측정 단위(파일)를 이름에 그대로 노출한다.
+count_recent_bridge_transcripts() {
+    local total=0 glob dir
+    [ -d "$PROJECTS_DIR" ] || { echo 0; return; }
+    for glob in "${BRIDGE_TRANSCRIPT_GLOBS[@]}"; do
+        while IFS= read -r dir; do
+            [ -n "$dir" ] || continue
+            total=$((total + $(find "$dir" -maxdepth 1 -name '*.jsonl' -mmin "-$IDLE_THRESHOLD_MINUTES" 2>/dev/null | wc -l)))
+        done < <(find "$PROJECTS_DIR" -maxdepth 1 -type d -name "$glob" 2>/dev/null)
+    done
+    echo "$total"
+}
+
+# bridge가 스폰한 세션 프로세스 수 (transcript 명명에 비의존인 2차 신호).
+# pgrep -c는 매치 0일 때도 "0"을 출력하며 rc=1이므로, || echo를 쓰면 "0"이
+# 이중 출력된다 — 캡처 후 실패 시 대입으로 처리한다.
+count_bridge_session_procs() {
+    local count
+    count=$(pgrep -u "$(id -u)" -c -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null) || count=0
+    echo "$count"
+}
+
+# 재시작이 안전한지 판정. 반환: 0=안전, 1=defer(활동 중), 2=defer(판정 불가)
+restart_gate() {
+    RECENT_TRANSCRIPT_COUNT=$(count_recent_bridge_transcripts)
+    local session_procs
+    session_procs=$(count_bridge_session_procs)
+
+    if [ "$RECENT_TRANSCRIPT_COUNT" -gt 0 ]; then
+        return 1 # 최근 활동 세션 존재 — 재시작하면 tombstone
+    fi
+    if [ "$session_procs" -eq 0 ]; then
+        return 0 # 세션 프로세스 자체가 없음 — 재시작 안전
+    fi
+    # 세션 프로세스는 있는데 최근 transcript가 없는 경우:
+    # 허용 glob 매치 디렉토리가 존재하면 명명 규칙이 현재도 유효하다는 증거이므로
+    # idle 세션으로 판단해 재시작하고, 매치가 0이면 upstream 명명 규칙 drift
+    # 가능성이 있어 보수적으로 유예한다 (tombstone 재시작 직행 방지).
+    if [ "$(count_matching_transcript_dirs)" -gt 0 ]; then
+        return 0
+    fi
+    return 2
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# bridge 시작/재시작
+#───────────────────────────────────────────────────────────────────────────────
+# systemd LoadCredential의 CREDENTIALS_DIRECTORY와 Pushover env가 장기 실행
+# tmux server → bridge → 스폰 세션 트리로 상속되지 않도록 항상 env를 정리해 시작한다.
+start_bridge() {
+    env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+        "$CLAUDE_RC_BIN" --detach \
+        --permission-mode "$CLAUDE_RC_PERMISSION_MODE" \
+        --capacity "$CLAUDE_RC_CAPACITY" \
+        --name "$CLAUDE_RC_NAME"
+    # tmux server가 이 maint 유닛 환경에서 새로 떴을 경우 global env에 복사된
+    # credential 경로를 제거한다 (이미 없으면 no-op).
+    tmux set-environment -gu CREDENTIALS_DIRECTORY 2>/dev/null || true
+    tmux set-environment -gu PUSHOVER_CRED_FILE 2>/dev/null || true
+}
+
+restart_bridge() {
+    tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+    start_bridge
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# 상태 기록 + 알림
+#───────────────────────────────────────────────────────────────────────────────
+write_status() {
+    local exit_code="${1:-0}"
+    mkdir -p "$STATE_DIR"
+    local tmp
+    tmp=$(mktemp "$STATE_DIR/status.XXXXXX") || return 1
+    jq -n \
+        --arg timestamp "$(date -Is)" \
+        --arg runningVersion "$RUNNING_VERSION" \
+        --arg desiredVersion "$DESIRED_VERSION" \
+        --arg action "$ACTION" \
+        --argjson recentTranscriptCount "$RECENT_TRANSCRIPT_COUNT" \
+        --argjson exitCode "$exit_code" \
+        '{
+          timestamp: $timestamp,
+          runningVersion: $runningVersion,
+          desiredVersion: $desiredVersion,
+          action: $action,
+          recentTranscriptCount: $recentTranscriptCount,
+          exitCode: $exitCode
+        }' >"$tmp" || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$STATE_DIR/status.json"
+}
+
+load_alerting() {
+    # shellcheck source=/dev/null
+    [ -n "$SERVICE_LIB" ] && [ -f "$SERVICE_LIB" ] && source "$SERVICE_LIB"
+    local cred="$PUSHOVER_CRED_FILE"
+    if [ -z "$cred" ] && [ -n "${CREDENTIALS_DIRECTORY:-}" ]; then
+        cred="$CREDENTIALS_DIRECTORY/pushover-system-monitor"
+    fi
+    if [ -n "$cred" ] && [ -r "$cred" ]; then
+        # shellcheck source=/dev/null
+        source "$cred"
+    fi
+}
+
+send_alerts() {
+    local exit_code="$1"
+    # graceful fallback: 크리덴셜/서비스 lib이 없는 호스트(예: work-MacBookPro는
+    # pushover-system-monitor.age가 minipcOnly 암호화라 복호화 불가)에서 수동
+    # 실행해도 알림만 스킵하고 ensure 본체는 정상 동작한다.
+    if ! command -v send_notification >/dev/null 2>&1 \
+        || [ -z "${PUSHOVER_TOKEN:-}" ] || [ -z "${PUSHOVER_USER:-}" ]; then
+        log_info "알림 스킵 (Pushover 크리덴셜/서비스 lib 없음)"
+        return 0
+    fi
+
+    local now state_file last_failure_file previous
+    now=$(date +%s)
+    state_file="$STATE_DIR/last-health-state"
+    last_failure_file="$STATE_DIR/last-failure-alert"
+    previous="unknown"
+    [ -f "$state_file" ] && previous=$(cat "$state_file" 2>/dev/null || echo unknown)
+
+    if [ "$exit_code" -eq 0 ]; then
+        if [ "$previous" = "failed" ]; then
+            send_notification "Claude RC Recovered" \
+                "greenhead-minipc claude-rc bridge is healthy (${RUNNING_VERSION:-unknown})." 0
+        fi
+        echo "healthy" >"$state_file"
+        return 0
+    fi
+
+    local last=0
+    [ -f "$last_failure_file" ] && last=$(cat "$last_failure_file" 2>/dev/null || echo 0)
+    if [ $((now - last)) -ge "$ALERT_COOLDOWN_SECONDS" ]; then
+        send_notification "Claude RC Ensure Failed" \
+            "exit=${exit_code}, action=${ACTION}, running=${RUNNING_VERSION:-unknown}, desired=${DESIRED_VERSION:-unknown}" 0
+        echo "$now" >"$last_failure_file"
+    fi
+    echo "failed" >"$state_file"
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# ensure 본체 (조기 exit 없음 — action만 설정하고 cmd_ensure의 finalizer가 마무리)
+#───────────────────────────────────────────────────────────────────────────────
+ensure_core() {
+    DESIRED_VERSION=$(desired_claude_version) || {
+        ACTION="desired-version-unresolvable"
+        return 1
+    }
+
+    if ! bridge_session_alive; then
+        # tmux 세션 부재/stale — 부팅 후 자동 시작 겸 자가 복구
+        start_bridge
+        ACTION="started"
+        log_info "bridge 시작됨 (session absent/stale)"
+        return 0
+    fi
+
+    local pid
+    if ! pid=$(find_bridge_pid); then
+        # 세션은 살아있는데 bridge 프로세스가 없음 — 래퍼 루프가 backoff 재시작
+        # 중일 수 있으므로 maint는 개입하지 않는다 (다음 주기 재확인).
+        ACTION="no-bridge-process"
+        log_info "bridge 프로세스 없음 — 래퍼 루프에 위임 (다음 주기 재확인)"
+        return 0
+    fi
+
+    RUNNING_VERSION=$(pid_exe_version "$pid") || {
+        ACTION="running-version-unresolvable"
+        return 1
+    }
+
+    if [ "$RUNNING_VERSION" = "$DESIRED_VERSION" ]; then
+        ACTION="healthy"
+        return 0
+    fi
+
+    # version drift — 활성 세션 게이트 통과 시에만 재시작
+    local gate_rc=0
+    restart_gate || gate_rc=$?
+    case "$gate_rc" in
+        0)
+            restart_bridge
+            ACTION="restarted-version-drift"
+            log_info "재시작: ${RUNNING_VERSION} → ${DESIRED_VERSION}"
+            ;;
+        1)
+            ACTION="deferred-active-sessions"
+            log_info "drift 감지했으나 활성 세션 ${RECENT_TRANSCRIPT_COUNT}건 — 유예"
+            ;;
+        2)
+            ACTION="deferred-unknown-activity"
+            log_info "drift 감지했으나 활동 판정 불가 (transcript 명명 drift 의심) — 유예"
+            ;;
+    esac
+    return 0
+}
+
+#───────────────────────────────────────────────────────────────────────────────
+# 서브커맨드
+#───────────────────────────────────────────────────────────────────────────────
+cmd_ensure() {
+    local rc=0
+    with_lock ensure_core || rc=$?
+    # 단일 finalizer: 어떤 분기도 이 경로를 우회하지 않는다
+    # (recovered/failure 알림 상태 전이가 모든 실행에서 평가되도록).
+    write_status "$rc" || true
+    load_alerting
+    send_alerts "$rc" || true
+    return "$rc"
+}
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: claude-rc-maint ensure
+
+env:
+  CLAUDE_RC_BIN, CLAUDE_BIN, STATE_DIR, TMUX_SESSION,
+  IDLE_THRESHOLD_MINUTES (default 30), MAINT_LOCK_TIMEOUT_SECONDS (default 120),
+  ALERT_COOLDOWN_SECONDS (default 1800), PUSHOVER_CRED_FILE, SERVICE_LIB,
+  CLAUDE_RC_PERMISSION_MODE, CLAUDE_RC_CAPACITY, CLAUDE_RC_NAME
+
+상태 확인: cat $STATE_DIR/status.json (기본 ~/.local/state/claude-rc/status.json)
+EOF
+}
+
+main() {
+    case "${1:-}" in
+        ensure) cmd_ensure ;;
+        -h | --help | help) usage ;;
+        *)
+            usage
+            return 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -331,7 +331,9 @@ cmd_ensure() {
     # 단일 finalizer: 어떤 분기도 이 경로를 우회하지 않는다
     # (recovered/failure 알림 상태 전이가 모든 실행에서 평가되도록).
     write_status "$rc" || true
-    load_alerting
+    # source되는 credential/lib 파일이 malformed여도 (source가 && 리스트의
+    # 마지막 명령이라 set -e 발동) finalizer가 send_alerts 전에 죽지 않게 guard.
+    load_alerting || true
     send_alerts "$rc" || true
     return "$rc"
 }

--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -38,18 +38,42 @@ usage() {
     cat <<'EOF'
 claude-rc: Claude Code Remote Control tmux wrapper
 
+Claude 모바일 앱/claude.ai에서 이 머신의 Claude Code 세션을 원격 조종하는
+bridge 서버(`claude remote-control`)를 tmux 세션 안에서 상시 구동한다.
+구조: tmux 세션 "claude-rc" → 이 래퍼의 재시작 루프(backoff) → claude remote-control
+
 사용법:
   claude-rc                              서버 시작 (tmux attach)
   claude-rc --detach                     서버 시작 (백그라운드)
   claude-rc --attach                     기존 세션 접속
-  claude-rc --stop                       서버 종료
+  claude-rc --stop                       서버 종료 (아래 "세션 수명주기 경고" 참조)
   claude-rc --cleanup                    zombie 세션 + stale worktree 정리
 
 옵션:
-  --permission-mode <mode>   권한 모드 (default: bypassPermissions)
+  --permission-mode <mode>   스폰 세션 권한 모드 (default: bypassPermissions)
+                             acceptEdits|bypassPermissions|default|dontAsk|plan
   --capacity <N>             동시 세션 수 (default: 5)
-  --name <name>              세션 이름 (default: minipc)
+  --name <name>              claude.ai/앱에 표시되는 이름 (default: minipc)
   --help                     이 도움말 출력
+
+세션 수명주기 경고 (--stop / 재시작 시):
+  bridge가 죽으면 활성 원격 세션은 모바일 앱에서 이어쓸 수 없게 된다
+  (기록은 보이지만 프롬프트가 무시되는 tombstone 상태).
+  대화 기록 자체는 보존된다:
+    - 로컬 transcript: ~/.claude/projects/<프로젝트 디렉토리>/<uuid>.jsonl
+    - 재개: 해당 worktree에서 `claude --resume <uuid>`,
+      또는 (claude 2.1.200+) `claude remote-control --session-id <cse_...>`
+
+--cleanup 배경 (upstream workaround):
+  upstream의 "disconnect ≠ end session" 설계로 세션 프로세스가 종료되지 않아
+  capacity 슬롯이 영구 점유될 수 있다. 세션 revoke(#28917)와 idle timeout(#32050)
+  요청은 모두 미구현 상태로 종결되어 이 workaround는 계속 필요하다.
+
+자동 재시작 (버전 drift 감시):
+  NixOS에서는 systemd timer(claude-rc-ensure)가 30분마다 claude-rc-maint를 실행해
+  bridge 바이너리가 구버전이면 idle 시점에 자동 재시작한다.
+  상태 확인: cat ~/.local/state/claude-rc/status.json
+  상세: .claude/skills/managing-claude-rc/SKILL.md
 EOF
 }
 

--- a/modules/shared/programs/shell/nixos.nix
+++ b/modules/shared/programs/shell/nixos.nix
@@ -46,11 +46,16 @@ in
     executable = true;
   };
 
+  # store 패키지로 배선 — NixOS systemd 모듈(claude-remote-control.nix)의
+  # claude-rc-maint가 같은 표현식을 같은 인자로 평가해 동일 산출물을 CLAUDE_RC_BIN
+  # 절대경로로 호출한다 (HM activation 산출물에 시스템 서비스가 의존하지 않도록).
   home.file.".local/bin/claude-rc" = {
-    source = pkgs.replaceVars "${nixosScriptsDir}/claude-rc.sh" {
-      flakePath = nixosConfigDefaultPath;
-    };
-    executable = true;
+    source = "${
+      import ../../../nixos/lib/claude-rc-package.nix {
+        inherit pkgs;
+        flakePath = nixosConfigDefaultPath;
+      }
+    }/bin/claude-rc";
   };
 
   # NixOS: mise prebuilt 바이너리 사용 (소스 빌드 방지)


### PR DESCRIPTION
## Summary

- Claude Remote Control bridge가 시작 시점 바이너리로 고정된 채 launcher 최신 버전과 drift가 누적되는 문제(실측 23개 릴리스: 2.1.169 vs 2.1.201)를 codex-remote-control 패턴을 차용한 30분 systemd timer로 자동 해소한다.
- 자동 재시작이 활성 원격 세션을 끊지 않도록 idle 게이트(transcript 활동 + 세션 프로세스 2차 신호)를 두고, 운영 옵션(capacity/name 등)을 NixOS 옵션으로 승격해 재시작 후에도 보존한다.
- claude-rc 운영 지식(기전/세션 수명주기/tombstone/트러블슈팅)을 managing-claude-rc 스킬로 문서화한다.

## 기존 문제/배경

bridge(`claude remote-control`)는 tmux 세션 안에서 상시 구동되며 시작 시점 바이너리로 고정된다. 반면 claude launcher(`~/.local/bin/claude`)는 자체 업데이터가 최신 버전 symlink로 굴린다.

AS-IS 실측 (2026-07-06):

- 6/11에 시작된 bridge가 2.1.169로 고정된 채 23개 릴리스 뒤처짐. 그 사이 upstream에서 mobile 연결 시 silent model switch(2.1.176 수정), killed agent의 locked worktree 등록 누수(2.1.187 수정), reconnect 실패 시 잔여 세션 누적(2.1.200 수정) 등 이 구성의 핵심 경로에 걸리는 버그가 수정됐지만 반영되지 못했다.
- 부팅 후 자동 시작 배선이 없어 재부팅하면 bridge가 꺼진 채 방치된다. 공식 문서상 10분 이상 네트워크 단절 시 프로세스가 자기 종료하는 제약도 supervisor 없이는 복구되지 않는다.
- 운영 문서가 레포에 전무했다 (기전/세션 수명주기/트러블슈팅).

같은 레포의 codex remote-control은 이미 동일 문제를 systemd timer + maint 스크립트(version drift 감지 → stop/start)로 해결하고 있어, 그 패턴을 차용했다.

## CIR (Change Intent Record)

- v1 (이번 변경 초안): 사용자 래퍼(claude-rc.sh)에 `--ensure`를 직접 추가하고 systemd가 `~/.local/bin/claude-rc`를 호출하는 구상 → systemd는 `ExecStart`의 `~`를 확장하지 않고, 시스템 서비스가 Home Manager activation 산출물에 의존하는 경계 문제가 확인되어 기각.
- v2: claude-rc를 store 패키지로 통일하고 ensure를 래퍼에 통합 → interactive CLI와 maintenance 엔진(락/drift 판정/상태/알림)의 책임 결합이 codex 원본의 분리 구조(사용자 CLI vs maint 스크립트)와 어긋남을 확인, 별도 `claude-rc-maint.sh`로 분리.
- v3 (이번 변경): 세부 안전장치 확정 — (a) systemd credential(`CREDENTIALS_DIRECTORY`)이 장기 실행 tmux/bridge 트리로 상속되지 않도록 시작 경로에서 env 정리, (b) 자동 재시작이 운영 옵션을 래퍼 기본값(capacity 5/minipc)으로 되돌리는 회귀를 막기 위해 옵션을 NixOS 선언으로 승격, (c) 활동 판정 불가 시 재시작 대신 보수적 유예.

trade-off: 활성 세션 판정이 transcript 프로젝트 디렉토리 명명 규칙(비공식 관찰 사실)에 의존한다. upstream이 명명을 바꾸면 판정이 깨질 수 있어, selector를 스크립트 상단 상수로 격리하고 "세션 프로세스는 있는데 매치 디렉토리가 없으면 재시작하지 않고 유예"하는 안전장치로 완화했다 (오판 시 결과가 tombstone 재시작이 아니라 업데이트 지연이 되도록).

Pushover fallback 범위: maint 스크립트는 크리덴셜/서비스 lib 부재 시 알림만 스킵하고 정상 동작한다 (pushover-system-monitor.age가 minipcOnly 암호화라 복호화 불가능한 호스트에서의 수동 실행 대비). systemd 유닛 수준에서는 MiniPC의 agenix secret을 전제로 codex 모듈과 동일하게 ConditionPathExists로 게이트한다 — credential 부재는 agenix 장애 신호이므로 unit skip이 진단 가능하고 안전하다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 수동 운영 유지 | 사용자가 필요 시 tmux에서 직접 재시작 | 변경 없음 | drift 23개 릴리스 방치 실증, 부팅 후 자동 시작 없음 | ❌ |
| 래퍼에 ensure 통합 | claude-rc.sh에 `--ensure` 추가 | 파일 1개 | interactive CLI와 maint 엔진 책임 결합, codex 분리 구조와 불일치 | ❌ |
| maint 스크립트 분리 | 별도 claude-rc-maint.sh를 systemd가 호출 | codex 골격과 정합, 래퍼는 사용자 조작만 유지 | 파일 추가 | ✅ |
| ExecStart에 HM 경로 | `~/.local/bin/claude-rc` 직접 호출 | 배선 단순 | systemd `~` 미확장으로 기동 실패, HM activation 의존 | ❌ |
| store 패키지 공유 | 공용 표현식을 HM/systemd가 같은 인자로 평가 | 동일 산출물 보장(실측 검증), 절대경로 확보 | 공용 lib 파일 추가 | ✅ |
| LoadCredential 무조건 선언 | credential을 항상 주입 | 배선 단순 | credential 부재 시 EXIT_CREDENTIALS(243)로 ensure 본체까지 차단 | ❌ |
| ConditionPathExists 게이트 | credential 존재 시에만 unit 실행 | codex/temp-monitor 관례 정합, 부재 시 진단 가능한 skip | credential 없으면 자동 재시작도 중단 (agenix 장애 신호로 수용) | ✅ |
| transcript mtime 단독 게이트 | 최근 활동 파일 수만으로 idle 판정 | 구현 단순 | 명명 규칙 drift 시 활성 세션을 idle로 오판 → tombstone | ❌ |
| mtime + 프로세스 2차 신호 + unknown 유예 | 판정 불가 시 재시작하지 않고 defer | 오판 결과가 "업데이트 지연"으로 안전 강하 | 게이트 로직 복잡도 소폭 증가 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh` | 신규 | drift 감시 엔진: flock 직렬화(fd 상속 차단), `/proc/PID/exe` vs launcher symlink 비교, idle 게이트, 재시작(credential env 정리), status.json, Pushover 상태 전이 알림 |
| `modules/nixos/programs/claude-remote-control.nix` | 신규 | oneshot 서비스 + 30분 timer, `KillMode=process`(방금 시작한 tmux/bridge 보호), `ConditionPathExists`+`LoadCredential`, 운영 옵션 env 주입, PATH tail로 launcher 해석 |
| `modules/nixos/lib/claude-rc-package.nix` | 신규 | claude-rc store 패키지 공용 표현식 (HM/systemd 동일 산출물) |
| `modules/nixos/options/homeserver.nix` | 수정 | `claudeRemoteControl.{enable,permissionMode,capacity,name,idleThresholdMinutes}` 옵션 + 정적 imports 배선 |
| `modules/nixos/configuration.nix` | 수정 | enable + 현행 운영값(capacity 10, name 미니피시) 선언 |
| `modules/shared/programs/shell/nixos.nix` | 수정 | HM 배선을 store 패키지 참조로 교체 |
| `modules/nixos/scripts/claude-rc.sh` | 수정 | usage 고도화: 세션 tombstone 경고/재개 경로, cleanup의 upstream workaround 배경, 자동 재시작 안내 |
| `.claude/skills/managing-claude-rc/SKILL.md` | 신규 | 운영 스킬: 3계층 기전, 세션 수명주기, ensure 동작, 트러블슈팅 표 |

### 핵심 코드 — restart 게이트 (활성 세션 보호)

```bash
# 재시작이 안전한지 판정. 반환: 0=안전, 1=defer(활동 중), 2=defer(판정 불가)
restart_gate() {
    RECENT_TRANSCRIPT_COUNT=$(count_recent_bridge_transcripts)
    ...
    if [ "$RECENT_TRANSCRIPT_COUNT" -gt 0 ]; then return 1; fi
    if [ "$session_procs" -eq 0 ]; then return 0; fi
    # 세션 프로세스는 있는데 최근 transcript가 없는 경우: 허용 glob 매치
    # 디렉토리가 존재하면 명명 규칙이 유효하다는 증거이므로 idle로 판단해
    # 재시작하고, 매치가 0이면 upstream 명명 drift 가능성이 있어 보수적으로 유예.
    if [ "$(count_matching_transcript_dirs)" -gt 0 ]; then return 0; fi
    return 2
}
```

### 검증 결과 (로컬 실측)

- bash -n + shellcheck 통과
- E2E 드라이런: 실제 drift 상태(2.1.169→2.1.201)에서 활성 세션 1건을 감지해 `deferred-active-sessions`로 올바르게 유예, status.json 기록, 크리덴셜 부재 시 알림 스킵 로그 확인
- 드라이런 중 실버그 2건 발견·수정: 스폰 세션 argv[0]이 절대경로라 `claude .*--sdk-url` 패턴 미매치(→ `[-]-sdk-url`), `pgrep -c` 실패 시 "0" 이중 출력
- nix eval: ExecStart store 경로, 운영 옵션 주입(미니피시/10), HM·systemd 동일 store path 공유 확인

## 참고 레퍼런스

- PR #226 — claude-rc 최초 tmux 래퍼 (재시작 루프, stale 감지)
- PR #228 — `--cleanup` workaround (upstream "disconnect ≠ end session" 대응)
- PR #983 — codex maint의 flock fd가 spawn 데몬에 상속되는 leak 차단 (`9>&-` 패턴의 근거)
- PR #1003 — codex-remote-control 모듈 (차용 원본 골격)
- anthropics/claude-code#60568 — 세션 age-out(sessionTimeoutSeconds) 미배선 실증 (외부 정리 필요성의 근거)
- anthropics/claude-code#28917, anthropics/claude-code#32050 — 세션 revoke/idle timeout 요청, 미구현 stale 종결 (cleanup workaround 유지 근거)
- anthropics/claude-code#74049 — 스폰 세션이 UI 선택 모델 무시 (OPEN, 운영 참고)

## Human Test Plan

### 정상 동작 검증

1. `nrs`로 rebuild 후 timer 등록을 확인한다: `systemctl list-timers claude-rc-ensure`
   - 기대: 30분 주기 timer가 활성화되어 있다.
   - 실패 시: `homeserver.claudeRemoteControl.enable` 값과 `journalctl -u claude-rc-ensure`를 확인한다.
2. 수동 실행: `systemctl start claude-rc-ensure` 후 `cat ~/.local/state/claude-rc/status.json`
   - 기대: 현재 drift 상태(running 2.1.169 vs desired 최신)가 기록되고, 활성 세션이 있으면 `action: deferred-active-sessions`, 전부 idle이면 `restarted-version-drift`.
   - 실패 시: `journalctl -u claude-rc-ensure -n 50`으로 maint 로그를 확인한다.
3. 재시작이 발동한 경우 모바일 앱에서 bridge 이름/capacity를 확인한다.
   - 기대: "미니피시", capacity 10 유지 (기본값 5/minipc로 회귀하지 않음).
   - 실패 시: `systemctl show claude-rc-ensure -p Environment`에서 `CLAUDE_RC_*` 주입값을 확인한다.
4. 재시작 후 bridge 버전을 확인한다: `pgrep -f 'claude remote-control'` → `readlink /proc/<PID>/exe`
   - 기대: launcher와 동일한 최신 버전.

### Negative / 회귀 검증

5. `ls -la ~/.local/bin/claude-rc`
   - 기대: `/nix/store/...-claude-rc/bin/claude-rc`를 가리키는 심링크 (HM 재배선 확인). `claude-rc --help`가 tombstone 경고를 포함한 신규 usage를 출력한다.
6. 기존 래퍼 조작 회귀: `claude-rc --attach`(접속), detach 후 `tmux has-session -t claude-rc`
   - 기대: 기존 start/attach/stop 흐름이 그대로 동작한다.
7. bridge가 새로 시작된 뒤 tmux 환경에 credential이 새지 않는지 확인: `tmux show-environment -g | grep -E 'CREDENTIALS|PUSHOVER'`
   - 기대: 출력 없음.
8. 재부팅 후 2~3분 내 bridge가 자동 시작되는지 확인: `tmux has-session -t claude-rc`
   - 기대: 세션 존재 (OnBootSec=2m 자동 복구).
   - 실패 시: `systemctl status claude-rc-ensure`의 Condition 결과(agenix credential 존재)를 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Claude Code Remote Control bridge support on NixOS (enable toggle, capacity, permission mode, display name, idle threshold).
  * Added automated monitoring to keep the bridge running and aligned after restarts.
* **Bug Fixes**
  * Improved stale detection and restart gating using recent transcript activity to reduce unnecessary restarts and version drift.
* **Documentation**
  * Expanded `claude-rc` help with clearer lifecycle and troubleshooting guidance.
  * Added a NixOS-focused skill document for operating the remote-control bridge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->