### PR TITLE
feat(skills): finish-pr 신규 스킬 — PR 머지 후 종결 절차 표준화

### DIFF
--- a/modules/shared/programs/claude/default.nix
+++ b/modules/shared/programs/claude/default.nix
@@ -211,6 +211,10 @@ in
     ".claude/skills/create-pr".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/create-pr";
 
+    # finish-pr 스킬 (user-scope)
+    ".claude/skills/finish-pr".source =
+      config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/finish-pr";
+
     # issuing-codex-pairing-code 스킬 (user-scope)
     ".claude/skills/issuing-codex-pairing-code".source =
       config.lib.file.mkOutOfStoreSymlink "${claudeFilesPath}/skills/issuing-codex-pairing-code";

--- a/modules/shared/programs/claude/files/skills/create-pr/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-pr/SKILL.md
@@ -5,6 +5,7 @@ description: |
   Create structured PR. Default: create new PR. Args: update (existing PR body).
   Trigger: 'PR 만들어줘', 'PR 생성', 'PR 올려', 'create PR', 'PR 업데이트', 'Human Test'.
   NOT for DA (use run-da). NOT for PR 코멘트 (use review-pr-feedback).
+  NOT for 머지 후 종결 절차 (use finish-pr).
 ---
 
 # 상세 PR 작성

