### PR TITLE
fix(skills): 스킬 문서 죽은 참조·dangling 8건 일괄 수정

### DIFF
--- a/modules/shared/programs/claude/files/skills/analyzing-da-sessions/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/analyzing-da-sessions/SKILL.md
@@ -31,7 +31,7 @@ PR #670에서 사용한 session log 정량 측정 워크플로의 정식 Skill. 
 /analyzing-da-sessions --hosts mac
 /analyzing-da-sessions --hosts minipc
 
-# pinned corpus 모드 (PR #670 회귀 게이트 검증용)
+# pinned corpus 모드 (PR #670 회귀 게이트 검증용; 미생성 — 별도 follow-up에서 capture)
 /analyzing-da-sessions --corpus references/pr-670-baseline.json
 
 # JSON sidecar 위치 명시 (영구 저장 의도)

--- a/modules/shared/programs/claude/files/skills/create-pr/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/create-pr/SKILL.md
@@ -78,7 +78,7 @@ PR을 생성하기 전에, 작업 결과의 처리 방향을 결정한다:
 - 제거/되돌림 결정의 근거 보존: 변경이 기존 코드/정책을 제거·되돌리는 것이면, CIR에 "무엇을 왜 제거하며, 그것이 과거에 의도적으로 도입된 것이면 도입 근거·출처(PR#/commit/issue#)"를 명시한다. 비자명한 방어 로직·트레이드오프 선택은 코드 옆 인라인 `# CIR:` 주석으로 "왜 이렇게 했는지(제거 시 주의)"를 남긴다 — 미래 세션의 의사결정·회귀 조사가 읽을 신호 품질을 높인다 ([`../run-da/references/decision-regression-audit.md`](../run-da/references/decision-regression-audit.md)).
 - 도구-중립 기술 (Codex / Claude Code / headless 공통): 특정 AI 에이전트 전용 도구명을 본문에 하드코딩하지 않는다. "gh pr create를 실행한다"가 아니라 "PR을 생성한다"처럼 행동 의도로 기술한다. 단, 참조/예시에서의 CLI 명령(`gh pr create` 등)은 예외로 허용한다.
 - PR 본문 박제 금지 항목: 라운드 번호(`Round N`), DA finding ID(예: `Correctness-1`, `CORR-2`), partial commit hash chain, 워크트리 절대경로.
-  - 변경 의도(why)는 자연어 설명으로 표현한다. lefthook commit-msg hook은 라운드 번호/DA finding ID/DA 키워드만 warn-only로 감지한다. partial commit hash chain은 CLAUDE.md `Durable output pinning policy`의 prose 가이드로 직접 점검하고, 워크트리 절대경로는 본 가이드 자체에서 PR 본문 작성 시 자연어 설명·repo-relative 경로로 대체하여 점검한다. PR 본문도 동일 정책을 따른다.
+  - 변경 의도(why)는 자연어 설명으로 표현한다. lefthook commit-msg hook은 라운드 번호/DA finding ID/DA 키워드만 warn-only로 감지한다. partial commit hash chain 감지 패턴의 실존 SSOT는 [`../../lib/pinning-patterns.sh`](../../lib/pinning-patterns.sh)이며, PR 본문 작성 시에는 본 가이드의 prose 규칙으로 직접 점검한다. 워크트리 절대경로는 본 가이드 자체에서 자연어 설명·repo-relative 경로로 대체하여 점검한다. PR 본문도 동일 정책을 따른다.
 
 ## 참조 자료
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
@@ -207,17 +207,17 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
 
    (a) 기본 경로 + config 차단 (권장, 간단):
    - `CODEX_HOME`을 그대로 두어 기본 auth chain(`auth.json` 등)을 유지한다.
-   - codex exec 호출에 `--ignore-user-config`를 추가하여 사용자 `config.toml`(MCP 서버 포함) 로딩을 차단한다. `using-codex-exec/SKILL.md:113`에 기록된 대로 이 플래그는 config만 차단하고 auth는 유지한다.
+   - codex exec 호출에 `--ignore-user-config`를 추가하여 사용자 `config.toml`(MCP 서버 포함) 로딩을 차단한다. [`using-codex-exec/SKILL.md`](../../using-codex-exec/SKILL.md)의 `--ignore-user-config` 옵션 설명처럼 이 플래그는 config만 차단하고 auth는 유지한다.
    - 주의: `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model` / `model_reasoning_effort` 등 user config 설정을 함께 제거한다. Arbiter는 strong review profile(high)을 유지해야 하므로 `-c model="gpt-5.5"`와 `-c model_reasoning_effort="high"`를 명시적으로 재지정한다 (defensive explicit pin — config.toml default가 차단되므로).
    - 부작용: `~/.codex/sessions` 기반 세션이 생성되므로 동시 N=3 실행 시 세션 파일 경합이 발생할 수 있다. `--ephemeral`로 session 저장 자체를 회피한다.
 
    (b) scratch CODEX_HOME + auth 복사 (세션 충돌 완전 분리가 필요할 때):
    - `CODEX_HOME=$(mktemp -d /tmp/codex-home-${_DA_SID}-selective-XXXXXX)`로 사용자 홈과 격리된 scratch 설정 디렉토리 생성.
    - auth 자격을 함께 전달한다. 세 가지 방식 중 하나:
-     - 환경변수 `CODEX_API_KEY`가 이미 설정되어 있으면 그것이 사용됨 (auth chain 우선순위 `CODEX_API_KEY > ephemeral tokens > auth.json`, `using-codex-exec/SKILL.md:214` 참조). 이 경우 추가 조치 불필요.
+     - 환경변수 `CODEX_API_KEY`가 이미 설정되어 있으면 그것이 사용됨 (auth chain 우선순위 `CODEX_API_KEY > ephemeral tokens > auth.json`, [`using-codex-exec/references/known-issues.md`](../../using-codex-exec/references/known-issues.md#17-exec-auth-chain-우선순위와-login-status-한계) 참조). 이 경우 추가 조치 불필요.
      - 그렇지 않으면 `cp ~/.codex/auth.json "$CODEX_HOME/"`로 기존 auth.json을 scratch로 복사.
      - 둘 다 불가능하면 scratch CODEX_HOME에서 `codex login status`가 `Not logged in`으로 실패하므로 방식 (a)로 돌아간다.
-   - 최소 `$CODEX_HOME/config.toml`을 작성하되 `[mcp_servers.<name>]` 테이블(실제 Codex TOML 스키마, `modules/shared/programs/codex/files/config.darwin.toml:34` 참조)을 포함하지 않는다. 또는 TOML 파서로 기존 config를 복사한 뒤 `mcp_servers` 테이블 전체를 삭제한다. (참고: `[[mcp_servers]]` array-of-table 문법은 현재 Codex가 사용하지 않으므로 혼동 방지를 위해 `[mcp_servers.*]` 정확 표기를 사용한다.)
+   - 최소 `$CODEX_HOME/config.toml`을 작성하되 `[mcp_servers.<name>]` 테이블(실제 Codex TOML 스키마는 [`sync-codex-config.py`](../../../../../codex/files/sync-codex-config.py)의 user-owned `mcp_servers` 보존 정책과 [`scenario-D-mcp-servers-coexist.toml`](../../../../../../../../tests/fixtures/codex-hooks/sync-preservation/scenario-D-mcp-servers-coexist.toml) fixture로 확인)을 포함하지 않는다. 또는 TOML 파서로 기존 config를 복사한 뒤 `mcp_servers` 테이블 전체를 삭제한다. (참고: `[[mcp_servers]]` array-of-table 문법은 현재 Codex가 사용하지 않으므로 혼동 방지를 위해 `[mcp_servers.*]` 정확 표기를 사용한다.)
    - 모델/효과 옵션은 필수로 명시적으로 지정한다: `-c model="gpt-5.5"`와 `-c model_reasoning_effort="high"`. scratch `CODEX_HOME`이므로 user config default가 적용되지 않아 호출 시점 기본값 의존이 불가하다.
 3. Claude Code 세션: `run_in_background: true`로 3개를 병렬 발사 후 완료 알림을 기다린다 (sleep/poll 금지). headless 세션: 3개 프로세스를 serial foreground로 순차 실행한다 (각 종료 확인 후 다음). 결과 파일 경로는 두 경로 모두 `/tmp/da-${_DA_SID}-arbiter-selective-<round>/arbiter-{1,2,3}-result.md`로 라운드별 분리.
 4. 수집 후 세션 scope의 `fleiss-kappa.py`(Claude: `~/.claude/scripts/fleiss-kappa.py`, Codex: `~/.codex/scripts/fleiss-kappa.py`)에 `arbiter-1-result.md arbiter-2-result.md arbiter-3-result.md`를 인자로 전달하여 vote-shape를 얻는다. `--offline` 플래그는 배포 후 kappa 관찰 목적일 때만 부가한다.
@@ -295,7 +295,7 @@ DA 에이전트/Arbiter와 달리, Review Intensity는 별도 subprocess/subagen
 | 입력 | diff 전체 또는 계획 전체 | `git diff --stat` 또는 계획 파일 목록 |
 | 출력 | findings/verdicts (markdown + VERDICT_JSON) | 체크리스트 표 + SKIP/LITE/FULL 판정 + 근거 |
 | 참조 | da-domains.md, arbiter-prompt.md | intensity-rules.md |
-| 실패 시 | NEEDS_MORE_INFO 승격 | FULL 강제 (체크리스트 미작성, 룰 2-4 매치/불확실 포함) |
+| 실패 시 | NEEDS_MORE_INFO 승격 | FULL 강제 (체크리스트 미작성, fail-closed rule group 매치/불확실 포함) |
 
 - 절차 SSOT는 [`intensity-procedure.md`](intensity-procedure.md)의 "인라인 체크리스트 절차".
 - 메인 LLM은 자유 추론 금지. 모든 룰을 평가한 표(매치/미매치/불확실 + 근거)를 plan/대화에 남기지 않으면 SKIP/LITE 판정 자체가 무효이며 강한 검토로 fail-closed.

--- a/modules/shared/programs/claude/files/skills/run-da/references/intensity-procedure.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/intensity-procedure.md
@@ -4,7 +4,7 @@ Review Intensity 판단의 실행 절차. 판단 알고리즘 규칙 SSOT는 [`i
 `/run-da` 진입 preflight에서 mode 선택과 기본 판정에 필요한 최소 룰은 [`../SKILL.md`](../SKILL.md)의 compact 표에 inline되어 있다.
 이 문서는 preflight 필수 reference가 아니며, 선택된 mode의 Step 0을 실제 실행하거나 handoff/fixture replay 세부가 필요할 때 lazy load한다.
 
-Review Intensity 판정은 메인 LLM이 인라인으로 8 룰 체크리스트를 기계적으로 적용한다. 별도 독립 process(codex exec / native subagent)를 띄우지 않는다. 메인 LLM은 룰을 자유롭게 추론해서는 안 되고, [`intensity-rules.md`](intensity-rules.md)의 룰 1-8을 순서대로 평가해 결과 표를 plan/대화에 남겨야 한다.
+Review Intensity 판정은 메인 LLM이 인라인으로 8 룰 체크리스트를 기계적으로 적용한다. 별도 독립 process(codex exec / native subagent)를 띄우지 않는다. 메인 LLM은 룰을 자유롭게 추론해서는 안 되고, [`intensity-rules.md`](intensity-rules.md)의 `RULE-MAX-MODIFIER`부터 `RULE-UNCLEAR`까지 표 순서대로 평가해 결과 표를 plan/대화에 남겨야 한다.
 
 기본 진입점은 `/run-da` 호출 직후다. 예외적으로 문서화된 자동 호출자는 같은 절차를 `/run-da` 호출 직전에 적용할 수 있다. 자동 호출자가 만든 handoff가 유효하면 `/run-da`는 그 체크리스트 결과를 재사용하고, handoff가 없거나 stale이면 현재 입력으로 이 절차를 다시 수행한다.
 

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -227,7 +227,7 @@ env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제�
 
 1. `--search`는 exec에서 미동작: `error: unexpected argument '--search' found`. 대안: `-c web_search=live` (재확인: 2026-07-03, 0.142.5에서도 동일)
 2. 과거 자동 실행 플래그(승인 자동화 + `--sandbox workspace-write`를 함께 지정하던 단축 플래그)는 0.142.5에서 완전히 제거됨: 그 이름 그대로 호출하면 `error: unexpected argument ... found`. exec에서는 `-s workspace-write`로 명시한다. 재확인 결과 이 조합은 config.toml의 `sandbox_mode`를 조용히 override하지 않는다 — 명시한 `-s` 값이 그대로 적용된다 (2026-07-03 실측: `-s read-only` 지정 시 config.toml이 `danger-full-access`여도 실제로 `read-only`로 실행됨).
-3. CODEX_API_KEY는 exec 전용: interactive TUI와 VS Code extension에서는 무시됨. OPENAI_API_KEY는 auth 체인에 미참여 (TUI prefill 전용). 우선순위: CODEX_API_KEY > ephemeral tokens > auth.json (상세: [known-issues.md](references/known-issues.md) 워크트리 참고)
+3. CODEX_API_KEY는 exec 전용: interactive TUI와 VS Code extension에서는 무시됨. OPENAI_API_KEY는 auth 체인에 미참여 (TUI prefill 전용). 우선순위: CODEX_API_KEY > ephemeral tokens > auth.json (상세: [known-issues.md §17](references/known-issues.md#17-exec-auth-chain-우선순위와-login-status-한계))
 4. ephemeral 세션 resume 불가: `--ephemeral`으로 실행한 세션은 파일 미저장되어 `No saved session found` 에러 발생
 5. `codex review` (top-level) vs `codex exec review`: 전자는 `-m`, `--json`, `-o`, `--output-schema`, `--ephemeral`, `-s/--sandbox` 등 미지원 (재확인: 2026-07-03, `codex review --help`). 비대화형 자동화에는 반드시 `codex exec review` 사용
 6. Bash tool sandbox에서 `&` + `$!` 미작동: Claude Code의 Bash tool에서 background process PID 캡처(`$!`)가 리터럴 문자열로 반환됨. shell-level 병렬 대신 여러 병렬 Bash tool 호출 (예: codex exec 경로의 `run-da` — audit 모드 포함) + `cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -` stdin pipe를 사용한다. 이 제약은 Codex 세션의 native subagent 경로에는 적용되지 않는다. 상세: [known-issues.md](references/known-issues.md) §11

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -586,3 +586,24 @@ nix shell nixpkgs#bubblewrap --command env CODEX_PROGRAMMATIC=1 codex exec -s wo
   직접 시도하지 않았다.
 - `read-only` / `workspace-write`에서는 네트워크가 차단되었고, `danger-full-access` 및 config 기본값에서는 허용되었다.
 - `~/.codex/config.toml`의 `sandbox_mode = "danger-full-access"` 기본값은 이 이슈에서 변경하지 않는다.
+
+### 17. exec auth chain 우선순위와 login status 한계
+
+심각도: 정보 — scratch `CODEX_HOME`이나 `--ignore-user-config`를 쓰는 자동화에서 auth 경계를 오해하면 `Not logged in` 또는 의도치 않은 계정 사용으로 실패한다.
+
+운영 계약: `codex exec` 경로의 auth 우선순위는 `CODEX_API_KEY > ephemeral tokens > auth.json`이다. `OPENAI_API_KEY`는 exec auth chain에 참여하지 않으며, interactive TUI에서 API key 입력을 보조하는 prefill로만 취급한다.
+
+현재 CLI에서 실측 가능한 경계:
+- `codex exec --help` (codex-cli 0.142.5, 2026-07-07)는 `--ignore-user-config`를 "`$CODEX_HOME/config.toml`은 로드하지 않지만 auth는 `CODEX_HOME`을 계속 사용"하는 플래그로 설명한다. 따라서 이 플래그는 MCP/config 표면 차단용이지 auth 차단용이 아니다.
+- 빈 scratch `CODEX_HOME`에서 `codex login status`는 `Not logged in`을 반환했고, 같은 조건에 더미 `OPENAI_API_KEY`를 추가해도 결과는 바뀌지 않았다. host `CODEX_HOME`에서는 `Logged in using ChatGPT`가 반환되어, `auth.json`/저장된 ChatGPT token 계열은 `CODEX_HOME`에 묶여 있음을 확인했다.
+- `CODEX_API_KEY`는 exec 전용 경로이므로 `codex login status`만으로 우선순위 전체를 검증하지 않는다. scratch `CODEX_HOME`을 쓰는 automation은 `CODEX_API_KEY`를 명시적으로 전달하거나, 필요한 경우 기존 `auth.json`을 scratch `CODEX_HOME`으로 복사한 뒤 `codex login status`로 저장 auth 존재만 확인한다.
+
+재검증:
+
+```bash
+codex exec --help | rg -- '--ignore-user-config|auth still uses'
+tmp=$(mktemp -d /tmp/codex-auth-check-XXXXXX)
+CODEX_HOME="$tmp" codex login status
+CODEX_HOME="$tmp" OPENAI_API_KEY=sk-dummy codex login status
+rm -rf "$tmp"
+```

--- a/modules/shared/programs/claude/files/skills/write-handoff/references/llm-friendly-checklist.md
+++ b/modules/shared/programs/claude/files/skills/write-handoff/references/llm-friendly-checklist.md
@@ -21,7 +21,7 @@
 ### B. 근거 / 레퍼런스 (Evidence-first)
 
 - [ ] B1. 비자명한 주장에 인라인 citation을 붙인다 (`[링크 텍스트](URL)`). `write-handoff`는 가이드 본문 인라인에 붙이고, `create-issue`는 필수 `References` 섹션에서 출처 링크 목록으로 제공한다. 출처: [Anthropic: Reduce hallucinations](https://docs.anthropic.com/en/docs/test-and-evaluate/strengthen-guardrails/reduce-hallucinations), [Learning Fine-Grained Grounded Citations (ACL Findings 2024)](https://aclanthology.org/2024.findings-acl.838/).
-- [ ] B4. 파일/함수/PR/doc URL은 본문에 직접 적는다 (예: `path/to/file.nix:42`, `#123`). commit hash 약식 인용은 PR 번호나 머지된 long SHA 같은 안정적 식별자로 대체한다 (CLAUDE.md `Durable output pinning policy` 참조). 출처: [Anthropic: Best Practices for Claude Code (2025)](https://code.claude.com/docs/en/best-practices).
+- [ ] B4. 파일/함수/PR/doc URL은 본문에 직접 적는다 (예: `path/to/file.nix:42`, `#123`). commit hash 약식 인용은 PR 번호나 머지된 long SHA 같은 안정적 식별자로 대체한다. 관련 감지 패턴의 실존 SSOT는 [`../../../lib/pinning-patterns.sh`](../../../lib/pinning-patterns.sh)이며, checklist 본문은 prose 가이드로 직접 점검한다. 출처: [Anthropic: Best Practices for Claude Code (2025)](https://code.claude.com/docs/en/best-practices).
 
 ### C. PoC / 재현 (Reproducibility-first)
 


### PR DESCRIPTION
## Summary

- 스킬 문서의 죽은 참조·dangling 8건 일괄 수정 — 삭제된 CLAUDE.md 섹션 참조 2곳을 pinning-patterns.sh SSOT로, 라인 번호 하드코딩 3곳을 앵커/서술 참조로, 룰 번호 참조를 RULE-ID로 교체
- auth chain 우선순위의 SSOT를 using-codex-exec known-issues §17로 신설 (실측 경계 + 재검증 명령 포함) — 양방향 역참조 교착 해소
- Closes #1017

## 기존 문제/배경

스킬 전수 감사에서 참조 대상이 사라졌거나 어긋난 8건이 실측 확인됐다 (전건 별도 검증자 재검증 통과). 특히 auth chain 우선순위는 run-da 문서가 using-codex-exec의 특정 라인을 가리키고 그 라인의 "상세" 참조는 내용이 없는 곳을 가리키는 교착 상태 — 실제 SSOT가 어디에도 없었다. 죽은 참조 8건 중 다수가 파일:라인 하드코딩에서 발생.

## CIR (Change Intent Record)

수정 원칙은 이슈에서 확정: 라인 번호 하드코딩을 전부 섹션 앵커/서술 참조로 전환해 재발 표면 자체를 줄인다. mcp_servers 스키마 근거는 원 참조(config.darwin.toml — 해당 내용 0건)를 대체할 실존 근거를 실측으로 찾아 sync-codex-config.py의 보존 정책과 scenario-D fixture로 교체했다. §17 신설 시 executor가 scratch CODEX_HOME에서 `codex login status` 실측을 수행해 이 레포의 "실측 각주 + 재검증 명령" 관례를 따랐다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 앵커/서술 참조 전환 | 라인 대신 섹션·개념 참조 | 라인 이동에 면역 | 앵커 rename 시 여전히 취약(빈도 낮음) | ✅ |
| 라인 번호만 현행화 | off-by-one 등 정정 | 최소 변경 | 다음 편집에서 즉시 재부패 | ❌ |
| auth chain 참조 삭제 | 죽은 참조만 제거 | 저비용 | SSOT 부재 지속 — 동일 질문 재발 | ❌ (§17 신설) |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `run-da/references/arbiter-scaling.md` | 죽은 참조 3건 교체 (SKILL.md 라인 2건 → 앵커/서술, config.darwin.toml → sync-codex-config.py+fixture), 룰 번호 → fail-closed rule group |
| `run-da/references/intensity-procedure.md` | "룰 1-8" → RULE-ID 범위 참조 |
| `using-codex-exec/SKILL.md` | Gotcha 3 참조를 §17 앵커로 |
| `using-codex-exec/references/known-issues.md` | §17 신설: auth chain 우선순위(CODEX_API_KEY > ephemeral > auth.json) + 실측 경계 + 재검증 명령 |
| `create-pr/SKILL.md`, `write-handoff/references/llm-friendly-checklist.md` | dangling "Durable output pinning policy" → `lib/pinning-patterns.sh` SSOT |
| `analyzing-da-sessions/SKILL.md` | 미생성 corpus 예시에 "(미생성 — follow-up)" 단서 |

## 참고 레퍼런스

- #1017 (본 이슈), #1010 (스킬 감사 epic)
- `modules/shared/programs/claude/files/lib/pinning-patterns.sh` — 1·2번 대체 SSOT

## Human Test Plan

1. `bash tests/test-skill-doc-sync.sh` → 4/4 sync pairs PASS
2. 수정된 상대 링크 전건 실존: `rg -o '\]\((\.\./)+[^)]+\)' modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md` 결과의 각 경로를 realpath로 확인
3. known-issues §17의 재검증 명령 블록 실행 → 서술과 동일 결과 확인
4. 실패 시 진단: 앵커 참조가 깨지면 대상 헤딩의 rename 여부를 먼저 확인

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM
