### PR TITLE
feat(claude-rc): macOS(darwin) 지원 — 래퍼 배선 + launchd 자동 재시작

### DIFF
--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -10,8 +10,16 @@ description: |
 
 # Claude Code Remote Control (claude-rc) 관리
 
-Claude 모바일 앱/claude.ai에서 MiniPC의 Claude Code 세션을 원격 조종하는
-bridge 서버의 운영 가이드. NixOS(MiniPC) 전용 — macOS/darwin 배포는 별도 이슈 범위.
+Claude 모바일 앱/claude.ai에서 이 flake가 관리하는 머신의 Claude Code 세션을
+원격 조종하는 bridge 서버의 운영 가이드.
+
+| 플랫폼 | 래퍼 | 자동 재시작 (ensure) | Pushover 알림 | 배선 모듈 |
+|--------|------|---------------------|---------------|-----------|
+| NixOS (MiniPC) | `~/.local/bin/claude-rc` | systemd timer 30분 | `pushover-system-monitor.age` (minipcOnly) | `modules/nixos/programs/claude-remote-control.nix` |
+| macOS (MacBook, personal/work) | `~/.local/bin/claude-rc` | launchd agent 30분 (`StartInterval`) | `pushover-share.age` (양쪽 맥북 복호화 가능) | `modules/darwin/programs/claude-remote-control.nix` |
+
+운영 옵션 선언 위치: NixOS는 `homeserver.claudeRemoteControl.*` 옵션, darwin은
+모듈 내 hostType 분기 상수 (`bridgeName`/`bridgeCapacity` 등 — 옵션화는 수요 시).
 
 ## 기전 (3계층)
 
@@ -42,18 +50,21 @@ tmux 세션 "claude-rc" (detached 상시 구동)
 | `claude-rc --cleanup` | 서버 종료 + worktree prune + orphan 디렉토리 삭제 |
 
 옵션: `--permission-mode <mode>`, `--capacity <N>`, `--name <name>`.
-수동 실행 시에도 **NixOS 선언값(`homeserver.claudeRemoteControl.*`)과 일치시켜야**
-자동 재시작 후 동작이 달라지지 않는다.
+수동 실행 시에도 **배선 모듈의 선언값(NixOS `homeserver.claudeRemoteControl.*` /
+darwin 모듈 상수)과 일치시켜야** 자동 재시작 후 동작이 달라지지 않는다.
 
-## 자동 재시작 (claude-rc-ensure timer)
+## 자동 재시작 (claude-rc-ensure)
 
-`homeserver.claudeRemoteControl.enable = true` 시 systemd timer가 부팅 2분 후 +
-30분마다 `claude-rc-maint ensure`를 실행한다
-(`modules/nixos/programs/claude-remote-control.nix`).
+NixOS는 `homeserver.claudeRemoteControl.enable = true` 시 systemd timer가 부팅 2분 후 +
+30분마다, macOS는 launchd agent(`StartInterval = 1800` + `RunAtLoad`)가 로그인 시 +
+30분마다 `claude-rc-maint ensure`를 실행한다.
 
 판정 흐름:
-1. tmux 세션 부재/stale → bridge 시작 (부팅 후 자동 복구 겸함)
-2. 실행 중 bridge의 `/proc/PID/exe` 버전 vs `readlink -f ~/.local/bin/claude` 비교
+1. tmux 세션 부재/stale → bridge 시작 (부팅/로그인 후 자동 복구 겸함)
+2. 실행 중 bridge 바이너리 버전 vs `readlink -f ~/.local/bin/claude` 비교.
+   실행 바이너리 경로 조회는 `pid_exe_path` 플랫폼 분기 — Linux `/proc/PID/exe`,
+   macOS `lsof -a -p PID -d txt -Fn` 첫 항목 (macOS는 삭제된 바이너리에 `(deleted)`
+   suffix가 없지만 버전이 파일명이라 문자열 비교로 drift가 감지된다)
 3. drift 없음 → healthy
 4. drift 있음 → idle 게이트:
    - 최근 `IDLE_THRESHOLD_MINUTES`(기본 30분) 내 활동한 bridge transcript가 있으면 유예
@@ -62,12 +73,14 @@ tmux 세션 "claude-rc" (detached 상시 구동)
    - 둘 다 아니면 재시작 (`restarted-version-drift`)
 5. 모든 경로에서 status 기록 + Pushover 알림 (상태 전이 기반, cooldown 30분)
 
-운영 옵션(permissionMode/capacity/name)은 nix 옵션으로 선언되어 재시작 시 보존된다:
-`hosts` 설정은 `modules/nixos/configuration.nix`의 `homeserver.claudeRemoteControl` 블록.
+운영 옵션(permissionMode/capacity/name)은 선언되어 재시작 시 보존된다:
+NixOS는 `modules/nixos/configuration.nix`의 `homeserver.claudeRemoteControl` 블록,
+darwin은 `modules/darwin/programs/claude-remote-control.nix`의 상수.
 
-Pushover fallback: 크리덴셜(`pushover-system-monitor.age`, minipcOnly)이 없는 호스트에서
-maint를 수동 실행하면 알림만 스킵되고 ensure 본체는 정상 동작한다.
-systemd 유닛은 `ConditionPathExists`로 credential 부재 시 조용히 skip된다 (agenix 장애 신호).
+Pushover fallback: 크리덴셜이 없거나 읽을 수 없는 호스트에서 maint를 실행하면
+알림만 스킵되고 ensure 본체는 정상 동작한다.
+NixOS systemd 유닛은 `ConditionPathExists`로 credential 부재 시 조용히 skip된다
+(agenix 장애 신호). darwin launchd agent는 조건 없이 실행되고 fallback에 의존한다.
 
 ## 세션 수명주기 (중요)
 
@@ -84,19 +97,31 @@ systemd 유닛은 `ConditionPathExists`로 credential 부재 시 조용히 skip�
 
 ## 트러블슈팅
 
+공통:
+
 ```bash
-# ensure 상태/이력
-cat ~/.local/state/claude-rc/status.json
+cat ~/.local/state/claude-rc/status.json                    # ensure 상태
+tmux has-session -t claude-rc && tmux attach -t claude-rc   # 래퍼 로그 확인
+pgrep -fl 'claude remote-control'                           # bridge 프로세스
+```
+
+NixOS (MiniPC):
+
+```bash
 journalctl -u claude-rc-ensure --since -2d
 systemctl list-timers claude-rc-ensure
+readlink /proc/<PID>/exe          # 실행 중 바이너리 버전
+systemctl start claude-rc-ensure  # 수동 ensure (drift 즉시 확인)
+```
 
-# bridge 실체 확인
-tmux has-session -t claude-rc && tmux attach -t claude-rc   # 래퍼 로그 확인
-pgrep -af 'claude remote-control'
-readlink /proc/<PID>/exe    # 실행 중 바이너리 버전
+macOS (맥북):
 
-# 수동 ensure (drift 즉시 확인)
-systemctl start claude-rc-ensure
+```bash
+launchctl list | grep claude-rc                                # agent 로드 확인
+launchctl print "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"  # 상세 (마지막 exit 등)
+tail -50 ~/Library/Logs/claude-rc-ensure.log                   # ensure 실행 로그
+lsof -a -p <PID> -d txt -Fn | head -2                          # 실행 중 바이너리 경로 (/proc 대체)
+launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"  # 수동 ensure
 ```
 
 | 증상 | 원인/조치 |
@@ -104,7 +129,8 @@ systemctl start claude-rc-ensure
 | status.json `action: deferred-active-sessions` | 활성 세션 존재 — 정상 유예. 다음 주기 재시도 |
 | `action: deferred-unknown-activity` | transcript 명명 규칙 drift 의심 — `claude-rc-maint.sh`의 `BRIDGE_TRANSCRIPT_GLOBS` 갱신 검토 |
 | `action: no-bridge-process` | 래퍼 backoff 루프가 재시작 중 — 지속되면 `tmux attach -t claude-rc`로 루프 로그 확인 |
-| unit이 실행 안 됨 (Condition failed) | `/run/agenix/pushover-system-monitor` 부재 — agenix 상태 확인 |
+| unit이 실행 안 됨 (Condition failed, NixOS) | `/run/agenix/pushover-system-monitor` 부재 — agenix 상태 확인 |
+| macOS에서 알림이 안 옴 | `~/.config/pushover/share` 복호화 확인 (agenix HM) — 부재 시 알림만 스킵되는 정상 fallback |
 | capacity 꽉 참 (앱에서 새 세션 불가) | idle 프로세스가 슬롯 점유 — 앱에서 "세션 종료" 또는 `claude-rc --cleanup` |
 | 모바일 세션이 응답 없음 (기록만 보임) | tombstone — 위 재개 경로 사용 |
 
@@ -112,6 +138,8 @@ systemctl start claude-rc-ensure
 
 - 래퍼: `modules/nixos/scripts/claude-rc.sh` (store 패키지: `modules/nixos/lib/claude-rc-package.nix`)
 - maint 엔진: `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh`
-- systemd 모듈: `modules/nixos/programs/claude-remote-control.nix`
-- 옵션: `modules/nixos/options/homeserver.nix` (`claudeRemoteControl.*`)
-- HM 배선: `modules/shared/programs/shell/nixos.nix`
+  (패키징: `modules/nixos/lib/claude-rc-maint-package.nix` — runtimeInputs 플랫폼 분기)
+- systemd 모듈 (NixOS): `modules/nixos/programs/claude-remote-control.nix`
+- launchd 모듈 (darwin): `modules/darwin/programs/claude-remote-control.nix` (래퍼 배선 포함)
+- 옵션 (NixOS): `modules/nixos/options/homeserver.nix` (`claudeRemoteControl.*`)
+- HM 배선 (NixOS): `modules/shared/programs/shell/nixos.nix`

--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -61,7 +61,10 @@ NixOS는 `homeserver.claudeRemoteControl.enable = true` 시 systemd timer가 부
 
 판정 흐름:
 1. tmux 세션 부재/stale → bridge 시작 (부팅/로그인 후 자동 복구 겸함)
-2. 실행 중 bridge 바이너리 버전 vs `readlink -f ~/.local/bin/claude` 비교.
+2. 실행 중 bridge 바이너리 버전 vs claude launcher(`~/.local/bin/claude`)가 가리키는
+   최신 버전 비교. desired 버전 조회(maint의 `desired_claude_version`)는 GNU coreutils
+   `readlink -f`를 쓰며, maint 패키지의 runtimeInputs가 두 플랫폼 모두 nix coreutils로
+   해석하므로 macOS BSD `readlink`에 의존하지 않는다.
    실행 바이너리 경로 조회는 `pid_exe_path` 플랫폼 분기 — Linux `/proc/PID/exe`,
    macOS `lsof -a -p PID -d txt -Fn` 첫 항목 (macOS는 삭제된 바이너리에 `(deleted)`
    suffix가 없지만 버전이 파일명이라 문자열 비교로 drift가 감지된다)

--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -101,6 +101,7 @@ in
 
         # macOS 전용
         ./programs/opnix-rotate.nix # Mac SA token 90일 rotation 만료 알림 (#872 후속)
+        ./programs/claude-remote-control.nix # claude-rc 래퍼 + version-drift launchd 감시 (#1007)
         ./programs/hammerspoon
         ./programs/vscode
         ./programs/folder-actions

--- a/modules/darwin/programs/claude-remote-control.nix
+++ b/modules/darwin/programs/claude-remote-control.nix
@@ -1,0 +1,83 @@
+# modules/darwin/programs/claude-remote-control.nix
+# Claude Code Remote Control bridge의 macOS(darwin) 배선 (#1007)
+#
+# MiniPC의 systemd 버전(modules/nixos/programs/claude-remote-control.nix)의 launchd
+# 이식판. 래퍼(~/.local/bin/claude-rc) 설치와 30분 주기 version-drift 감시
+# (claude-rc-ensure launchd agent)를 한 모듈에 응집한다 — bridge 이름/capacity가
+# 래퍼 기본값과 maint env 양쪽에 일관되게 흘러야 하기 때문.
+#
+# NixOS와의 차이:
+#   - 옵션 네임스페이스 없음: darwin에는 homeserver.*가 없어 hostType 분기 상수로
+#     시작한다 (opnix-rotate.nix 관례, 옵션화는 수요 생기면 도입 — YAGNI).
+#   - Pushover: minipcOnly인 pushover-system-monitor.age 대신 shared secrets의
+#     pushover-share.age(~/.config/pushover/share, 양쪽 맥북 복호화 가능)를 쓴다.
+#     파일 형식(PUSHOVER_TOKEN/PUSHOVER_USER env)은 maint의 source 인터페이스와 동일.
+#     복호화 전(agenix 미완료)이면 maint의 graceful fallback이 알림만 스킵한다.
+#   - Persistent 미대응: launchd StartInterval은 놓친 실행을 다음 주기로 수용.
+{
+  config,
+  pkgs,
+  hostType,
+  nixosConfigDefaultPath,
+  ...
+}:
+
+let
+  homeDir = config.home.homeDirectory;
+  username = config.home.username;
+  stateDir = "${homeDir}/.local/state/claude-rc";
+  pushoverCredPath = "${config.xdg.configHome}/pushover/share";
+  serviceLib = import ../../nixos/lib/service-lib.nix { inherit pkgs; };
+
+  # bridge 운영 상수 — NixOS의 homeserver.claudeRemoteControl.* 대응.
+  # 자동 재시작이 이 값들을 명시 전달해야 래퍼 기본값으로 되돌아가는 회귀가 없다.
+  bridgeName = if hostType == "work" then "work-MacBook" else "MacBook";
+  bridgeCapacity = 8; # work-MacBookPro 수동 운영 실측값 승계
+  bridgePermissionMode = "bypassPermissions";
+  idleThresholdMinutes = 30;
+
+  # NixOS HM 배선(shell/nixos.nix)과 같은 표현식 — flakePath/defaultName만 darwin 값.
+  claudeRcPkg = import ../../nixos/lib/claude-rc-package.nix {
+    inherit pkgs;
+    flakePath = nixosConfigDefaultPath;
+    defaultName = bridgeName;
+  };
+  maintenanceCli = import ../../nixos/lib/claude-rc-maint-package.nix { inherit pkgs; };
+in
+{
+  home.file.".local/bin/claude-rc".source = "${claudeRcPkg}/bin/claude-rc";
+
+  launchd.agents.claude-rc-ensure = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${maintenanceCli}/bin/claude-rc-maint"
+        "ensure"
+      ];
+      # 30분 주기 (systemd OnUnitActiveSec=30m 대응) + 로그인 시 1회
+      # (OnBootSec=2m 대응 — ensure가 bridge 부재 시 시작하므로 부팅 후 자동 구동).
+      StartInterval = 1800;
+      RunAtLoad = true;
+      EnvironmentVariables = {
+        HOME = homeDir;
+        STATE_DIR = stateDir;
+        CLAUDE_RC_BIN = "${claudeRcPkg}/bin/claude-rc";
+        SERVICE_LIB = "${serviceLib}";
+        PUSHOVER_CRED_FILE = pushoverCredPath;
+        IDLE_THRESHOLD_MINUTES = toString idleThresholdMinutes;
+        ALERT_COOLDOWN_SECONDS = "1800";
+        CLAUDE_RC_PERMISSION_MODE = bridgePermissionMode;
+        CLAUDE_RC_CAPACITY = toString bridgeCapacity;
+        CLAUDE_RC_NAME = bridgeName;
+        CLAUDE_RC_ALERT_HOST = bridgeName;
+        # writeShellApplication runtimeInputs가 앞에 붙는다. 이 tail은
+        # ~/.local/bin(claude launcher + claude-rc 내부 bare `claude` 호출),
+        # nix 프로필, 그리고 /usr/bin(시스템 pgrep — darwin은 procps 미지원이라
+        # maint 패키징이 시스템 바이너리에 의존)을 해석하기 위해 필요하다.
+        PATH = "${homeDir}/.local/bin:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+      };
+      StandardOutPath = "${homeDir}/Library/Logs/claude-rc-ensure.log";
+      StandardErrorPath = "${homeDir}/Library/Logs/claude-rc-ensure.log";
+    };
+  };
+}

--- a/modules/darwin/programs/claude-remote-control.nix
+++ b/modules/darwin/programs/claude-remote-control.nix
@@ -35,6 +35,7 @@ let
   bridgeCapacity = 8; # work-MacBookPro 수동 운영 실측값 승계
   bridgePermissionMode = "bypassPermissions";
   idleThresholdMinutes = 30;
+  alertCooldownSeconds = 1800;
 
   # NixOS HM 배선(shell/nixos.nix)과 같은 표현식 — flakePath/defaultName만 darwin 값.
   claudeRcPkg = import ../../nixos/lib/claude-rc-package.nix {
@@ -65,7 +66,7 @@ in
         SERVICE_LIB = "${serviceLib}";
         PUSHOVER_CRED_FILE = pushoverCredPath;
         IDLE_THRESHOLD_MINUTES = toString idleThresholdMinutes;
-        ALERT_COOLDOWN_SECONDS = "1800";
+        ALERT_COOLDOWN_SECONDS = toString alertCooldownSeconds;
         CLAUDE_RC_PERMISSION_MODE = bridgePermissionMode;
         CLAUDE_RC_CAPACITY = toString bridgeCapacity;
         CLAUDE_RC_NAME = bridgeName;

--- a/modules/nixos/lib/claude-rc-maint-package.nix
+++ b/modules/nixos/lib/claude-rc-maint-package.nix
@@ -1,0 +1,35 @@
+# claude-rc-maint CLI의 store 패키지 표현식.
+#
+# NixOS systemd 모듈(claude-remote-control.nix)과 darwin launchd 모듈
+# (modules/darwin/programs/claude-remote-control.nix)이 같은 표현식을 평가해
+# 스크립트 본체를 공유한다. runtimeInputs만 플랫폼 분기한다:
+#   - Linux: procps(pgrep) + util-linux(flock)
+#   - Darwin: 둘 다 darwin 미지원 패키지라 flock(discoteq — darwin 빌드 존재)과
+#     lsof(pid_exe_path의 /proc 대체)를 넣는다. pgrep은 nixpkgs 대체가 없어
+#     시스템 /usr/bin/pgrep에 의존한다 — 호출측 launchd agent가 PATH tail에
+#     /usr/bin을 포함해야 한다.
+{ pkgs }:
+pkgs.writeShellApplication {
+  name = "claude-rc-maint";
+  runtimeInputs =
+    with pkgs;
+    [
+      coreutils
+      findutils
+      gawk
+      gnugrep
+      gnused
+      jq
+      tmux
+      curl # service-lib send_notification
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      procps
+      util-linux # flock
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      flock
+      lsof
+    ];
+  text = builtins.readFile ../programs/claude-remote-control/files/claude-rc-maint.sh;
+}

--- a/modules/nixos/lib/claude-rc-package.nix
+++ b/modules/nixos/lib/claude-rc-package.nix
@@ -4,7 +4,16 @@
 # CLAUDE_RC_BIN)이 같은 인자로 이 표현식을 평가하면 동일 store path를 공유한다.
 # systemd ExecStart/env는 절대 store 경로가 필요하므로 (~ 미확장) HM 산출물이
 # 아닌 store 패키지로 경계를 통일한다.
-{ pkgs, flakePath }:
+# defaultName: 옵션 미지정 수동 실행 시 claude.ai에 표시되는 bridge 이름.
+# darwin 배선이 머신별 이름을 주입한다. NixOS의 두 배선(HM/systemd)은 미지정으로
+# 같은 기본값을 받아 동일 store path 공유가 유지된다.
+{
+  pkgs,
+  flakePath,
+  defaultName ? "minipc",
+}:
 pkgs.runCommand "claude-rc" { } ''
-  install -Dm755 ${pkgs.replaceVars ../scripts/claude-rc.sh { inherit flakePath; }} $out/bin/claude-rc
+  install -Dm755 ${
+    pkgs.replaceVars ../scripts/claude-rc.sh { inherit flakePath defaultName; }
+  } $out/bin/claude-rc
 ''

--- a/modules/nixos/programs/claude-remote-control.nix
+++ b/modules/nixos/programs/claude-remote-control.nix
@@ -28,22 +28,8 @@ let
     flakePath = nixosConfigDefaultPath;
   };
 
-  maintenanceCli = pkgs.writeShellApplication {
-    name = "claude-rc-maint";
-    runtimeInputs = with pkgs; [
-      coreutils
-      findutils
-      gawk
-      gnugrep
-      gnused
-      jq
-      procps
-      tmux
-      util-linux # flock
-      curl # service-lib send_notification
-    ];
-    text = builtins.readFile ./claude-remote-control/files/claude-rc-maint.sh;
-  };
+  # darwin launchd 모듈과 공유하는 패키징 (runtimeInputs 플랫폼 분기 포함).
+  maintenanceCli = import ../lib/claude-rc-maint-package.nix { inherit pkgs; };
 in
 {
   config = lib.mkIf cfg.enable {

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -2,10 +2,12 @@
 # claude-rc-maint: Claude Code Remote Control bridge의 version-drift 감시 엔진.
 #
 # 사용자 래퍼(claude-rc)와 책임을 분리한 maintenance 전용 스크립트로,
-# systemd timer(claude-rc-ensure)가 주기 실행한다. codex-remote-control-maint.sh 골격 차용.
+# NixOS는 systemd timer(claude-rc-ensure), macOS는 launchd agent가 주기 실행한다.
+# codex-remote-control-maint.sh 골격 차용.
 #
-# 동작: 실행 중 bridge 바이너리(/proc/PID/exe)와 claude launcher가 가리키는
-# 최신 버전을 비교해 drift가 있으면 — 활성 원격 세션이 없을 때만 — bridge를 재시작한다.
+# 동작: 실행 중 bridge 바이너리(pid_exe_path — Linux /proc, macOS lsof)와 claude
+# launcher가 가리키는 최신 버전을 비교해 drift가 있으면 — 활성 원격 세션이 없을
+# 때만 — bridge를 재시작한다.
 # bridge 재시작은 활성 세션을 tombstone시키므로 idle 게이트가 핵심 안전장치다.
 set -euo pipefail
 
@@ -21,12 +23,14 @@ MAINT_LOCK_TIMEOUT_SECONDS="${MAINT_LOCK_TIMEOUT_SECONDS:-120}"
 ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
 PUSHOVER_CRED_FILE="${PUSHOVER_CRED_FILE:-}"
 SERVICE_LIB="${SERVICE_LIB:-}"
-# bridge 시작 옵션 — NixOS 모듈(homeserver.claudeRemoteControl.*)이 주입한다.
-# maint가 명시 전달하지 않으면 자동 재시작 시 래퍼 기본값으로 조용히 되돌아가므로
-# (예: capacity 10 → 5) 반드시 전량 전달한다.
+# bridge 시작 옵션 — 배선 모듈(NixOS homeserver.claudeRemoteControl.* / darwin
+# claude-remote-control.nix)이 주입한다. maint가 명시 전달하지 않으면 자동 재시작 시
+# 래퍼 기본값으로 조용히 되돌아가므로 (예: capacity 10 → 5) 반드시 전량 전달한다.
 CLAUDE_RC_PERMISSION_MODE="${CLAUDE_RC_PERMISSION_MODE:-bypassPermissions}"
 CLAUDE_RC_CAPACITY="${CLAUDE_RC_CAPACITY:-5}"
 CLAUDE_RC_NAME="${CLAUDE_RC_NAME:-minipc}"
+# 알림 메시지의 머신 식별자 (recovered 알림 본문에 사용)
+CLAUDE_RC_ALERT_HOST="${CLAUDE_RC_ALERT_HOST:-greenhead-minipc}"
 
 #───────────────────────────────────────────────────────────────────────────────
 # upstream 의존 selector — Claude Code CLI/spawn process shape 또는 transcript
@@ -81,12 +85,28 @@ bridge_session_alive() {
     [ "$rc_active" = "CLAUDE_RC_ACTIVE=1" ]
 }
 
+# 플랫폼별 실행 바이너리 경로 조회.
+# - Linux: /proc/PID/exe. 삭제된 바이너리는 " (deleted)" suffix가 붙는다.
+# - Darwin: /proc이 없어 lsof의 첫 txt(code segment) 항목을 쓴다. 실행 파일이
+#   항상 첫 txt로 나열되고(-F 필드 출력은 경로 공백 안전; 실측 work-MacBookPro),
+#   ps -o comm=은 argv[0] 기반이라 symlink 경유 실행 시 실경로를 잃는다.
+#   삭제된 바이너리도 suffix 없이 원경로가 그대로 나오지만, 버전이 파일명이라
+#   desired와의 문자열 비교로 drift가 감지되므로 (deleted) 표식 없이도 충분하다.
+pid_exe_path() {
+    local pid="$1"
+    case "$(uname -s)" in
+        Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
+        *) readlink "/proc/$pid/exe" 2>/dev/null ;;
+    esac
+}
+
 # 첫 번째 유효 bridge PID를 출력. 유효 = exe가 claude versions 디렉토리 아래.
 find_bridge_pid() {
     local pid exe
     while IFS= read -r pid; do
         [ -n "$pid" ] || continue
-        exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || continue
+        exe=$(pid_exe_path "$pid") || continue
+        [ -n "$exe" ] || continue
         case "${exe% (deleted)}" in
             "$VERSIONS_DIR"/*) echo "$pid"; return 0 ;;
         esac
@@ -94,11 +114,12 @@ find_bridge_pid() {
     return 1
 }
 
-# /proc/PID/exe 기준 실행 중 버전. 바이너리가 삭제된 구버전이면 "deleted"를 붙여
-# 호출측이 drift로 취급하게 한다.
+# pid_exe_path 기준 실행 중 버전. 바이너리가 삭제된 구버전이면 "deleted"를 붙여
+# 호출측이 drift로 취급하게 한다 (Linux 전용 신호 — Darwin 주석은 pid_exe_path 참조).
 pid_exe_version() {
     local pid="$1" exe
-    exe=$(readlink "/proc/$pid/exe" 2>/dev/null) || return 1
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
     case "$exe" in
         *" (deleted)") echo "$(basename "${exe% (deleted)}") (deleted)" ;;
         *) basename "$exe" ;;
@@ -137,11 +158,12 @@ count_recent_bridge_transcripts() {
 }
 
 # bridge가 스폰한 세션 프로세스 수 (transcript 명명에 비의존인 2차 신호).
-# pgrep -c는 매치 0일 때도 "0"을 출력하며 rc=1이므로, || echo를 쓰면 "0"이
-# 이중 출력된다 — 캡처 후 실패 시 대입으로 처리한다.
+# pgrep -c는 GNU procps 전용이라 macOS BSD pgrep에서 usage 에러(rc=2)가 난다
+# (실측) — PID 출력을 wc -l로 세는 플랫폼 중립 방식을 쓴다. 매치 0이면
+# pgrep rc=1 → pipefail로 대입이 실패하므로 실패 시 대입으로 0 처리한다.
 count_bridge_session_procs() {
     local count
-    count=$(pgrep -u "$(id -u)" -c -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null) || count=0
+    count=$(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null | wc -l) || count=0
     echo "$count"
 }
 
@@ -249,7 +271,7 @@ send_alerts() {
     if [ "$exit_code" -eq 0 ]; then
         if [ "$previous" = "failed" ]; then
             send_notification "Claude RC Recovered" \
-                "greenhead-minipc claude-rc bridge is healthy (${RUNNING_VERSION:-unknown})." 0
+                "${CLAUDE_RC_ALERT_HOST} claude-rc bridge is healthy (${RUNNING_VERSION:-unknown})." 0
         fi
         echo "healthy" >"$state_file"
         return 0
@@ -346,7 +368,7 @@ env:
   CLAUDE_RC_BIN, CLAUDE_BIN, STATE_DIR, TMUX_SESSION,
   IDLE_THRESHOLD_MINUTES (default 30), MAINT_LOCK_TIMEOUT_SECONDS (default 120),
   ALERT_COOLDOWN_SECONDS (default 1800), PUSHOVER_CRED_FILE, SERVICE_LIB,
-  CLAUDE_RC_PERMISSION_MODE, CLAUDE_RC_CAPACITY, CLAUDE_RC_NAME
+  CLAUDE_RC_PERMISSION_MODE, CLAUDE_RC_CAPACITY, CLAUDE_RC_NAME, CLAUDE_RC_ALERT_HOST
 
 상태 확인: cat $STATE_DIR/status.json (기본 ~/.local/state/claude-rc/status.json)
 EOF

--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 #───────────────────────────────────────────────────────────────────────────────
 WORK_DIR="@flakePath@"
 TMUX_SESSION="claude-rc"
-RC_NAME="minipc"
+RC_NAME="@defaultName@"
 RC_PERMISSION_MODE="bypassPermissions"
 RC_SPAWN="worktree"
 RC_CAPACITY=5
@@ -53,7 +53,7 @@ bridge 서버(`claude remote-control`)를 tmux 세션 안에서 상시 구동한
   --permission-mode <mode>   스폰 세션 권한 모드 (default: bypassPermissions)
                              acceptEdits|bypassPermissions|default|dontAsk|plan
   --capacity <N>             동시 세션 수 (default: 5)
-  --name <name>              claude.ai/앱에 표시되는 이름 (default: minipc)
+  --name <name>              claude.ai/앱에 표시되는 이름 (default: @defaultName@)
   --help                     이 도움말 출력
 
 세션 수명주기 경고 (--stop / 재시작 시):
@@ -70,8 +70,8 @@ bridge 서버(`claude remote-control`)를 tmux 세션 안에서 상시 구동한
   요청은 모두 미구현 상태로 종결되어 이 workaround는 계속 필요하다.
 
 자동 재시작 (버전 drift 감시):
-  NixOS에서는 systemd timer(claude-rc-ensure)가 30분마다 claude-rc-maint를 실행해
-  bridge 바이너리가 구버전이면 idle 시점에 자동 재시작한다.
+  NixOS는 systemd timer, macOS는 launchd agent(모두 claude-rc-ensure)가 30분마다
+  claude-rc-maint를 실행해 bridge 바이너리가 구버전이면 idle 시점에 자동 재시작한다.
   상태 확인: cat ~/.local/state/claude-rc/status.json
   상세: .claude/skills/managing-claude-rc/SKILL.md
 EOF


### PR DESCRIPTION
## Summary

- NixOS(miniPC) 전용이던 claude-rc 스택(bridge tmux 래퍼 + version-drift 자동 재시작)을 macOS(darwin) 2대 MacBook으로 이식한다.
- maint 엔진의 `/proc` 의존을 플랫폼 분기(`pid_exe_path`)로 해소하고, launchd agent(30분 주기 + 로그인 시 1회)로 systemd timer를 대응한다.
- 이식 과정에서 macOS BSD pgrep의 `-c` 미지원(usage 에러 rc=2)을 실측 발견하여 `wc -l` 카운트로 플랫폼 중립화했다.

Closes #1007

## 기존 문제/배경

PR #1005 로 도입된 claude-rc 스택은 NixOS 전용으로 설계됐다 (당시 설계 리뷰에서 macOS 분기를 "사용처 없는 미래 대비"로 의도적 제외). 이후 두 MacBook에서도 bridge를 상시 구동하고 자동 최신화하려는 수요가 확정됐다.

방치 시: MacBook에서 bridge를 수동으로 띄워야 하고, miniPC에서 실측된 version-drift가 그대로 재현된다. 실제로 이번 작업 중 work 호스트에서 수동으로 띄워둔 bridge가 running 2.1.193 vs desired 2.1.202로 9개 릴리스 뒤처진 상태가 실측됐다 — 이 이슈가 해결하려는 문제의 살아있는 재현이었다.

## CIR (Change Intent Record)

- v1 (PR #1005): claude-rc 도입 시 macOS `/proc` 가드를 "배포 경계와 맞지 않는 미래 대비 분기"로 판정해 의도적으로 제외.
- v2 (이번 변경): 사용처(2대 MacBook)가 확정되어 그 결정을 명시적으로 뒤집음 — 이슈 #1007에 문서화된 정당한 번복이며 회귀가 아님. PR #1005의 나머지 설계 계약(store 패키지 공유, 운영 옵션 env 전량 명시 전달, idle 게이트, flock fd `9>&-` 규칙)은 그대로 유지.
- 구현 중 발견/전환: (1) macOS BSD pgrep에 `-c`가 없어(rc=2 실측) `count_bridge_session_procs`가 항상 0을 반환 → idle 게이트의 보수적 유예(2차 신호)가 무력화되는 문제를 발견, `pgrep | wc -l`로 플랫폼 중립화. (2) 이슈는 work 호스트의 Pushover 알림 스킵을 전제했으나, shared secrets의 `pushover-share.age`(`~/.config/pushover/share`)가 양쪽 MacBook에서 복호화 가능함을 실측 — 두 호스트 모두 알림 배선으로 개선. (3) 래퍼 배선을 이슈 초안의 `shell/darwin.nix` 대신 darwin launchd 모듈에 응집 — bridge 이름/capacity가 래퍼 기본값과 maint env 양쪽에 일관되게 흘러야 하기 때문.

trade-off: darwin 운영 옵션은 NixOS의 `homeserver.*` 같은 옵션 네임스페이스 없이 모듈 내 hostType 분기 상수로 시작한다 (YAGNI — 옵션화는 수요 시). maint의 darwin pgrep은 nixpkgs 대체가 없어 시스템 `/usr/bin/pgrep`에 의존한다 (launchd PATH tail로 해석).

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| lsof 첫 txt 항목 (`-Fn`) | macOS에서 PID의 code segment 첫 항목을 실행 바이너리로 사용 | 실측 검증 완료 (nixpkgs lsof 4.99.6 + 시스템 lsof 모두), 필드 출력이라 경로 공백 안전 | 삭제된 바이너리에 `(deleted)` suffix 없음 — 단 버전이 파일명이라 문자열 비교로 drift 감지 가능 | ✅ |
| `ps -o comm=` | argv[0] 기반 조회 | 의존성 없음 | symlink 경유 실행 시 실경로 손실 (실측: `claude`만 반환) | ❌ |
| maint 파일 shared/ 승격 | 스크립트를 `modules/shared/`로 이동 | 구조적으로 명확 | 이동 diff 발생, 두 번째 사용처가 자리잡기 전 성급 | ❌ (darwin 모듈이 nixos 경로를 상대 참조 — 이슈 가이드 권장안) |
| 패키징 중복 vs 공용화 | writeShellApplication 블록을 양쪽 모듈에 복제 vs lib로 추출 | 중복은 모듈 독립성 | runtimeInputs 플랫폼 분기가 두 곳에 흩어짐 | ✅ 공용화 (`claude-rc-maint-package.nix`) |
| 래퍼 이름 하드코딩 유지 | `RC_NAME="minipc"` 그대로 두고 darwin은 옵션으로만 오버라이드 | diff 최소 | 수동 실행 시 claude.ai에 "minipc"로 표시되는 혼란 — PR #1005의 "조용히 잘못된 기본값" 문제와 동종 | ❌ (`defaultName` 파라미터화, NixOS는 기본값으로 store path 공유 유지) |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh` | 수정 | `pid_exe_path` 플랫폼 분기 (Linux `/proc`, Darwin `lsof -Fn`), `pgrep -c` → `wc -l`, 알림 호스트명 `CLAUDE_RC_ALERT_HOST` 파라미터화 |
| `modules/nixos/lib/claude-rc-maint-package.nix` | 신규 | maint CLI 패키징 공용화 — runtimeInputs 플랫폼 분기 (Linux: procps/util-linux, Darwin: flock/lsof) |
| `modules/nixos/lib/claude-rc-package.nix` | 수정 | `defaultName ? "minipc"` 인자 추가 (NixOS 두 배선은 미지정으로 동일 store path 공유 유지) |
| `modules/nixos/scripts/claude-rc.sh` | 수정 | `RC_NAME="@defaultName@"` 치환 지점 + usage 문구 플랫폼 일반화 |
| `modules/nixos/programs/claude-remote-control.nix` | 수정 | 인라인 writeShellApplication을 공용 표현식 import로 교체 (동작 불변) |
| `modules/darwin/programs/claude-remote-control.nix` | 신규 | 래퍼 home.file + launchd agent (`StartInterval 1800` + `RunAtLoad`), 운영 옵션 env 전량 명시 주입, Pushover는 `pushover-share.age` |
| `modules/darwin/home.nix` | 수정 | 신규 모듈 import 1줄 |
| `.claude/skills/managing-claude-rc/SKILL.md` | 수정 | scope를 플랫폼 매트릭스로 갱신 + macOS 트러블슈팅 (launchctl) |

### 핵심 코드

```bash
# 플랫폼별 실행 바이너리 경로 조회 (claude-rc-maint.sh)
pid_exe_path() {
    local pid="$1"
    case "$(uname -s)" in
        Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
        *) readlink "/proc/$pid/exe" 2>/dev/null ;;
    esac
}

# BEFORE: GNU procps 전용 — macOS BSD pgrep은 -c 미지원 (rc=2) → count가 항상 0
count=$(pgrep -u "$(id -u)" -c -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null) || count=0
# AFTER: 플랫폼 중립
count=$(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null | wc -l) || count=0
```

## 참고 레퍼런스

- Issue #1007 — 본 이식 요구 + 이행 가이드 (Phase 1 실측 gate 포함)
- PR #1005 — claude-rc NixOS 구현 본체 (macOS 분기 제외 결정 이력, 운영 옵션 보존 계약)
- `modules/darwin/programs/opnix-rotate.nix` — darwin launchd 주기 실행 배선 선례 (systemd → launchd 이식 패턴)

## Human Test Plan

작성 시점에 work 호스트(darwin)에서 실측 완료된 항목은 ✅로 표기.

### macOS 정상 동작 검증 (darwin 호스트)

1. `nrs` 실행 후 배선 확인. ✅
   - 기대: `~/.local/bin/claude-rc`가 store 심링크, `launchctl list | grep claude-rc`에 agent 로드.
   - 실패 시: `~/Library/LaunchAgents/org.nix-community.home.claude-rc-ensure.plist` 존재와 darwin home.nix import를 확인.
2. `claude-rc --help`의 `--name` 기본값이 머신별 이름(work: `work-MacBook`)인지 확인. ✅
3. `launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"` 후 `cat ~/.local/state/claude-rc/status.json`. ✅
   - 기대: `action`이 `started`/`healthy`/`restarted-version-drift`/`deferred-*` 중 하나, `exitCode` 0. tmux 세션 `claude-rc`에 bridge가 운영 옵션(name/capacity/permission-mode) 명시 인자로 떠 있음.
   - 실패 시: `tail -50 ~/Library/Logs/claude-rc-ensure.log`로 maint 로그 확인.
4. drift 자동 재시작 검증: 구버전 바이너리로 실행 중인 bridge가 있는 상태에서 ensure 실행. ✅ (실측: 2.1.193 → 2.1.202 재시작 완주)
5. 수동 bridge 정리 (전환 단계): 래퍼 밖에서 직접 띄운 `claude remote-control` 프로세스가 남아 있으면 maint가 그 PID를 먼저 발견해 매 주기 재시작이 반복된다.
   - 기대: 수동 bridge 종료 후 다음 ensure에서 `action: healthy`로 수렴.
   - 실패 시: `pgrep -fl 'claude remote-control'`로 tmux 밖 잔존 프로세스를 확인.

### 알림 (darwin)

6. `~/.config/pushover/share` 복호화 상태에서 ensure가 실패→복구 전이를 겪으면 Pushover recovered 알림에 머신 식별자(`work-MacBook` 등)가 표기된다.
   - 실패 시: launchd plist의 `PUSHOVER_CRED_FILE` env와 agenix HM 상태 확인. 파일 부재 시 알림만 스킵되는 graceful fallback이 정상.

### NixOS 회귀 (miniPC — 미실측, 병합 후 확인 필요)

7. miniPC에서 `nrs` 후 `systemctl start claude-rc-ensure && cat ~/.local/state/claude-rc/status.json`.
   - 기대: 기존과 동일하게 `healthy`/`deferred-*`/`restarted-*` 중 하나, `exitCode` 0. 알림 메시지의 머신 식별자도 기존과 동일(`greenhead-minipc` — 스크립트 기본값 유지).
   - 근거: Linux 경로는 함수 추출 + 카운트 방식 변경뿐으로 semantics 동일 (`pgrep -f | wc -l` ≡ `pgrep -c -f`), nixos toplevel eval 통과. 단 실기 실행은 이 PR 작성 환경(darwin)에서 SSH 미설정으로 미수행.
   - 실패 시: `journalctl -u claude-rc-ensure --since -1h`.
8. Negative: miniPC의 `~/.local/bin/claude-rc` usage에서 이름 기본값이 여전히 `minipc`인지 확인 (defaultName 파라미터화가 NixOS 산출물을 바꾸지 않았는지).

---
https://claude.ai/code/session_01L2GoFkoe3cx9bPojBkQbbT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added macOS support for the remote-control bridge via Home Manager, including automatic setup and periodic health/ensure runs.

* **Bug Fixes**
  * Improved bridge process/version detection on both Linux and macOS.
  * Recovery/healthy notifications now use a configurable alert host, and alert credential absence results in safe “skip alert, keep working” behavior.

* **Documentation**
  * Expanded platform-specific operation, ensure/restart behavior, and troubleshooting guidance, including updated manual ensure and troubleshooting steps.

* **Refactor**
  * Made the default session/display name configurable for the remote-control wrapper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->