--- a/modules/shared/programs/claude/files/skills/finish-pr/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/finish-pr/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: finish-pr
+argument-hint: "[pr-number|pr-url|branch]"
+description: |
+  PR 머지 후 종결 절차를 수행한다. 대상 PR 확인, CI 상태 확인, squash merge, main pull 후 로컬 실측 검증, PR 후속 코멘트, 관련 이슈 동기화, 산출물 위생 점검, worktree cleanup까지 다룬다.
+  Trigger: '머지해줘', 'squash merge', '머지 후 정리', 'PR 마무리', 'PR 종결', 'finish-pr'.
+  NOT for PR 생성 (use create-pr). NOT for PR 코멘트 처리 (use review-pr-feedback).
+---
+
+# PR 종결
+
+사용자 인자로 PR 번호, PR URL, 또는 브랜치 힌트를 수신하면 그 값을 우선하고, 없으면 현재 브랜치에서 대상 PR을 추론한다.
+
+## 원칙
+
+- 현재 레포의 `CLAUDE.md`, `AGENTS.md`, 스킬 문서, 빌드 관례가 이 스킬보다 우선한다.
+- STOP 지점에 도달하면 이후 GitHub 쓰기, 이슈 close, 워크트리 정리를 진행하지 않고 사용자에게 원인과 다음 선택지를 보고한다.
+- GitHub 본문이 길거나 셸 해석 문자가 섞이면 임시 파일과 `--body-file`을 사용한다.
+- 검증 실패도 숨기지 않는다. 이미 머지된 뒤 검증이 실패하면 실패 명령, 핵심 stderr/stdout, 재현 조건을 PR 코멘트로 남긴 뒤 STOP한다.
+
+## 절차
+
+### 1. 대상 PR 확인 + CI 상태 확인
+
+1. 대상 PR을 확정한다. 인자가 없으면 `gh pr view --json number,url,headRefName,baseRefName,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,body,commits`로 현재 브랜치의 PR을 확인한다.
+2. base가 의도한 기본 브랜치인지, PR이 open 상태인지, draft가 아닌지 확인한다.
+3. CI와 review 상태를 확인한다. 미완료 check가 있으면 대기하거나 사용자에게 현재 상태를 보고한다. 실패 check, merge conflict, required review 미승인은 STOP한다.
+
+Skip 조건:
+- PR이 이미 merge된 상태면 squash merge 단계는 건너뛰고, 머지된 main을 최신화한 뒤 로컬 검증부터 진행한다.
+- 사용자가 CI 실패를 알고도 강행하라고 한 경우에도 required gate를 우회하지 않는다. 가능한 우회가 정책상 허용되는지 먼저 보고한다.
+
+### 2. squash merge
+
+1. `gh pr merge <pr> --squash`로 squash merge한다.
+2. merge 실패, 충돌, 미승인, 권한 오류가 나면 STOP하고 원문 오류를 요약해 보고한다.
+3. merge 성공 후 PR 번호, URL, merge 결과 메시지, squash commit SHA를 가능한 범위에서 기록해 둔다.
+
+Skip 조건:
+- 이미 merge된 PR이면 이 단계는 건너뛴다.
+- 사용자가 merge 방식 변경을 명시하지 않는 한 squash를 유지한다.
+
+### 3. main pull + 로컬 실측 검증
+
+1. 현재 레포 관례에 맞는 main checkout 또는 main worktree로 이동해 기본 브랜치를 최신화한다.
+2. 로컬 검증 명령은 레포 컨텍스트에 위임한다. 이 레포 기본값은 main pull 후 `nrs`를 실행하고, 변경 영향 범위에 맞는 실측을 추가하는 것이다.
+3. 영향 범위별 실측 예시:
+   - 스킬 또는 AI 호환성 변경: 해당 스킬을 읽어 트리거/경계가 맞는지 확인하고, `./scripts/ai/check-skill-noise.sh`, 필요한 경우 `./scripts/ai/verify-ai-compat.sh`를 실행한다.
+   - 서비스 또는 컨테이너 변경: 해당 서비스의 상태, 로그, 포트, healthcheck를 확인한다.
+   - 에디터, shell, macOS/NixOS 설정 변경: 관련 CLI 동작 또는 설정 반영 여부를 직접 확인한다.
+4. 실행한 명령, exit code, 핵심 결과를 PR 후속 코멘트용으로 기록한다.
+
+Skip 조건:
+- 문서 전용이나 주석 전용처럼 runtime 실측이 무의미한 변경은 레포의 최소 검증으로 축소하고 축소 사유를 기록한다.
+- `nrs`가 명백히 불필요한 레포에서는 해당 레포의 빌드/테스트 관례를 따른다.
+- 검증이 환경 제약으로 불가능하면 대체 확인을 수행하고, 불가능한 항목과 이유를 PR 코멘트에 명시한다.
+
+### 4. PR 후속 코멘트로 검증 결과 박제
+
+1. PR에 후속 코멘트를 남긴다. 포함 항목:
+   - merge 결과와 main 최신화 여부
+   - 실행한 검증 명령
+   - 성공/실패 요약
+   - 실패 시 원문 오류의 핵심 부분과 다음 조치
+2. 검증 실패 시 코멘트를 남긴 뒤 STOP한다. 관련 이슈 close와 워크트리 정리는 하지 않는다.
+
+Skip 조건:
+- GitHub API 장애로 코멘트 게시가 실패하면 로컬에 본문을 남기고 사용자에게 재시도 명령을 보고한다.
+
+### 5. 관련 이슈 동기화
+
+1. PR 본문, 커밋 메시지, 브랜치명에서 참조 이슈를 수집한다.
+2. `gh issue list --search`로 제목, 브랜치 키워드, 주요 변경 키워드를 검색해 누락된 관련 이슈를 확인한다.
+3. 완료된 이슈는 근거 코멘트를 남긴 뒤 close한다. 부분 진행 이슈는 close하지 않고 현재 상태와 남은 작업을 코멘트로 갱신한다.
+4. close 사유에는 머지된 PR 번호, 로컬 검증 결과, 완료로 판단한 근거를 포함한다.
+
+Skip 조건:
+- 관련 이슈가 없으면 없음으로 기록하고 넘어간다.
+- 검증 실패, 범위 불명확, 일부 미완료가 있으면 close하지 않는다.
+- 이슈가 다른 repo에 속할 수 있으면 URL 또는 repo를 재확인한 뒤 진행한다.
+
+### 6. 산출물 위생 점검
+
+1. 선택 단계로 머지된 diff를 훑어 코드/문서에 남은 프로세스 메타데이터, 임시 이슈 번호, 라운드 번호, finding ID, dangling partial hash, 작업용 절대경로를 확인한다.
+2. 발견하면 이번 PR 후속 정리로 처리할지 별도 이슈/PR로 남길지 제안한다.
+
+Skip 조건:
+- 바이너리, lockfile, 단순 버전 핀처럼 사람이 읽는 산출물이 아닌 변경은 이 단계를 생략할 수 있다.
+
+### 7. 워크트리 정리
+
+1. `CLAUDE.md`의 비대화형 `wt` 규칙을 따른다.
+2. 현재 작업이 완료됐고 dirty/unpushed 변경이 없으면 `wt cleanup <name>` 또는 `wt cleanup --auto`로 정리한다.
+3. dirty 또는 unpushed 상태가 있으면 STOP하고 어떤 파일/커밋 때문에 정리하지 않았는지 보고한다. 사용자 승인 없이 `--yes`로 우회하지 않는다.
+
+Skip 조건:
+- worktree 기반 작업이 아니면 정리할 대상이 없다고 보고하고 생략한다.
+- 사용자가 보존을 요청한 worktree는 정리하지 않는다.

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -43,6 +43,7 @@ let
     "analyzing-da-sessions"
     "create-issue"
     "create-pr"
+    "finish-pr"
     "issuing-codex-pairing-code"
     "playwright-cli"
     "review-pr-feedback"

--- a/scripts/ai/verify-ai-compat.sh
+++ b/scripts/ai/verify-ai-compat.sh
@@ -29,6 +29,7 @@ EXPECTED_EXPOSED=(
   analyzing-da-sessions
   create-issue
   create-pr
+  finish-pr
   issuing-codex-pairing-code
   playwright-cli
   review-pr-feedback


### PR DESCRIPTION
## Summary

- 신규 글로벌 스킬 `finish-pr` 추가 — PR 머지 후 종결 절차(squash merge → main pull + 로컬 실측 → PR 후속 코멘트 → 관련 이슈 동기화 → 산출물 위생 점검 → worktree 정리)를 표준화
- claude/codex 배선 + verify-ai-compat EXPECTED 등재 + create-pr에 역방향 NOT-for 추가
- Closes #1011

## 기존 문제/배경

세션로그 시계열 감사(4개월, 양 머신)에서 머지 후 종결 절차가 거의 동일한 형태로 50회 이상 반복 수동 지시된 것이 확인됐다 — 전 기간 단일 최다 반복 패턴. create-pr는 PR 생성에서 끝나 머지 이후가 스킬 커버리지 공백이었다.

## CIR (Change Intent Record)

스킬 감사 epic(#1010)의 최우선 후속. 설계는 사전 논의로 확정됐다: (1) create-pr 모드 확장이 아닌 별도 경량 스킬 — 시점(생성 vs 종결)과 트리거가 다르고, create-pr는 과거 비대화로 다이어트를 거친 이력이 있어 재비대화를 피함, (2) 로컬 실측 검증의 이 레포 기본값은 nrs + 변경 영향 범위 선별 실측(검증 명령 자체는 레포 컨텍스트에 위임하는 골격 구조), (3) 완료 후 산출물 위생 점검(프로세스 메타데이터·임시 참조 잔존 확인) 포함 — 세션에서 반복 확립된 관습의 박제. SKILL.md는 참조 파일 없이 단일 파일(98줄)로 얇게 시작하며, 인라인 인자 치환 토큰을 두지 않는 저작 규칙(#1013)을 선반영했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 신규 경량 스킬 | finish-pr 별도 신설 | 트리거 명확, small-composable 방향 일치 | 스킬 수 +1 (description 상시 부담) | ✅ |
| create-pr post-merge 모드 | 기존 스킬에 모드 추가 | 스킬 수 유지 | 다이어트 완료 스킬의 재비대화, 시점 혼재 | ❌ |
| 제안 이슈로 보류 | 설계만 기록 | 무비용 | 반복 50회+의 방치 지속 | ❌ |

Codex 노출은 create-pr과 동일하게 exposedCodexSkills로 분류 (merge/이슈 동기화가 gh CLI 기반이라 Codex 세션에서도 동일 가치).

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claude/files/skills/finish-pr/SKILL.md` | 신규 (98줄, description 285자) — 7단계 절차 + 단계별 skip/STOP 조건 |
| `modules/shared/programs/claude/default.nix` | `.claude/skills/finish-pr` mkOutOfStoreSymlink 배선 |
| `modules/shared/programs/codex/default.nix` | exposedCodexSkills에 finish-pr 추가 |
| `scripts/ai/verify-ai-compat.sh` | EXPECTED_EXPOSED에 finish-pr 등재 |
| `modules/shared/programs/claude/files/skills/create-pr/SKILL.md` | description에 "NOT for 머지 후 종결 절차 (use finish-pr)" 추가 |

절차 골격의 안전 경계: required CI gate 우회 금지, 검증 실패 시 이슈 close·worktree 정리 중단(STOP), `wt cleanup` 시 dirty/unpushed면 사용자 승인 없이 `--yes` 우회 금지.

## 참고 레퍼런스

- #1011 (본 이슈), #1010 (스킬 감사 epic)
- `modules/shared/programs/claude/files/skills/create-pr/SKILL.md` — 구조 준거

## Human Test Plan

1. merge 후 main에서 `nrs` 실행 → `~/.claude/skills/finish-pr` 심링크 생성 확인 (`ls -la ~/.claude/skills/ | grep finish-pr`)
2. `./scripts/ai/verify-ai-compat.sh` 실행 → 완전 통과 확인 (merge+nrs 전에는 EXPECTED에만 있고 배포가 없어 실패하는 것이 정상)
3. 새 세션에서 "이 PR 머지하고 마무리해줘" 류 발화 → finish-pr 자동 트리거 확인
4. `/finish-pr` 명시 호출 → 절차 1(대상 PR 확인)부터 진행되는지 확인
5. 실패 시 진단: 심링크가 없으면 nrs 미실행 또는 claude/default.nix 배선 누락, 트리거 안 되면 description 확인 (`head -8 ~/.claude/skills/finish-pr/SKILL.md`)

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM
