### PR TITLE
docs(skills): 마이그레이션 기인 stale 스킬 문서 정렬 (ssh·macos·secrets·sharing-text)

### DIFF
--- a/.claude/skills/managing-macos/references/troubleshooting.md
+++ b/.claude/skills/managing-macos/references/troubleshooting.md
@@ -292,20 +292,21 @@ sleep 1                                        # 1초 대기
 # 1. 멈춘 darwin-rebuild를 Ctrl+C로 중단
 
 # 2. 에이전트 수동 정리 (sudo 없이 실행!)
-launchctl bootout gui/$(id -u)/com.green.folder-action.compress-rar 2>/dev/null
-launchctl bootout gui/$(id -u)/com.green.folder-action.compress-video 2>/dev/null
-launchctl bootout gui/$(id -u)/com.green.folder-action.convert-video-to-gif 2>/dev/null
-launchctl bootout gui/$(id -u)/com.green.folder-action.rename-asset 2>/dev/null
+launchctl bootout gui/$(id -u)/com.greenhead.folder-action.compress-rar 2>/dev/null
+launchctl bootout gui/$(id -u)/com.greenhead.folder-action.compress-video 2>/dev/null
+launchctl bootout gui/$(id -u)/com.greenhead.folder-action.convert-video-to-gif 2>/dev/null
+launchctl bootout gui/$(id -u)/com.greenhead.folder-action.rename-asset 2>/dev/null
+launchctl bootout gui/$(id -u)/com.greenhead.folder-action.upload-immich 2>/dev/null
 
 # 3. plist 파일 삭제
-rm -f ~/Library/LaunchAgents/com.green.*.plist
+rm -f ~/Library/LaunchAgents/com.greenhead.folder-action.*.plist
 
 # 4. 2-3초 대기 후 재시도
 sleep 3
 sudo darwin-rebuild switch --flake ~/Workspace/nixos-config
 ```
 
-예방: `nrs` alias 사용 시 자동으로 에이전트를 정리합니다.
+예방: `nrs` alias 사용 시 자동으로 에이전트를 정리합니다. `nrs` 정리는 `com.green.*`와 `com.greenhead.*`를 모두 동적으로 처리하므로, 위 수동 절차는 `nrs` 자체가 실패할 때만 사용합니다.
 
 ---
 
@@ -348,7 +349,7 @@ restart_hammerspoon() {
 
 ```bash
 # 등록된 에이전트 확인
-launchctl list | grep com.green
+launchctl list | grep com.greenhead
 
 # 로그 확인
 cat ~/Library/Logs/folder-actions/*.log

--- a/.claude/skills/managing-secrets/references/troubleshooting.md
+++ b/.claude/skills/managing-secrets/references/troubleshooting.md
@@ -151,7 +151,7 @@ tail -20 ~/Library/Logs/agenix/stderr
 rm -rf "$(getconf DARWIN_USER_TEMP_DIR)/agenix.d/<broken-gen-number>"
 
 # agenix agent 재시작
-launchctl kickstart -k "gui/$(id -u)/com.green.activate-agenix"
+launchctl kickstart -k "gui/$(id -u)/org.nix-community.home.activate-agenix"
 ```
 
 예방 코드: `modules/shared/programs/secrets/default.nix`에 `cleanupAgenixStaleGenerations` activation이 추가됨. `setupLaunchAgents` 전에 `.tmp` 파일이 있는 stale generation 디렉토리를 자동 삭제한다.

--- a/.claude/skills/managing-ssh/SKILL.md
+++ b/.claude/skills/managing-ssh/SKILL.md
@@ -20,16 +20,12 @@ sudo에서 SSH_AUTH_SOCK 유실
 - `sudo` 실행 시 환경변수가 초기화되어 SSH 키 인증 실패
 - 해결: `sudo -E` 또는 sudoers에서 `SSH_AUTH_SOCK` 유지 설정
 
-재부팅 후 SSH 키 미로드 (NixOS/GitHub 맥락)
-- launchd agent로 자동 로드 설정되어 있지만 실패할 수 있음
-- 수동 로드: `ssh-add $HOME/.ssh/id_ed25519`
-
 macOS에서 `ssh minipc` preflight 차단 (1Password agent)
 - Phase 2a 후 macOS SSH는 1Password agent(mac-ssh)로 인증 — 로컬 id_ed25519는 archive됨
 - 1Password 데스크탑 미실행/잠금 시 `ssh()` preflight가 안내·자동 기동·최대 15초 대기
 - 해결: 1Password 잠금 해제. 즉시 접속은 `ssh minipc-emergency` (passphrase). 상세: references/troubleshooting.md
 
-NixOS에서 SSH 키 자동 로드 방식 혼동
+NixOS에서 SSH 키 자동 로드 실패
 - NixOS는 launchd가 아니라 `services.ssh-agent` + `programs.keychain`으로 키 로드
 - 수동 로드: `ssh-add $HOME/.ssh/id_ed25519`
 
@@ -66,36 +62,43 @@ tailscale ip -4
 | 파일 | 용도 |
 |------|------|
 | `$HOME/.ssh/config` | SSH 호스트 설정 |
-| `$HOME/.ssh/id_ed25519` | 개인 키 |
-| `$HOME/.ssh/id_ed25519.pub` | 공개 키 |
+| `$HOME/.ssh/mac-ssh.pub` | macOS `minipc` IdentityFile 고정용 공개키 (`constants.sshDeviceKeys.macSsh`에서 생성) |
+| `$HOME/.ssh/emergency_ed25519` | 1Password 장애 시 `minipc-emergency` fallback 개인 키 |
+| `$HOME/.ssh/id_ed25519` | NixOS/GitHub 로컬 개인 키 |
 | `$HOME/.ssh/authorized_keys` | 인증된 키 (서버) |
-| `modules/darwin/programs/ssh/default.nix` | macOS SSH/launchd 설정 |
+| `modules/darwin/programs/ssh/default.nix` | macOS 1Password SSH agent/host 설정 |
 | `modules/nixos/programs/ssh-client/default.nix` | NixOS SSH 클라이언트 설정 |
 | `modules/nixos/programs/tailscale.nix` | NixOS Tailscale VPN + 방화벽 설정 |
 | `modules/nixos/programs/mosh.nix` | NixOS mosh 설정 (Tailscale 전용, LAN 비노출) |
 | `modules/nixos/home.nix` | NixOS `services.ssh-agent`/`programs.keychain` 설정 |
+| `libraries/constants.nix` | SSH 공개키, 1Password agent socket, Tailscale IP 단일 소스 |
 
 ### authorizedKeys 추가 (NixOS)
 
 ```nix
 # hosts/<hostname>/default.nix
-users.users.<username>.openssh.authorizedKeys.keys = [
-  "ssh-ed25519 AAAA... user@host"
+users.users.${username}.openssh.authorizedKeys.keys = with constants.sshDeviceKeys; [
+  macSsh
+  mobile
+  emergency
 ];
 ```
 
+공개키 문자열은 직접 하드코딩하지 말고 `libraries/constants.nix`의 `sshDeviceKeys`를 참조한다. 실제 MiniPC 구성은 `hosts/greenhead-minipc/default.nix` 기준.
+
 ## 핵심 절차
 
-1. `ssh-add -l`과 Tailscale 상태를 먼저 확인한다.
-2. 실패 증상을 키 형식/agent/sudo 환경변수 문제로 분류한다.
-3. NixOS는 `home.nix`의 `services.ssh-agent`와 `programs.keychain` 설정을 점검한다.
-4. 서버 키 배포는 `authorizedKeys` 선언 후 재적용으로 처리한다.
+1. macOS `ssh minipc` 인증 실패는 먼저 1Password 데스크탑/agent 상태를 본다. `modules/darwin/programs/ssh/default.nix`의 `IdentityAgent`, `agent.toml`, `onepassword-autostart`와 `modules/shared/programs/shell/darwin.nix`의 `ssh()` preflight가 현행 경로다.
+2. `Load key ... invalid format`이면 키 파일 형식 문제로 분류한다. 파일 끝 개행, CRLF, 복사 손상을 확인한다.
+3. 인증이 아니라 timeout/no route 계열이면 Tailscale 상태(`tailscale status`, `tailscale up`)를 확인한다.
+4. NixOS 로컬 키 문제는 `home.nix`의 `services.ssh-agent`와 `programs.keychain`, `ssh-add -l`을 점검한다.
+5. 서버 키 배포는 `libraries/constants.nix`의 `sshDeviceKeys`를 갱신한 뒤 `authorizedKeys` 선언을 재적용한다.
 
 ## 자주 발생하는 문제
 
-1. SSH 키 invalid format: 키 파일 끝에 개행 문자 필요
-2. GitHub SSH 접근 실패: `ssh-add -l`로 키 로드 확인
-3. Tailscale 만료: `tailscale up`으로 재인증
+1. 1Password agent 미실행/잠금: `ssh minipc` preflight 안내에 따라 1Password 잠금 해제, 긴급 시 `ssh minipc-emergency`
+2. SSH 키 invalid format: 키 파일 끝 개행, CRLF, 복사 손상 확인
+3. Tailscale 만료/미연결: `tailscale status`, `tailscale up`으로 확인
 4. sudo 인증 실패: `sudo -E` 또는 SSH_AUTH_SOCK 유지
 
 ## 레퍼런스

--- a/.claude/skills/managing-ssh/references/tailscale.md
+++ b/.claude/skills/managing-ssh/references/tailscale.md
@@ -16,39 +16,61 @@ SSH 키 자동 로드와 Tailscale VPN 관련 설정입니다.
 
 ## SSH 키 자동 로드 (macOS)
 
-macOS는 launchd agent로 로그인 시 SSH 키를 자동 로드합니다.
+macOS는 로컬 `id_ed25519`를 `ssh-add`로 자동 로드하지 않고, 1Password SSH agent를 `IdentityAgent`로 사용합니다. 현행 구성은 `modules/darwin/programs/ssh/default.nix`와 `libraries/constants.nix`가 단일 소스입니다.
 
 아키텍처:
 
 ```
 macOS 로그인
     │
-    └──▶ com.green.ssh-add-keys (launchd agent)
-            └──▶ ssh-add ~/.ssh/id_ed25519
+    └──▶ launchd.agents.onepassword-autostart
+            └──▶ 1Password 데스크탑 기동
+                    └──▶ 1Password SSH agent socket
+                            └──▶ ssh minipc → mac-ssh 키로 인증
 ```
 
 컴포넌트:
 
 | 컴포넌트 | 역할 |
 | -------- | ---- |
-| `programs.ssh` | `~/.ssh/config` 생성 (`AddKeysToAgent=yes`, `IdentityFile`) |
-| `launchd.agents.ssh-add-keys` | 로그인 시 SSH 키 자동 로드 |
+| `programs.ssh.settings."*".IdentityAgent` | 1Password agent socket 사용 (`constants.onePassword.agentSocketRelPath`) |
+| `programs.ssh.settings."minipc"` | Tailscale IP, `User = "greenhead"`, `IdentityFile = ~/.ssh/mac-ssh.pub`, `IdentitiesOnly = yes` |
+| `programs.ssh.settings."minipc-emergency"` | 1Password 우회 fallback (`IdentityAgent = none`, `~/.ssh/emergency_ed25519`) |
+| `home.file.".config/1Password/ssh/agent.toml"` | SSH vault를 1Password agent에 노출 (`constants.onePassword.vaults.ssh`) |
+| `home.file.".ssh/mac-ssh.pub"` | `constants.sshDeviceKeys.macSsh` 공개키 배포 |
+| `launchd.agents.onepassword-autostart` | 로그인 시 1Password 백그라운드 기동 |
 
 생성되는 `~/.ssh/config`:
 
 ```text
 Host *
-  IdentityFile /Users/<user>/.ssh/id_ed25519
   AddKeysToAgent yes
+  IdentityAgent <home>/<constants.onePassword.agentSocketRelPath>
+
+Host minipc
+  HostName <constants.network.minipcTailscaleIP>
+  User greenhead
+  IdentityFile ~/.ssh/mac-ssh.pub
+  IdentitiesOnly yes
+
+Host minipc-emergency
+  HostName <constants.network.minipcTailscaleIP>
+  User greenhead
+  IdentityFile ~/.ssh/emergency_ed25519
+  IdentityAgent none
+  IdentitiesOnly yes
 ```
 
 확인 방법:
 
 ```bash
-ssh-add -l
-launchctl list | grep ssh-add
-cat ~/Library/Logs/ssh-add-keys.log
+ssh minipc
+ssh minipc-emergency
 ```
+
+`ssh minipc`에서 1Password agent가 `mac-ssh` 키를 제공하지 못하면 shell의 `ssh()` preflight가 1Password 기동과 잠금 해제를 안내한다. 상세 진단은 `references/troubleshooting.md`의 "Mac에서 `ssh minipc`가 1Password preflight로 차단됨" 섹션을 따른다.
+
+이력: 과거 `com.green.ssh-add-keys` launchd agent가 `ssh-add ~/.ssh/id_ed25519`를 실행하던 구성은 1Password SSH agent 전환 후 제거/archived 되었다.
 
 ## SSH 키 자동 로드 (NixOS)
 
@@ -101,7 +123,7 @@ networking.firewall = {
 
 | 항목 | 설명 |
 |------|------|
-| VPN 접근 | MiniPC는 Tailscale IP(`100.79.80.95`)로 접근 |
+| VPN 접근 | MiniPC는 `constants.network.minipcTailscaleIP`로 접근 |
 | Routing 기능 | `useRoutingFeatures = "server"` |
 | 방화벽 | `tailscale0` 전체 신뢰 + Tailscale UDP 포트 허용 |
 | TCP 포트 개방 | per-interface `allowedTCPPorts` 규칙은 사용하지 않음 |
@@ -112,15 +134,15 @@ networking.firewall = {
 # macOS → MiniPC
 ssh minipc
 # 또는
-ssh greenhead@100.79.80.95
+ssh greenhead@<minipc Tailscale IP>
 
 # MiniPC → macOS
 ssh mac
 # 또는
-ssh green@100.65.50.98
+ssh greenhead@<macbook Tailscale IP>
 
 # 불안정한 네트워크에서 mosh
-mosh greenhead@100.79.80.95 -- tmux attach -t main
+mosh greenhead@<minipc Tailscale IP> -- tmux attach -t main
 ```
 
 양방향 SSH 요약:

--- a/.claude/skills/managing-ssh/references/troubleshooting.md
+++ b/.claude/skills/managing-ssh/references/troubleshooting.md
@@ -2,68 +2,44 @@
 
 ## SSH/인증 관련
 
-### 재부팅 후 SSH 키가 ssh-agent에 로드되지 않음
+### 재부팅 후 nix-daemon이 GitHub SSH 키를 찾지 못함
 
 > 발생 시점: 2026-01-15
-> 해결: launchd agent + nrs 자동 로드
-> Phase 2a(#833) 이후 갱신: macOS SSH 인증은 1Password SSH agent(IdentityAgent)로 전환되었고, 아래의 `ssh-add-keys` launchd agent와 로컬 `~/.ssh/id_ed25519`는 제거(archive)되었다. 현재 SSH 키는 1Password가 제공하며, 로그인 시 자동 기동(`launchd.agents.onepassword-autostart`)으로 agent socket 생존을 보장한다. 아래 내용은 전환 전 이력으로 남겨둔다.
+> 현행 기준: macOS의 `ssh minipc` 인증은 1Password SSH agent가 담당한다. GitHub/nix-daemon용 로컬 `~/.ssh/id_ed25519` 점검은 이 항목에서 다루되, macOS 1Password agent 구성은 `modules/darwin/programs/ssh/default.nix`와 `references/tailscale.md`의 "SSH 키 자동 로드 (macOS)"를 기준으로 본다.
 
-증상: 재부팅 후 `nrs` 또는 `darwin-rebuild switch` 실행 시 GitHub SSH fetch 실패.
+증상: 재부팅 후 `nrs` 실행 중 GitHub SSH fetch 실패.
 
 ```
 error: Failed to fetch git repository ssh://git@github.com/... : git@github.com: Permission denied (publickey).
 ```
 
-원인: macOS의 `ssh-agent`는 재부팅 시 SSH 키를 자동으로 로드하지 않습니다.
+원인: nix-daemon은 별도 프로세스로 실행되어 macOS Keychain에 직접 접근하지 못한다. GitHub fetch에 로컬 `~/.ssh/id_ed25519`가 필요한 경우, 해당 키가 현재 SSH agent 경로에서 보이는지 먼저 확인해야 한다. 이는 1Password `mac-ssh` 키로 `minipc`에 접속하는 현행 macOS SSH 구성과 별도 맥락이다.
 
 ```bash
 # 재부팅 후 확인
 $ ssh-add -l
-The agent has no identities.  # ← 키가 없음!
+The agent has no identities.  # GitHub용 로컬 키가 agent에 없음
 
-# 일반 ssh 명령은 작동 (macOS Keychain 직접 참조)
+# 일반 GitHub SSH 인증 확인
 $ ssh -T git@github.com
 Hi greenheadHQ! You've successfully authenticated...
 ```
 
-nix-daemon은 별도 프로세스로 실행되어 Keychain에 직접 접근하지 못하고, `ssh-agent`만 사용합니다.
+해결:
 
-해결: 두 가지 방법으로 자동화
-
-1. launchd agent (`com.green.ssh-add-keys`): 로그인 시 자동으로 `ssh-add` 실행
-2. nrs: darwin-rebuild 전에 키 로드 여부 확인
-
-설정 파일: `modules/darwin/programs/ssh/default.nix`
-
-```nix
-# launchd agent - 로그인 시 SSH 키 자동 로드
-launchd.agents.ssh-add-keys = {
-  enable = true;
-  config = {
-    Label = "com.green.ssh-add-keys";
-    ProgramArguments = [ "${sshAddScript}" ];
-    RunAtLoad = true;
-    EnvironmentVariables = { HOME = homeDir; };
-  };
-};
-```
+1. `nrs`로 실행한다. 직접 `darwin-rebuild`를 실행하지 않는다.
+2. GitHub fetch가 실패하면 `ssh-add -l`과 `ssh -T git@github.com`으로 현재 agent에 GitHub용 로컬 키가 보이는지 확인한다.
+3. 로컬 `~/.ssh/id_ed25519`를 계속 쓰는 GitHub/nix-daemon 경로라면 필요한 세션에서 `ssh-add ~/.ssh/id_ed25519`로 키를 로드한 뒤 다시 시도한다.
+4. `ssh minipc` 실패는 이 항목이 아니라 아래 "Mac에서 `ssh minipc`가 1Password preflight로 차단됨" 섹션을 따른다.
 
 확인 방법:
 
 ```bash
-# SSH agent에 키 로드 확인
 ssh-add -l
-
-# launchd agent 상태 확인
-launchctl list | grep ssh-add
-
-# 로그 확인
-cat ~/Library/Logs/ssh-add-keys.log
+ssh -T git@github.com
 ```
 
-macOS의 `AddKeysToAgent yes` 설정은 SSH를 처음 사용할 때 키를 agent에 로드합니다. 재부팅 후 바로 SSH 작업을 하면 키가 로드되지 않은 상태일 수 있습니다.
-
-> 참고: SSH 키 자동 로드는 launchd agent에서 처리됩니다.
+이력: 과거 `com.green.ssh-add-keys` launchd agent가 로그인 시 `ssh-add ~/.ssh/id_ed25519`를 실행했으나, 1Password SSH agent 전환 후 제거/archived 되었다.
 
 ---
 

--- a/.claude/skills/sharing-text/references/push-implementation.md
+++ b/.claude/skills/sharing-text/references/push-implementation.md
@@ -2,51 +2,15 @@
 
 ## 소스 위치
 
-`modules/shared/programs/shell/default.nix` 내 `push()` 함수
+`push()` 함수 본문은 `modules/shared/programs/shell/default.nix`에 있습니다. Pushover 전송 구현은 `modules/shared/scripts/lib/pushover.sh`의 `pushover_send()`가 담당하며, Home Manager가 이 helper를 `$HOME/.local/lib/pushover.sh`로 배포합니다.
 
-## 함수 코드
+## 동작 요약
 
-```bash
-push() {
-  local text
-  if [ $# -gt 0 ]; then
-    text="$*"
-  elif [ ! -t 0 ]; then
-    text=$(cat)
-  elif [ -n "$TMUX" ]; then
-    text=$(tmux save-buffer - 2>/dev/null)
-  fi
-  [ -z "$text" ] && { echo "Usage: push <text> or pipe input"; return 1; }
-
-  local cred="$HOME/.config/pushover/share"
-  if [ ! -f "$cred" ]; then
-    echo "Error: Pushover credentials not found" >&2
-    return 1
-  fi
-
-  local PUSHOVER_TOKEN="" PUSHOVER_USER=""
-  source "$cred"
-  [ -n "${PUSHOVER_TOKEN:-}" ] && [ -n "${PUSHOVER_USER:-}" ] || {
-    echo "Error: Pushover credentials are incomplete" >&2
-    return 1
-  }
-
-  local response
-  if response=$(curl --fail-with-body --show-error --silent --max-time 10 -X POST \
-    -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-    --data-urlencode "token=$PUSHOVER_TOKEN" \
-    --data-urlencode "user=$PUSHOVER_USER" \
-    --data-urlencode "title=📋 텍스트 공유 (${#text}자)" \
-    --data-urlencode "message=$text" \
-    https://api.pushover.net/1/messages.json); then
-    echo "✓ Pushover 전송 (${#text}자)"
-  else
-    echo "Error: Pushover 전송 실패" >&2
-    [ -n "$response" ] && echo "$response" >&2
-    return 1
-  fi
-}
-```
+- 입력 텍스트는 인자, stdin, tmux buffer 순서로 선택합니다.
+- credential 파일은 `$HOME/.config/pushover/share`를 사용합니다.
+- helper 파일 `$HOME/.local/lib/pushover.sh`가 읽기 가능해야 하며, 없으면 즉시 실패합니다.
+- helper를 `source`한 뒤 credential을 검증하고 `pushover_send "$cred" "📋 텍스트 공유 (${#text}자)" "$text" 0` 형태로 전송합니다.
+- `curl` 호출 세부사항은 `push()`에 복사하지 않고 `pushover_send()` helper에 둡니다.
 
 ## 입력 우선순위
 
@@ -64,6 +28,6 @@ push() {
 |------|--------|------|
 | 입력 없음 | `Usage: push <text> or pipe input` | stdout |
 | credential 파일 없음 | `Error: Pushover credentials not found` | stderr |
+| helper 파일 없음 | `Error: Pushover helper not found` | stderr |
 | token/user 비어있음 | `Error: Pushover credentials are incomplete` | stderr |
-| HTTP 에러 (4xx/5xx) | `Error: Pushover 전송 실패` + API 응답 body | stderr |
-| 네트워크 실패 / 타임아웃 | curl 에러 + `Error: Pushover 전송 실패` | stderr |
+| helper 전송 실패 | `Error: Pushover 전송 실패` | stderr |


### PR DESCRIPTION
## Summary

- 인프라 마이그레이션(1Password SSH agent 전환, username rename, pushover 헬퍼 전환)이 만든 stale 스킬 문서를 현행 코드 기준으로 정렬 (managing-ssh, managing-macos, managing-secrets, sharing-text — 6개 파일)
- 재발 방지 원칙 적용: 코드 전문 복사·구체값 하드코딩을 소스 포인터 방식으로 전환
- Closes #1019

## 기존 문제/배경

인프라 코드는 마이그레이션됐는데 스킬 문서가 구 세계관으로 남아, 문서를 믿으면 틀리는 상태였다. 실비용 실증: SSH 인증 실패를 3회 별도 세션에서 원점 재진단(managing-ssh가 1Password 이전 세대 서술), launchd 수동 복구 절차가 no-op(구 `com.green.*` label), push() 구현 서술이 제거된 구버전 함수 전문.

## CIR (Change Intent Record)

스킬 전수 감사의 문서↔코드 실측 대조에서 발견됐고, 발견 전건을 별도 검증자(codex) 재검증으로 확정한 뒤 작업했다. 수정 방침은 "현행 코드 기준 재작성 + 과거 방식은 이력 한 줄"로 통일했다. 부패의 근원이 문서 내 코드 전문 복사와 구체값 하드코딩이었으므로, 이번 수정에서 함수 전문·공개키 문자열·Tailscale IP를 각각 소스 파일 포인터(`modules/...`, `constants.sshDeviceKeys`, `constants.network.minipcTailscaleIP`)로 대체했다. 작업 중 managing-ssh의 references/troubleshooting.md에 남은 구세대 launchd 서술이 추가 발견되어 같은 기준으로 정렬했다. 게이트 수준의 재발 방지(마이그레이션 PR의 구 식별자 grep)는 #1014로 분리.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 현행 기준 재작성 + 이력 한 줄 | stale 서술을 현행 구성으로 교체 | 문서 신뢰 회복, 이력 추적 가능 | 재작성 비용 | ✅ |
| 이력 주석만 추가 | 구 서술 위에 "전환됨" 노트 | 저비용 | 본문이 여전히 오도 (기존 상태가 정확히 이 형태였고 실패함) | ❌ |
| 해당 섹션 삭제 | stale 부분 제거만 | 최저 비용 | 유효한 맥락(GitHub/nix-daemon 로컬 키 등)까지 소실 | ❌ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `.claude/skills/managing-ssh/SKILL.md` | 진단 절차를 1Password agent → 키 형식 → Tailscale 순 결정트리로 재작성, 내부 모순(NixOS launchd) 제거, authorizedKeys 예시를 `constants.sshDeviceKeys` 참조로 교체 |
| `.claude/skills/managing-ssh/references/tailscale.md` | macOS 섹션을 1Password agent(IdentityAgent, mac-ssh, minipc-emergency, onepassword-autostart) 기준 재작성, Tailscale IP 하드코딩을 constants 포인터로 |
| `.claude/skills/managing-ssh/references/troubleshooting.md` | nix-daemon 항목의 구 launchd agent 서술·nix 코드 전문 제거, GitHub 로컬 키 맥락과 1Password 경로 분리 |
| `.claude/skills/managing-macos/references/troubleshooting.md` | launchd label을 `com.greenhead.folder-action.*`로 갱신 + upload-immich 추가 + "nrs는 dual namespace 자동 처리" 단서 |
| `.claude/skills/managing-secrets/references/troubleshooting.md` | agenix agent label을 `org.nix-community.home.activate-agenix`로 정정 |
| `.claude/skills/sharing-text/references/push-implementation.md` | 구버전 함수 전문을 소스 포인터 + 동작 요약으로 교체, 실패 모드 표 현행화 |

## 참고 레퍼런스

- #1019 (본 이슈), #1010 (스킬 감사 epic), #1014 (게이트 수준 재발 방지)
- 현행 코드 근거: `modules/darwin/programs/ssh/default.nix`, `modules/darwin/programs/folder-actions/default.nix`, `modules/shared/programs/shell/default.nix`, `libraries/constants.nix`

## Human Test Plan

1. MiniPC: `grep -rn "com.green\." .claude/skills/managing-ssh .claude/skills/managing-macos .claude/skills/managing-secrets` → 이력 표기 1건 외 잔존 없음 확인
2. Mac (권장): managing-ssh SKILL.md의 진단 결정트리를 따라 `ssh minipc` 1회 실행 — 1Password 잠금 상태에서 preflight 안내가 문서 서술과 일치하는지 확인
3. Mac (권장): managing-macos troubleshooting의 `launchctl list | grep com.greenhead` 실행 — folder-action agent 5종(upload-immich 포함)이 보이는지 확인
4. `push "test"` 실행 → sharing-text 문서의 동작 요약(헬퍼 경유)과 일치하는지 확인
5. 실패 시 진단: 문서가 가리키는 소스 파일(`modules/...`)과 실제 동작을 대조 — 불일치하면 문서가 아니라 이 PR의 정렬 누락이므로 코멘트로 보고

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM
