### PR TITLE
perf(tests): 훅 테스트 러너 병렬화 + GNU 보장 (#1009)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,11 @@ Bash tool의 inline 스크립트는 zsh에서 실행된다. 아래 bash 전용 �
 
 이 저장소(devShell 자동 활성화)에서는 nix coreutils가 PATH 우선이라, GNU/BSD 옵션 의미가 다른 macOS 시스템 도구를 그냥 호출하면 GNU 도구가 가로채 옵션 미스매치로 실패할 수 있다. macOS BSD 옵션 문법이 필요한 경우 해당 도구의 실제 시스템 경로를 절대경로로 호출한다.
 
-현재 확인된 사례: 파일 mtime epoch — GNU `stat -c %Y file` vs macOS BSD `/usr/bin/stat -f %m file`. 같은 종류의 GNU/BSD 옵션 충돌이 새로 발견되면 같은 단락에 케이스를 추가한다.
+현재 확인된 사례:
+- (GNU 우선 환경에서 BSD 문법이 필요한 경우) 파일 mtime epoch — GNU `stat -c %Y file` vs macOS BSD `/usr/bin/stat -f %m file`. 시스템 도구를 절대경로로 호출한다.
+- (BSD 우선 환경에서 GNU 문법이 필요한 경우) 테스트 fixture의 GNU 전용 옵션 `touch -d '40 days ago'`·`find -printf` — devShell 밖(direnv 비활성) 훅/CI 셸에서는 BSD 도구가 잡혀 실패하므로, 테스트 런타임 wrap에서 `nixpkgs#coreutils`/`nixpkgs#findutils`를 명시 제공한다 (#1009; `scripts/ai/lib/tomlkit-bootstrap.sh` self-wrap + `lefthook.yml`/`tests/run-all-tests.sh` 의 shell-script-tests wrap).
+
+같은 종류의 GNU/BSD 옵션 충돌이 새로 발견되면 같은 단락에 케이스를 추가한다.
 
 ## 상수
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -87,15 +87,23 @@ commit-msg:
       run: '[ -f ./scripts/ai/commit-msg-pinning.sh ] && bash ./scripts/ai/commit-msg-pinning.sh {1} || true'
 
 pre-push:
+  # 4개 command(shell-script-tests·codex-hook-fixtures·flake-check·statusline-bats)를 병렬 실행한다.
+  # 각 command는 독립적이고 read-only 검증이라 순서 의존이 없다. 러너 자체 병렬화(job-pool)와
+  # over-subscribe되지만 대부분 I/O 바운드(git/파일/nix eval)라 경합이 흡수되어, 순차 합보다 크게
+  # 빠르다(실측: 순차 합 ~82s → 병렬 wall-clock ~42s). 러너 병렬화 + GNU 보장(#1009) 전까지는
+  # pre-push가 ~175s 걸리고 karakeep fixture 실패로 push가 차단됐다 — 이 변경으로 둘 다 해소된다.
+  parallel: true
   commands:
     shell-script-tests:
-      # nix shell wrap: codex-config fixture가 tomlkit을 필요로 하므로, repo-pinned
-      # packages.${system}.pythonWithTomlkit(flake.nix)를 PATH에 얹어 실행. devShell은
-      # 건드리지 않아 direnv/bare python3 해석 영향이 없고, nixpkgs# 임시 registry
-      # fetch 대신 flake input에 고정된 store path를 재사용해 오버헤드도 최소화.
-      # `_TOMLKIT_BOOTSTRAP_READY=1` env를 명시적으로 넘겨, `tests/run-shell-script-tests.sh`
-      # 내부의 tomlkit-bootstrap.sh가 중첩 `nix shell ...`을 다시 exec하지 않도록 한다.
-      run: nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh
+      # nix shell wrap: codex-config fixture의 tomlkit + karakeep/backup fixture의 GNU 전용 확장
+      # (`touch -d '40 days ago'`, `find -printf`)을 위해 repo-pinned pythonWithTomlkit + GNU
+      # coreutils/findutils를 PATH에 얹어 실행한다(#1009: devShell 밖 BSD 도구로 karakeep fixture
+      # 실패). devShell은 건드리지 않아 direnv/bare python3 해석 영향이 없다. `--inputs-from .`로
+      # nixpkgs#를 repo flake.lock에 pin해 임시 registry fetch를 피한다(statusline-bats와 동일 패턴).
+      # `_TOMLKIT_BOOTSTRAP_READY=1`로 run-shell-script-tests.sh 내부 tomlkit-bootstrap.sh의 중첩
+      # `nix shell` re-exec을 막는다(이 wrap이 이미 동일 hermetic 런타임을 제공). 테스트 병렬 실행은
+      # 러너 자체(tests/lib/parallel-harness.sh job-pool)가 담당하므로 여기서 추가 배선은 없다.
+      run: nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh
     codex-hook-fixtures:
       # pre-commit에 이미 동일 명령이 있지만 push 직전 재검증해 stale state 회귀 차단.
       # runner self-bootstrap이라 추가 nix shell wrap 불필요. live propagation은 attach하지 않음.

--- a/scripts/ai/lib/tomlkit-bootstrap.sh
+++ b/scripts/ai/lib/tomlkit-bootstrap.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 # scripts/ai/lib/tomlkit-bootstrap.sh
 #
-# tomlkit 포함 Python interpreter 부트스트랩 helper. verifier/test runner가 source한 뒤
-# `tomlkit_bootstrap_require` 를 호출한다. 같은 파일을 여러 진입점이 재사용하므로 재진입
-# guard env var와 nix shell re-exec 정책을 한 곳에만 둔다.
+# tomlkit 포함 Python interpreter + GNU coreutils/findutils 테스트 런타임 부트스트랩 helper.
+# verifier/test runner가 source한 뒤 `tomlkit_bootstrap_require` 를 호출한다. 같은 파일을 여러
+# 진입점이 재사용하므로 재진입 guard env var와 nix shell re-exec 정책을 한 곳에만 둔다.
+# (함수/파일명은 역사적 이유로 tomlkit_* 유지 — 실제 책임은 테스트 hermetic runtime 전반이다.)
 #
 # 정책:
 #   1) 이미 `_TOMLKIT_BOOTSTRAP_READY=1` 이면 추가 검사 없이 즉시 반환한다.
-#      lefthook pre-push가 `nix shell .#pythonWithTomlkit --command ...`로 이미 감쌌거나,
-#      자체 스크립트가 이전에 self-wrap으로 재진입한 경우다.
-#   2) 아니면 ambient `python3`가 tomlkit을 import할 수 있는지와 **무관하게** 항상
-#      repo-pinned `nix shell .#pythonWithTomlkit --command bash "$0" ...`로 재실행한다.
-#      host python에 우연히 tomlkit이 있더라도 pre-push와 동일한 store path의
-#      interpreter를 쓰게 만들어 hermetic 속성을 유지한다.
+#      lefthook pre-push가 `nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils
+#      nixpkgs#findutils --command ...`로 이미 감쌌거나, 자체 스크립트가 이전에 self-wrap으로
+#      재진입한 경우다.
+#   2) 아니면 ambient `python3`/GNU 도구 유무와 **무관하게** 항상 repo-pinned `nix shell
+#      --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command bash
+#      "$0" ...`로 재실행한다. host 에 우연히 tomlkit 이 있거나 GNU 도구가 없더라도 pre-push 와
+#      동일한 store path 의 interpreter + GNU coreutils/findutils(karakeep/backup fixture 의
+#      `touch -d`/`find -printf` 의존, #1009)를 쓰게 만들어 hermetic 속성을 유지한다.
 #   3) nix가 없으면 마지막 fallback으로 ambient python3 tomlkit import를 체크해 있으면 그대로
 #      진행(경고 출력), 없으면 hard fail. 개발자가 직접 nix shell을 띄운 상태라면 (1)으로 빠진다.
 #
@@ -62,9 +65,15 @@ tomlkit_bootstrap_require() {
   # (2) nix 가용 → repo-pinned runtime으로 재실행 (hermetic 강제). 스크립트 자체는 self_path
   #     (snapshot 경로 가능)에서 계속 실행하고, flake root 만 실제 repo 로 고정한다.
   if command -v nix >/dev/null 2>&1; then
-    echo "  tomlkit bootstrap: nix shell ${flake_root}#pythonWithTomlkit --command bash $self_path" >&2
+    echo "  test runtime bootstrap: nix shell --inputs-from ${flake_root} ${flake_root}#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command bash $self_path" >&2
     export _TOMLKIT_BOOTSTRAP_READY=1
-    exec nix shell "${flake_root}#pythonWithTomlkit" --command bash "$self_path" "$@"
+    # pythonWithTomlkit(tomlkit) 외에 GNU coreutils/findutils 를 함께 얹어, 테스트 fixture 가
+    # GNU 전용 확장(`touch -d '40 days ago'`, `find -printf`)에 의존해도 devShell 밖(BSD 시스템
+    # 도구 우선) 셸에서 hermetic 하게 통과하도록 한다 (#1009). lefthook pre-push / run-all-tests /
+    # 수동 실행 모두 이 단일 self-wrap 을 경유하므로 여기 한 곳이 세 경로를 커버한다.
+    # `--inputs-from ${flake_root}` 로 nixpkgs# 를 repo flake.lock 의 nixpkgs 에 pin 하여 임시
+    # registry fetch 를 피한다(statusline-bats 의 `nix shell --inputs-from . nixpkgs#bats` 와 동일 패턴).
+    exec nix shell --inputs-from "${flake_root}" "${flake_root}#pythonWithTomlkit" nixpkgs#coreutils nixpkgs#findutils --command bash "$self_path" "$@"
   fi
 
   # (3) nix 부재 fallback — ambient python3에 tomlkit이 있으면 경고 후 진행

--- a/tests/lib/parallel-harness.sh
+++ b/tests/lib/parallel-harness.sh
@@ -1,0 +1,90 @@
+# tests/lib/parallel-harness.sh — run_test 를 job-pool 병렬 실행으로 교체하는 공유 하네스.
+# shellcheck shell=bash
+#
+# aggregator(shell-script-tests.sh / test-codex-hook-fixtures.sh)가 자신의 run_test 정의 "뒤"에
+# 이 파일을 source 하여 run_test 를 override 하고, 모든 run_test 등록 후 `parallel_barrier` 로
+# 완료를 수집한다. 각 테스트는 독립 sandbox(new_sandbox / new_hook_sandbox)라 병렬 격리가 성립한다
+# (실측: shell-script-tests 순차 112s → 병렬 35s, 실패 0 동일 — I/O 바운드라 CPU 배수보단 낮다).
+#
+# 동시성: TEST_JOBS(기본 CPU 코어수). TEST_JOBS=1 이면 순차(즉시 출력)로 폴백하여 디버깅/결정성을
+#   보장한다 — 이 경우 run_test 는 기존과 동일하게 즉시 실행하고 첫 실패에서 set -e 로 중단한다.
+# 출력: 병렬 모드는 각 테스트의 stdout/stderr 를 per-test 파일에 모으고, barrier 에서 등록 순서대로
+#   일괄 출력한다(결정적). 통과는 "==> name", 실패는 그 출력 전체를 들여쓰기해 함께 보여준다.
+# 격리: 각 job 은 독립 subshell 이라 실패가 다른 job 에 전파되지 않으며, 실패가 하나라도 있으면
+#   parallel_barrier 가 non-zero 로 종료한다(aggregator 의 set -e 가 이를 최종 실패로 전파).
+
+# 동시성 결정 (TEST_JOBS override > nproc > sysctl > 4)
+_ph_detect_jobs() {
+  if [ -n "${TEST_JOBS:-}" ]; then printf '%s' "$TEST_JOBS"; return 0; fi
+  { command -v nproc >/dev/null 2>&1 && nproc; } 2>/dev/null \
+    || sysctl -n hw.ncpu 2>/dev/null \
+    || echo 4
+}
+_PH_JOBS="$(_ph_detect_jobs)"
+# wait -n 은 bash 4.3+ 기능이다. 그 미만(예: macOS 기본 /bin/bash 3.2)에서는 아래 job-pool 상한
+# 게이트의 `wait -n`이 매번 `invalid option`으로 실패해 게이트가 무력화되고 unbounded 병렬이 된다.
+# lefthook 훅은 push 셸의 PATH(bash 포함)를 상속하므로 devShell 밖에서 구형 bash 가 잡힐 수 있어,
+# 안전하게 순차로 폴백한다(정확성 우선 — 병렬 이득은 bash 4.3+ 에서만 취한다).
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ] || { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -lt 3 ]; }; then
+  _PH_JOBS=1
+fi
+_PH_RESULT_DIR=""
+_PH_SEQ=0
+
+_ph_init() {
+  [ -n "$_PH_RESULT_DIR" ] && return 0
+  _PH_RESULT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/parallel-harness.XXXXXX")"
+}
+
+# run_test 를 override. 순차(_PH_JOBS=1)면 즉시 실행, 아니면 job-pool 병렬 큐잉.
+run_test() {
+  local name="$1"
+  shift
+  if [ "$_PH_JOBS" = "1" ]; then
+    echo "==> $name"
+    "$@"
+    return
+  fi
+  _ph_init
+  local seq="$_PH_SEQ"
+  _PH_SEQ=$((_PH_SEQ + 1))
+  printf '%s\n' "$name" > "$_PH_RESULT_DIR/$seq.name"
+  # 동시성 상한: 실행 중 job 이 상한이면 하나 끝날 때까지 대기
+  while [ "$(jobs -rp | wc -l)" -ge "$_PH_JOBS" ]; do
+    wait -n 2>/dev/null || break
+  done
+  {
+    # 부모의 set -euo pipefail 을 subshell 이 상속 → fail() 의 exit 1 이 이 subshell 만 종료.
+    # if 조건이라 set -e 가 즉시 abort 하지 않고 PASS/FAIL 로 분기한다.
+    if ( "$@" ) > "$_PH_RESULT_DIR/$seq.out" 2>&1; then
+      printf 'PASS\n' > "$_PH_RESULT_DIR/$seq.status"
+    else
+      printf 'FAIL\n' > "$_PH_RESULT_DIR/$seq.status"
+    fi
+  } &
+}
+
+# aggregator 끝에서 호출. 모든 job 대기 후 등록 순서대로 결과 출력. 실패가 있으면 non-zero 반환.
+parallel_barrier() {
+  [ "$_PH_JOBS" = "1" ] && return 0
+  [ -n "$_PH_RESULT_DIR" ] || return 0
+  wait
+  local total="$_PH_SEQ" seq=0 pass=0 fail=0 name status
+  while [ "$seq" -lt "$total" ]; do
+    name="$(cat "$_PH_RESULT_DIR/$seq.name" 2>/dev/null)"
+    status="$(cat "$_PH_RESULT_DIR/$seq.status" 2>/dev/null)"
+    if [ "$status" = "PASS" ]; then
+      pass=$((pass + 1))
+      echo "==> $name"
+    else
+      # status 파일 부재(=job 이 비정상 종료해 기록조차 못 함)도 FAIL 로 취급한다(fail-closed).
+      fail=$((fail + 1))
+      echo "==> $name  [FAIL]"
+      sed 's/^/    | /' "$_PH_RESULT_DIR/$seq.out" 2>/dev/null
+    fi
+    seq=$((seq + 1))
+  done
+  printf '병렬 실행 요약: 통과 %d · 실패 %d (jobs=%d)\n' "$pass" "$fail" "$_PH_JOBS"
+  rm -rf "$_PH_RESULT_DIR"
+  [ "$fail" -eq 0 ]
+}

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -56,10 +56,11 @@ run_driver() {
 run_driver "eval-tests" bash tests/run-eval-tests.sh
 
 # 2) shell-script-tests — 배포 레이아웃 fixture. runner가 repo-pinned pythonWithTomlkit으로
-#    self-wrap하지만, 미가용 환경 대비 명시적으로 nix shell wrap + _TOMLKIT_BOOTSTRAP_READY=1로
-#    중첩 nix shell 재실행을 방지한다(lefthook pre-push와 동일).
+#    self-wrap하지만, 명시적으로 nix shell wrap + GNU coreutils/findutils(karakeep/backup fixture의
+#    `touch -d`/`find -printf` 의존, #1009) + _TOMLKIT_BOOTSTRAP_READY=1(중첩 nix shell 방지)로
+#    실행한다(lefthook pre-push와 동일). `--inputs-from .`로 nixpkgs#를 flake.lock에 pin한다.
 run_driver "shell-script-tests" \
-  nix shell .#pythonWithTomlkit --command env _TOMLKIT_BOOTSTRAP_READY=1 \
+  nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command env _TOMLKIT_BOOTSTRAP_READY=1 \
   bash tests/run-shell-script-tests.sh
 
 # 3) codex-hook-fixtures — Codex stable hook 회귀 차단 결정적 fixture. --no-live, Python stdlib only.

--- a/tests/run-shell-script-tests.sh
+++ b/tests/run-shell-script-tests.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # tests/run-shell-script-tests.sh
 # Shell script fixture 테스트 실행기.
-# tomlkit bootstrap 정책은 scripts/ai/lib/tomlkit-bootstrap.sh 단일 소스에서 관리한다.
-# 수동 실행(`bash tests/run-shell-script-tests.sh`)과 lefthook pre-push 경로가 동일한
-# hermetic runtime (flake-pinned `.#pythonWithTomlkit`)을 쓰도록 강제한다.
+# 테스트 런타임 bootstrap 정책은 scripts/ai/lib/tomlkit-bootstrap.sh 단일 소스에서 관리한다.
+# 수동 실행(`bash tests/run-shell-script-tests.sh`)과 lefthook pre-push 경로가 동일한 hermetic
+# runtime(flake-pinned `.#pythonWithTomlkit` + GNU coreutils/findutils, #1009)을 쓰도록 강제한다.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -16,6 +16,11 @@ unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_OBJECT_DIRECTORY
 unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_IMPLICIT_WORK_TREE
 
 . "$SCRIPT_DIR/lib/test-common.sh"
+# run_test 를 job-pool 병렬 실행으로 override (test-common 의 순차 run_test 뒤에 source).
+# suites 는 test-common 을 재source 하지 않으므로(정의 전용) override 가 유지된다. 모든 run_test
+# 등록 후 파일 끝의 parallel_barrier 로 수집한다. TEST_JOBS=1 이면 기존 순차 동작으로 폴백한다.
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/parallel-harness.sh"
 
 # 도메인 스위트(정의 전용) find 디스커버리 — tests/suites/ 한정(기존 test-*.sh 하네스 자동 제외)
 while IFS= read -r -d '' _suite; do
@@ -219,3 +224,7 @@ if codex_config_tomlkit_available; then
 else
   echo "==> codex-config fixtures: SKIPPED (tomlkit 미가용; 'nix shell .#pythonWithTomlkit --command bash tests/run-shell-script-tests.sh'로 전건 실행 권장; pre-push hook은 자동 wrap됨)" >&2
 fi
+
+# 병렬 큐잉된 모든 run_test 를 대기·집계한다(TEST_JOBS=1 순차 모드면 no-op). 실패가 하나라도 있으면
+# non-zero 로 종료해 run-shell-script-tests.sh 의 "All shell script tests passed" 출력과 pre-push 통과를 막는다.
+parallel_barrier

--- a/tests/test-codex-hook-fixtures.sh
+++ b/tests/test-codex-hook-fixtures.sh
@@ -1385,11 +1385,17 @@ EOF
 }
 
 # ─── 실행 진입점 ───
-run_test() {
-  local label="$1"; shift
-  echo "==> $label"
-  "$@"
-}
+# run_test 를 job-pool 병렬 실행으로 제공하는 공유 하네스로 교체한다 (각 테스트는 독립
+# new_hook_sandbox 라 병렬 격리 성립). 모든 run_test 등록 후 아래 parallel_barrier 로 수집한다.
+# TEST_JOBS=1 이면 순차 폴백. harness 의 run_test 는 $1 을 라벨로 받아 시그니처가 동일하다.
+# --live 모드의 두 live fixture(invocation matrix → programmatic env inheritance)는 순서 계약이
+# 있으므로(#647/#593: issue #593 wrapper/process-group 회귀 신호를 먼저 확보) 병렬화하지 않고
+# 순차로 강제한다. deterministic(--no-live; lefthook pre-commit/pre-push 경로)만 job-pool 병렬로
+# 실행한다. LIVE_MODE 판정은 위 CLI 파싱에서 이미 끝났다.
+# shellcheck disable=SC2034  # TEST_JOBS 는 바로 아래 source 하는 parallel-harness.sh 가 읽는다.
+[ "$LIVE_MODE" = "1" ] && TEST_JOBS=1
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/lib/parallel-harness.sh"
 
 run_test "stdin payloads (codex $CODEX_HOOK_SCHEMA_BASELINE) create expected hook artifacts" \
   test_stdin_payloads_create_expected_hook_artifacts_codex_0_124
@@ -1432,4 +1438,7 @@ else
   echo "==> programmatic env inheritance live  (skip; --live 또는 CODEX_HOOK_LIVE=1로 활성화)"
 fi
 
+# 병렬 큐잉된 모든 run_test 를 대기·집계한다(TEST_JOBS=1 순차면 no-op). 실패가 하나라도 있으면
+# non-zero 로 종료해 아래 성공 메시지 출력과 pre-commit/pre-push 통과를 막는다.
+parallel_barrier
 echo "All codex hook fixture tests passed."


### PR DESCRIPTION
## Summary

- 테스트 러너를 job-pool 병렬화하고(`tests/lib/parallel-harness.sh` 신규) pre-push에 `parallel: true`를 적용해, `git push` 훅을 순차 ~175초 → 병렬 ~57초로 단축한다.
- karakeep/backup fixture의 GNU 전용 옵션(`touch -d '40 days ago'`/`find -printf`) 의존을, 테스트 런타임 wrap에 GNU coreutils/findutils를 보장해 해소한다 — devShell 밖(direnv 비활성) 셸에서 무관한 변경의 push까지 차단되던 문제를 고친다.

Closes #1009

## 기존 문제/배경

`lefthook` pre-push는 `parallel` 미설정으로 4개 command(`shell-script-tests`·`codex-hook-fixtures`·`flake-check`·`statusline-bats`)를 **순차 실행**해 로컬 실측 ~175초가 걸렸다. 최대 병목은 `shell-script-tests`(155개 fixture 순차, ~101초)와 `codex-hook-fixtures`(~54초)로, 두 러너 모두 `run_test`가 테스트를 순차 호출하고 각 테스트가 sandbox를 매번 재구성하는 구조였다.

여기에 더해, `#950`/`#989`로 최근 도입된 karakeep 특성화 테스트가 GNU 전용 `find -printf`·`touch -d '40 days ago'`에 의존하는데, 테스트 fixture는 스크립트를 raw `bash`로 실행해 호출 셸 PATH에 암묵 의존했다. devShell(direnv) 밖 셸에서는 BSD 도구가 잡혀 fixture가 실패했고(#1009), lefthook pre-push는 push한 셸의 PATH를 상속하므로 **karakeep과 무관한 변경의 push까지 차단**됐다.

## CIR (Change Intent Record)

훅이 느린 원인을 단계별 timestamp로 실측해 병목을 확정했다(shell 러너 순차 112초·codex 러너 54초). 이어 훅이 무거워진 경위를 시계열로 전수 조사한 결과, PR `#831`(perf)이 pre-commit을 glob 조건부로 경량화하면서 "무관 커밋은 pre-commit에서 skip하되 pre-push가 전체를 재검증"하는 안전망을 뒀음을 확인했다. 그 안전망의 전제는 "CI 부재로 pre-push가 유일한 push-time 게이트"였는데, 이 전제는 이후 `#914`로 GitHub Actions CI(`.github/workflows/check.yml` → `tests/run-all-tests.sh`)가 도입되며 무너졌다 — 즉 pre-push가 하는 검증을 CI가 PR 시점에 이미 중복 수행한다.

이 지점에서 두 방향을 검토했다: (A) 무거운 검증을 CI에 위임하고 pre-push를 경량화, (B) 테스트 러너 자체를 병렬화해 로컬 즉시 피드백을 유지. (A)는 push는 빨라지지만 회귀를 push 시점이 아닌 PR CI에서야 발견하게 되고(피드백 지연), CI가 강제 머지 게이트가 아니라는 점(우회 가능)이 리스크였다. 로컬 피드백 상실 없이 근본적으로 빠르게 만드는 (B)를 택했다.

병렬화 전, 프로토타입으로 실측 검증했다: 각 테스트는 독립 sandbox(`mktemp -d`)라 병렬 격리가 성립하고, 순차 112초 → 병렬 35초(실패 0 동일)로 단축됨을 확인했다. 병렬 실행이 드러낸 숨은 hermeticity 결함(순차는 첫 실패에서 중단돼 가려졌던 `touch -d` 의존)도 함께 잡아 GNU 보장 범위를 `find`뿐 아니라 `coreutils`까지 확장했다.

구현 후 다중 관점 audit(6 auditor)으로 검증해 4건을 반영했다: `wait -n`(bash 4.3+) 부재 환경의 unbounded 병렬 방지(순차 폴백), `--live` 모드의 순서 계약(`#647`/`#593`) 보존(순차 강제), 정책 주석·문서(CLAUDE.md)의 GNU 반영.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| A. CI 재분배 | 무거운 검증을 CI에 위임, pre-push는 flake-check만 | push 수 초 | 로컬 즉시 피드백 상실, PR 전 브랜치 push 공백, CI 미차단 게이트라 우회 시 무방비 | ❌ |
| **B. 러너 병렬화 + parallel:true** | `run_test`를 job-pool 병렬화 + pre-push 4 command 병렬 | 로컬 즉시 피드백 유지, ~3배 단축, 커버리지 불변 | nix eval-cache 경합 잔존(후속 여지) | ✅ |
| C. fixture 경량화 | `git worktree add` 등 매 테스트 setup 감소 | I/O 자체 감소 | 복잡도·회귀 리스크 대비 이득 불확실(I/O 바운드라 병렬화로 대부분 흡수) | ❌ (후속 여지) |

GNU 보장 방식도 두 갈래를 검토했다: (a) `tomlkit-bootstrap.sh` self-wrap exec에 GNU 도구 추가(수동 실행 경로 커버), (b) lefthook/run-all-tests의 nix shell wrap에 추가(`_TOMLKIT_BOOTSTRAP_READY=1`로 bootstrap이 skip되는 경로 커버). 두 경로가 상호 배타적이라 **둘 다** 적용했다.

## 구현 상세

| 파일 | 변경 |
|------|------|
| `tests/lib/parallel-harness.sh` (신규) | `run_test`를 job-pool 병렬로 override + `parallel_barrier` 집계. 동시성 `TEST_JOBS`(기본 코어수), `TEST_JOBS=1`·bash<4.3 순차 폴백 |
| `tests/shell-script-tests.sh` | test-common 뒤 harness source + 끝에 barrier |
| `tests/test-codex-hook-fixtures.sh` | harness source + barrier. `--live`는 순서 계약 보존 위해 `TEST_JOBS=1` 순차 강제 |
| `scripts/ai/lib/tomlkit-bootstrap.sh` | self-wrap exec에 `--inputs-from . nixpkgs#coreutils nixpkgs#findutils` 추가 + 정책 주석 GNU 반영 |
| `lefthook.yml` | pre-push `parallel: true` + shell-script-tests wrap에 GNU 도구 |
| `tests/run-all-tests.sh` | shell-script-tests wrap에 GNU 도구(lefthook과 동기화) |
| `tests/run-shell-script-tests.sh` | 주석 GNU 반영 |
| `CLAUDE.md` | BSD/GNU 라우팅 단락에 양방향 케이스(`touch -d`/`find -printf`) 추가 |

핵심 — 병렬 게이트의 bash 버전 방어:

```bash
# wait -n 은 bash 4.3+ 기능. 미만(예: macOS 기본 /bin/bash 3.2)에서는 게이트가 무력화되어
# unbounded 병렬이 되므로 순차로 폴백한다. lefthook 훅은 push 셸 PATH(bash 포함)를 상속한다.
if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ] || { [ "${BASH_VERSINFO[0]:-0}" -eq 4 ] && [ "${BASH_VERSINFO[1]:-0}" -lt 3 ]; }; then
  _PH_JOBS=1
fi
```

## 실측

| 대상 | before(순차) | after(병렬) |
|------|-------------|-------------|
| shell-script-tests | 112초 | 35초 |
| codex-hook-fixtures | 54초 | 28초 |
| pre-push 전체 | ~175초(+#1009로 push 차단) | ~57초 |

`run-all-tests.sh` 7통과/0실패. pre-push 병렬 wall-clock은 nix eval-cache 경합(동시 `nix eval`의 `SQLite busy`)으로 개별 합보다 절약폭이 줄지만, 여전히 순차 대비 ~3배 빠르다(경합 완화는 후속 과제).

## 참고 레퍼런스

- #1009 — karakeep fixture의 PATH 암묵 의존(BSD find) 이슈 (Closes)
- #831 — pre-commit glob 조건부 경량화 + pre-push 재검증 안전망(전제: CI 부재)
- #914 — push-time 검증용 GitHub Actions CI 도입(안전망 전제를 바꾼 변경)
- #647 / #593 — codex `--live` fixture의 invocation-matrix→env-inheritance 순서 계약
- #950 / #989 — karakeep 특성화 테스트 도입(GNU 의존을 들여온 지점)

## Human Test Plan

1. **devShell 밖 셸에서 push** (direnv 비활성): 이 브랜치를 push하면 pre-push가 전부 통과해야 한다(shell 155·codex 13·statusline 25·flake, 모두 0 실패). 이전엔 karakeep fixture 실패로 차단됐다.
   - 실패 시: `git log`로 커밋이 안 들어갔는지 확인 → pre-push 로그에서 어느 command가 FAIL인지 확인.
2. **수동 러너 병렬 동작**: `bash tests/run-shell-script-tests.sh` → "병렬 실행 요약: 통과 155 · 실패 0 (jobs=N)" + "All shell script tests passed".
   - 실패 시: `bash --version`이 4.3+ 인지 확인(미만이면 순차 폴백돼 느리지만 통과해야 함).
3. **순차 폴백**: `TEST_JOBS=1 bash tests/run-shell-script-tests.sh` → 기존처럼 순차 실행(`==>` 즉시 출력), 통과.
4. **codex live 순서 보존**: `bash tests/test-codex-hook-fixtures.sh --live`(codex 실제 실행 환경) → deterministic은 병렬, live 2개는 순차 실행.
5. **lefthook guard**: 만약 `lefthook-guard-self-check`가 "staged-config guard missing"으로 차단하면, devShell 안에서 `bash scripts/ai/install-lefthook-hooks.sh`로 hook을 복원(이 변경과 무관한 공유 hook 손상 시나리오).

https://claude.ai/code/session_01GJLBJobmkMwJe2sbng4AcS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test runs now support parallel execution in more cases, which should make the suite finish faster.
  * Shell-script tests now use a more consistent runtime environment with GNU tools available during execution.

* **Bug Fixes**
  * Improved handling of test failures so results are reported more reliably and successful completion is only shown when all tests pass.
  * Preserved correct ordering for cases that must run sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->