### PR TITLE
feat(ai): 스킬 구 식별자 잔존 warn 게이트 — 마이그레이션 diff 검사

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,6 +19,8 @@ pre-commit:
         fi
     ai-skills-consistency:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-consistency.sh
+    ai-skill-stale-identifiers:
+      run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-stale-identifiers.sh
     gitleaks:
       run: bash ./scripts/ai/run-gitleaks-staged-policy.sh
     nixfmt:

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -96,6 +96,8 @@ pre-commit:
         fi
     ai-skills-consistency:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-consistency.sh
+    ai-skill-stale-identifiers:
+      run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-stale-identifiers.sh
     gitleaks:
       run: bash ./scripts/ai/run-gitleaks-staged-policy.sh
     nixfmt:
@@ -143,6 +145,7 @@ repo_scripts=(
   "scripts/ai/run-staged-snapshot.sh"
   "scripts/ai/lib/staged-snapshot-cache.sh"
   "scripts/ai/warn-skill-consistency.sh"
+  "scripts/ai/warn-skill-stale-identifiers.sh"
   "scripts/ai/run-gitleaks-staged-policy.sh"
   "tests/run-eval-tests.sh"
   "tests/test-codex-hook-fixtures.sh"

--- a/scripts/ai/warn-skill-stale-identifiers.sh
+++ b/scripts/ai/warn-skill-stale-identifiers.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# warn-skill-stale-identifiers.sh
+# 목적: 인프라 rename/migration diff에서 제거된 고유 식별자가 스킬 문서에 잔존하는지 경고
+# 정책:
+# - 항상 warning-only (exit 0)
+# - 우회: SKIP_AI_SKILL_CHECK=1 (또는 true/yes)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GIT_ROOT="${STAGED_SNAPSHOT_SOURCE_ROOT:-$REPO_ROOT}"
+DIFF_FILE_OVERRIDE="${SKILL_STALE_IDENTIFIERS_DIFF_FILE:-}"
+TMP_DIR=""
+
+cleanup() {
+  if [ -n "${TMP_DIR:-}" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+warn() {
+  echo "[WARN] $1" >&2
+}
+
+is_true() {
+  local val="${1:-}"
+  val="${val,,}"
+  [ "$val" = "1" ] || [ "$val" = "true" ] || [ "$val" = "yes" ]
+}
+
+normalize_repo_path() {
+  local path="$1"
+  path="${path#./}"
+  printf '%s\n' "$path"
+}
+
+write_staged_paths() {
+  local output_file="$1"
+  local path
+
+  : > "$output_file"
+
+  if [ -n "${STAGED_SNAPSHOT_STAGED_FILES_NUL_FILE:-}" ] && [ -f "$STAGED_SNAPSHOT_STAGED_FILES_NUL_FILE" ]; then
+    while IFS= read -r -d '' path; do
+      [ -n "$path" ] || continue
+      normalize_repo_path "$path"
+    done < "$STAGED_SNAPSHOT_STAGED_FILES_NUL_FILE" >> "$output_file"
+  elif [ -n "${SKILL_STALE_IDENTIFIERS_STAGED_FILES_FILE:-}" ] && [ -f "$SKILL_STALE_IDENTIFIERS_STAGED_FILES_FILE" ]; then
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      normalize_repo_path "$path"
+    done < "$SKILL_STALE_IDENTIFIERS_STAGED_FILES_FILE" >> "$output_file"
+  elif git -C "$GIT_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$GIT_ROOT" diff --name-only --cached | while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      normalize_repo_path "$path"
+    done >> "$output_file"
+  fi
+
+  sort -u -o "$output_file" "$output_file"
+}
+
+write_staged_diff() {
+  local output_file="$1"
+
+  if [ -n "$DIFF_FILE_OVERRIDE" ]; then
+    if [ -f "$DIFF_FILE_OVERRIDE" ]; then
+      cp "$DIFF_FILE_OVERRIDE" "$output_file"
+    else
+      warn "diff 입력 파일 없음: $DIFF_FILE_OVERRIDE"
+      : > "$output_file"
+    fi
+    return 0
+  fi
+
+  if git -C "$GIT_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    git -C "$GIT_ROOT" diff --cached --no-ext-diff --unified=0 > "$output_file" || : > "$output_file"
+  else
+    : > "$output_file"
+  fi
+}
+
+extract_candidates() {
+  local diff_file="$1"
+  local output_file="$2"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    warn "python3 없음: stale identifier 추출 생략"
+    : > "$output_file"
+    return 0
+  fi
+
+  if ! python3 - "$diff_file" > "$output_file" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+diff_path = Path(sys.argv[1])
+text = diff_path.read_text(encoding="utf-8", errors="replace")
+
+reverse_dns_re = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:com|org)\.[A-Za-z0-9][A-Za-z0-9_-]*(?:\.[A-Za-z0-9][A-Za-z0-9_-]*)+(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
+image_re = re.compile(
+    r"(?<![A-Za-z0-9_./-])(?:[A-Za-z0-9][A-Za-z0-9._-]*(?::[0-9]+)?/)+[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._-]*(?![A-Za-z0-9_./-])"
+)
+attr_re = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:constants|launchd|systemd|services|virtualisation|age|homeserver)\.[A-Za-z][A-Za-z0-9_-]*(?:\.[A-Za-z][A-Za-z0-9_-]*)+(?![A-Za-z0-9_-])"
+)
+func_res = [
+    re.compile(r"^\s*(?:function\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*\)\s*(?:\{|$)"),
+    re.compile(r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:\{|$)"),
+]
+
+file_ext_re = re.compile(
+    r"\.(?:age|bash|conf|json|log|md|nix|py|service|sh|sock|timer|toml|txt|yaml|yml|zsh)$",
+    re.IGNORECASE,
+)
+generic_function_names = {
+    "cleanup",
+    "debug",
+    "die",
+    "err",
+    "fail",
+    "handler",
+    "log_error",
+    "log_info",
+    "log_warn",
+    "main",
+    "pass",
+    "usage",
+    "warn",
+}
+
+
+def valid_common(token: str) -> bool:
+    return len(token) >= 6 and not token.isdigit()
+
+
+def clean_token(token: str) -> str:
+    return token.strip("`\"'()[]{}<>.,;")
+
+
+def add(out: dict[str, str], token: str, kind: str) -> None:
+    token = clean_token(token)
+    if not valid_common(token):
+        return
+    out.setdefault(token, kind)
+
+
+def add_image(out: dict[str, str], token: str) -> None:
+    token = clean_token(token)
+    image_name = token.rsplit(":", 1)[0]
+    image_base = image_name.rsplit("/", 1)[-1]
+    if "/" not in image_name:
+        return
+    if "://" in token or file_ext_re.search(image_base):
+        return
+    add(out, token, "container-image")
+
+
+def add_function(out: dict[str, str], name: str) -> None:
+    if name in generic_function_names:
+        return
+    if "_" not in name and len(name) < 12:
+        return
+    add(out, name, "shell-function")
+
+
+candidates: dict[str, str] = {}
+for line in text.splitlines():
+    if not line.startswith("-") or line.startswith("---"):
+        continue
+    deleted = line[1:]
+
+    for match in reverse_dns_re.finditer(deleted):
+        add(candidates, match.group(0), "reverse-dns")
+    for match in image_re.finditer(deleted):
+        add_image(candidates, match.group(0))
+    for match in attr_re.finditer(deleted):
+        add(candidates, match.group(0), "nix-attr-path")
+    for func_re in func_res:
+        match = func_re.match(deleted)
+        if match:
+            add_function(candidates, match.group(1))
+            break
+
+for identifier, kind in candidates.items():
+    print(f"{identifier}\t{kind}")
+PY
+  then
+    warn "stale identifier 추출 실패"
+    : > "$output_file"
+  fi
+}
+
+is_staged_path() {
+  local path="$1"
+  local staged_paths_file="$2"
+  grep -Fxq -- "$path" "$staged_paths_file"
+}
+
+scan_identifier() {
+  local identifier="$1"
+  local staged_paths_file="$2"
+  local matches_file="$3"
+  local rel_dir match path rest line_no
+  local skill_dirs=(
+    ".claude/skills"
+    "modules/shared/programs/claude/files/skills"
+  )
+
+  : > "$matches_file"
+
+  for rel_dir in "${skill_dirs[@]}"; do
+    [ -d "$REPO_ROOT/$rel_dir" ] || continue
+    while IFS= read -r match; do
+      path="${match%%:*}"
+      rest="${match#*:}"
+      line_no="${rest%%:*}"
+      [[ "$line_no" =~ ^[0-9]+$ ]] || continue
+      if is_staged_path "$path" "$staged_paths_file"; then
+        continue
+      fi
+      printf '%s:%s\n' "$path" "$line_no" >> "$matches_file"
+    done < <(cd "$REPO_ROOT" && LC_ALL=C grep -RInF -- "$identifier" "$rel_dir" 2>/dev/null || true)
+  done
+
+  sort -u -o "$matches_file" "$matches_file"
+}
+
+main() {
+  local diff_file staged_paths_file candidates_file matches_file
+  local identifier kind warnings
+
+  if is_true "${SKIP_AI_SKILL_CHECK:-}"; then
+    return 0
+  fi
+
+  TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/skill-stale-identifiers.XXXXXX")"
+  diff_file="$TMP_DIR/staged.diff"
+  staged_paths_file="$TMP_DIR/staged-paths.txt"
+  candidates_file="$TMP_DIR/candidates.tsv"
+  matches_file="$TMP_DIR/matches.txt"
+
+  write_staged_diff "$diff_file"
+  [ -s "$diff_file" ] || return 0
+
+  extract_candidates "$diff_file" "$candidates_file"
+  [ -s "$candidates_file" ] || return 0
+
+  write_staged_paths "$staged_paths_file"
+
+  warnings=0
+  while IFS=$'\t' read -r identifier kind; do
+    [ -n "$identifier" ] || continue
+    scan_identifier "$identifier" "$staged_paths_file" "$matches_file"
+    [ -s "$matches_file" ] || continue
+
+    warn "스킬 문서 구 식별자 잔존 의심: $identifier ($kind)"
+    while IFS= read -r match; do
+      warn "  $match"
+    done < "$matches_file"
+    warn "  스킬 문서 갱신 필요 여부 확인"
+    warnings=$((warnings + 1))
+  done < "$candidates_file"
+
+  if [ "$warnings" -gt 0 ]; then
+    warn "stale skill identifier 경고 ${warnings}건 (warn-only)"
+  fi
+}
+
+main "$@" || warn "stale skill identifier 검사 중 내부 오류 발생 (warn-only)"
+exit 0

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -134,6 +134,8 @@ run_test "check-skill-noise staged mode rejects non-regular markdown" test_check
 run_test "check-skill-noise follows symlink skill projection" test_check_skill_noise_worktree_follows_symlink_projection
 run_test "check-skill-noise rejects external symlink skill projection" test_check_skill_noise_worktree_rejects_external_symlink
 run_test "warn-skill-consistency ignores managed plugin skill projection" test_warn_skill_consistency_ignores_managed_plugin_skill_projection
+run_test "warn-skill-stale-identifiers detects residual skill doc" test_warn_skill_stale_identifiers_detects_residual_skill_doc
+run_test "warn-skill-stale-identifiers clean pass stays quiet" test_warn_skill_stale_identifiers_clean_pass_stays_quiet
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 run_test "darwin nrs no-change activates when Codex artifact missing" test_darwin_nrs_no_changes_activates_when_codex_artifact_missing

--- a/tests/suites/skill-stale-identifiers.sh
+++ b/tests/suites/skill-stale-identifiers.sh
@@ -1,0 +1,109 @@
+# tests/suites/skill-stale-identifiers.sh — stale skill identifier warning fixtures
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+skill_stale_git() {
+  local repo_root="$1"
+  shift
+  local home_dir
+  home_dir="$(dirname "$repo_root")/home"
+  HOME="$home_dir" \
+    XDG_CONFIG_HOME="$home_dir/.config" \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_NOSYSTEM=1 \
+    git -C "$repo_root" \
+    -c core.hooksPath=/dev/null \
+    -c commit.gpgSign=false \
+    -c init.templateDir= \
+    "$@"
+}
+
+create_skill_stale_fixture_repo() {
+  local repo_root="$1"
+  local sandbox_root home_dir
+  sandbox_root="$(dirname "$repo_root")"
+  home_dir="$sandbox_root/home"
+
+  mkdir -p \
+    "$repo_root/scripts/ai" \
+    "$repo_root/.claude/skills/demo" \
+    "$repo_root/modules/darwin/programs/folder-actions" \
+    "$repo_root/modules/shared/programs/claude/files/skills" \
+    "$home_dir/.config"
+  cp "$REPO_ROOT/scripts/ai/warn-skill-stale-identifiers.sh" \
+    "$repo_root/scripts/ai/warn-skill-stale-identifiers.sh"
+
+  (
+    cd "$repo_root"
+    skill_stale_git "$repo_root" init >/dev/null 2>&1
+    skill_stale_git "$repo_root" config user.name "Test User"
+    skill_stale_git "$repo_root" config user.email "test@example.com"
+    printf 'fixture\n' > README.md
+    skill_stale_git "$repo_root" add .
+    skill_stale_git "$repo_root" commit -m "initial" >/dev/null 2>&1
+  )
+}
+
+test_warn_skill_stale_identifiers_detects_residual_skill_doc() {
+  local sandbox repo_root output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  create_skill_stale_fixture_repo "$repo_root"
+
+  cat > "$repo_root/modules/darwin/programs/folder-actions/default.nix" <<'EOF'
+{
+  launchd.agents.fixture = {
+    Label = "com.example.fixture.old-label";
+  };
+}
+EOF
+  cat > "$repo_root/.claude/skills/demo/SKILL.md" <<'EOF'
+Use launchctl print gui/501/com.example.fixture.old-label when diagnosing the fixture.
+EOF
+  skill_stale_git "$repo_root" add .
+  skill_stale_git "$repo_root" commit -m "add old label" >/dev/null 2>&1
+
+  cat > "$repo_root/modules/darwin/programs/folder-actions/default.nix" <<'EOF'
+{
+  launchd.agents.fixture = {
+    Label = "com.example.fixture.new-label";
+  };
+}
+EOF
+  skill_stale_git "$repo_root" add modules/darwin/programs/folder-actions/default.nix
+
+  output=$(cd "$repo_root" && bash scripts/ai/warn-skill-stale-identifiers.sh 2>&1)
+  assert_contains "$output" "[WARN] 스킬 문서 구 식별자 잔존 의심: com.example.fixture.old-label"
+  assert_contains "$output" ".claude/skills/demo/SKILL.md:1"
+  assert_contains "$output" "스킬 문서 갱신 필요 여부 확인"
+}
+
+test_warn_skill_stale_identifiers_clean_pass_stays_quiet() {
+  local sandbox repo_root output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  create_skill_stale_fixture_repo "$repo_root"
+
+  cat > "$repo_root/modules/darwin/programs/folder-actions/default.nix" <<'EOF'
+{
+  launchd.agents.compress-rar = {
+    Label = "com.green.folder-action.compress-rar";
+  };
+}
+EOF
+  printf 'No stale folder-action label here.\n' > "$repo_root/.claude/skills/demo/SKILL.md"
+  skill_stale_git "$repo_root" add .
+  skill_stale_git "$repo_root" commit -m "add clean label" >/dev/null 2>&1
+
+  cat > "$repo_root/modules/darwin/programs/folder-actions/default.nix" <<'EOF'
+{
+  launchd.agents.compress-rar = {
+    Label = "com.greenhead.folder-action.compress-rar";
+  };
+}
+EOF
+  skill_stale_git "$repo_root" add modules/darwin/programs/folder-actions/default.nix
+
+  output=$(cd "$repo_root" && bash scripts/ai/warn-skill-stale-identifiers.sh 2>&1)
+  [ -z "$output" ] || fail "expected clean stale identifier check to stay quiet, got: $output"
+}


### PR DESCRIPTION
## Summary

- 신규 warn-only 게이트 `warn-skill-stale-identifiers.sh`: 마이그레이션/rename PR의 staged diff에서 삭제된 고유 식별자를 추출해 스킬 코퍼스 잔존을 커밋 시점에 경고
- lefthook pre-commit에 staged-snapshot 경유 배선 + fixture 테스트 2종
- Closes #1014

## 기존 문제/배경

인프라 마이그레이션 PR이 스킬 문서의 관련 서술을 갱신하지 않은 채 머지되는 사고가 4계열 실증됐다 (1Password 전환 → SSH 장애 3회 원점 재진단, username rename → 복구 절차 no-op, pinned tag 전환 → 업데이트 서술 5곳 오도, 헬퍼 전환 → 구버전 함수 전문 잔존). 기존 게이트(warn-skill-consistency)는 스킬 파일 자체가 staged일 때만 동작해 인프라 코드만 바뀌는 마이그레이션 PR은 통과한다.

## CIR (Change Intent Record)

형태는 사전 확정: lefthook warn-only (차단 없음 — 과거 pinning-guard가 스킬 자기 산출물을 오차단해 제거된 마찰을 반면교사로, fail 승격 없이 시작). 휴리스틱은 보수적으로: reverse-DNS 라벨, 컨테이너 이미지 참조, 함수 정의, constants/launchd 계열 nix attr path만 추출하고 6자 미만·순수 숫자·generic 이름은 제외. staged로 함께 수정되는 스킬 파일은 잔존 검색에서 제외해 "정상적으로 같이 고치는" PR에는 침묵한다. 실제 사고 케이스(`com.green.folder-action.compress-rar` 삭제)를 diff 주입으로 재현해 현행 코퍼스(이미 정렬됨) 기준 무경고 통과를 실측했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| lefthook warn-only | 커밋 시 자동 경고, 차단 없음 | 자동 실행, false positive 무해 | 경고 무시 가능 | ✅ |
| 절차 체크리스트만 | create-pr/finish-pr 문서에 명문화 | 구현 비용 0 | LLM/사람이 잊으면 무력 — 4회 연속 실패한 방식 | ❌ |
| fail 승격 게이트 | 잔존 시 커밋 차단 | 강제력 최대 | 휴리스틱 특성상 false positive 마찰 필연 | ❌ (warn 시작, 신뢰 쌓이면 재검토) |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `scripts/ai/warn-skill-stale-identifiers.sh` | 신규 — staged diff 삭제 라인에서 식별자 추출 → 두 스킬 코퍼스 grep → `[WARN]` 출력, 항상 exit 0, `SKIP_AI_SKILL_CHECK` 우회, diff/staged 파일 주입용 테스트 훅 |
| `lefthook.yml` | pre-commit `ai-skill-stale-identifiers` 항목 (run-staged-snapshot 경유 — 기존 관습) |
| `scripts/ai/check-lefthook-staged-config.sh` | 신규 항목의 staged-snapshot 정합 등록 |
| `tests/suites/skill-stale-identifiers.sh`, `tests/shell-script-tests.sh` | fixture 테스트 2종 (잔존 감지, clean 통과) |

## 참고 레퍼런스

- #1014 (본 이슈), #1010 (스킬 감사 epic), #1019/#1020 (이 게이트가 막을 사고의 정렬 작업)

## Human Test Plan

1. 아무 커밋에서 lefthook pre-commit 로그에 `ai-skill-stale-identifiers` ✔️ 확인 (빈 diff → 침묵 통과)
2. 임의 nix 파일에서 `com.example.test-label` 같은 라벨 라인을 삭제 stage + 임의 스킬 문서에 같은 문자열 삽입(unstaged) → 커밋 시도 시 `[WARN]` + 파일:라인 출력, 커밋은 진행됨을 확인 후 원복
3. `bash tests/suites/skill-stale-identifiers.sh` → 통과
4. 실패 시 진단: 경고가 안 뜨면 식별자가 보수 휴리스틱 범위(6자 이상, 지원 패턴)에 드는지 확인

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM
