### PR TITLE
feat(skills): run-da agent= 실행 프로파일 인자 도입 + silent fallback 제거

### DIFF
--- a/modules/shared/programs/claude/files/skills/run-da/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/run-da/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: run-da
-argument-hint: "[for_plan|for_pr|both|audit] [MAX] [fresh]"
+argument-hint: "[for_plan|for_pr|both|audit] [MAX] [fresh] [agent=codex-xhigh|codex-high|codex-medium|claude]"
 description: |
-  Run Devil's Advocate review on plans or code. Args: for_plan, for_pr, both, audit. Modifier: MAX, fresh.
+  Run Devil's Advocate review on plans or code. Args: for_plan, for_pr, both, audit. Modifier: MAX, fresh, agent=<profile>.
   Trigger: 'DA', '피드백 루프', 'YAGNI 리뷰', '코드 리뷰 루프', 'run-da',
   'HALLUCINATION 관점에서 코드 검증', '설계 검토', '코드 품질 리뷰', '간단한 변경 DA 필요 여부', 'DA 필요', 'DA 생략',
   '사이드이펙트 조사', '회귀 조사', '회귀 감사', '병렬 감사'.
@@ -47,7 +47,7 @@ SKIP이어도 질문 도구 승인 전에는 완료가 아니며, 이 gate가 �
 
 ## 모드
 
-스킬 호출 인자의 첫 토큰이 모드다. 이후 토큰은 `MAX`/`fresh` modifier로 해석한다.
+스킬 호출 인자의 첫 토큰이 모드다. 이후 토큰은 `MAX`/`fresh` modifier와 `agent=` 실행 프로파일 인자로 해석한다.
 
 | 모드 (호출 인자 첫 토큰) | 동작 |
 |--------------|------|
@@ -56,6 +56,22 @@ SKIP이어도 질문 도구 승인 전에는 완료가 아니며, 이 gate가 �
 | `both` | for_plan 전체 → 사용자의 계획 승인 → 구현 → 1차 커밋 → for_pr 전체 → 최종 커밋 후 push + PR 생성. 각 단계의 실행 강도는 Review Intensity에 따라 독립적으로 결정 |
 | `audit` | 일회성 사이드이펙트/회귀 감사 — 6 auditor bundle 병렬, Review Intensity 우회, 1 round 보고 후 종료 ([`modes/audit.md`](modes/audit.md)) |
 | *(비어있음)* | 사용자에게 모드 선택을 질문한다 |
+
+### `agent=` 실행 프로파일 인자
+
+모드 뒤에는 선택적으로 `agent=` 실행 프로파일 인자를 하나 둘 수 있다. 이 인자는 설정 파일 없이 해당 호출에만 적용되며, reviewer/auditor와 Arbiter 실행 단위 전체에 같은 실행 경로와 reasoning effort를 적용한다. Review Intensity는 메인 LLM 인라인 체크리스트이므로 이 인자의 적용 대상이 아니다.
+
+| 값 | 의미 |
+|----|------|
+| `agent=codex-xhigh` | codex exec 경로를 사용하고 reviewer/auditor와 Arbiter 전체에 `xhigh` reasoning effort를 적용한다 |
+| `agent=codex-high` | codex exec 경로를 사용하고 reviewer/auditor와 Arbiter 전체에 `high` reasoning effort를 적용한다 |
+| `agent=codex-medium` | codex exec 경로를 사용하고 reviewer/auditor와 Arbiter 전체에 `medium` reasoning effort를 적용한다 |
+| `agent=claude` | Claude Code 서브에이전트 경로를 사용한다. 모델은 Claude Code 세션 모델을 상속하며 특정 모델명을 고정하지 않는다 |
+| 미지정 | 기존 기본 정책을 사용한다. role별 기본 effort와 런타임 경로의 관계는 [`references/arbiter-scaling.md`](references/arbiter-scaling.md)가 SSOT다 |
+
+`agent=codex-*`는 호출자가 codex exec 경로를 명시적으로 선택한 것이다. codex 사전점검이 실패하면 Claude 경로로 자동 대체하지 않고, 실패 원인과 대안(Claude 경로 진행 또는 중단)을 사용자에게 고지한 뒤 확인을 받아야 한다.
+
+`agent=claude`는 Claude Code 세션에서만 실행 가능한 경로다. 현재 런타임에서 Claude Code 서브에이전트 경로를 사용할 수 없으면 다른 경로로 조용히 대체하지 않고 사용자에게 고지한다.
 
 ### `MAX` modifier
 
@@ -99,7 +115,7 @@ Review Intensity 판단을 건너뛰고 exhaustive override를 실행한다.
 
 | 시점 | 필수 문서 | 목적 |
 |------|-----------|------|
-| `/run-da` 진입 preflight | 이 `SKILL.md`만 | mode 선택, `MAX`/`fresh` modifier 해석, compact Review Intensity 판정, reviewer bundle/Arbiter/selective consistency invariant 확인 |
+| `/run-da` 진입 preflight | 이 `SKILL.md`만 | mode 선택, `MAX`/`fresh` modifier와 `agent=` 실행 프로파일 해석, compact Review Intensity 판정, reviewer bundle/Arbiter/selective consistency invariant 확인 |
 
 Preflight에서 아래 lazy reference를 미리 열지 않는다. mode가 비어 있으면 이 파일의 모드 표만 보고 질문 도구로 mode를 선택한다.
 
@@ -113,6 +129,7 @@ Preflight에서 아래 lazy reference를 미리 열지 않는다. mode가 비어
 | `audit` | [`modes/audit.md`](modes/audit.md) | mode 확정 후 즉시. Review Intensity 우회이므로 `intensity-procedure.md`는 읽지 않는다 |
 | `fresh` modifier | 이 `SKILL.md`; 후속 라운드 propagation 조립 시 [`references/protocol.md`](references/protocol.md), ledger suppression이 필요하면 [`references/dismissal-ledger.md`](references/dismissal-ledger.md) | preflight에서는 추가 reference 없음. 이전 라운드 맥락과 selective propagation을 모두 끊어야 하는 시점에만 protocol을 확인한다. current changeset에 valid ledger가 있을 때만 dismissal-ledger를 확인한다 |
 | `MAX` modifier | 선택 mode 문서, [`references/da-domains.md`](references/da-domains.md) | Review Intensity를 건너뛰고 exhaustive 6-domain fan-out 조립 직전. `intensity-procedure.md`는 읽지 않는다 |
+| `agent=` 실행 프로파일 | 이 `SKILL.md`; 실제 경로/effort 조립 시 [`references/runtime-mapping.md`](references/runtime-mapping.md), [`references/arbiter-scaling.md`](references/arbiter-scaling.md) | preflight에서는 값 검증만 한다. fan-out 실행 단위 조립 직전에 런타임 매핑과 role별 command 계약을 확인한다 |
 | LITE/FULL reviewer fan-out | [`references/da-domains.md`](references/da-domains.md), [`references/runtime-mapping.md`](references/runtime-mapping.md), [`references/hardening-contract.md`](references/hardening-contract.md) | Step 2에서 실제 reviewer prompt/런타임을 조립할 때 |
 | codex exec fallback 또는 literal 재사용 위험 | [`../using-codex-exec/references/known-issues.md`](../using-codex-exec/references/known-issues.md#literal-재사용-시-random-suffix-환각-금지-issue-632), [`references/arbiter-scaling.md`](references/arbiter-scaling.md) | native delegation이 거부되거나 codex exec 경로를 실제로 사용할 때 |
 | findings ≥ 1로 first-pass Arbiter 진입 | [`references/arbiter-prompt.md`](references/arbiter-prompt.md), [`references/protocol.md`](references/protocol.md), [`references/arbiter-scaling.md`](references/arbiter-scaling.md) | Step 5a에서 Arbiter prompt/실행 계약을 조립할 때 |
@@ -167,8 +184,8 @@ Preflight에서 아래 lazy reference를 미리 열지 않는다. mode가 비어
 
 - 매 라운드 새 reviewer/Arbiter 실행 단위를 사용한다.
 - Codex 세션 경로에서는 completed reviewer/Arbiter thread를 다음 round/retry 전에 명시적으로 `close_agent`로 닫는다. 닫지 않으면 open-thread slot이 회수되지 않는다.
-- Codex 세션 경로의 reviewer/auditor는 standard review profile, Arbiter는 strong review profile을 사용한다 ([`references/runtime-mapping.md`](references/runtime-mapping.md) review profile 매핑).
-- codex exec 경로의 DA `codex exec` 프로세스는 `codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral` (Layer 1)로 실행되어 코드/계획 write를 read-only sandbox로 구조적으로 차단한다. `--ignore-rules`는 user/project execpolicy `.rules`의 network/system mutation allow rule(예: `git push`)도 차단한다. 프롬프트에서도 수정 금지를 명시한다.
+- Codex 세션 경로의 reviewer/auditor는 standard review profile, Arbiter는 strong review profile을 사용한다. `agent=`가 지정되면 해당 호출에서는 그 실행 프로파일이 reviewer/auditor와 Arbiter 전체에 우선한다 ([`references/runtime-mapping.md`](references/runtime-mapping.md) review profile 매핑).
+- codex exec 경로의 DA `codex exec` 프로세스는 `codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral` (Layer 1)로 실행되어 코드/계획 write를 read-only sandbox로 구조적으로 차단한다. `--ignore-rules`는 user/project execpolicy `.rules`의 network/system mutation allow rule(예: `git push`)도 차단한다. 모델명은 고정하지 않고, reasoning effort만 기본 role profile 또는 `agent=` 인자에서 결정한다. 프롬프트에서도 수정 금지를 명시한다.
 - "사용자 지시"만으로 DA 지적을 기각하지 않는다. 기술적 근거가 필수이다.
 - DA 결과에서 다른 bundle 범위를 침범한 지적은 해당 bundle의 DA 결과로 이관하거나 무시한다.
 - 피드백 루프 결과는 PR 코멘트로 게시하여 이력을 보존한다 ([`references/protocol.md`](references/protocol.md) 참조).

--- a/modules/shared/programs/claude/files/skills/run-da/modes/audit.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/audit.md
@@ -17,6 +17,7 @@ audit 모드는 preflight 체크리스트를 건너뛴다 — 감사 자체가 �
 | open thread cap | current session의 `agents.max_threads` (unset 기본 6) |
 | `MAX` modifier | 기본 6 bundle을 10개 세부 관점으로 확장 (exhaustive override) |
 | `fresh` modifier | audit 모드 부적용 — 라운드 반복이 없으므로 해석하지 않는다 |
+| `agent=` 실행 프로파일 | 호출 단위 실행 경로/effort override. 정본은 [`../SKILL.md`](../SKILL.md). 예: `run-da audit agent=codex-high` |
 | trailing 자유 텍스트 | `audit` (및 `MAX`) 토큰 뒤 나머지 인자 전체를 메인 에이전트의 우선순위 판단 컨텍스트로 보존 (Step 1 `git diff` 결과와 결합) |
 | 정수 에이전트 수 인자 | 폐지 — fan-out 크기는 기본 6 bundle / `MAX` 10 관점으로만 결정한다 |
 | 에이전트 권한 | 읽기 전용. codex exec 경로(Claude Code/headless)는 Layer 1(`codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules`)으로 구조적 강제. Codex 세션(`spawn_agent`)은 정책 + 프롬프트 + self-report로 운영 (Non-goals 참조) |
@@ -40,7 +41,7 @@ auditor-specific delta: audit 모드의 fan-out 대상은 auditor다 (standard r
 | 경로 | 조건 |
 |------|------|
 | Codex 세션 | Codex CLI가 호스트 — native subagent fan-out (delegation 허용 시). delegation-denied fallback은 [`../references/hardening-contract.md`](../references/hardening-contract.md)의 "Delegation fallback" 참조 |
-| Claude Code 세션 | Claude Code가 호스트 — codex exec 기본 (사전점검: `command -v codex` + `command -v codex-exec-supervised` + `codex-exec-supervised --check` 모두 성공해야 한다. wrapper `--check`는 setsid/timeout/codex 의존성을 자체 검증하고 OK 시 exit 0, 부재 시 exit 127을 반환한다 — codex exec를 호출하지 않으므로 사전점검 비용이 작다). codex 또는 wrapper 미가용/capability probe 실패 시 Claude Code fallback (아래 Step 3c) |
+| Claude Code 세션 | Claude Code가 호스트 — codex exec 기본 (사전점검: `command -v codex` + `command -v codex-exec-supervised` + `codex-exec-supervised --check` 모두 성공해야 한다. wrapper `--check`는 setsid/timeout/codex 의존성을 자체 검증하고 OK 시 exit 0, 부재 시 exit 127을 반환한다 — codex exec를 호출하지 않으므로 사전점검 비용이 작다). codex 또는 wrapper 미가용/capability probe 실패 시 Claude Code fallback으로 자동 대체하지 않고 실패 원인과 대안(Claude 경로 진행 / 중단)을 사용자에게 확인한다 |
 | headless 세션 | CI, `claude -p`, `codex exec` subprocess |
 
 `CODEX_CI=1`만으로 세션 유형을 구분하지 않는다.
@@ -176,13 +177,13 @@ N개 에이전트를 한 턴에 병렬 실행한다 (런타임이 지원하는 �
   [ -d "$DA_DIR" ] || { echo "missing DA_DIR=$DA_DIR"; exit 1; }
   [ -f "$DA_DIR/$UNIT.md" ] || { echo "missing prompt=$DA_DIR/$UNIT.md"; exit 1; }
   ```
-  `--ignore-user-config`/`--ignore-rules`/model-effort pins/`CODEX_PROGRAMMATIC=1` placement 등 command literal은 [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md)의 role별 명령이 SSOT다.
+  `--ignore-user-config`/`--ignore-rules`/effort resolution/`CODEX_PROGRAMMATIC=1` placement 등 command literal은 [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md)의 role별 명령이 SSOT다.
 - 세션 네임스페이스(`$_DA_SID`)와 stdin pipe 패턴은 [`../references/runtime-mapping.md`](../references/runtime-mapping.md)의 "codex exec 경로 위생 규칙"을 따른다.
 - 임시 prompt/result 파일, stderr/result 검증, 백그라운드 실행 제어, stdin pipe 경쟁, heredoc hang 제약은 [/using-codex-exec 스킬](../../using-codex-exec/SKILL.md)과 [known-issues.md](../../using-codex-exec/references/known-issues.md)를 따른다.
 
-### Step 3c: Claude Code fallback (codex 미가용 시)
+### Step 3c: Claude Code fallback (사용자 확인 후)
 
-- 위 표 사전점검(`command -v codex` + `command -v codex-exec-supervised` + `codex-exec-supervised --check`) 실패 또는 codex exec 실행 실패 시에만 진입한다.
+- 위 표 사전점검(`command -v codex` + `command -v codex-exec-supervised` + `codex-exec-supervised --check`) 실패 또는 codex exec 실행 실패의 원인을 사용자에게 고지하고, 사용자가 Claude 경로 진행을 확인했거나 `agent=claude`를 명시한 경우에만 진입한다.
 - bundle별 병렬 실행을 수행한다. 실행 binding 상세(Claude Code 고유 fallback lifecycle, 완료 알림 수신, thread 관리)는 [`../references/runtime-mapping.md`](../references/runtime-mapping.md)의 "Claude Code 세션 fallback 세부 정보" 섹션을 참조한다.
 - 프롬프트에 read-only/no-write 범위를 명시한다.
 - 완료 알림 수신 후 결과를 집계하고, `RECOVERABLE VIOLATION`/`STATEFUL VIOLATION` 분류 규칙은 Step 4와 동일하게 적용한다.

--- a/modules/shared/programs/claude/files/skills/run-da/modes/for_plan.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/for_plan.md
@@ -32,6 +32,7 @@
 ## Step 2: reviewer bundle 병렬 실행
 
 선택된 reviewer bundle 또는 explicit exhaustive override의 세부 도메인별 DA 에이전트를 병렬 실행한다. 런타임별 도구 매핑은 [`../references/runtime-mapping.md`](../references/runtime-mapping.md) 참조.
+호출 단위 실행 프로파일은 [`../SKILL.md`](../SKILL.md)의 `agent=` 정의가 정본이다. 예: `run-da for_plan agent=codex-high`.
 
 ### Codex 세션 경로
 
@@ -66,7 +67,7 @@
   [ -d "$DA_DIR" ] || { echo "missing DA_DIR=$DA_DIR"; exit 1; }
   [ -f "$DA_DIR/$UNIT.md" ] || { echo "missing prompt=$DA_DIR/$UNIT.md"; exit 1; }
   ```
-  `--ignore-user-config`/`--ignore-rules`/model-effort pins 등 command literal은 [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md)의 role별 명령이 SSOT다. Claude Code 세션의 기본 병렬 경로와 fallback 경로(codex exec 사전점검 실패 시)는 [`../references/runtime-mapping.md`](../references/runtime-mapping.md)의 "런타임 도구 매핑" 표 binding을 따른다. headless 세션은 serial foreground (완료 알림·`&+wait` 없음).
+  `--ignore-user-config`/`--ignore-rules`/effort resolution 등 command literal은 [`../references/arbiter-scaling.md`](../references/arbiter-scaling.md)의 role별 명령이 SSOT다. Claude Code 세션의 기본 병렬 경로와 fallback 경로(codex exec 사전점검 실패 원인 고지 후 사용자 확인 시)는 [`../references/runtime-mapping.md`](../references/runtime-mapping.md)의 "런타임 도구 매핑" 표 binding을 따른다. headless 세션은 serial foreground (완료 알림·`&+wait` 없음).
 - Claude Code 세션: 병렬 실행 완료 알림을 수신하면 sleep/poll 없이 바로 결과를 수집한다. headless 세션: 각 subprocess 종료를 직렬로 확인한다.
 - 모든 런타임 공통: `& + wait` shell-level 병렬 금지, `cat file | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral ... -` stdin pipe (Layer 1)로 프롬프트 전달. pipe EOF가 stdin을 닫으므로 `< /dev/null`은 불필요. 인라인 인자 `"$(cat file)"`는 사용하지 않는다. `CODEX_PROGRAMMATIC=1` env assignment는 codex 프로세스에 적용되어야 한다 (회피: `CODEX_PROGRAMMATIC=1 cat ...`은 cat에만 적용 — issue #585).
 - [`../../using-codex-exec/SKILL.md`](../../using-codex-exec/SKILL.md) 패턴 5의 실행 흐름(`-o` 사용법, 결과 파일 검증, 명령 실행 순서)만 참고한다. 프롬프트 내용 규칙은 본 스킬의 `fresh`/프롬프트 조향 금지 규칙이 우선한다.

--- a/modules/shared/programs/claude/files/skills/run-da/modes/for_pr.md
+++ b/modules/shared/programs/claude/files/skills/run-da/modes/for_pr.md
@@ -4,6 +4,8 @@
 
 `for_pr`은 `for_plan`과 7-step 구조가 동일하다. 입력(diff vs 계획), 임시 디렉토리 prefix, write phase의 코드 수정+커밋 방식, Step 8 push만 다르다. 동일 절차는 [`./for_plan.md`](./for_plan.md)를 참조하고, 본 파일은 차이점만 step 번호별로 명시한다.
 
+호출 단위 실행 프로파일은 [`../SKILL.md`](../SKILL.md)의 `agent=` 정의가 정본이다. 예: `run-da for_pr agent=codex-xhigh`.
+
 ## Step 번호별 delta (vs for_plan)
 
 | Step | for_plan | for_pr (delta) |

--- a/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/arbiter-scaling.md
@@ -8,6 +8,8 @@ P0 기본값은 항상 단일 강한 Arbiter 1개다.
 `run-da`의 reviewer fan-out을 4 bundle로 줄이더라도, Arbiter는 기본적으로 늘리지 않는다.
 비용을 늘려 여러 Arbiter를 붙이기보다, 한 명의 강한 Arbiter가 selective escalation set을 판정하는 구조를 유지한다.
 
+`agent=` 실행 프로파일 인자가 지정되면 해당 호출의 reviewer/auditor와 Arbiter 전체에 그 값이 우선한다. 인자가 없을 때만 role별 기본값을 사용한다: reviewer/auditor는 standard profile effort, Arbiter는 strong profile effort를 따른다. 값 정의와 경로 의미는 [`runtime-mapping.md`](runtime-mapping.md)의 review profile 매핑이 정본이다.
+
 ## v1: 단순 스케일링
 
 | Findings 개수 | Arbiter 수 |
@@ -63,8 +65,8 @@ Claude Code에서 Codex CLI를 subprocess로 호출할 때, 비대화형 automat
 - `-o "$ARBITER_DIR/arbiter-result.md"` 결과 파일
 - `cat "$ARBITER_DIR/arbiter-prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised ... -` stdin pipe로 프롬프트 전달 (pipe EOF가 stdin hang 방지; marker는 codex 프로세스에 적용 — issue #585)
 - `2>"$ARBITER_DIR/arbiter-stderr.log"` stderr 분리
-- `-c model="gpt-5.5"` 명시 (`--ignore-user-config`로 `$CODEX_HOME/config.toml`의 model이 차단되므로 explicit pin 필수)
-- Arbiter는 strong review profile(`model="gpt-5.5"`, `model_reasoning_effort="high"`)을 사용한다. `--ignore-user-config`로 config.toml의 model과 effort가 모두 차단되므로 둘 다 explicit하게 명시한다.
+- 모델명은 명시하지 않는다. `RUN_DA_CODEX_EFFORT`를 role별 기본 profile 또는 `agent=` 인자에서 결정한 뒤 `-c model_reasoning_effort="$RUN_DA_CODEX_EFFORT"`만 명시한다.
+- Arbiter는 인자 미지정 시 strong review profile effort를 사용한다. `agent=codex-*`가 지정되면 Arbiter도 reviewer/auditor와 같은 effort override를 적용한다.
 - 프롬프트에서 "리뷰만 수행하고 파일을 수정하지 마라" 명시
 - `--ephemeral`로 세션 히스토리 오염 방지
 
@@ -77,36 +79,53 @@ Codex 세션에서 `spawn_agent`가 정책상 거부될 때(예: `multi_agent=fa
 
 공통:
 - `--sandbox read-only` + `--ignore-user-config` + `--ignore-rules`를 함께 강제한다. `--sandbox read-only`는 model-generated shell command의 파일시스템 쓰기만 막고, user `config.toml`의 MCP server/plugin/connector 로딩은 차단하지 못한다. `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 user MCP/plugin/connector surface를 차단하지만, cwd 기반 project config (`.codex/config.toml`의 `[mcp_servers.*]`)는 차단하지 못한다. 현재 worktree에 project-scoped MCP connector가 있을 때의 project-config 한계는 `run-da/SKILL.md` Non-goals #1이 canonical이다. `--ignore-rules`는 user/project execpolicy `.rules` 파일을 차단해 read-only sandbox로 막을 수 없는 network/system mutation 명령(예: `git push`, `aws ec2 describe`)이 reviewer/auditor에서 실행되지 않게 한다.
-- `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model`/`model_reasoning_effort`도 차단하므로 role별 표의 `-c model="gpt-5.5"`·`-c model_reasoning_effort="..."` 명시가 필수다 (defensive explicit pin).
+- `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model_reasoning_effort`도 차단하므로 role별 표의 `RUN_DA_CODEX_EFFORT` guard와 `-c model_reasoning_effort="$RUN_DA_CODEX_EFFORT"` 명시가 필수다. 모델명은 pin하지 않는다.
 - `--ephemeral`로 세션 히스토리 오염 방지.
 - `exec_command`를 `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral ... - 2>stderr.log` 형태로 stdin pipe 전달.
 - 각 review unit은 독립 subprocess (fresh 판정 경계는 프로세스 경계로 보존).
 - 사용자 승인 후에만 실행 ([`hardening-contract.md`](hardening-contract.md) "Delegation fallback" 섹션 참조).
 
-role별 명령 (각 역할이 사용하는 임시 디렉토리와 파일 이름 규약은 [`../modes/for_plan.md`](../modes/for_plan.md) / [`../modes/for_pr.md`](../modes/for_pr.md) 본문 절차를 따른다). 아래 fenced code block은 caller가 `DA_DIR`/`UNIT`을 현재 flow의 stdout 리터럴 값으로 설정한 뒤 guard와 함께 실행한다. standard/strong profile의 model/effort 값은 literal로 고정한다. profile 이름·의미의 SSOT는 [`runtime-mapping.md`](runtime-mapping.md)의 review profile 매핑 불릿이며, 값이 바뀌면 아래 literal도 함께 갱신해야 한다 (문서-코드 manual sync contract — selective consistency harness와 동일한 패턴). 현재 effort 매핑: `medium` = standard profile (reviewer/auditor), `high` = strong profile (Arbiter), `xhigh` = `config.toml` `model_reasoning_effort` 기본값 (보존; Arbiter 호출 경로에서만 `-c`로 `high`로 다운그레이드).
+role별 명령 (각 역할이 사용하는 임시 디렉토리와 파일 이름 규약은 [`../modes/for_plan.md`](../modes/for_plan.md) / [`../modes/for_pr.md`](../modes/for_pr.md) 본문 절차를 따른다). 아래 fenced code block은 caller가 `DA_DIR`/`UNIT`을 현재 flow의 stdout 리터럴 값으로 설정하고, `RUN_DA_CODEX_EFFORT`를 profile resolution 결과로 설정한 뒤 guard와 함께 실행한다. 모델명은 literal로 고정하지 않는다. 기본 role effort 매핑은 [`runtime-mapping.md`](runtime-mapping.md)의 review profile 매핑 표가 SSOT다.
+
+| profile | 기본 `RUN_DA_CODEX_EFFORT` |
+|---------|----------------------------|
+| `standard` | `medium` |
+| `strong` | `high` |
+
+`agent=codex-xhigh`, `agent=codex-high`, `agent=codex-medium`이 지정되면 위 기본값 대신 각각 `xhigh`, `high`, `medium`을 reviewer/auditor와 Arbiter 전체에 사용한다.
 
 reviewer / Auditor (standard profile):
 
 ```bash
 : "${DA_DIR:?missing DA_DIR}"
 : "${UNIT:?missing UNIT}"
+: "${RUN_DA_CODEX_EFFORT:?missing RUN_DA_CODEX_EFFORT}"
 case "$UNIT" in
   *[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-]*)
     echo "invalid UNIT=$UNIT"; exit 1 ;;
+esac
+case "$RUN_DA_CODEX_EFFORT" in
+  medium|high|xhigh) ;;
+  *) echo "invalid RUN_DA_CODEX_EFFORT=$RUN_DA_CODEX_EFFORT"; exit 1 ;;
 esac
 [ -d "$DA_DIR" ] || { echo "missing DA_DIR=$DA_DIR"; exit 1; }
 [ -f "$DA_DIR/$UNIT.md" ] || { echo "missing prompt=$DA_DIR/$UNIT.md"; exit 1; }
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
 cat "$DA_DIR/$UNIT.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-  -c model="gpt-5.5" -c model_reasoning_effort="medium" \
+  -c model_reasoning_effort="$RUN_DA_CODEX_EFFORT" \
   -o "$DA_DIR/$UNIT-result.md" - 2>"$DA_DIR/$UNIT-stderr.log"
 ```
 
 Arbiter (strong profile):
 
 ```bash
+: "${RUN_DA_CODEX_EFFORT:?missing RUN_DA_CODEX_EFFORT}"
+case "$RUN_DA_CODEX_EFFORT" in
+  medium|high|xhigh) ;;
+  *) echo "invalid RUN_DA_CODEX_EFFORT=$RUN_DA_CODEX_EFFORT"; exit 1 ;;
+esac
 cat "$ARBITER_DIR/arbiter-prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-  -c model="gpt-5.5" -c model_reasoning_effort="high" \
+  -c model_reasoning_effort="$RUN_DA_CODEX_EFFORT" \
   -o "$ARBITER_DIR/arbiter-result.md" - 2>"$ARBITER_DIR/arbiter-stderr.log"
 ```
 
@@ -145,12 +164,15 @@ PROMPT
 [ -f "$ARBITER_DIR/arbiter-prompt.md" ] || { echo "ARBITER_FAILED: missing prompt=$ARBITER_DIR/arbiter-prompt.md"; exit 1; }
 
 # 3. codex exec 실행 (foreground)
-# Arbiter는 strong review profile(model="gpt-5.5", model_reasoning_effort="high") — --ignore-user-config로
-# config.toml의 model과 model_reasoning_effort가 모두 차단되므로 둘 다 explicit하게 명시한다.
+# RUN_DA_CODEX_EFFORT는 role별 기본 profile 또는 agent= 인자에서 결정한다.
+RUN_DA_CODEX_EFFORT="${RUN_DA_CODEX_EFFORT:-high}"
+case "$RUN_DA_CODEX_EFFORT" in
+  medium|high|xhigh) ;;
+  *) echo "ARBITER_FAILED: invalid RUN_DA_CODEX_EFFORT=$RUN_DA_CODEX_EFFORT"; exit 1 ;;
+esac
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
 cat "$ARBITER_DIR/arbiter-prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-  -c model="gpt-5.5" \
-  -c model_reasoning_effort="high" \
+  -c model_reasoning_effort="$RUN_DA_CODEX_EFFORT" \
   -o "$ARBITER_DIR/arbiter-result.md" \
   - \
   2>"$ARBITER_DIR/arbiter-stderr.log"
@@ -203,12 +225,12 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
 - headless 세션: serial foreground로 3개 프로세스를 순차 실행한다 (완료 알림/`&+wait` 없음, 각 프로세스 종료 후 다음 프로세스 기동). 결과 파일 경로·환경 격리 방식은 아래와 동일하게 적용하되, 실행 방식만 serial로 바꾼다.
 
 1. 동일 Arbiter 프롬프트 파일을 3번 실행하기 위해 3개의 `codex exec` 프로세스를 기동한다 (Claude Code: background, headless: serial foreground). reviewer fan-out과 달리 Arbiter N=3 자체는 모두 같은 프롬프트다(프롬프트 조향 금지, 독립 판정 원칙).
-2. 환경 격리 — first-pass Arbiter와 selective consistency N=3 모두 strong review profile(high)을 사용한다. `~/.codex/config.toml` 기본값(xhigh)과 다르므로 반드시 `-c model_reasoning_effort="high"`를 명시한다. selective consistency N=3은 외부 표면과 충돌을 줄이기 위해 다음 두 방식 중 하나를 선택한다:
+2. 환경 격리 — first-pass Arbiter와 selective consistency N=3 모두 같은 resolved effort를 사용한다. 인자 미지정 시 strong review profile 기본 effort는 `high`이며, `agent=codex-*`가 지정되면 그 effort가 N=3에도 그대로 적용된다. selective consistency N=3은 외부 표면과 충돌을 줄이기 위해 다음 두 방식 중 하나를 선택한다:
 
    (a) 기본 경로 + config 차단 (권장, 간단):
    - `CODEX_HOME`을 그대로 두어 기본 auth chain(`auth.json` 등)을 유지한다.
    - codex exec 호출에 `--ignore-user-config`를 추가하여 사용자 `config.toml`(MCP 서버 포함) 로딩을 차단한다. [`using-codex-exec/SKILL.md`](../../using-codex-exec/SKILL.md)의 `--ignore-user-config` 옵션 설명처럼 이 플래그는 config만 차단하고 auth는 유지한다.
-   - 주의: `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model` / `model_reasoning_effort` 등 user config 설정을 함께 제거한다. Arbiter는 strong review profile(high)을 유지해야 하므로 `-c model="gpt-5.5"`와 `-c model_reasoning_effort="high"`를 명시적으로 재지정한다 (defensive explicit pin — config.toml default가 차단되므로).
+   - 주의: `--ignore-user-config`는 `$CODEX_HOME/config.toml`의 `model_reasoning_effort` 등 user config 설정을 함께 제거한다. Arbiter는 resolved effort를 유지해야 하므로 `-c model_reasoning_effort="$RUN_DA_CODEX_EFFORT"`를 명시적으로 재지정한다. 모델명은 pin하지 않는다.
    - 부작용: `~/.codex/sessions` 기반 세션이 생성되므로 동시 N=3 실행 시 세션 파일 경합이 발생할 수 있다. `--ephemeral`로 session 저장 자체를 회피한다.
 
    (b) scratch CODEX_HOME + auth 복사 (세션 충돌 완전 분리가 필요할 때):
@@ -218,7 +240,7 @@ selective consistency trigger([stability-measurement.md](stability-measurement.m
      - 그렇지 않으면 `cp ~/.codex/auth.json "$CODEX_HOME/"`로 기존 auth.json을 scratch로 복사.
      - 둘 다 불가능하면 scratch CODEX_HOME에서 `codex login status`가 `Not logged in`으로 실패하므로 방식 (a)로 돌아간다.
    - 최소 `$CODEX_HOME/config.toml`을 작성하되 `[mcp_servers.<name>]` 테이블(실제 Codex TOML 스키마는 [`sync-codex-config.py`](../../../../../codex/files/sync-codex-config.py)의 user-owned `mcp_servers` 보존 정책과 [`scenario-D-mcp-servers-coexist.toml`](../../../../../../../../tests/fixtures/codex-hooks/sync-preservation/scenario-D-mcp-servers-coexist.toml) fixture로 확인)을 포함하지 않는다. 또는 TOML 파서로 기존 config를 복사한 뒤 `mcp_servers` 테이블 전체를 삭제한다. (참고: `[[mcp_servers]]` array-of-table 문법은 현재 Codex가 사용하지 않으므로 혼동 방지를 위해 `[mcp_servers.*]` 정확 표기를 사용한다.)
-   - 모델/효과 옵션은 필수로 명시적으로 지정한다: `-c model="gpt-5.5"`와 `-c model_reasoning_effort="high"`. scratch `CODEX_HOME`이므로 user config default가 적용되지 않아 호출 시점 기본값 의존이 불가하다.
+   - effort 옵션은 필수로 명시적으로 지정한다: `-c model_reasoning_effort="$RUN_DA_CODEX_EFFORT"`. scratch `CODEX_HOME`이므로 user config default가 적용되지 않아 호출 시점 기본값 의존이 불가하다. 모델명은 pin하지 않는다.
 3. Claude Code 세션: `run_in_background: true`로 3개를 병렬 발사 후 완료 알림을 기다린다 (sleep/poll 금지). headless 세션: 3개 프로세스를 serial foreground로 순차 실행한다 (각 종료 확인 후 다음). 결과 파일 경로는 두 경로 모두 `/tmp/da-${_DA_SID}-arbiter-selective-<round>/arbiter-{1,2,3}-result.md`로 라운드별 분리.
 4. 수집 후 세션 scope의 `fleiss-kappa.py`(Claude: `~/.claude/scripts/fleiss-kappa.py`, Codex: `~/.codex/scripts/fleiss-kappa.py`)에 `arbiter-1-result.md arbiter-2-result.md arbiter-3-result.md`를 인자로 전달하여 vote-shape를 얻는다. `--offline` 플래그는 배포 후 kappa 관찰 목적일 때만 부가한다.
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md
@@ -10,8 +10,8 @@ codex exec 경로(Claude Code 세션 · headless 세션)는 [`arbiter-scaling.md
 
 | 용어 | 뜻 | 우선순위 |
 |------|-----|---------|
-| strong review profile | Arbiter spawn의 강한 리뷰 설정 (model/effort literal은 [`runtime-mapping.md`](runtime-mapping.md)의 review profile 매핑 불릿이 단일 소스) | Arbiter spawn 기본값 |
-| standard review profile | reviewer/auditor spawn의 기본 리뷰 설정 ([`runtime-mapping.md`](runtime-mapping.md) review profile 매핑 불릿이 단일 소스) | DA spawn 기본값 |
+| strong review profile | Arbiter spawn의 강한 리뷰 설정 (role별 effort 매핑은 [`runtime-mapping.md`](runtime-mapping.md)의 review profile 매핑 표가 단일 소스) | Arbiter spawn 기본값 |
+| standard review profile | reviewer/auditor spawn의 기본 리뷰 설정 ([`runtime-mapping.md`](runtime-mapping.md) review profile 매핑 표가 단일 소스) | DA spawn 기본값 |
 | conservative wait | `wait_agent` timeout이나 단순 지연은 실패 신호가 아니다. 명시적 agent failure, documented violation, 최종 응답 파싱 실패 전에는 kill/self-auditing 대체를 금지한다. 검토 강도 인라인 판정에는 적용되지 않는다 (메인 에이전트의 동기 체크리스트). | 조급한 조기 종료보다 우선 |
 | single-writer | tracked workspace write, 최종 파일 수정, branch mutation, commit/push, GitHub comment/issue/PR write는 메인 에이전트 소유다. explicit delegation만 예외다 | generic PoC 허용보다 우선 |
 | main-agent-only commands | `wt`, `nrs`, rebuild 계열과 host/repo 상태를 바꾸는 동급 명령은 direct fan-out subagent가 실행하지 않는다 | lock-sensitive convenience보다 우선 |
@@ -35,7 +35,7 @@ Direct Codex 세션에서 사용자가 `$run-da`, `$run-da audit`처럼 fan-out 
 
 이 권한은 delegated reviewer/auditor/Arbiter의 read-only/no-write 경계를 약화하지 않는다. tracked workspace write, branch mutation, commit/push, GitHub write, `wt`, `nrs`, rebuild 계열 명령은 별도 explicit delegation 없이는 계속 메인 에이전트 전용이다.
 
-이 권한은 native subagent 경로에만 적용된다. Skill invocation itself does not authorize `codex-exec-supervised` fallback. `codex-exec-supervised` fallback은 아래 Delegation fallback 절차에 따라 native delegation 거부/미지원 사유 기록과 별도 사용자 승인을 받은 뒤에만 사용한다.
+이 권한은 native subagent 경로에만 적용된다. Skill invocation itself does not authorize `codex-exec-supervised` fallback. 단, 사용자가 `agent=codex-*`를 호출 인자로 지정한 경우는 fallback이 아니라 해당 호출의 codex exec 경로 선택이다. `codex-exec-supervised` fallback은 아래 Delegation fallback 절차에 따라 native delegation 거부/미지원 사유 기록과 별도 사용자 승인을 받은 뒤에만 사용한다.
 
 ## `VIOLATION` 공통 처리
 
@@ -56,7 +56,7 @@ Codex 세션에서 `spawn_agent`가 정책상 거부되면(예: `multi_agent=fal
 1. BLOCKED + 사용자 승인 대기 (기본): `spawn_agent` 거부 감지 시 현재 DA 라운드 중단, 사용자에게 "delegation 거부 감지 — codex exec subprocess fallback 승인?"을 보고한다. 승인 수단은 런타임별로 다음과 같이 취한다:
    - 질문 도구 지원 런타임 (Claude Code 세션, Codex 세션): 질문 도구로 즉시 승인 요청. 승인 시 같은 턴에서 바로 fallback 단계 진행.
    - 질문 도구 미지원 런타임 (headless 세션 등): plain-text로 상황 보고 후 DA 루프 종료한다. 사용자는 새 메시지에서 "fallback 진행"으로 명시 승인하거나 `run-da <mode>`를 다시 실행하여 새 라운드로 재개한다 (이전 라운드 상태는 복원하지 않음, 깨끗한 fresh round로 시작). 명시 승인 없이 자동 재개하지 않는다.
-2. codex exec subprocess fallback (사용자 승인 후에만): [`arbiter-scaling.md`](arbiter-scaling.md)의 "Codex delegation-denied fallback" 섹션이 정의한 role별 Layer 1 명령(standard profile = `model="gpt-5.5"`+medium, strong profile = `model="gpt-5.5"`+high)을 그대로 사용한다 — 실제 명령 literal과 플래그(`codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral` + role별 model/effort pin)는 `arbiter-scaling.md`의 role별 명령 표가 SSOT다. user config의 MCP/plugin/connector surface 차단을 위해 `--ignore-user-config`가 필수이고, user/project execpolicy `.rules`의 mutation allow rule(예: `git push`) 차단을 위해 `--ignore-rules`가 필수다. cwd 기반 project config (`.codex/config.toml`)는 차단하지 못하므로 한계는 [`SKILL.md` Non-goals](../SKILL.md#non-goals) #1 참조. 각 unit은 독립 subprocess.
+2. codex exec subprocess fallback (사용자 승인 후에만): [`arbiter-scaling.md`](arbiter-scaling.md)의 "Codex delegation-denied fallback" 섹션이 정의한 role별 Layer 1 명령을 그대로 사용한다. 실제 명령 literal과 플래그(`codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral` + role별 또는 `agent=` resolved effort)는 `arbiter-scaling.md`의 role별 명령 표가 SSOT다. 모델명은 pin하지 않는다. user config의 MCP/plugin/connector surface 차단을 위해 `--ignore-user-config`가 필수이고, user/project execpolicy `.rules`의 mutation allow rule(예: `git push`) 차단을 위해 `--ignore-rules`가 필수다. cwd 기반 project config (`.codex/config.toml`)는 차단하지 못하므로 한계는 [`SKILL.md` Non-goals](../SKILL.md#non-goals) #1 참조. 각 unit은 독립 subprocess.
 
    Project-scoped MCP 차단 한계 (caveat — `--ignore-user-config`는 부분적 차단): `--ignore-user-config`는 `$CODEX_HOME/config.toml` 로드만 차단하고, **cwd 기반 project config (`.codex/config.toml`의 `[mcp_servers.*]`)는 차단하지 않는다**. 현재 worktree에 project-scoped MCP connector가 있으면, fallback subprocess가 repo root에서 실행될 때 그 surface가 reviewer/Arbiter에게 남는다. 완전 차단이 필요하면 `codex exec -C <non-repo-scratch-dir>`로 cwd를 project config 없는 디렉토리로 이동시키는 별도 follow-up이 필요하다 (run-da [`SKILL.md` Non-goals](../SKILL.md#non-goals) 1번 항목과 동일 내용).
 

--- a/modules/shared/programs/claude/files/skills/run-da/references/runtime-mapping.md
+++ b/modules/shared/programs/claude/files/skills/run-da/references/runtime-mapping.md
@@ -8,7 +8,7 @@
 |------|-----------|------------------|---------------|
 | 사용자에게 질문 (blocking tool call) | `request_user_input` | `AskUserQuestion` 도구 | 미지원 (자동 전이 적용) |
 | fan-out 실행 (기본) | `spawn_agent` → `wait_agent` → `close_agent` (delegation 허용 시) | `Bash tool` + `run_in_background: true`로 `codex exec` subprocess 병렬 발사 (codex exec 사전점검 성공 시 기본) | `codex exec` subprocess를 serial foreground로 순차 실행 (완료 알림/`&+wait` 없음) |
-| fan-out 실행 (fallback) | codex exec subprocess (아래 "Delegation fallback" + `arbiter-scaling.md` 실행 계약) | `Agent` tool + `run_in_background: true` (codex exec 사전점검 실패 시 — "Claude Code 세션 fallback 세부 정보" 섹션) | — |
+| fan-out 실행 (fallback) | codex exec subprocess (아래 "Delegation fallback" + `arbiter-scaling.md` 실행 계약) | `Agent` tool + `run_in_background: true` (codex exec 사전점검 실패 원인 고지 후 사용자가 Claude 경로 진행을 확인한 경우만) | — |
 | 결과 수집 | `wait_agent` 반환값, 또는 `exec_command`로 `cat`/`sed` 셸 읽기 | `Read` 도구 | `cat`/`sed` via shell |
 | 파일 읽기 | `exec_command`로 `cat`/`sed`/`rg` | `Read` 도구 | `cat`/`sed`/`rg` |
 
@@ -16,9 +16,21 @@ Skill-internal fan-out authorization: Direct Codex 세션에서 fan-out 스킬 �
 
 plain-text 재개 ≠ 질문 도구 — 일반 채팅 "질문 후 다음 턴 재개"는 blocking tool call이 아니므로 질문 도구로 간주하지 않는다. 질문 도구가 필수인 지점(SKIP 승인, 3회 반복 판정, 5회 라운드 초과, 추세 기반 조기 중단, fresh 모드 반복 감지)에서 Codex 세션은 `request_user_input`을 호출하고, headless 세션은 stdin 입력 불가로 자동 상태 전이 경로(arbiter-scaling.md)로 처리한다.
 
-review profile 매핑 (fan-out 대상 역할별):
-- Arbiter (strong review profile) — Codex: `model="gpt-5.5"`, `reasoning_effort="high"`. Claude Code: `model: "opus"`.
-- reviewer / auditor (standard review profile) — Codex: `model="gpt-5.5"`, `reasoning_effort="medium"`. Claude Code: `model: "sonnet"`.
+review profile 매핑 (fan-out 대상 역할별, `agent=` 미지정 기본값):
+
+| profile | 대상 | 모델 선택 | codex exec effort |
+|---------|------|-----------|-------------------|
+| `strong` | Arbiter | 세션/런타임 기본 모델 상속 | `high` |
+| `standard` | reviewer / auditor | 세션/런타임 기본 모델 상속 | `medium` |
+
+호출 인자 `agent=`가 지정되면 위 기본 profile보다 우선한다. 적용 범위는 해당 호출의 reviewer/auditor와 Arbiter 전체다.
+
+| agent 값 | 실행 경로 | effort / 모델 처리 |
+|----------|-----------|--------------------|
+| `agent=codex-xhigh` | codex exec | `xhigh` reasoning effort. 모델명은 고정하지 않고 런타임 기본값을 사용한다 |
+| `agent=codex-high` | codex exec | `high` reasoning effort. 모델명은 고정하지 않고 런타임 기본값을 사용한다 |
+| `agent=codex-medium` | codex exec | `medium` reasoning effort. 모델명은 고정하지 않고 런타임 기본값을 사용한다 |
+| `agent=claude` | Claude Code `Agent` tool | Claude Code 세션 모델을 상속한다. 특정 모델명을 지정하지 않는다 |
 
 Review Intensity는 fan-out 대상이 아니다 — 메인 LLM 인라인 체크리스트(`intensity-rules.md`의 8 룰 기계적 적용)이므로 별도 review profile이 적용되지 않는다. 절차는 [`intensity-procedure.md`](intensity-procedure.md) SSOT.
 
@@ -48,7 +60,7 @@ Review Intensity는 fan-out 대상이 아니다 — 메인 LLM 인라인 체크�
   zsh `(N)` qualifier로 매칭 파일 없을 때 오류를 방지한다. legacy glob(NS 없음)은 전환기 고아 디렉토리 정리용이다.
 - 결과 파일 참조: `$DA_DIR`, `$ARBITER_DIR` 변수로 정확히 참조한다. `/tmp/da-*` 와일드카드 glob 금지 — 이전 실행의 결과가 섞인다. (Intensity는 메인 LLM 인라인 체크리스트라 별도 임시 디렉토리를 만들지 않는다.)
 - 셸 호출 간 변수 유지 (모든 런타임 공통): 위 공통 주의 참조. 런타임 종류와 무관하게 셸 호출마다 별도 shell이 생성되므로 `mktemp -d` 결과를 stdout으로 출력해 메인 에이전트가 다음 호출에서 리터럴로 재사용하거나 단일 shell에 체이닝한다. 상세 패턴은 [`arbiter-scaling.md`](arbiter-scaling.md)의 "셸 호출 변수 유실 방지" 참조.
-- stdin pipe로 프롬프트 전달 (Layer 1 supervised wrapper): 모든 programmatic codex exec 호출은 `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral -c model="gpt-5.5" -c model_reasoning_effort="..." -o "$DIR/result.md" -` 형태의 Layer 1 supervised wrapper 호출을 사용한다 (raw `codex exec` 직접 호출은 user-interactive 전용이며 SKILL 내 programmatic 경로에서는 사용하지 않는다). `--ignore-rules`는 user/project execpolicy `.rules` 파일을 차단해 read-only sandbox로 막을 수 없는 network/system mutation 명령(예: `git push`, `aws ec2 describe`)이 reviewer/auditor에서 실행되지 않게 한다. pipe EOF가 stdin을 자동으로 닫아 background 전환 시 stdin hang을 구조적으로 방지한다. `< /dev/null`은 pipe가 대체하므로 불필요. 인라인 인자 `"$(cat file)"`는 사용하지 않는다. `CODEX_PROGRAMMATIC=1` env assignment는 pipeline 우측 codex 프로세스에 적용되어야 한다 (issue #585). wrapper 상세는 [`../../using-codex-exec/references/known-issues.md`](../../using-codex-exec/references/known-issues.md) §15 참조.
+- stdin pipe로 프롬프트 전달 (Layer 1 supervised wrapper): 모든 programmatic codex exec 호출은 `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral -c model_reasoning_effort="$RUN_DA_CODEX_EFFORT" -o "$DIR/result.md" -` 형태의 Layer 1 supervised wrapper 호출을 사용한다 (raw `codex exec` 직접 호출은 user-interactive 전용이며 SKILL 내 programmatic 경로에서는 사용하지 않는다). 모델명은 고정하지 않고, `$RUN_DA_CODEX_EFFORT`만 기본 role profile 또는 `agent=` 인자에서 결정한다. `--ignore-rules`는 user/project execpolicy `.rules` 파일을 차단해 read-only sandbox로 막을 수 없는 network/system mutation 명령(예: `git push`, `aws ec2 describe`)이 reviewer/auditor에서 실행되지 않게 한다. pipe EOF가 stdin을 자동으로 닫아 background 전환 시 stdin hang을 구조적으로 방지한다. `< /dev/null`은 pipe가 대체하므로 불필요. 인라인 인자 `"$(cat file)"`는 사용하지 않는다. `CODEX_PROGRAMMATIC=1` env assignment는 pipeline 우측 codex 프로세스에 적용되어야 한다 (issue #585). wrapper 상세는 [`../../using-codex-exec/references/known-issues.md`](../../using-codex-exec/references/known-issues.md) §15 참조.
 - Arbiter는 foreground 실행 (단일 exec): 결과를 즉시 확인한다. reviewer만 병렬 실행 (런타임별 병렬 실행 매커니즘은 위 표 참조).
 
 ### literal 재사용 시 random suffix 환각 금지 (issue #632)
@@ -57,7 +69,7 @@ Generic codex exec split-call rule은 [`using-codex-exec/references/known-issues
 
 ## Claude Code 세션 fallback 세부 정보
 
-Claude Code 세션에서 codex exec 사전점검이 실패했을 때 legacy fallback으로 대체하는 경로의 Claude-Code-고유 lifecycle이다. review profile 매핑은 위 표 참조.
+Claude Code 세션에서 codex exec 사전점검이 실패했을 때는 legacy fallback으로 조용히 대체하지 않는다. 메인 에이전트는 실패 원인을 사용자에게 고지하고, 대안으로 Claude Code 서브에이전트 경로 진행 또는 중단을 확인받는다. 아래는 사용자가 Claude 경로 진행을 확인했거나 `agent=claude`를 명시한 경우의 Claude-Code-고유 lifecycle이다. 모델은 Claude Code 세션 모델을 상속한다.
 
 | 항목 | Claude Code fallback |
 |------|----------------------|

--- a/tests/skill-doc-sync.py
+++ b/tests/skill-doc-sync.py
@@ -39,6 +39,8 @@ EXPECTED_RULE_IDS = {
 EXPECTED_CONSTANTS = {"STABLE_MIN", "ESCALATE_MIN"}
 EXPECTED_PROFILES = {"strong", "standard"}
 EXPECTED_BUNDLES = ("Correctness", "Design", "Regression", "Maintainability")
+EXPECTED_AGENT_ARGS = {"agent=codex-xhigh", "agent=codex-high", "agent=codex-medium", "agent=claude"}
+FORBIDDEN_MODEL_LITERALS = ("gpt-5", "opus", "sonnet")
 
 
 class CheckFailure(Exception):
@@ -127,12 +129,11 @@ def check_kappa_constants() -> None:
 def extract_runtime_profiles() -> dict[str, dict[str, str]]:
     profiles = {}
     pattern = re.compile(
-        r"^- .*?\((strong|standard) review profile\).*?"
-        r'Codex:\s*`model="([^"]+)"`,\s*`reasoning_effort="([^"]+)"`',
+        r"^\|\s*`(strong|standard)`\s*\|[^|]+\|[^|]+\|\s*`(medium|high|xhigh)`\s*\|",
         re.M,
     )
-    for profile, model, effort in pattern.findall(read_text(RUNTIME_MAPPING)):
-        profiles[profile] = {"model": model, "effort": effort}
+    for profile, effort in pattern.findall(read_text(RUNTIME_MAPPING)):
+        profiles[profile] = {"effort": effort}
 
     found = set(profiles)
     if found != EXPECTED_PROFILES:
@@ -150,40 +151,71 @@ def fenced_block_after(text: str, label: str) -> str:
     return match.group(1)
 
 
-def extract_command_profile(block: str, label: str) -> dict[str, str]:
-    models = re.findall(r'-c\s+model="([^"]+)"', block)
-    efforts = re.findall(r'-c\s+model_reasoning_effort="([^"]+)"', block)
-    details = []
-    if len(models) != 1:
-        details.append(f"{label}: expected exactly one model literal, got {models}")
-    if len(efforts) != 1:
-        details.append(f"{label}: expected exactly one model_reasoning_effort literal, got {efforts}")
-    if details:
-        raise CheckFailure("\n".join(details))
-    return {"model": models[0], "effort": efforts[0]}
+def extract_arbiter_profile_efforts() -> dict[str, dict[str, str]]:
+    profiles = {}
+    pattern = re.compile(r"^\|\s*`(standard|strong)`\s*\|\s*`(medium|high|xhigh)`\s*\|", re.M)
+    for profile, effort in pattern.findall(read_text(ARBITER_SCALING)):
+        profiles[profile] = {"effort": effort}
+
+    found = set(profiles)
+    if found != EXPECTED_PROFILES:
+        raise CheckFailure(
+            f"{ARBITER_SCALING}: expected profiles {sorted(EXPECTED_PROFILES)}, got {sorted(found)}"
+        )
+    return profiles
 
 
-def check_profile_literals() -> None:
+def check_profile_efforts() -> None:
     runtime_profiles = extract_runtime_profiles()
-    arbiter_text = read_text(ARBITER_SCALING)
-    command_profiles = {
-        "standard": extract_command_profile(
-            fenced_block_after(arbiter_text, "reviewer / Auditor (standard profile)"),
-            "reviewer / Auditor (standard profile)",
-        ),
-        "strong": extract_command_profile(
-            fenced_block_after(arbiter_text, "Arbiter (strong profile)"),
-            "Arbiter (strong profile)",
-        ),
-    }
+    arbiter_profiles = extract_arbiter_profile_efforts()
 
-    if runtime_profiles != command_profiles:
-        details = ["review profile literal mismatch:"]
+    if runtime_profiles != arbiter_profiles:
+        details = ["review profile effort mismatch:"]
         for profile in sorted(EXPECTED_PROFILES):
             details.append(
                 f"  {profile}: {RUNTIME_MAPPING}={runtime_profiles[profile]}, "
-                f"{ARBITER_SCALING}={command_profiles[profile]}"
+                f"{ARBITER_SCALING}={arbiter_profiles[profile]}"
             )
+        raise CheckFailure("\n".join(details))
+
+
+def check_codex_command_contract() -> None:
+    arbiter_text = read_text(ARBITER_SCALING)
+    details = []
+    for label in ("reviewer / Auditor (standard profile)", "Arbiter (strong profile)"):
+        block = fenced_block_after(arbiter_text, label)
+        if "-c model=" in block:
+            details.append(f"{label}: command block must not pin a model literal")
+        if '-c model_reasoning_effort="$RUN_DA_CODEX_EFFORT"' not in block:
+            details.append(f"{label}: missing RUN_DA_CODEX_EFFORT effort pin")
+        if 'RUN_DA_CODEX_EFFORT:?missing RUN_DA_CODEX_EFFORT' not in block:
+            details.append(f"{label}: missing RUN_DA_CODEX_EFFORT guard")
+
+    if details:
+        raise CheckFailure("\n".join(details))
+
+
+def extract_agent_args(path: Path) -> set[str]:
+    values = set(re.findall(r"`(agent=(?:codex-xhigh|codex-high|codex-medium|claude))`", read_text(path)))
+    if values != EXPECTED_AGENT_ARGS:
+        raise CheckFailure(f"{path}: expected agent args {sorted(EXPECTED_AGENT_ARGS)}, got {sorted(values)}")
+    return values
+
+
+def check_agent_args() -> None:
+    extract_agent_args(SKILL)
+    extract_agent_args(RUNTIME_MAPPING)
+
+
+def check_no_hardcoded_model_literals() -> None:
+    root = Path("modules/shared/programs/claude/files/skills/run-da")
+    details = []
+    for path in sorted(root.rglob("*.md")):
+        text = read_text(path)
+        for literal in FORBIDDEN_MODEL_LITERALS:
+            if literal in text:
+                details.append(f"{path}: forbidden model literal {literal!r}")
+    if details:
         raise CheckFailure("\n".join(details))
 
 
@@ -246,7 +278,10 @@ def main() -> int:
     checks = (
         ("intensity rules", check_intensity_rules),
         ("kappa constants", check_kappa_constants),
-        ("review profile literals", check_profile_literals),
+        ("review profile efforts", check_profile_efforts),
+        ("codex command contract", check_codex_command_contract),
+        ("agent args", check_agent_args),
+        ("no hardcoded model literals", check_no_hardcoded_model_literals),
         ("reviewer bundle subdomains", check_bundle_subdomains),
     )
 


### PR DESCRIPTION
## Summary

- run-da에 `agent=` 실행 프로파일 인자 도입 — reviewer/auditor·Arbiter의 실행 경로와 reasoning effort를 호출별 1회성 인자로 지정 (`agent=codex-xhigh|codex-high|codex-medium|claude`)
- codex 사전점검 실패 시 조용한 Claude 대체(silent fallback)를 금지하고 고지 후 확인으로 전환
- runtime-mapping의 모델 literal 3종 제거(세션 상속으로) + sync 테스트에 금지 literal 잔존 게이트 신설
- Closes #1012

## 기존 문제/배경

reviewer 실행 엔진·effort를 지속 지정하는 채널이 없어 4개월간 30회 이상 자연어로 매 호출 수동 지정했고, codex 사전점검 실패 시 Claude 경로로 조용히 대체되는 서술이 사용자 기대와 어긋난 실행을 만들었다. 자동화(Goal) 맥락에서는 이 문제로 스킬 우회 지시까지 관측됐다.

## CIR (Change Intent Record)

방식은 사전 인터뷰로 확정: 설정 파일(옵션 A/C)은 상태 관리·발견성에서 DX가 나빠 기각, 호출 인자(옵션 B) 채택 — 기존 장문 자연어 지정을 짧은 토큰으로 대체하는 방향. 적용 범위는 reviewer/auditor+Arbiter 전체(실수요가 "에이전트 전부 X만"이었음), Review Intensity는 메인 LLM 인라인 체크리스트라 제외. 특정 모델명은 스킬 기본값에 박지 않는다(기간 한정 모델 선호의 박제 금지 피드백) — 이 원칙을 문서 서술에 그치지 않고 sync 테스트의 FORBIDDEN_MODEL_LITERALS(gpt-5/opus/sonnet) 잔존 검사로 게이트화했다. 기존 sync 계약은 "모델 literal 문서 간 일치"를 검사했으므로 literal 제거에 따라 "effort 일치" 검사로 재작성이 필연적이었다 (4→7 pairs).

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| B: 호출 인자 | agent= 1회성 인자 | 무상태, 발견성(argument-hint), 짧은 토큰 | 매 호출 타이핑 | ✅ (사용자 DX 결정) |
| A: 설정 파일 | 전역 프로파일 파일 | 반복 완전 제거 | 상태 추적·발견성 나쁨, 세션 간 의도치 않은 전파 | ❌ |
| C: A+B 조합 | 파일 기본값 + 인자 override | 유연성 최대 | A의 단점 상속 + 복잡도 | ❌ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `run-da/SKILL.md` | argument-hint·description 갱신, `agent=` 인자 표 + fallback 고지 규칙, lazy reference 표에 행 추가 |
| `references/runtime-mapping.md` | profile 매핑을 표로 재작성 (모델 literal 3종 → 세션 상속 + effort만), supervised wrapper 예시의 모델 고정 제거, fallback 행에 고지 조건 |
| `references/arbiter-scaling.md` | 기본 effort 정책과 `agent=` override 관계 명시 |
| `references/hardening-contract.md`, `modes/{for_plan,for_pr,audit}.md` | 인자 예시·계약 정합 |
| `tests/skill-doc-sync.py` | 계약 재작성: effort 일치 검사 + FORBIDDEN_MODEL_LITERALS 잔존 게이트 + agent= 값 집합 검사 (4→7 pairs) |

## 참고 레퍼런스

- #1012 (본 이슈), #1010 (스킬 감사 epic)
- `tests/test-skill-doc-sync.sh` — sync contract 진입점

## Human Test Plan

1. `bash tests/test-skill-doc-sync.sh` → 7/7 pairs in sync
2. `rg -n "gpt-5|opus|sonnet" modules/shared/programs/claude/files/skills/run-da/` → 0건
3. 새 세션에서 `/run-da for_pr agent=codex-xhigh` 호출 → 인자가 모드+프로파일로 해석되는지 확인 (reviewer/Arbiter 실행 로그의 effort)
4. codex를 의도적으로 불가 상태로 만들고(`PATH`에서 제거 등) `agent=codex-xhigh` 호출 → 조용한 Claude 대체 없이 고지+확인 질문이 오는지 확인
5. 실패 시 진단: sync 테스트가 깨지면 SKILL.md ↔ runtime-mapping ↔ arbiter-scaling 간 agent= 서술 드리프트부터 확인

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM
