### PR TITLE
feat(ai): skill-usage-report — log-skill 계측 데이터 소비처 재건

### DIFF
--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -3,6 +3,7 @@
 # Thariq(Anthropic) gist 기반 — session_id, repo context 추가
 #
 # Log format (TSV): timestamp user session_id repo skill args
+# scripts/ai/skill-usage-report.sh consumes this column order; update both files together.
 # 예: 1742302800	greenhead	abc123	nixos-config	managing-minipc	""
 
 command -v jq >/dev/null 2>&1 || exit 0
@@ -10,6 +11,7 @@ command -v jq >/dev/null 2>&1 || exit 0
 HOOK_RUNTIME_LIB="${HOOK_RUNTIME_LIB:-$HOME/.claude/lib/hook-runtime.sh}"
 [ -f "$HOOK_RUNTIME_LIB" ] || exit 0
 # shellcheck source=../lib/hook-runtime.sh
+# shellcheck disable=SC1091
 . "$HOOK_RUNTIME_LIB"
 
 INPUT=$(cat)
@@ -27,10 +29,11 @@ REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || tr
 
 # 로그 파일 owner-only 권한 (민감 args 보호)
 umask 077
+SKILL_USAGE_LOG="${SKILL_USAGE_LOG:-$HOME/.claude/skill-usage.log}"
 
 printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
   "$(date -u +%s)" "$USER" "${SESSION_ID:-unknown}" \
   "${REPO:-unknown}" "$SKILL" "$ARGS" \
-  >> "$HOME/.claude/skill-usage.log" 2>/dev/null || true
+  >> "$SKILL_USAGE_LOG" 2>/dev/null || true
 
 exit 0

--- a/scripts/ai/skill-usage-report.sh
+++ b/scripts/ai/skill-usage-report.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# skill-usage-report.sh - summarize Claude Skill hook usage.
+# Usage: scripts/ai/skill-usage-report.sh [--log PATH] [--since YYYY-MM-DD]
+# Usage: scripts/ai/skill-usage-report.sh --log ~/skill-usage.log --since 2026-01-01
+#
+# Consumes the TSV emitted by modules/shared/programs/claude/files/hooks/log-skill.sh.
+# Column definitions live in that hook; this parser depends on that order.
+set -euo pipefail
+
+DEFAULT_LOG="${HOME}/.claude/skill-usage.log"
+log_file="$DEFAULT_LOG"
+since_date=""
+
+usage() {
+  cat <<'EOF'
+Usage: skill-usage-report.sh [--log PATH] [--since YYYY-MM-DD]
+
+Summarize Claude Skill usage from the log-skill.sh TSV log.
+EOF
+}
+
+die() {
+  echo "skill-usage-report: $*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --log)
+      [ "$#" -ge 2 ] || die "--log requires a path"
+      log_file="$2"
+      shift 2
+      ;;
+    --since)
+      [ "$#" -ge 2 ] || die "--since requires YYYY-MM-DD"
+      since_date="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ -n "$since_date" ] && [[ ! "$since_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  die "invalid --since date: $since_date (expected YYYY-MM-DD)"
+fi
+
+if [ ! -e "$log_file" ]; then
+  die "skill usage log not found: $log_file (default: $DEFAULT_LOG; use --log PATH for imported logs)"
+fi
+if [ ! -f "$log_file" ]; then
+  die "skill usage log is not a regular file: $log_file"
+fi
+if [ ! -r "$log_file" ]; then
+  die "skill usage log is not readable: $log_file"
+fi
+
+command -v python3 >/dev/null 2>&1 || die "python3 is required"
+
+python3 - "$log_file" "$since_date" <<'PY'
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime, time, timezone
+import sys
+
+log_path = sys.argv[1]
+since_arg = sys.argv[2]
+
+since_epoch = None
+if since_arg:
+    try:
+        since_day = date.fromisoformat(since_arg)
+    except ValueError:
+        print(
+            f"skill-usage-report: invalid --since date: {since_arg}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    since_epoch = int(
+        datetime.combine(since_day, time.min, tzinfo=timezone.utc).timestamp()
+    )
+
+rows: dict[str, dict[str, int]] = defaultdict(
+    lambda: {"count": 0, "first": 0, "recent": 0}
+)
+
+with open(log_path, "r", encoding="utf-8", errors="replace", newline="") as handle:
+    for raw_line in handle:
+        line = raw_line.rstrip("\n")
+        if not line:
+            continue
+        fields = line.split("\t")
+        if len(fields) < 5:
+            continue
+
+        try:
+            timestamp = int(fields[0])
+        except ValueError:
+            continue
+
+        if since_epoch is not None and timestamp < since_epoch:
+            continue
+
+        skill = fields[4]
+        if not skill:
+            continue
+
+        row = rows[skill]
+        row["count"] += 1
+        row["first"] = timestamp if row["first"] == 0 else min(row["first"], timestamp)
+        row["recent"] = max(row["recent"], timestamp)
+
+print("skill\tcount\tfirst_used\trecent_used")
+for skill, row in sorted(rows.items(), key=lambda item: (-item[1]["count"], item[0])):
+    first = datetime.fromtimestamp(row["first"], tz=timezone.utc).date().isoformat()
+    recent = datetime.fromtimestamp(row["recent"], tz=timezone.utc).date().isoformat()
+    print(f"{skill}\t{row['count']}\t{first}\t{recent}")
+PY

--- a/tests/fixtures/shell-scripts/skill-usage-report.expected
+++ b/tests/fixtures/shell-scripts/skill-usage-report.expected
@@ -1,0 +1,4 @@
+skill	count	first_used	recent_used
+managing-minipc	2	2026-01-01	2026-02-01
+run-da	2	2026-01-02	2026-02-03
+configuring-codex	1	2026-02-03	2026-02-03

--- a/tests/fixtures/shell-scripts/skill-usage-report.since.expected
+++ b/tests/fixtures/shell-scripts/skill-usage-report.since.expected
@@ -1,0 +1,4 @@
+skill	count	first_used	recent_used
+configuring-codex	1	2026-02-03	2026-02-03
+managing-minipc	1	2026-02-01	2026-02-01
+run-da	1	2026-02-03	2026-02-03

--- a/tests/fixtures/shell-scripts/skill-usage-report.tsv
+++ b/tests/fixtures/shell-scripts/skill-usage-report.tsv
@@ -1,0 +1,6 @@
+1767225600	tester	sid-a	nixos-config	managing-minipc	boot
+1767355200	tester	sid-b	nixos-config	run-da	
+1769934600	tester	sid-c	nixos-config	managing-minipc	check
+1770147900	tester	sid-d	nixos-config	configuring-codex	docs
+1770147900	tester	sid-e	nixos-config	run-da	both
+not-a-timestamp	tester	sid-f	nixos-config	ignored-skill	ignored

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -138,6 +138,9 @@ run_test "check-skill-noise rejects external symlink skill projection" test_chec
 run_test "warn-skill-consistency ignores managed plugin skill projection" test_warn_skill_consistency_ignores_managed_plugin_skill_projection
 run_test "warn-skill-stale-identifiers detects residual skill doc" test_warn_skill_stale_identifiers_detects_residual_skill_doc
 run_test "warn-skill-stale-identifiers clean pass stays quiet" test_warn_skill_stale_identifiers_clean_pass_stays_quiet
+run_test "skill-usage-report aggregates sample TSV" test_skill_usage_report_aggregates_sample_tsv
+run_test "skill-usage-report --since filters sample TSV" test_skill_usage_report_since_filters_sample_tsv
+run_test "skill-usage-report missing log errors" test_skill_usage_report_missing_log_errors
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 run_test "darwin nrs no-change activates when Codex artifact missing" test_darwin_nrs_no_changes_activates_when_codex_artifact_missing

--- a/tests/suites/skill-usage-report.sh
+++ b/tests/suites/skill-usage-report.sh
@@ -1,0 +1,36 @@
+# tests/suites/skill-usage-report.sh - skill usage report fixtures
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2164
+
+_skill_usage_report_script() {
+  printf '%s\n' "$REPO_ROOT/scripts/ai/skill-usage-report.sh"
+}
+
+_skill_usage_report_fixture() {
+  printf '%s\n' "$FIXTURE_DIR/skill-usage-report.tsv"
+}
+
+test_skill_usage_report_aggregates_sample_tsv() {
+  local output expected
+  output=$(bash "$(_skill_usage_report_script)" --log "$(_skill_usage_report_fixture)")
+  expected=$(cat "$FIXTURE_DIR/skill-usage-report.expected")
+  [[ "$output" == "$expected" ]] || fail "unexpected skill usage report output: $output"
+}
+
+test_skill_usage_report_since_filters_sample_tsv() {
+  local output expected
+  output=$(bash "$(_skill_usage_report_script)" --log "$(_skill_usage_report_fixture)" --since 2026-02-01)
+  expected=$(cat "$FIXTURE_DIR/skill-usage-report.since.expected")
+  [[ "$output" == "$expected" ]] || fail "unexpected filtered skill usage report output: $output"
+}
+
+test_skill_usage_report_missing_log_errors() {
+  local sandbox output
+  sandbox=$(new_sandbox)
+
+  if output=$(bash "$(_skill_usage_report_script)" --log "$sandbox/missing.log" 2>&1); then
+    fail "expected missing skill usage log to fail"
+  fi
+  assert_contains "$output" "skill usage log not found"
+  assert_contains "$output" "use --log PATH"
+}


### PR DESCRIPTION
## Summary

- `skill-usage-report.sh` 신설 — log-skill.sh가 쌓기만 하던 Skill 호출 TSV를 집계 (스킬별 호출 수·최초/최근 사용일, `--since` 필터, `--log` 오버라이드)
- hook에는 소비자 상호 참조 주석 + 테스트용 경로 env만 추가 (동작 불변)
- Closes #1025

## 기존 문제/배경

log-skill.sh hook이 모든 Skill 호출을 TSV로 기록 중인데 소비 코드가 repo에 0건이었다 (과거 eval 인프라 제거 때 소비처 소멸). 스킬 전수 감사에서 "스킬별 사용 빈도"를 얻으려고 세션로그 수백 MB를 별도 파싱해야 했던 비용의 직접 원인. 이 데이터는 스킬 포트폴리오 재평가와 dead feature 판정("한 번도 안 씀")의 근거가 된다.

## CIR (Change Intent Record)

수동 실행 스크립트로 최소 구현 (타이머/CI 강제는 YAGNI 보류 — 이슈 방침). TSV 열 순서 의존은 스키마 복사 대신 양쪽 파일 상호 참조 주석으로 관리. 로그 성장을 실측한 결과(257KiB/109일 ≈ 0.85MiB/년) 로테이션도 YAGNI 보류 — 실측 근거를 남겨 향후 판단 가능하게 함.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 수동 집계 스크립트 | 필요할 때 실행 | 최소 구현, 무상태 | 자동 리포트 없음 | ✅ |
| 주기 타이머 + 리포트 | systemd timer로 정기 산출 | 자동 관측 | 소비 시나리오가 아직 부정기적 (YAGNI) | ❌ |
| 로테이션 동시 구현 | 로그 크기 관리 | 무한 성장 차단 | 실측상 0.85MiB/년 — 불필요 | ❌ (실측 기록만) |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `scripts/ai/skill-usage-report.sh` | 신규 — TSV 집계, --since/--log, 로그 부재 시 명확한 에러 |
| `modules/shared/programs/claude/files/hooks/log-skill.sh` | 스키마 소비자 상호 참조 주석 + `SKILL_USAGE_LOG` env (기본값 기존 경로 동일 — 동작 불변) |
| `tests/suites/skill-usage-report.sh` + fixtures + `tests/shell-script-tests.sh` | 집계/--since/부재 케이스 |

실로그 검증 샘플 (이 머신, 2026-03-21~07-07): run-da 84, create-pr 56, parallel-audit 39, create-issue 33 — 세션로그 파싱 없이 즉답 가능해짐.

## 참고 레퍼런스

- #1025 (본 이슈), #1010 (스킬 감사 epic)

## Human Test Plan

1. `bash scripts/ai/skill-usage-report.sh` → 스킬별 집계 표 출력
2. `bash scripts/ai/skill-usage-report.sh --since 2026-06-01` → 기간 필터 동작
3. `bash tests/suites/skill-usage-report.sh` → rc=0
4. 아무 스킬 1회 호출 후 재실행 → 해당 스킬 count 증가 확인 (hook 동작 불변 검증)
5. 실패 시 진단: 로그 부재 에러면 `~/.claude/skill-usage.log` 존재와 hook 배선(settings.json) 확인

---
https://claude.ai/code/session_01Viq14wqebC8heNoLdrQTMM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a report for skill usage logs with summary counts and first/most recent use dates.
  * Added support for choosing a custom log file location and filtering results by date.

* **Bug Fixes**
  * Improved handling of missing or unreadable log files with clearer error guidance.
  * Ensured log output uses a consistent column order for reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->