### PR TITLE
docs(skills): 코드 진화 미추적 stale 문서 정렬 — 7개 스킬 일괄

### DIFF
--- a/.claude/skills/automating-hammerspoon/SKILL.md
+++ b/.claude/skills/automating-hammerspoon/SKILL.md
@@ -44,8 +44,14 @@ Ghostty 새 인스턴스 문제
 | `Ctrl+;` | 영어 입력으로 전환 |
 | `Cmd+Shift+Space` | 영어 전환 후 Homerow 실행 |
 | `Ctrl+B` | 영어 전환 후 tmux prefix 전달 |
-| `Ctrl+C/U/K/W/A/E/L/F` | Ghostty 전용 Ctrl 단축키 (CSI u 우회) |
-| `Opt+B/F` | 터미널 앱에서 단어 단위 이동 |
+| 터미널 Ctrl/Opt 단축키 | 현행 목록은 `references/hotkeys.md`, 정본 배열은 `modules/darwin/programs/hammerspoon/files/init.lua` |
+
+현행 처리 키 확인:
+
+```bash
+grep -n "ghosttyCtrlKeys" modules/darwin/programs/hammerspoon/files/init.lua
+grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
+```
 
 ### 설정 파일 위치
 

--- a/.claude/skills/automating-hammerspoon/references/hotkeys.md
+++ b/.claude/skills/automating-hammerspoon/references/hotkeys.md
@@ -23,20 +23,36 @@ Claude Code 2.1.0+에서 한글 입력소스일 때 Ctrl/Opt 단축키가 동작
 
 해결 방식: Hammerspoon이 시스템 레벨에서 키 입력을 가로채서 영어로 전환 후 키 전달
 
+정본 확인:
+
+```bash
+grep -n "ghosttyCtrlKeys" modules/darwin/programs/hammerspoon/files/init.lua
+grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
+```
+
 ### Ghostty 전용 (Ctrl 키)
 
-| 단축키   | 기능                   |
-| -------- | ---------------------- |
-| `Ctrl+C` | 프로세스 종료 (SIGINT) |
-| `Ctrl+U` | 줄 삭제                |
-| `Ctrl+K` | 커서 뒤 삭제           |
-| `Ctrl+W` | 단어 삭제              |
-| `Ctrl+A` | 줄 처음으로            |
-| `Ctrl+E` | 줄 끝으로              |
-| `Ctrl+L` | 화면 지우기            |
-| `Ctrl+F` | 앞으로 이동            |
+| 단축키 | 동작 |
+|--------|------|
+| `Ctrl+C` | 영어 전환 후 원래 Ctrl+C 전달 |
+| `Ctrl+U` | 영어 전환 후 원래 Ctrl+U 전달 |
+| `Ctrl+K` | 영어 전환 후 원래 Ctrl+K 전달 |
+| `Ctrl+W` | 영어 전환 후 원래 Ctrl+W 전달 |
+| `Ctrl+A` | 영어 전환 후 원래 Ctrl+A 전달 |
+| `Ctrl+E` | 영어 전환 후 원래 Ctrl+E 전달 |
+| `Ctrl+L` | 영어 전환 후 원래 Ctrl+L 전달 |
+| `Ctrl+F` | 영어 전환 후 원래 Ctrl+F 전달 |
+| `Ctrl+S` | 영어 전환 후 원래 Ctrl+S 전달 |
+| `Ctrl+V` | 영어 전환 후 원래 Ctrl+V 전달 |
+| `Ctrl+Z` | 영어 전환 후 원래 Ctrl+Z 전달 |
+| `Ctrl+D` | 영어 전환 후 원래 Ctrl+D 전달 |
+| `Ctrl+R` | 영어 전환 후 원래 Ctrl+R 전달 |
+| `Ctrl+G` | 영어 전환 후 원래 Ctrl+G 전달 |
+| `Ctrl+O` | 영어 전환 후 원래 Ctrl+O 전달 |
+| `Ctrl+T` | 영어 전환 후 원래 Ctrl+T 전달 |
+| `Ctrl+Y` | 영어 전환 후 원래 Ctrl+Y 전달 |
 
-> Ghostty 외 앱에서는 원래 동작을 유지합니다 (예: VS Code에서 Ctrl+C는 복사).
+> Ghostty 외 앱에서는 Ctrl+V/Z/S 등 확장된 처리 키도 원래 앱 동작으로 재전달됩니다.
 
 ### 모든 터미널 앱 (Opt 키)
 
@@ -44,6 +60,7 @@ Claude Code 2.1.0+에서 한글 입력소스일 때 Ctrl/Opt 단축키가 동작
 | ------- | ---------------- |
 | `Opt+B` | 단어 뒤로 이동   |
 | `Opt+F` | 단어 앞으로 이동 |
+| `Opt+D` | 단어 삭제        |
 
 > 터미널 앱: Ghostty, Terminal.app, Warp, iTerm2
 

--- a/.claude/skills/automating-hammerspoon/references/troubleshooting.md
+++ b/.claude/skills/automating-hammerspoon/references/troubleshooting.md
@@ -221,11 +221,11 @@ end)
 
 ### 한글 입력소스에서 Ctrl/Opt 단축키가 동작하지 않음
 
-증상: Claude Code 2.1.0+ 사용 시, 한글 입력소스에서 Ctrl+C, Ctrl+U, Opt+B 등의 단축키가 동작하지 않음. 영문 입력소스로 전환하면 정상 동작.
+증상: Claude Code 2.1.0+ 사용 시, 한글 입력소스에서 Ctrl+C, Ctrl+U, Ctrl+S, Ctrl+V, Opt+B, Opt+D 등의 단축키가 동작하지 않음. 영문 입력소스로 전환하면 정상 동작.
 
 원인: Claude Code 2.1.0이 enhanced keyboard 모드(CSI u)를 적극 활용하면서 발생하는 문제입니다.
 
-| 환경 | Ctrl 단축키 | Opt+B/F |
+| 환경 | Ctrl 단축키 | Opt 단축키 |
 |------|------------|---------|
 | Terminal.app | ✅ 입력소스 무관 | ❌ 한글일 때 문제 |
 | Ghostty + Claude Code | ❌ 영문일 때만 | ❌ 영문일 때만 |
@@ -246,40 +246,11 @@ Claude Code가 enhanced keyboard 모드 활성화 → Ghostty keybind 우회됨 
 
 Hammerspoon이 키 입력을 시스템 레벨에서 가로채서 영어로 전환 후 키를 다시 전달합니다. Claude Code보다 먼저 처리되므로 확실히 동작합니다.
 
-설정 파일: `modules/darwin/programs/hammerspoon/files/init.lua`
+현행 처리 키 목록은 `references/hotkeys.md`에만 유지합니다. 정본 배열과 실제 분기 로직은 `modules/darwin/programs/hammerspoon/files/init.lua`에서 확인합니다.
 
-```lua
--- Ghostty 전용: Ctrl 키 조합
-local ghosttyCtrlKeys = {'c', 'u', 'k', 'w', 'a', 'e', 'l', 'f'}
-
-for _, key in ipairs(ghosttyCtrlKeys) do
-    local bind
-    bind = hs.hotkey.bind({'ctrl'}, key, function()
-        if isGhostty() then
-            convertToEngAndSendKey(bind, {'ctrl'}, key)
-        else
-            bind:disable()
-            hs.eventtap.keyStroke({'ctrl'}, key)
-            bind:enable()
-        end
-    end)
-end
-
--- 모든 터미널: Opt 키 조합
-local terminalOptKeys = {'b', 'f'}
-
-for _, key in ipairs(terminalOptKeys) do
-    local bind
-    bind = hs.hotkey.bind({'alt'}, key, function()
-        if isTerminalApp() then
-            convertToEngAndSendKey(bind, {'alt'}, key)
-        else
-            bind:disable()
-            hs.eventtap.keyStroke({'alt'}, key)
-            bind:enable()
-        end
-    end)
-end
+```bash
+grep -n "ghosttyCtrlKeys" modules/darwin/programs/hammerspoon/files/init.lua
+grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
 ```
 
 검증:
@@ -292,15 +263,15 @@ hs -c 'print(hs.application.frontmostApplication():bundleID())'
 # Ghostty에서 한글 입력소스로 테스트
 # 1. claude 실행
 # 2. Ctrl+C → 정상 중단되어야 함
-# 3. Ctrl+U → 줄 삭제되어야 함
-# 4. Opt+B/F → 단어 이동되어야 함
+# 3. Ctrl+U/S/V/Z 등 → 해당 Ctrl 동작이 전달되어야 함
+# 4. Opt 단축키 → 단어 이동/삭제 동작이 전달되어야 함
 ```
 
 주의사항:
 
 | 항목 | 설명 |
 |------|------|
-| Ghostty 외 앱 | Ctrl 키는 원래 동작 유지 (VS Code에서 Ctrl+C는 복사) |
+| Ghostty 외 앱 | Ctrl+V/Z/S 등 확장된 Ctrl 키도 원래 앱 동작으로 재전달 |
 | 터미널 외 앱 | Opt 키는 원래 동작 유지 (브라우저에서 특수문자 입력) |
 | 입력소스 전환 | 메뉴바 아이콘이 잠깐 깜빡일 수 있음 (기능 문제 없음) |
 

--- a/.claude/skills/configuring-git/SKILL.md
+++ b/.claude/skills/configuring-git/SKILL.md
@@ -64,8 +64,9 @@ rm -rf .git/rr-cache
 | `modules/shared/programs/git/default.nix` | Git + delta 설정 |
 | `modules/shared/programs/shell/default.nix` | 동적 side-by-side 제어 (.zshenv + precmd) |
 | `modules/shared/programs/lazygit/default.nix` | lazygit 설정 (delta pager 통합) |
-| `$HOME/.gitconfig` | 생성된 Git/delta 설정 (Nix 관리) |
-| `~/Library/Application Support/lazygit/config.yml` | 생성된 lazygit 설정 (Nix 관리, macOS) |
+| `~/.config/git/config` | 생성된 Git/delta 설정 (Home Manager 관리) |
+| `$HOME/.gitconfig` | 수동 Git 설정 위치 (존재하면 HM 설정과 병합되어 충돌 가능) |
+| `~/Library/Application Support/lazygit/config.yml` (macOS) / `~/.config/lazygit/config.yml` (Linux) | 생성된 lazygit 설정 (Nix 관리) |
 
 ## 핵심 절차
 

--- a/.claude/skills/configuring-neovim/SKILL.md
+++ b/.claude/skills/configuring-neovim/SKILL.md
@@ -42,7 +42,7 @@ modules/shared/programs/neovim/
         │   ├── keymaps.lua          # 커스텀 키맵 (jk→Esc)
         │   └── autocmds.lua         # 모바일 화면 감지, FocusGained 한글 IM 전환
         └── plugins/
-            ├── disabled.lua         # Mason (mason-org/), mini.surround (nvim-mini/), tokyonight.nvim, indent-blankline.nvim, neo-tree.nvim 비활성화
+            ├── disabled.lua         # Mason (mason-org/), mason-nvim-dap.nvim, mini.surround (nvim-mini/), tokyonight.nvim, indent-blankline.nvim, neo-tree.nvim 비활성화
             ├── colorscheme.lua      # Catppuccin Mocha
             ├── lsp.lua              # 추가 LSP (cssls, html)
             ├── dap.lua              # nvim-dap JS/TS attach (--inspect 9229, Linux cond)

--- a/.claude/skills/configuring-neovim/references/details.md
+++ b/.claude/skills/configuring-neovim/references/details.md
@@ -25,8 +25,8 @@ mini.nvim 0.17.0 (2025-12)에서 `echasnovski` → `nvim-mini` 조직으로 이�
 ## 모바일 최적화 (iPad Termius)
 
 - `jk` → Esc (Insert 모드) — 소프트웨어 키보드 UX
-- 100컬럼 미만: `relativenumber=false`, `wrap=true`, 좁은 neo-tree
-- telescope `flex` 레이아웃: 좁은 화면에서 수직 전환
+- 100컬럼 미만: `autocmds.lua`에서 `relativenumber=false`, `wrap=true` 등으로 폭 기반 UI 조정
+- snacks.picker 레이아웃: `editor.lua`에서 100컬럼 미만은 `vertical`, 그 이상은 `default` preset으로 전환
 
 ## 클립보드 전략
 

--- a/.claude/skills/configuring-neovim/references/troubleshooting.md
+++ b/.claude/skills/configuring-neovim/references/troubleshooting.md
@@ -14,7 +14,7 @@
 - [ESLint 진단 중복](#eslint-진단-중복)
 - [macOS에서 nrs 빌드가 수십 분 멈춤 (LLVM 소스 빌드)](#macos에서-nrs-빌드가-수십-분-멈춤-llvm-소스-빌드)
 - [marksman이 Swift 소스 빌드를 트리거 (빌드 실패)](#marksman이-swift-소스-빌드를-트리거-빌드-실패)
-- [indent-blankline setup 함수 호출 실패](#indent-blankline-setup-함수-호출-실패)
+- [indent-blankline은 disabled 상태](#indent-blankline은-disabled-상태)
 - [tree-sitter CLI 누락 (파서 컴파일 불가)](#tree-sitter-cli-누락-파서-컴파일-불가)
 - [mini.surround 조직 이름 변경 경고](#minisurround-조직-이름-변경-경고)
 - [which-key 사용법](#which-key-사용법)
@@ -207,26 +207,16 @@ marksman = { enabled = false },
 
 교훈: extraPackages 추가 시 `nix path-info -r nixpkgs#패키지명 | grep -ci swift` 등으로 무거운 의존성 체인이 없는지 사전 확인할 것.
 
-## indent-blankline setup 함수 호출 실패
+## indent-blankline은 disabled 상태
 
-```
-Error: You are trying to call the setup function of indent-blankline...
-Take a look at the GitHub wiki for instructions on how to migrate.
-```
+현행 구성은 `indent-blankline.nvim`을 직접 설정하지 않습니다. `modules/shared/programs/neovim/files/nvim/lua/plugins/disabled.lua`에서 비활성화하고, LazyVim v14+의 `snacks.indent`를 사용합니다.
 
-원인: indent-blankline v3에서 모듈 이름이 `indent_blankline` → `ibl`로 변경됨. lazy.nvim이 플러그인명에서 모듈명을 추론하면 `indent-blankline`을 호출 → v2 호환 에러 발생.
-
-해결: ui.lua의 플러그인 spec에 `main = "ibl"` 명시.
-
-```lua
-{
-  "lukas-reineke/indent-blankline.nvim",
-  main = "ibl",  -- v3 필수: 모듈명 명시
-  opts = { ... },
-}
+```bash
+grep -n "indent-blankline" modules/shared/programs/neovim/files/nvim/lua/plugins/disabled.lua
+rg -n "snacks.nvim|indent" modules/shared/programs/neovim/files/nvim/lua/plugins
 ```
 
-참고: LazyVim 코어가 `main = "ibl"`을 설정하더라도, 커스텀 spec에서 명시적으로 지정하는 것이 안전함.
+따라서 `main = "ibl"`을 추가하는 방식의 해결책은 현재 구성에 맞지 않습니다. indent 관련 문제가 있으면 `snacks.nvim` 설정과 LazyVim 기본 동작을 먼저 확인합니다.
 
 ## tree-sitter CLI 누락 (파서 컴파일 불가)
 

--- a/.claude/skills/managing-minipc/references/features.md
+++ b/.claude/skills/managing-minipc/references/features.md
@@ -32,24 +32,10 @@ MiniPC(greenhead-minipc)에서 사용되는 NixOS 전용 설정입니다.
 
 `modules/nixos/configuration.nix`에서 `homeserver.*` 옵션으로 관리됩니다.
 
-```nix
-homeserver.immich.enable = true;
-homeserver.uptimeKuma.enable = true;
-homeserver.immichCleanup.enable = true;            # Claude Code Temp 앨범 매일 전체 삭제
-homeserver.immichUpdate.enable = true;              # Immich 버전 체크 + 업데이트 알림
-homeserver.uptimeKumaUpdate.enable = true;          # Uptime Kuma 버전 체크 + 업데이트 알림
-homeserver.copypartyUpdate.enable = true;           # Copyparty 버전 체크 + 업데이트 알림
-homeserver.copyparty.enable = true;                 # 셀프호스팅 파일 서버
-homeserver.karakeep.enable = true;                  # Karakeep 웹 아카이버/북마크 관리 (3컨테이너)
-homeserver.karakeepBackup.enable = true;            # Karakeep SQLite 매일 백업 (HDD)
-homeserver.karakeepNotify.enable = true;            # Karakeep 웹훅→Pushover 브리지
-homeserver.karakeepLogMonitor.enable = true;        # Karakeep 로그 모니터 (OOM/실패 알림)
-homeserver.karakeepFallbackSync.enable = true;      # fallback HTML 자동 재연결 (API)
-homeserver.karakeepSinglefileBridge.enable = true;  # SingleFile 대용량 자동 분기 (링크+보관 fullPageArchive)
-homeserver.karakeepUpdate.enable = true;            # Karakeep 버전 체크 + 업데이트 알림
-homeserver.immichBackup.enable = true;              # Immich PostgreSQL 매일 백업 (HDD)
-homeserver.reverseProxy.enable = true;              # Caddy HTTPS 리버스 프록시
-homeserver.smokeTest.enable = true;                 # 런타임 스모크 테스트 (헬스체크 + 백업 신선도)
+현행 활성화 목록은 `modules/nixos/configuration.nix`의 `# 홈서버 서비스 활성화` 블록을 정본으로 확인합니다. 문서에는 옵션 열거를 복사하지 않습니다.
+
+```bash
+grep -n "homeserver\\." modules/nixos/configuration.nix
 ```
 
 모든 옵션 정의와 모듈 import는 `modules/nixos/options/homeserver.nix`에 있습니다.

--- a/.claude/skills/managing-tmux/references/shortcuts.md
+++ b/.claude/skills/managing-tmux/references/shortcuts.md
@@ -36,11 +36,11 @@ Prefix: `Ctrl+b`
 | 단축키       | 기능                             |
 | ------------ | -------------------------------- |
 | `prefix + r` | 설정 리로드 (`~/.config/tmux/tmux.conf`) |
-| `prefix + a` | 도움말 (사용 가능한 단축키 표시) |
+| `prefix + C` | cheatsheet 팝업                  |
 | `prefix + s` | 세션 선택                        |
 | `prefix + ,` | 창 이름 변경                     |
 | `prefix + $` | 세션 이름 변경                   |
-| `prefix + P` | Pane 제목 설정                   |
+| `prefix + I` | Pane 제목 설정                   |
 
 ---
 
@@ -209,4 +209,3 @@ tmux attach -t session-name
 # 세션 분리 (tmux 내에서)
 prefix + d
 ```
-

--- a/.claude/skills/managing-tmux/references/troubleshooting.md
+++ b/.claude/skills/managing-tmux/references/troubleshooting.md
@@ -303,7 +303,7 @@ macOS/일부 Linux 환경에서 UTF-8 한글 문자열의 정렬 시 locale 설�
 
 ### 증상
 
-- `prefix + e`(노트 편집) 또는 `prefix + v`(노트 보기) 시 popup에서 `nvim: command not found`, `bat: command not found` 에러 발생
+- `prefix + n`(노트 편집) 또는 `prefix + v`(노트 보기) 시 popup에서 `nvim: command not found`, `bat: command not found` 에러 발생
 - 일반 tmux pane에서는 `nvim`, `bat` 모두 정상 동작하지만, `display-popup`에서만 실패
 
 ### 원인

--- a/.claude/skills/managing-vscode/references/extensions.md
+++ b/.claude/skills/managing-vscode/references/extensions.md
@@ -13,7 +13,6 @@ Nix(Home Manager `programs.vscode` 모듈)로 VSCode 확장을 선언적으로 �
 | usernamehw.errorlens | 인라인 에러 표시 |
 | streetsidesoftware.code-spell-checker | 맞춤법 검사 |
 | aaron-bond.better-comments | 주석 하이라이팅 |
-| eamodio.gitlens | Git 기록/blame |
 | github.vscode-pull-request-github | GitHub PR 통합 |
 | jnoortheen.nix-ide | Nix 언어 지원 (nixd LSP) |
 | buenon.scratchpads | 스크래치패드 |
@@ -32,6 +31,12 @@ Nix(Home Manager `programs.vscode` 모듈)로 VSCode 확장을 선언적으로 �
 | atommaterial.a-file-icon-vscode | 파일 아이콘 |
 | mermaidchart.vscode-mermaid-chart | Mermaid 다이어그램 미리보기 |
 
+### Open-VSX release pin
+
+| 확장 ID | Nix attr | 설명 |
+|---------|----------|------|
+| eamodio.gitlens | `pkgs.open-vsx-release.eamodio.gitlens` | Git 기록/blame. 일반 `open-vsx` latest의 pre-release 만료 시 current-line blame 잠김과 재시작 팝업 회귀가 있어 release variant로 고정 |
+
 ## 확장 추가/제거 방법
 
 ### 1. 설정 파일 수정
@@ -45,6 +50,10 @@ profiles.default = {
       # 여기에 open-vsx 확장 추가
       dbaeumer.vscode-eslint
     ])
+    ++ [
+      # pre-release를 피해야 하는 확장은 release variant 사용
+      pkgs.open-vsx-release.eamodio.gitlens
+    ]
     ++ (with pkgs.vscode-marketplace; [
       # 여기에 marketplace 확장 추가
       ms-vscode.vscode-typescript-next
@@ -66,12 +75,14 @@ nrs
 
 | 소스 | 용도 | 예시 |
 |------|------|------|
-| `open-vsx` | 오픈소스 확장 (대부분) | ESLint, Prettier, GitLens |
+| `open-vsx` | 오픈소스 확장 (대부분) | ESLint, Prettier |
+| `open-vsx-release` | pre-release 만료 회귀를 피해야 하는 Open-VSX 확장 | GitLens |
 | `vscode-marketplace` | MS 전용/open-vsx에 없는 확장 | TypeScript, C# |
 
 선택 방법:
 1. 먼저 https://open-vsx.org 에서 검색
-2. 없으면 https://marketplace.visualstudio.com 사용
+2. pre-release 만료나 기능 잠김 회귀가 있는 확장은 `pkgs.open-vsx-release` variant 사용
+3. 없으면 https://marketplace.visualstudio.com 사용
 
 ## 확장 ID 찾는 방법
 
@@ -105,6 +116,8 @@ flake.lock (버전 고정)
 nix-vscode-extensions flake
     ↓
 pkgs.open-vsx / pkgs.vscode-marketplace (overlay)
+    ↓
+필요 시 pkgs.open-vsx-release로 release variant 고정
     ↓
 modules/darwin/programs/vscode/default.nix
     ↓

--- a/.claude/skills/managing-vscode/references/troubleshooting.md
+++ b/.claude/skills/managing-vscode/references/troubleshooting.md
@@ -71,6 +71,22 @@ mdls -name kMDItemCFBundleIdentifier ~/Applications/Home\ Manager\ Apps/Visual\ 
 # 불일치 시 modules/darwin/programs/vscode/default.nix의 vscodeBundleId 수정
 ```
 
+### vscode:// 링크 클릭이 VSCode가 아닌 Finder로 열림
+
+증상: statusline 등에서 `vscode://` 링크를 클릭했는데 VSCode가 열리지 않고 Finder나 다른 fallback 핸들러가 실행됨.
+
+원인: macOS LaunchServices DB의 VSCode URL scheme handler 등록이 stale 상태. 파일 확장자 기본 앱 매핑(`duti`)과 별개로, `.app` bundle의 `CFBundleURLTypes` 재등록이 필요함.
+
+해결: `modules/darwin/programs/vscode/default.nix`의 `home.activation.refreshVSCodeLaunchServices`가 `nrs` 시 Home Manager Apps trampoline을 `lsregister -f`로 재등록합니다.
+
+진단:
+
+```bash
+rg -n "refreshVSCodeLaunchServices|lsregister" modules/darwin/programs/vscode/default.nix
+```
+
+수동 확인 후에도 계속 Finder로 빠지면 `nrs`를 재실행하고 VSCode 앱이 `~/Applications/Home Manager Apps/Visual Studio Code.app`에 존재하는지 확인합니다.
+
 ### darwin-rebuild 시 setupLaunchAgents에서 멈춤
 
 `nrs` 실행 시 `Activating setVSCodeAsDefaultEditor` 후 `setupLaunchAgents`에서 멈추는 경우:

--- a/.claude/skills/understanding-nix/references/features.md
+++ b/.claude/skills/understanding-nix/references/features.md
@@ -159,22 +159,22 @@ regexes = [
 
 > 주의: 실제 키를 `...EXAMPLE` 형태로 위장하면 탐지를 우회할 수 있으므로, PR 리뷰 시 주의가 필요합니다.
 
-eval-tests (E2E 보안 검증):
+eval-tests (E2E 보안/intent 검증):
 
 `nix eval --impure --file tests/eval-tests.nix`로 최종 NixOS config 속성을 직접 검사합니다. Nix lazy evaluation 덕분에 ~1.2초에 완료됩니다.
 
-검증 항목 (20개):
-- 포트 충돌 없음 (homeserver.*.port 고유성)
-- 컨테이너 포트 localhost-only (127.0.0.1: 접두사 강제)
-- extraOptions에 -p/--publish/-P 우회 노출 금지
-- --network=host allowlist 강제 (현재: uptime-kuma만)
-- host network 컨테이너의 listen address 검증 (UPTIME_KUMA_HOST=127.0.0.1)
-- Caddy virtualHost listenAddresses = Tailscale IP 전용
-- Caddy globalConfig default_bind = Tailscale IP
-- openssh openFirewall 검증
-- 방화벽 정책 (allowedTCPPorts=[], trustedInterfaces allowlist, 인터페이스별 포트 없음 등)
-- Tailscale CGNAT IP 범위 독립 검증 (100.64.0.0/10)
-- 수동 nftables 규칙(extraInputRules/extraForwardRules) 없음
+주요 검증 카테고리:
+- NixOS 네트워크 노출 경계: homeserver 포트 충돌, 컨테이너 localhost 바인딩, publish 우회, host network allowlist
+- Caddy/Tailscale 경계: virtualHost listenAddresses, default_bind, bind 우회, subdomain vhost 완전성
+- SSH/방화벽 경화: openssh 설정, trustedInterfaces, TCP/UDP 포트, 인터페이스별 포트, 수동 규칙 인젝션
+- 1Password/opnix materialization: vault/account 상수, SA token 권한, tmpfs secret 경로
+- Darwin intent: expected host, sudo/Touch ID, Dock/keyboard 설정, zsh compinit 단일 정본
+
+현행 전체 테스트는 `tests/eval-tests.nix`가 정본입니다. 건수와 세부 항목은 문서에 복사하지 않고 이 파일에서 확인합니다.
+
+```bash
+rg -n 'name = "Test' tests/eval-tests.nix
+```
 
 ```bash
 # 직접 실행
@@ -241,51 +241,39 @@ NixOS 전용 alias:
 | `nrh`         | 최근 10개 세대 히스토리 (`nix-env` alias) |
 | `nrh-all`     | 전체 세대 히스토리 (`nix-env` alias) |
 
-`nrs` / `nrs --offline` 동작 흐름 (macOS 전용):
+`nrs` / `nrs --offline` 공통 동작:
 
 ```
-1. darwin-rebuild build + nvd diff (미리보기)
+1. 플랫폼별 rebuild build + nvd diff (미리보기)
    └── 빌드 실패 시 즉시 종료 (에러 처리)
 
-2. NO_CHANGES 판정 (store 경로 비교)
-   ├── 변경 없음 (NO_CHANGES=true) → 스킵 + --force 힌트 출력 후 종료
-   │   └── nrs --force 사용 시 스킵 우회 → 3번부터 계속 실행
+2. 공통 preview_changes()에서 NO_CHANGES 판정 (./result와 /run/current-system store 경로 비교)
+   ├── 변경 없음 (NO_CHANGES=true) → activation/switch 스킵
+   │   └── nrs --force 사용 시 스킵 우회
    └── 변경 있음 (NO_CHANGES=false) → 계속 실행
 
-3. launchd 에이전트 정리 (setupLaunchAgents 멈춤 방지)
-   └── com.green.* 에이전트 동적 탐색 → bootout + plist 삭제
+3. worktree symlink guard/relink 준비
+   └── 워크트리 빌드 시 out-of-store symlink 충돌을 피하도록 restore/relink 흐름 사용
 
-4. darwin-rebuild switch 실행
-   └── --offline 플래그 (nrs --offline만)
+4. 플랫폼별 switch 실행
+   └── macOS: darwin-rebuild switch
+   └── NixOS: nixos-rebuild switch (exit code 4는 transient unit failure로 경고 처리)
 
-5. Hammerspoon 완전 재시작 (HOME 오염 방지)
-   └── killall → sleep 1 → open -a Hammerspoon
-
-6. 빌드 아티팩트 정리
+5. 빌드 아티팩트 정리
    └── ./result* 심볼릭 링크 삭제
 ```
 
-`nrs` / `nrs --offline` 동작 흐름 (NixOS 전용):
+플랫폼별 추가 처리:
 
-```
-1. 외부 패키지 버전 갱신 (update_external_packages)
-   └── fetchurl 기반 패키지 업데이트 (--offline 시 스킵)
-
-2. nixos-rebuild build + nvd diff (미리보기)
-   └── 빌드 실패 시 즉시 종료 (에러 처리)
-
-3. nixos-rebuild switch 실행
-   └── --offline 플래그 (nrs --offline만)
-   └── exit code 4 (일시적 unit 실패)는 경고만 출력 후 계속
-
-4. 빌드 아티팩트 정리
-   └── ./result* 심볼릭 링크 삭제
-```
+- macOS: switch 전 launchd agent 정리, cask conflict preflight, switch 후 Hammerspoon 재시작
+- NixOS: 소스 빌드 preflight, rebuild lock, switch 후 relink/restore
+- worktree relink의 운영 전제는 repo 루트 `CLAUDE.md`의 빌드 절과 `modules/shared/scripts/lib/rebuild/relink.sh`를 기준으로 한다.
 
 구현:
 
 - macOS 스크립트: `modules/darwin/scripts/nrs.sh`, `modules/darwin/scripts/nrp.sh`, `modules/darwin/scripts/nrh.sh`
 - NixOS 스크립트: `modules/nixos/scripts/nrs.sh`, `modules/nixos/scripts/nrp.sh`
+- 공통 preview/NO_CHANGES 판정: `modules/shared/scripts/lib/rebuild/preview.sh`
 - 설치 위치: `~/.local/bin/nrs`, `~/.local/bin/nrp` (macOS는 `~/.local/bin/nrh` 추가)
 - PATH에 `~/.local/bin`이 포함되어 직접 실행 가능 (`nrs`, `nrs --offline`)
 


### PR DESCRIPTION
## Summary

- 코드가 점진 진화하는 동안 따라가지 못한 stale 스킬 문서 7계열 일괄 정렬 (configuring-git, automating-hammerspoon, understanding-nix, managing-tmux, managing-vscode, managing-minipc, configuring-neovim — 13개 파일)
- 재발 방지 원칙 적용: 키 목록·건수·옵션 열거 복사를 소스 포인터 + 판별 명령으로 전환
- Closes #1020

## 기존 문제/배경

문서를 믿고 따라 하면 틀리는 항목들이 실측 확인됐다 (전건 별도 검증자 재검증 통과): 키바인딩 오답 3건(tmux), 문서 내부 모순(git config 경로), 유령 기능 서술(제거된 update_external_packages), 4개월 미반영 단축키 목록(hammerspoon 8키 vs 실제 17키), 회귀 재발 경로(GitLens 일반 채널 안내) 등.

## CIR (Change Intent Record)

부패의 공통 원인이 "소스에서 복사해온 리터럴"(키 배열, 건수, 옵션 열거)이므로, 값을 현행화하는 데 그치지 않고 구조를 바꿨다: hammerspoon 키 목록은 정본 1곳(hotkeys.md)만 유지하고 나머지 2곳은 포인터+판별 명령으로, minipc homeserver 옵션은 열거를 제거하고 configuration.nix 블록 포인터로 (누락 4종을 채워넣는 방식은 재발 표면 유지라 지양). eval-tests "20개" 건수는 하드코딩 금지 원칙에 따라 건수 없는 서술로. 작업 중 configuring-neovim의 neo-tree stale 문구가 추가 발견되어 같은 기준(snacks.explorer 현행)으로 함께 정리했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 포인터+판별 명령 전환 | 열거 복사 제거, 소스 참조 | 재발 원천 제거 | 문서만으로 즉답 불가 (명령 1회 필요) | ✅ |
| 값 현행화만 | 낡은 값을 현재 값으로 교체 | 즉답 가능 | 다음 코드 변경에서 재부패 (이번 사고의 반복) | ❌ |
| 해당 서술 삭제 | stale 부분 제거 | 최저 비용 | 유효한 안내까지 소실 | ❌ |

## 구현 상세

| 스킬 | 변경 요지 |
|---|---|
| configuring-git | HM 생성 경로를 `~/.config/git/config`로 정정 (내부 모순 해소), lazygit Linux 경로 병기 |
| automating-hammerspoon | 키 목록 정본을 hotkeys.md 1곳으로, SKILL.md·troubleshooting은 init.lua 포인터+grep 명령, 확장 키 기준 주의 문구 갱신 |
| understanding-nix | 유령 기능 삭제, 건수 하드코딩 제거, NO_CHANGES를 공통 preview + 플랫폼 분기 기준 재작성 |
| managing-tmux | pane 제목 prefix+I, cheatsheet prefix+C(신규 문서화), 노트 편집 prefix+n — 오답 3건 제거 |
| managing-vscode | GitLens `open-vsx-release` pin과 사유(pre-release 만료 회귀) 반영, vscode:// LaunchServices stale 항목 추가 |
| managing-minipc | homeserver 옵션 열거 → configuration.nix 포인터 |
| configuring-neovim | indent-blankline·telescope 서술을 snacks 현행으로, mason-nvim-dap 목록 보완, neo-tree 문구 정정(추가 발견) |

## 참고 레퍼런스

- #1020 (본 이슈), #1010 (스킬 감사 epic)
- 대조 근거: `modules/darwin/programs/hammerspoon/files/init.lua`, `modules/shared/programs/tmux/files/tmux.conf`, `modules/darwin/programs/vscode/default.nix`, `modules/nixos/configuration.nix`, `modules/shared/programs/neovim/files/nvim/lua/plugins/`

## Human Test Plan

1. `grep -nE "bind-key (I|C|n) " modules/shared/programs/tmux/files/tmux.conf` ↔ managing-tmux shortcuts.md 표 대조 → 일치
2. `grep -n ghosttyCtrlKeys modules/darwin/programs/hammerspoon/files/init.lua` → hotkeys.md 정본 목록과 일치
3. tmux에서 prefix+I(제목)·prefix+C(cheatsheet)·prefix+n(노트) 실동작 확인
4. `rg "update_external_packages|검증 항목 \(2" .claude/skills/understanding-nix/` → 0건
5. 실패 시 진단: 포인터가 가리키는 소스 파일이 이동했는지 먼저 확인 (파일명 grep)

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM
