### PR TITLE
feat(claude-rc): 디렉토리 단위 headless multi-instance 재설계 — tmux 계층 폐기

### DIFF
--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -1,148 +1,220 @@
 ---
 name: managing-claude-rc
 description: |
-  Manage Claude Code Remote Control bridge (claude-rc): 기전, 세션 수명주기, 자동 재시작, 트러블슈팅.
+  Manage Claude Code Remote Control bridge (claude-rc): headless multi-instance,
+  instance lifecycle, version drift ensure, tombstone recovery, troubleshooting.
   Trigger: 'claude-rc', 'remote control', '리모트 컨트롤', 'bridge 서버', '모바일 세션',
   'claude-rc-ensure', 'claude-rc-maint', '세션 tombstone', 'bridge 재시작'.
   NOT for Codex remote control (use configuring-codex / issuing-codex-pairing-code).
-  NOT for tmux 일반 설정 (use managing-tmux).
 ---
 
 # Claude Code Remote Control (claude-rc) 관리
 
 Claude 모바일 앱/claude.ai에서 이 flake가 관리하는 머신의 Claude Code 세션을
-원격 조종하는 bridge 서버의 운영 가이드.
+원격 조종하는 `claude remote-control` 서버 운영 가이드.
 
-| 플랫폼 | 래퍼 | 자동 재시작 (ensure) | Pushover 알림 | 배선 모듈 |
-|--------|------|---------------------|---------------|-----------|
-| NixOS (MiniPC) | `~/.local/bin/claude-rc` | systemd timer 30분 | `pushover-system-monitor.age` (minipcOnly) | `modules/nixos/programs/claude-remote-control.nix` |
-| macOS (MacBook, personal/work) | `~/.local/bin/claude-rc` | launchd agent 30분 (`StartInterval`) | `pushover-share.age` (양쪽 맥북 복호화 가능) | `modules/darwin/programs/claude-remote-control.nix` |
+## 개요
 
-운영 옵션 선언 위치: NixOS는 `homeserver.claudeRemoteControl.*` 옵션, darwin은
-모듈 내 hostType 분기 상수 (`bridgeName`/`bridgeCapacity` 등 — 옵션화는 수요 시).
-
-## 기전 (3계층)
+`claude-rc`는 headless multi-instance 래퍼다. 인스턴스는 디렉토리 단위이며,
+각 디렉토리에서 서버 1개가 해당 claude.ai 환경 1개를 담당한다.
 
 ```text
-tmux 세션 "claude-rc" (detached 상시 구동)
- └─ claude-rc 래퍼 (modules/nixos/scripts/claude-rc.sh)
-     ├─ 재시작 루프: 비정상 종료 시 exponential backoff로 자동 재시작
-     ├─ stale 감지: tmux 환경변수 CLAUDE_RC_ACTIVE
-     └─ claude remote-control --spawn worktree --no-create-session-in-dir ...
-         └─ 모바일에서 새 세션 요청 시:
-             .claude/worktrees/bridge-cse_<세션ID> git worktree 생성 (locked) 후
-             `claude --print --sdk-url https://api.anthropic.com/v1/code/sessions/cse_...`
-             자식 프로세스 스폰 (outbound 연결만 사용, 인바운드 포트 없음)
+사용자/ensure
+  └─ claude-rc / claude-rc-maint
+      ├─ STATE_DIR/instances.json 동적 등록
+      ├─ STATE_DIR/<slug>/lock 중복 기동 방지
+      └─ cd /path/to/project && claude remote-control --spawn <mode> ...
 ```
 
-- transcript는 `~/.claude/projects/<정규화된 경로>/<uuid>.jsonl`에 기록된다.
-  프로젝트 디렉토리명은 경로의 비영숫자가 하이픈으로 정규화된다
-  (예: `bridge-cse_01AB...` worktree → `...--claude-worktrees-bridge-cse-01AB...`).
+- `STATE_DIR` 기본값: `~/.local/state/claude-rc`
+- slug: `basename(절대경로)-sha256(절대경로)앞8자`
+- 서버 프로세스가 `<slug>/lock`을 `flock`으로 직접 보유한다. lock 생사가 서버 생사다.
+- 래퍼를 우회한 순정 CLI 기동은 lock을 보유하지 않으므로, 래퍼는 실행 중
+  `claude remote-control` 프로세스의 cwd까지 검사한다.
 
-## 사용자 래퍼 (claude-rc)
+## 사용자 래퍼
 
 | 명령 | 동작 |
 |------|------|
-| `claude-rc` | 서버 시작 + tmux attach |
-| `claude-rc --detach` | 서버 시작 (백그라운드) |
-| `claude-rc --attach` | 기존 세션 접속 |
-| `claude-rc --stop` | 서버 종료 (활성 세션 tombstone — 아래 수명주기 참조) |
-| `claude-rc --cleanup` | 서버 종료 + worktree prune + orphan 디렉토리 삭제 |
+| `claude-rc` / `claude-rc start` | 현재 git top-level 디렉토리 인스턴스 시작 및 `instances.json` 등록 |
+| `claude-rc stop` | 현재 인스턴스 서버 종료 및 등록 해제. worktree 세션 존재 시 `--force` 필요 |
+| `claude-rc ls` | 등록 인스턴스, 실행 여부, PID, 버전, spawn, source, 로그 경로 출력 |
+| `claude-rc cleanup` | 현재 인스턴스의 orphan `.claude/worktrees/*` 디렉토리만 삭제 |
 
-옵션: `--permission-mode <mode>`, `--capacity <N>`, `--name <name>`.
-수동 실행 시에도 배선 모듈의 선언값(NixOS `homeserver.claudeRemoteControl.*` /
-darwin 모듈 상수)과 일치시켜야 자동 재시작 후 동작이 달라지지 않는다.
+옵션:
 
-## 자동 재시작 (claude-rc-ensure)
+| 옵션 | 기본 | 설명 |
+|------|------|------|
+| `--spawn worktree\|same-dir` | `worktree` | 원격 세션 스폰 방식 |
+| `--capacity N` | 미전달 | 동시 세션 수. 미전달 시 upstream 기본값 사용 |
+| `--permission-mode MODE` | `bypassPermissions` | `acceptEdits`, `bypassPermissions`, `default`, `dontAsk`, `plan` |
+| `--force` | false | `stop`에서 worktree 세션 tombstone 가드 우회 |
 
-NixOS는 `homeserver.claudeRemoteControl.enable = true` 시 systemd timer가 부팅 2분 후 +
-30분마다, macOS는 launchd agent(`StartInterval = 1800` + `RunAtLoad`)가 로그인 시 +
-30분마다 `claude-rc-maint ensure`를 실행한다.
+이미 실행 중인 인스턴스에 다른 옵션으로 `start`하면 옵션은 반영되지 않는다.
+변경하려면 `claude-rc stop` 후 다시 시작한다.
 
-판정 흐름:
-1. tmux 세션 부재/stale → bridge 시작 (부팅/로그인 후 자동 복구 겸함)
-2. 실행 중 bridge 바이너리 버전 vs claude launcher(`~/.local/bin/claude`)가 가리키는
-   최신 버전 비교. desired 버전 조회(maint의 `desired_claude_version`)는 GNU coreutils
-   `readlink -f`를 쓰며, maint 패키지의 runtimeInputs가 두 플랫폼 모두 nix coreutils로
-   해석하므로 macOS BSD `readlink`에 의존하지 않는다.
-   실행 바이너리 경로 조회는 `pid_exe_path` 플랫폼 분기 — Linux `/proc/PID/exe`,
-   macOS `lsof -a -p PID -d txt -Fn` 첫 항목 (macOS는 삭제된 바이너리에 `(deleted)`
-   suffix가 없지만 버전이 파일명이라 문자열 비교로 drift가 감지된다)
-3. drift 없음 → healthy
-4. drift 있음 → idle 게이트:
-   - 최근 `IDLE_THRESHOLD_MINUTES`(기본 30분) 내 활동한 bridge transcript가 있으면 유예
-   - 스폰 세션 프로세스가 있는데 transcript 명명 규칙 매치가 전혀 없으면
-     판정 불가로 보수적 유예 (`deferred-unknown-activity`)
-   - 둘 다 아니면 재시작 (`restarted-version-drift`)
-5. 모든 경로에서 status 기록 + Pushover 알림 (상태 전이 기반, cooldown 30분)
+## 상태 레이아웃
 
-운영 옵션(permissionMode/capacity/name)은 선언되어 재시작 시 보존된다:
-NixOS는 `modules/nixos/configuration.nix`의 `homeserver.claudeRemoteControl` 블록,
-darwin은 `modules/darwin/programs/claude-remote-control.nix`의 상수.
+```text
+~/.local/state/claude-rc/
+  instances.json
+  instances.json.lock
+  ensure.lock
+  status.json
+  <slug>/
+    lock
+    server.log
+    server.log.1
+```
 
-Pushover fallback: 크리덴셜이 없거나 읽을 수 없는 호스트에서 maint를 실행하면
-알림만 스킵되고 ensure 본체는 정상 동작한다.
-NixOS systemd 유닛은 `ConditionPathExists`로 credential 부재 시 조용히 skip된다
-(agenix 장애 신호). darwin launchd agent는 조건 없이 실행되고 fallback에 의존한다.
+`instances.json` schema v1:
 
-## 세션 수명주기 (중요)
+```json
+{
+  "version": 1,
+  "instances": {
+    "/path/to/project": {
+      "spawn": "worktree",
+      "capacity": null,
+      "permissionMode": "bypassPermissions",
+      "registeredAt": "2026-07-08T12:00:00+09:00",
+      "source": "manual"
+    }
+  }
+}
+```
 
-- disconnect ≠ end session: 모바일 앱 연결을 끊어도 세션 프로세스는 계속 살아
-  capacity 슬롯을 점유한다. upstream에 세션 age-out이 없다 (#60568 — schema에
-  sessionTimeoutSeconds만 있고 미배선; #28917 revoke, #32050 idle timeout 모두
-  미구현 stale 종결). → `--cleanup` workaround가 계속 필요한 근거.
-- bridge 재시작 = 활성 세션 tombstone: 앱에서 기록은 보이지만 프롬프트가
-  조용히 무시된다. 대화 기록은 보존된다:
-  - 로컬 재개: 해당 worktree에서 `claude --resume <uuid>`
-  - 원격 재개 (claude 2.1.200+): `claude remote-control --session-id <cse_...>`
-    (spawn 플래그와 병용 불가 — 세션 전용 프로세스로 떠야 함)
-- 알려진 upstream 버그: 스폰 세션이 UI 선택 모델을 무시할 수 있음 (#74049, OPEN).
+- `source=manual`: `claude-rc start`가 등록
+- `source=declared`: `claude-rc-maint ensure`가 Nix 선언에서 시드
+- `server.log`: 서버 stdout/stderr. 5MB 초과 시 1세대 rotate
+- `status.json`: 마지막 ensure 실행 결과. top-level timestamp/exitCode/action과
+  인스턴스별 `{path,runningVersion,desiredVersion,action}` 배열을 기록한다.
+
+## 자동화
+
+| 플랫폼 | 자동화 | 선언 위치 |
+|--------|--------|-----------|
+| NixOS | systemd timer `claude-rc-ensure` 30분 주기 | `homeserver.claudeRemoteControl.*` |
+| macOS | launchd agent `claude-rc-ensure` 30분 주기 | `modules/darwin/programs/claude-remote-control.nix` 상수 |
+
+`CLAUDE_RC_DECLARED_INSTANCES`는 JSON 배열이다.
+
+```json
+[
+  {
+    "path": "/path/to/project",
+    "spawn": "worktree",
+    "capacity": null,
+    "permissionMode": "bypassPermissions"
+  }
+]
+```
+
+ensure 판정 흐름:
+
+1. 선언 인스턴스가 `instances.json`에 없으면 `source=declared`로 추가한다.
+2. 인스턴스 경로가 없으면 `path-missing`으로 기록하고 등록은 유지한다.
+3. lock이 비어 있으면 서버를 headless로 시작한다.
+4. 살아 있으면 실행 중 바이너리 버전과 desired Claude launcher 버전을 비교한다.
+5. drift가 없으면 `healthy`.
+6. drift + `spawn=same-dir`이면 즉시 재시작한다.
+7. drift + `spawn=worktree`이면 idle gate를 통과할 때만 재시작한다.
+
+worktree idle gate:
+
+- 최근 `IDLE_THRESHOLD_MINUTES` 내 transcript가 있으면 `deferred-active-sessions`
+- `--sdk-url` 세션 프로세스는 있는데 worktree transcript 디렉토리 명명 매치가 0이면
+  `deferred-unknown-activity`
+- 둘 다 아니면 `restarted-version-drift`
+
+transcript 매칭은 `<정규화된 인스턴스 경로>--claude-worktrees-*`만 본다.
+인스턴스 root transcript는 로컬/same-dir 세션 활동일 수 있어 worktree drift gate에
+포함하지 않는다.
+
+## 환경과 세션 수명주기
+
+실측 기준: Claude Code v2.1.204.
+
+- 서버 1개 = claude.ai 환경 1개.
+- 환경은 디렉토리 경로 기준으로 서버측에 보존되고, 재시작하면 같은 환경을 회수한다.
+- 환경 표시명은 upstream이 호스트명 + 디렉토리 basename으로 정한다.
+- 같은 디렉토리에 서버 2개가 동시에 뜨면 두 번째가 새 환경을 만든다. 이후 하나만
+  회수되고 나머지는 삭제 불가능한 유령 환경으로 영구 잔존한다. 세션 0개여도 목록에
+  남고 삭제 UI가 없으며, 죽은 환경이 온라인으로 보일 수 있다.
+- 중복 기동 방지는 래퍼의 `flock` + cwd 실측 가드가 유일한 방어다.
+- same-dir 스폰 세션은 서버 재시작 후 자동 재연결된다. 같은 세션 ID가 재스폰된다.
+- worktree 스폰 세션만 tombstone된다. 재시작 후 재스폰되지 않고 원격 메시지가 로컬에
+  도달하지 않는 hang 상태가 된다.
+- tombstone 복구: 해당 worktree에서 `claude remote-control --session-id <cse_...>`를
+  실행하면 pending 프롬프트까지 처리된다.
+- 복구 프로세스도 cwd 기준 환경을 하나 등록한다. worktree 경로가 환경 이름으로 목록에
+  추가되는 오염 부작용이 있으므로 필요한 경우에만 쓴다.
+- claude.ai/모바일 앱 환경 상세의 "N 중 M" 탭에는 "세션 종료" UI가 있어 capacity 슬롯을
+  직접 해제할 수 있다.
+- 서버는 네트워크 약 10분 단절 시 자기 종료한다. 30분 ensure가 부활을 담당한다.
+- 서버 종료 시 정상 종료와 kill 모두 자식 세션 프로세스를 함께 정리한다.
 
 ## 트러블슈팅
 
 공통:
 
 ```bash
-cat ~/.local/state/claude-rc/status.json                    # ensure 상태
-tmux has-session -t claude-rc && tmux attach -t claude-rc   # 래퍼 로그 확인
-pgrep -fl 'claude remote-control'                           # bridge 프로세스
+claude-rc ls
+cat ~/.local/state/claude-rc/status.json
+tail -50 ~/.local/state/claude-rc/<slug>/server.log
+pgrep -fl 'claude remote-control'
 ```
 
-NixOS (MiniPC):
+NixOS:
 
 ```bash
 journalctl -u claude-rc-ensure --since -2d
 systemctl list-timers claude-rc-ensure
-readlink /proc/<PID>/exe          # 실행 중 바이너리 버전
-systemctl start claude-rc-ensure  # 수동 ensure (drift 즉시 확인)
+systemctl start claude-rc-ensure
 ```
 
-macOS (맥북):
+macOS:
 
 ```bash
-launchctl list | grep claude-rc                                # agent 로드 확인
-launchctl print "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"  # 상세 (마지막 exit 등)
-tail -50 ~/Library/Logs/claude-rc-ensure.log                   # ensure 실행 로그
-lsof -a -p <PID> -d txt -Fn | head -2                          # 실행 중 바이너리 경로 (/proc 대체)
-launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"  # 수동 ensure
+launchctl list | grep claude-rc
+launchctl print "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"
+tail -50 ~/Library/Logs/claude-rc-ensure.log
+launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"
 ```
 
-| 증상 | 원인/조치 |
-|------|----------|
-| status.json `action: deferred-active-sessions` | 활성 세션 존재 — 정상 유예. 다음 주기 재시도 |
-| `action: deferred-unknown-activity` | transcript 명명 규칙 drift 의심 — `claude-rc-maint.sh`의 `BRIDGE_TRANSCRIPT_GLOBS` 갱신 검토 |
-| `action: no-bridge-process` | 래퍼 backoff 루프가 재시작 중 — 지속되면 `tmux attach -t claude-rc`로 루프 로그 확인 |
-| unit이 실행 안 됨 (Condition failed, NixOS) | `/run/agenix/pushover-system-monitor` 부재 — agenix 상태 확인 |
-| macOS에서 알림이 안 옴 | `~/.config/pushover/share` 복호화 확인 (agenix HM) — 부재 시 알림만 스킵되는 정상 fallback |
-| capacity 꽉 참 (앱에서 새 세션 불가) | idle 프로세스가 슬롯 점유 — 앱에서 "세션 종료" 또는 `claude-rc --cleanup` |
-| 모바일 세션이 응답 없음 (기록만 보임) | tombstone — 위 재개 경로 사용 |
+| status action | 의미 / 조치 |
+|---------------|-------------|
+| `no-instances` | 등록된 인스턴스 없음. `claude-rc start` 또는 선언 env 확인 |
+| `path-missing` | 등록 경로가 없음. 등록은 유지되며 알림 대상 아님 |
+| `started` | 죽은 인스턴스를 시작함 |
+| `healthy` | 실행 버전과 desired 버전 일치 |
+| `restarted-version-drift` | version drift 재시작 완료 |
+| `deferred-active-sessions` | worktree 세션 활동 감지로 재시작 유예 |
+| `deferred-unknown-activity` | 세션 프로세스는 있으나 transcript 명명 매치가 없어 보수 유예 |
+| `start-failed` / `restart-failed` | `<slug>/server.log` 확인 |
+| `no-server-process` | lock은 잡혔지만 cwd가 같은 서버 PID를 못 찾음. stale lock 또는 프로세스 shape 확인 |
+| `running-version-unresolvable` | 실행 바이너리 경로 조회 실패. `lsof`/`/proc` 접근 확인 |
+| `declared-instances-invalid` | `CLAUDE_RC_DECLARED_INSTANCES` JSON/경로/spawn/capacity 오류 |
+| `lock-acquire-timeout` | ensure 중복 실행 또는 lock fd 누수 의심 |
+
+증상별 조치:
+
+| 증상 | 조치 |
+|------|------|
+| `claude-rc start`가 "이미 실행 중" 출력 | 정상 멱등. 옵션 변경은 `claude-rc stop` 후 재시작 |
+| "same-dir claude remote-control process already exists" | 래퍼 우회 기동 감지. 기존 순정 서버 종료 후 래퍼로 시작 |
+| worktree 세션이 응답 없음 | tombstone 가능성. 해당 worktree에서 `claude remote-control --session-id <cse_...>` |
+| capacity 부족 | claude.ai/모바일 앱 환경 상세의 "세션 종료" UI로 슬롯 해제 |
+| 서버가 주기적으로 사라짐 | 네트워크 단절 자기 종료 가능. 다음 ensure 주기와 `server.log` 확인 |
 
 ## 관련 파일
 
-- 래퍼: `modules/nixos/scripts/claude-rc.sh` (store 패키지: `modules/nixos/lib/claude-rc-package.nix`)
+- 래퍼: `modules/nixos/scripts/claude-rc.sh`
+- 래퍼 패키지: `modules/nixos/lib/claude-rc-package.nix`
 - maint 엔진: `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh`
-  (패키징: `modules/nixos/lib/claude-rc-maint-package.nix` — runtimeInputs 플랫폼 분기)
-- systemd 모듈 (NixOS): `modules/nixos/programs/claude-remote-control.nix`
-- launchd 모듈 (darwin): `modules/darwin/programs/claude-remote-control.nix` (래퍼 배선 포함)
-- 옵션 (NixOS): `modules/nixos/options/homeserver.nix` (`claudeRemoteControl.*`)
-- HM 배선 (NixOS): `modules/shared/programs/shell/nixos.nix`
+- maint 패키지: `modules/nixos/lib/claude-rc-maint-package.nix`
+- NixOS systemd 배선: `modules/nixos/programs/claude-remote-control.nix`
+- macOS launchd 배선: `modules/darwin/programs/claude-remote-control.nix`
+- NixOS 옵션: `modules/nixos/options/homeserver.nix`
+- NixOS Home Manager 래퍼 링크: `modules/shared/programs/shell/nixos.nix`
+- 테스트: `tests/suites/claude-remote-control.sh`

--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -154,6 +154,22 @@ transcript 매칭은 `<정규화된 인스턴스 경로>--claude-worktrees-*`만
 - 서버는 네트워크 약 10분 단절 시 자기 종료한다. 30분 ensure가 부활을 담당한다.
 - 서버 종료 시 정상 종료와 kill 모두 자식 세션 프로세스를 함께 정리한다.
 
+## 기존 tmux bridge에서 마이그레이션
+
+구 tmux 기반 bridge가 같은 디렉토리에서 아직 떠 있으면 새 `claude-rc-maint`는
+`unmanaged-server-present`로 기동을 거부한다. 같은 디렉토리에 두 번째 서버를 띄우면
+삭제 불가능한 유령 환경이 생기므로, 이 거부가 정상 안전장치다.
+
+절차:
+
+```bash
+tmux kill-session -t claude-rc
+claude-rc start
+```
+
+선언 인스턴스는 수동 `claude-rc start` 대신 다음 ensure 주기에 자동 기동시켜도 된다.
+같은 디렉토리 경로이므로 기존 claude.ai 환경을 회수한다.
+
 ## 트러블슈팅
 
 공통:
@@ -185,17 +201,31 @@ launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"
 | status action | 의미 / 조치 |
 |---------------|-------------|
 | `no-instances` | 등록된 인스턴스 없음. `claude-rc start` 또는 선언 env 확인 |
-| `path-missing` | 등록 경로가 없음. 등록은 유지되며 알림 대상 아님 |
+| `path-missing` | 등록 경로가 없음. 등록은 유지되며 알림 대상 아님. stale 등록이면 아래 flock+jq 예시로 제거 |
 | `started` | 죽은 인스턴스를 시작함 |
 | `healthy` | 실행 버전과 desired 버전 일치 |
 | `restarted-version-drift` | version drift 재시작 완료 |
 | `deferred-active-sessions` | worktree 세션 활동 감지로 재시작 유예 |
 | `deferred-unknown-activity` | 세션 프로세스는 있으나 transcript 명명 매치가 없어 보수 유예 |
 | `start-failed` / `restart-failed` | `<slug>/server.log` 확인 |
+| `unmanaged-server-present` | 같은 cwd의 unmanaged 서버 감지. legacy tmux bridge 잔존 포함. 기존 서버 종료 후 `claude-rc start` 또는 다음 ensure |
 | `no-server-process` | lock은 잡혔지만 cwd가 같은 서버 PID를 못 찾음. stale lock 또는 프로세스 shape 확인 |
 | `running-version-unresolvable` | 실행 바이너리 경로 조회 실패. `lsof`/`/proc` 접근 확인 |
 | `declared-instances-invalid` | `CLAUDE_RC_DECLARED_INSTANCES` JSON/경로/spawn/capacity 오류 |
 | `lock-acquire-timeout` | ensure 중복 실행 또는 lock fd 누수 의심 |
+
+stale 등록 수동 제거:
+
+```bash
+STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
+path="/path/to/project"
+(
+  flock 8
+  tmp=$(mktemp "$STATE_DIR/instances.XXXXXX")
+  jq --arg path "$path" 'del(.instances[$path])' "$STATE_DIR/instances.json" >"$tmp"
+  mv "$tmp" "$STATE_DIR/instances.json"
+) 8>"$STATE_DIR/instances.json.lock"
+```
 
 증상별 조치:
 

--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -37,7 +37,7 @@ Claude 모바일 앱/claude.ai에서 이 flake가 관리하는 머신의 Claude 
 | 명령 | 동작 |
 |------|------|
 | `claude-rc` / `claude-rc start` | 현재 git top-level 디렉토리 인스턴스 시작 및 `instances.json` 등록 |
-| `claude-rc stop` | 현재 인스턴스 서버 종료 및 등록 해제. worktree 세션 존재 시 `--force` 필요 |
+| `claude-rc stop [path]` | 현재 또는 지정 절대경로 인스턴스 서버 종료 및 등록 해제. worktree 세션 존재 시 `--force` 필요 |
 | `claude-rc ls` | 등록 인스턴스, 실행 여부, PID, 버전, spawn, source, 로그 경로 출력 |
 | `claude-rc cleanup` | 현재 인스턴스의 orphan `.claude/worktrees/*` 디렉토리만 삭제 |
 
@@ -117,8 +117,12 @@ ensure 판정 흐름:
 3. lock이 비어 있으면 서버를 headless로 시작한다.
 4. 살아 있으면 실행 중 바이너리 버전과 desired Claude launcher 버전을 비교한다.
 5. drift가 없으면 `healthy`.
-6. drift + `spawn=same-dir`이면 즉시 재시작한다.
-7. drift + `spawn=worktree`이면 idle gate를 통과할 때만 재시작한다.
+6. drift가 있으면 실행 중 서버 argv의 effective spawn을 실측한다.
+7. effective `spawn=same-dir`이면 즉시 재시작한다.
+8. effective `spawn=worktree` 또는 파싱 불가이면 idle gate를 통과할 때만 재시작한다.
+
+registry의 `spawn`은 desired state이며 부활/재기동 옵션으로만 쓴다. 재시작 안전성은
+이미 실행 중인 프로세스의 실제 spawn 모드가 결정한다.
 
 worktree idle gate:
 
@@ -201,7 +205,7 @@ launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"
 | status action | 의미 / 조치 |
 |---------------|-------------|
 | `no-instances` | 등록된 인스턴스 없음. `claude-rc start` 또는 선언 env 확인 |
-| `path-missing` | 등록 경로가 없음. 등록은 유지되며 알림 대상 아님. stale 등록이면 아래 flock+jq 예시로 제거 |
+| `path-missing` | 등록 경로가 없음. 등록은 유지되며 알림 대상 아님. stale 등록이면 `claude-rc stop /path/to/project`로 제거 |
 | `started` | 죽은 인스턴스를 시작함 |
 | `healthy` | 실행 버전과 desired 버전 일치 |
 | `restarted-version-drift` | version drift 재시작 완료 |
@@ -213,19 +217,6 @@ launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"
 | `running-version-unresolvable` | 실행 바이너리 경로 조회 실패. `lsof`/`/proc` 접근 확인 |
 | `declared-instances-invalid` | `CLAUDE_RC_DECLARED_INSTANCES` JSON/경로/spawn/capacity 오류 |
 | `lock-acquire-timeout` | ensure 중복 실행 또는 lock fd 누수 의심 |
-
-stale 등록 수동 제거:
-
-```bash
-STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
-path="/path/to/project"
-(
-  flock 8
-  tmp=$(mktemp "$STATE_DIR/instances.XXXXXX")
-  jq --arg path "$path" 'del(.instances[$path])' "$STATE_DIR/instances.json" >"$tmp"
-  mv "$tmp" "$STATE_DIR/instances.json"
-) 8>"$STATE_DIR/instances.json.lock"
-```
 
 증상별 조치:
 

--- a/modules/darwin/programs/claude-remote-control.nix
+++ b/modules/darwin/programs/claude-remote-control.nix
@@ -1,23 +1,21 @@
 # modules/darwin/programs/claude-remote-control.nix
-# Claude Code Remote Control bridge의 macOS(darwin) 배선 (#1007)
+# Claude Code Remote Control bridge의 macOS(darwin) headless 배선
 #
-# MiniPC의 systemd 버전(modules/nixos/programs/claude-remote-control.nix)의 launchd
+# NixOS systemd 버전(modules/nixos/programs/claude-remote-control.nix)의 launchd
 # 이식판. 래퍼(~/.local/bin/claude-rc) 설치와 30분 주기 version-drift 감시
-# (claude-rc-ensure launchd agent)를 한 모듈에 응집한다 — bridge 이름/capacity가
-# 래퍼 기본값과 maint env 양쪽에 일관되게 흘러야 하기 때문.
+# (claude-rc-ensure launchd agent)를 한 모듈에 응집한다.
 #
 # NixOS와의 차이:
-#   - 옵션 네임스페이스 없음: darwin에는 homeserver.*가 없어 hostType 분기 상수로
-#     시작한다 (opnix-rotate.nix 관례, 옵션화는 수요 생기면 도입 — YAGNI).
-#   - Pushover: minipcOnly인 pushover-system-monitor.age 대신 shared secrets의
-#     pushover-share.age(~/.config/pushover/share, 양쪽 맥북 복호화 가능)를 쓴다.
+#   - 옵션 네임스페이스 없음: darwin에는 homeserver.*가 없어 선언 인스턴스
+#     상수를 모듈 안에 둔다 (옵션화는 수요 생기면 도입 — YAGNI).
+#   - Pushover: NixOS 전용 pushover-system-monitor.age 대신 shared secrets의
+#     pushover-share.age(~/.config/pushover/share)를 쓴다.
 #     파일 형식(PUSHOVER_TOKEN/PUSHOVER_USER env)은 maint의 source 인터페이스와 동일.
 #     복호화 전(agenix 미완료)이면 maint의 graceful fallback이 알림만 스킵한다.
 #   - Persistent 미대응: launchd StartInterval은 놓친 실행을 다음 주기로 수용.
 {
   config,
   pkgs,
-  hostType,
   nixosConfigDefaultPath,
   ...
 }:
@@ -29,20 +27,23 @@ let
   pushoverCredPath = "${config.xdg.configHome}/pushover/share";
   serviceLib = import ../../nixos/lib/service-lib.nix { inherit pkgs; };
 
-  # bridge 운영 상수 — NixOS의 homeserver.claudeRemoteControl.* 대응.
-  # 자동 재시작이 이 값들을 명시 전달해야 래퍼 기본값으로 되돌아가는 회귀가 없다.
-  bridgeName = if hostType == "work" then "work-MacBook" else "MacBook";
-  bridgeCapacity = 8; # work-MacBookPro 수동 운영 실측값 승계
+  # 선언 인스턴스 운영 상수 — NixOS의 homeserver.claudeRemoteControl.* 대응.
+  bridgeSpawn = "worktree";
+  bridgeCapacity = null;
   bridgePermissionMode = "bypassPermissions";
   idleThresholdMinutes = 30;
   alertCooldownSeconds = 1800;
+  declaredInstances = builtins.toJSON [
+    {
+      path = nixosConfigDefaultPath;
+      spawn = bridgeSpawn;
+      capacity = bridgeCapacity;
+      permissionMode = bridgePermissionMode;
+    }
+  ];
 
-  # NixOS HM 배선(shell/nixos.nix)과 같은 표현식 — flakePath/defaultName만 darwin 값.
-  claudeRcPkg = import ../../nixos/lib/claude-rc-package.nix {
-    inherit pkgs;
-    flakePath = nixosConfigDefaultPath;
-    defaultName = bridgeName;
-  };
+  # NixOS HM 배선(shell/nixos.nix)과 같은 래퍼 패키지.
+  claudeRcPkg = import ../../nixos/lib/claude-rc-package.nix { inherit pkgs; };
   maintenanceCli = import ../../nixos/lib/claude-rc-maint-package.nix { inherit pkgs; };
 in
 {
@@ -59,20 +60,20 @@ in
       # (OnBootSec=2m 대응 — ensure가 bridge 부재 시 시작하므로 부팅 후 자동 구동).
       StartInterval = 1800;
       RunAtLoad = true;
+      # launchd는 job 종료 시 같은 process group의 잔여 프로세스를 정리한다.
+      # maint가 double-fork로 headless 서버를 re-parent해도 process group은 유지될 수
+      # 있으므로, ensure가 방금 띄운 서버를 같이 죽이지 않게 한다.
+      AbandonProcessGroup = true;
       EnvironmentVariables = {
         HOME = homeDir;
         STATE_DIR = stateDir;
-        CLAUDE_RC_BIN = "${claudeRcPkg}/bin/claude-rc";
+        CLAUDE_RC_DECLARED_INSTANCES = declaredInstances;
         SERVICE_LIB = "${serviceLib}";
         PUSHOVER_CRED_FILE = pushoverCredPath;
         IDLE_THRESHOLD_MINUTES = toString idleThresholdMinutes;
         ALERT_COOLDOWN_SECONDS = toString alertCooldownSeconds;
-        CLAUDE_RC_PERMISSION_MODE = bridgePermissionMode;
-        CLAUDE_RC_CAPACITY = toString bridgeCapacity;
-        CLAUDE_RC_NAME = bridgeName;
-        CLAUDE_RC_ALERT_HOST = bridgeName;
         # writeShellApplication runtimeInputs가 앞에 붙는다. 이 tail은
-        # ~/.local/bin(claude launcher + claude-rc 내부 bare `claude` 호출),
+        # ~/.local/bin(claude launcher + maint/래퍼 내부 bare `claude` 호출),
         # nix 프로필, 그리고 /usr/bin(시스템 pgrep — darwin은 procps 미지원이라
         # maint 패키징이 시스템 바이너리에 의존)을 해석하기 위해 필요하다.
         PATH = "${homeDir}/.local/bin:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin";

--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -127,8 +127,7 @@
   homeserver.opnix.enable = true; # 1Password SA token materialization + gh 인증
   homeserver.codexRemoteControl.enable = true; # Codex mobile remote-control app-server 회귀 방지
   homeserver.claudeRemoteControl = {
-    enable = true; # Claude Code RC bridge version-drift 감시 (30분 timer)
+    enable = true; # 선언 인스턴스(nixos-config) 상시 유지 + version-drift 감시 (30분 timer)
     capacity = 10; # 현행 운영값 — 자동 재시작 시 이 값으로 유지된다
-    name = "miniPC";
   };
 }

--- a/modules/nixos/lib/claude-rc-maint-package.nix
+++ b/modules/nixos/lib/claude-rc-maint-package.nix
@@ -30,5 +30,8 @@ pkgs.writeShellApplication {
       flock
       lsof
     ];
-  text = builtins.readFile ../programs/claude-remote-control/files/claude-rc-maint.sh;
+  text =
+    builtins.readFile ../scripts/claude-rc-lib.sh
+    + "\n"
+    + builtins.readFile ../programs/claude-remote-control/files/claude-rc-maint.sh;
 }

--- a/modules/nixos/lib/claude-rc-maint-package.nix
+++ b/modules/nixos/lib/claude-rc-maint-package.nix
@@ -3,11 +3,10 @@
 # NixOS systemd 모듈(claude-remote-control.nix)과 darwin launchd 모듈
 # (modules/darwin/programs/claude-remote-control.nix)이 같은 표현식을 평가해
 # 스크립트 본체를 공유한다. runtimeInputs만 플랫폼 분기한다:
-#   - Linux: procps(pgrep) + util-linux(flock)
-#   - Darwin: 둘 다 darwin 미지원 패키지라 flock(discoteq — darwin 빌드 존재)과
-#     lsof(pid_exe_path의 /proc 대체)를 넣는다. pgrep은 nixpkgs 대체가 없어
-#     시스템 /usr/bin/pgrep에 의존한다 — 호출측 launchd agent가 PATH tail에
-#     /usr/bin을 포함해야 한다.
+#   - Linux: procps(pgrep) + util-linux(flock) + lsof(cwd 조회)
+#   - Darwin: flock(discoteq — darwin 빌드 존재)과 lsof를 넣는다.
+#     pgrep은 nixpkgs 대체가 없어 시스템 /usr/bin/pgrep에 의존한다 —
+#     호출측 launchd agent가 PATH tail에 /usr/bin을 포함해야 한다.
 { pkgs }:
 pkgs.writeShellApplication {
   name = "claude-rc-maint";
@@ -20,12 +19,12 @@ pkgs.writeShellApplication {
       gnugrep
       gnused
       jq
-      tmux
       curl # service-lib send_notification
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
       procps
       util-linux # flock
+      lsof
     ]
     ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
       flock

--- a/modules/nixos/lib/claude-rc-package.nix
+++ b/modules/nixos/lib/claude-rc-package.nix
@@ -1,19 +1,33 @@
 # claude-rc 사용자 래퍼의 store 패키지 표현식.
 #
-# Home Manager(home.file 링크)와 NixOS systemd 모듈(claude-rc-maint의
-# CLAUDE_RC_BIN)이 같은 인자로 이 표현식을 평가하면 동일 store path를 공유한다.
-# systemd ExecStart/env는 절대 store 경로가 필요하므로 (~ 미확장) HM 산출물이
-# 아닌 store 패키지로 경계를 통일한다.
-# defaultName: 옵션 미지정 수동 실행 시 claude.ai에 표시되는 bridge 이름.
-# darwin 배선이 머신별 이름을 주입한다. NixOS의 두 배선(HM/systemd)은 미지정으로
-# 같은 기본값을 받아 동일 store path 공유가 유지된다.
-{
-  pkgs,
-  flakePath,
-  defaultName ? "minipc",
-}:
-pkgs.runCommand "claude-rc" { } ''
-  install -Dm755 ${
-    pkgs.replaceVars ../scripts/claude-rc.sh { inherit flakePath defaultName; }
-  } $out/bin/claude-rc
-''
+# Home Manager가 ~/.local/bin/claude-rc로 링크하는 단일 래퍼 패키지다.
+# headless multi-instance 래퍼는 flock/jq/lsof 등 일반 사용자 PATH에 없을 수
+# 있는 도구에 의존하므로 writeShellApplication runtimeInputs로 실행 환경을
+# 고정한다. claude 자체는 ~/.local/bin/claude launcher가 자체 업데이트를
+# 관리하므로 runtimeInputs에 넣지 않고 호출측 PATH tail에서 해석한다.
+{ pkgs }:
+pkgs.writeShellApplication {
+  name = "claude-rc";
+  runtimeInputs =
+    with pkgs;
+    [
+      coreutils
+      findutils
+      gawk
+      gnugrep
+      gnused
+      jq
+      git
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+      util-linux # flock
+      procps # pgrep
+      lsof
+    ]
+    ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+      flock # discoteq flock; darwin 빌드 존재
+      lsof
+      # pgrep은 nixpkgs 대체가 없어 호출측 PATH의 /usr/bin/pgrep으로 fallthrough.
+    ];
+  text = builtins.readFile ../scripts/claude-rc.sh;
+}

--- a/modules/nixos/lib/claude-rc-package.nix
+++ b/modules/nixos/lib/claude-rc-package.nix
@@ -29,5 +29,6 @@ pkgs.writeShellApplication {
       lsof
       # pgrep은 nixpkgs 대체가 없어 호출측 PATH의 /usr/bin/pgrep으로 fallthrough.
     ];
-  text = builtins.readFile ../scripts/claude-rc.sh;
+  text =
+    builtins.readFile ../scripts/claude-rc-lib.sh + "\n" + builtins.readFile ../scripts/claude-rc.sh;
 }

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -203,10 +203,19 @@
     };
 
     claudeRemoteControl = {
-      enable = lib.mkEnableOption "Claude Code Remote Control bridge version-drift guard";
+      enable = lib.mkEnableOption "Claude Code Remote Control 선언 인스턴스(nixos-config)의 상시 유지 + 전체 인스턴스 version-drift 감시";
 
-      # bridge 시작 옵션 — maint의 자동 재시작이 이 값들을 명시 전달한다.
-      # 선언하지 않으면 재시작 시 래퍼 기본값으로 조용히 되돌아가는 회귀가 생긴다.
+      # 선언 인스턴스 시작 옵션 — maint가 instances.json에 없는 선언 항목을
+      # 시드하고, 죽었거나 drift된 서버를 재기동할 때 이 값을 보존한다.
+      spawn = lib.mkOption {
+        type = lib.types.enum [
+          "worktree"
+          "same-dir"
+        ];
+        default = "worktree";
+        description = "Spawn mode for remote sessions; worktree sessions tombstone if their server restarts while active";
+      };
+
       permissionMode = lib.mkOption {
         type = lib.types.enum [
           "acceptEdits"
@@ -220,15 +229,9 @@
       };
 
       capacity = lib.mkOption {
-        type = lib.types.ints.positive;
-        default = 5;
-        description = "Max concurrent remote sessions";
-      };
-
-      name = lib.mkOption {
-        type = lib.types.str;
-        default = "minipc";
-        description = "Bridge name shown in claude.ai / mobile app";
+        type = lib.types.nullOr lib.types.ints.positive;
+        default = null;
+        description = "Max concurrent remote sessions; null omits --capacity and uses the upstream default";
       };
 
       idleThresholdMinutes = lib.mkOption {

--- a/modules/nixos/programs/claude-remote-control.nix
+++ b/modules/nixos/programs/claude-remote-control.nix
@@ -1,9 +1,9 @@
-# Claude Code Remote Control bridge의 version-drift 감시 (greenhead-minipc).
+# Claude Code Remote Control bridge의 headless multi-instance ensure.
 #
-# bridge(claude remote-control)는 tmux 안에서 상시 구동되며 시작 시점 바이너리로
-# 고정된다. claude launcher(~/.local/bin/claude)는 자체 업데이터가 최신으로 굴리므로
-# 방치하면 bridge만 구버전에 남는다 (실측: 23개 릴리스 drift). 이 모듈은 30분 timer로
-# claude-rc-maint를 실행해 drift를 감지하고, 활성 원격 세션이 없을 때만 재시작한다.
+# bridge(claude remote-control)는 시작 시점 바이너리로 고정된다.
+# claude launcher(~/.local/bin/claude)는 자체 업데이터가 최신으로 굴리므로
+# 방치하면 bridge만 구버전에 남는다. 이 모듈은 30분 timer로 claude-rc-maint를
+# 실행해 선언 인스턴스를 유지하고, drift된 전체 인스턴스를 안전한 시점에 재시작한다.
 {
   config,
   pkgs,
@@ -21,15 +21,17 @@ let
   pushoverCredPath = config.age.secrets.pushover-system-monitor.path;
   serviceLib = import ../lib/service-lib.nix { inherit pkgs; };
 
-  # HM 배선(modules/shared/programs/shell/nixos.nix)과 같은 인자로 평가되어
-  # 동일 store path를 공유한다.
-  claudeRcPkg = import ../lib/claude-rc-package.nix {
-    inherit pkgs;
-    flakePath = nixosConfigDefaultPath;
-  };
-
   # darwin launchd 모듈과 공유하는 패키징 (runtimeInputs 플랫폼 분기 포함).
   maintenanceCli = import ../lib/claude-rc-maint-package.nix { inherit pkgs; };
+
+  declaredInstances = builtins.toJSON [
+    {
+      path = nixosConfigDefaultPath;
+      spawn = cfg.spawn;
+      capacity = cfg.capacity;
+      permissionMode = cfg.permissionMode;
+    }
+  ];
 in
 {
   config = lib.mkIf cfg.enable {
@@ -67,12 +69,13 @@ in
         TimeoutSec = "300";
         ExecStart = "${maintenanceCli}/bin/claude-rc-maint ensure";
         LoadCredential = [ "pushover-system-monitor:${pushoverCredPath}" ];
-        # oneshot 종료 시 cgroup 정리가 방금 시작한 tmux server/bridge를
+        # oneshot 종료 시 cgroup 정리가 방금 스폰한 headless 서버를
         # 죽이지 않도록 main process만 kill 대상으로 한다.
         KillMode = "process";
 
-        # tmux 소켓(/tmp/tmux-<uid>/)에 접근해야 하므로 PrivateTmp는 쓸 수 없고,
-        # bridge/state가 홈 아래이므로 ProtectHome도 쓸 수 없다.
+        # headless 서버와 상태/로그/worktree가 사용자 홈 아래에서 동작하므로
+        # ProtectHome은 쓸 수 없다. PrivateTmp도 사용자 세션과 다른 /tmp view를
+        # 만들 수 있어 보수적으로 쓰지 않는다.
         ProtectSystem = "full";
         NoNewPrivileges = true;
         ProtectKernelTunables = true;
@@ -84,16 +87,13 @@ in
       environment = {
         HOME = homeDir;
         STATE_DIR = stateDir;
-        CLAUDE_RC_BIN = "${claudeRcPkg}/bin/claude-rc";
+        CLAUDE_RC_DECLARED_INSTANCES = declaredInstances;
         SERVICE_LIB = "${serviceLib}";
         IDLE_THRESHOLD_MINUTES = toString cfg.idleThresholdMinutes;
         ALERT_COOLDOWN_SECONDS = "1800";
-        # 자동 재시작이 운영 옵션을 래퍼 기본값으로 되돌리지 않도록 명시 주입.
-        CLAUDE_RC_PERMISSION_MODE = cfg.permissionMode;
-        CLAUDE_RC_CAPACITY = toString cfg.capacity;
-        CLAUDE_RC_NAME = cfg.name;
+        CLAUDE_RC_ALERT_HOST = config.networking.hostName;
         # writeShellApplication runtimeInputs가 앞에 붙는다. 이 tail은 자체 업데이터가
-        # 관리하는 claude launcher(~/.local/bin/claude)와 claude-rc 내부의 bare
+        # 관리하는 claude launcher(~/.local/bin/claude)와 maint/래퍼 내부의 bare
         # `claude` 호출을 해석하기 위해 필요하다 (codex 모듈 PATH 주석과 동일 패턴).
         PATH = lib.mkForce "${homeDir}/.local/bin:/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin";
       };

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -134,7 +134,14 @@ seed_declared_instances() {
         # temporarily uses different options, the next ensure reconciles the
         # registry back to the declaration and treats the manual change as an
         # experiment.
-        with_instances_lock reconcile_declared_instance_unlocked "$path" "$spawn" "$capacity" "$permission_mode"
+        # cmd_ensure runs this subtree under `|| rc=$?`, which disables set -e,
+        # so a reconcile failure (mktemp/jq) must be propagated explicitly or
+        # the declared instance is silently never registered nor ensured.
+        if ! with_instances_lock reconcile_declared_instance_unlocked "$path" "$spawn" "$capacity" "$permission_mode"; then
+            GLOBAL_ACTION="declared-instances-invalid"
+            log_error "failed to reconcile declared instance: $path"
+            return 1
+        fi
     done < <(jq -c '.[]' <<<"$payload")
 }
 
@@ -150,7 +157,13 @@ record_instance_result() {
 }
 
 desired_claude_version() {
-    basename "$(readlink -f "$CLAUDE_BIN")"
+    local resolved
+    # readlink 실패가 빈 문자열 + exit 0으로 새면 DESIRED_VERSION=""가 되어
+    # 모든 실행 버전이 drift로 보이고 재시작이 반복된다 — 실패를 명시 전파해
+    # ensure_core의 desired-version-unresolvable 경로가 받게 한다.
+    resolved=$(readlink -f "$CLAUDE_BIN") || return 1
+    [ -n "$resolved" ] || return 1
+    basename "$resolved"
 }
 
 normalized_instance_prefix() {

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # claude-rc-maint: Claude Code Remote Control headless multi-instance ensure.
 #
+# This file is packaged by concatenating modules/nixos/scripts/claude-rc-lib.sh
+# before it.
+#
 # NixOS systemd timer and macOS launchd run `claude-rc-maint ensure`
 # periodically. The script seeds declared instances, starts dead servers, and
 # restarts version-drifted servers when that will not tombstone active worktree
@@ -8,9 +11,6 @@
 set -euo pipefail
 
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
-STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
-INSTANCES_FILE="$STATE_DIR/instances.json"
-INSTANCES_LOCK="$STATE_DIR/instances.json.lock"
 IDLE_THRESHOLD_MINUTES="${IDLE_THRESHOLD_MINUTES:-30}"
 MAINT_LOCK_TIMEOUT_SECONDS="${MAINT_LOCK_TIMEOUT_SECONDS:-120}"
 ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
@@ -20,14 +20,7 @@ CLAUDE_RC_DECLARED_INSTANCES="${CLAUDE_RC_DECLARED_INSTANCES:-}"
 CLAUDE_RC_PERMISSION_MODE="${CLAUDE_RC_PERMISSION_MODE:-bypassPermissions}"
 CLAUDE_RC_ALERT_HOST="${CLAUDE_RC_ALERT_HOST:-$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-rc)}"
 
-LOG_MAX_BYTES=$((5 * 1024 * 1024))
 PROJECTS_DIR="$HOME/.claude/projects"
-BRIDGE_PROCESS_PATTERN='claude remote-control'
-# Spawned session argv may be the versioned Claude binary path, so --sdk-url is
-# the stable selector. The leading [-] avoids pgrep treating the pattern as an
-# option.
-BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
-TSV_NULL='__CLAUDE_RC_NULL__'
 
 DESIRED_VERSION=""
 GLOBAL_ACTION="none"
@@ -35,12 +28,6 @@ RESULTS_FILE=""
 
 log_info() { echo "[claude-rc-maint] $*"; }
 log_error() { echo "[claude-rc-maint] ERROR: $*" >&2; }
-
-iso_timestamp() {
-    local ts
-    ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
-    printf '%s:%s\n' "${ts%??}" "${ts: -2}"
-}
 
 #───────────────────────────────────────────────────────────────────────────────
 # flock 직렬화 (수동 실행과 timer의 동시 실행 방지)
@@ -64,99 +51,7 @@ with_lock() {
     "$@" 9>&-
 }
 
-with_instances_lock() {
-    mkdir -p "$STATE_DIR"
-    (
-        flock 8
-        "$@"
-    ) 8>"$INSTANCES_LOCK"
-}
-
-sha256_hex() {
-    local value="$1"
-    if command -v shasum >/dev/null 2>&1; then
-        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
-        return
-    fi
-    if command -v sha256sum >/dev/null 2>&1; then
-        printf '%s' "$value" | sha256sum | awk '{print $1}'
-        return
-    fi
-    log_error "required command not found in PATH: shasum or sha256sum"
-    return 1
-}
-
-canonical_existing_path() {
-    local path="$1"
-    (cd "$path" 2>/dev/null && pwd -P)
-}
-
-slug_for_path() {
-    local path="$1" base digest
-    base=$(basename "$path")
-    digest=$(sha256_hex "$path")
-    printf '%s-%s\n' "$base" "${digest:0:8}"
-}
-
-instance_dir_for_path() {
-    local path="$1" slug
-    slug=$(slug_for_path "$path")
-    printf '%s/%s\n' "$STATE_DIR" "$slug"
-}
-
-lock_path_for_path() {
-    local path="$1"
-    printf '%s/lock\n' "$(instance_dir_for_path "$path")"
-}
-
-log_path_for_path() {
-    local path="$1"
-    printf '%s/server.log\n' "$(instance_dir_for_path "$path")"
-}
-
-ensure_instance_dir() {
-    local path="$1"
-    mkdir -p "$(instance_dir_for_path "$path")"
-}
-
-lock_is_free() {
-    local lock_path="$1"
-    flock -n "$lock_path" true
-}
-
-rotate_log_if_needed() {
-    local log_path="$1" size
-    if [ ! -f "$log_path" ]; then
-        return 0
-    fi
-    size=$(wc -c <"$log_path" | tr -d '[:space:]')
-    if [ "${size:-0}" -gt "$LOG_MAX_BYTES" ]; then
-        mv -f "$log_path" "$log_path.1"
-    fi
-}
-
-init_instances_file() {
-    mkdir -p "$STATE_DIR"
-    if [ ! -f "$INSTANCES_FILE" ]; then
-        printf '{"version":1,"instances":{}}\n' >"$INSTANCES_FILE"
-    fi
-}
-
-validate_permission_mode() {
-    case "$1" in
-        acceptEdits|bypassPermissions|default|dontAsk|plan) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-validate_spawn() {
-    case "$1" in
-        worktree|same-dir) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-upsert_declared_if_absent_unlocked() {
+reconcile_declared_instance_unlocked() {
     local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
     local tmp capacity_json registered_at
     capacity_json="null"
@@ -173,7 +68,18 @@ upsert_declared_if_absent_unlocked() {
         --arg registeredAt "$registered_at" \
         --argjson capacity "$capacity_json" \
         'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
-         | if (.instances | has($path)) then .
+         | if (.instances | has($path)) then
+             if (.instances[$path].source // "manual") == "declared" then
+               .instances[$path] = (.instances[$path] + {
+                 spawn: $spawn,
+                 capacity: $capacity,
+                 permissionMode: $permissionMode,
+                 registeredAt: (.instances[$path].registeredAt // $registeredAt),
+                 source: "declared"
+               })
+             else
+               .
+             end
            else .instances[$path] = {
              spawn: $spawn,
              capacity: $capacity,
@@ -228,24 +134,10 @@ seed_declared_instances() {
             log_error "invalid declared permissionMode for $path: $permission_mode"
             return 1
         fi
-        with_instances_lock upsert_declared_if_absent_unlocked "$path" "$spawn" "$capacity" "$permission_mode"
+        # Manual registrations are user intent and win over declarations with
+        # the same path. Declared entries are reconciled to the current Nix env.
+        with_instances_lock reconcile_declared_instance_unlocked "$path" "$spawn" "$capacity" "$permission_mode"
     done < <(jq -c '.[]' <<<"$payload")
-}
-
-emit_instances_tsv_unlocked() {
-    init_instances_file
-    jq -r --arg tsv_null "$TSV_NULL" '
-        if (.version == 1 and (.instances | type) == "object") then .instances else {} end
-        | to_entries[]
-        | [
-            .key,
-            (.value.spawn // "worktree"),
-            (if (.value.capacity // null) == null then $tsv_null else (.value.capacity | tostring) end),
-            (.value.permissionMode // "bypassPermissions"),
-            (.value.source // "unknown")
-          ]
-        | @tsv
-    ' "$INSTANCES_FILE"
 }
 
 record_instance_result() {
@@ -259,84 +151,8 @@ record_instance_result() {
         >>"$RESULTS_FILE"
 }
 
-# 플랫폼별 실행 바이너리 경로 조회.
-# - Linux: /proc/PID/exe. 삭제된 바이너리는 " (deleted)" suffix가 붙는다.
-# - Darwin: /proc이 없어 lsof의 첫 txt(code segment) 항목을 쓴다. 실행 파일이
-#   항상 첫 txt로 나열되고(-F 필드 출력은 경로 공백 안전; 실측), ps -o comm=은
-#   argv[0] 기반이라 symlink 경유 실행 시 실경로를 잃는다.
-#   삭제된 바이너리도 suffix 없이 원경로가 그대로 나오지만, 버전이 파일명이라
-#   desired와의 문자열 비교로 drift가 감지되므로 (deleted) 표식 없이도 충분하다.
-pid_exe_path() {
-    local pid="$1"
-    case "$(uname -s)" in
-        Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
-        *) readlink "/proc/$pid/exe" 2>/dev/null ;;
-    esac
-}
-
-# pid_exe_path 기준 실행 중 버전. 바이너리가 삭제된 구버전이면 "deleted"를 붙여
-# 호출측이 drift로 취급하게 한다 (Linux 전용 신호 — Darwin 주석은 pid_exe_path 참조).
-pid_exe_version() {
-    local pid="$1" exe
-    exe=$(pid_exe_path "$pid") || return 1
-    [ -n "$exe" ] || return 1
-    case "$exe" in
-        *" (deleted)") echo "$(basename "${exe% (deleted)}") (deleted)" ;;
-        *) basename "$exe" ;;
-    esac
-}
-
 desired_claude_version() {
     basename "$(readlink -f "$CLAUDE_BIN")"
-}
-
-pid_cwd() {
-    local pid="$1"
-    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}'
-}
-
-same_cwd_as_path() {
-    local pid="$1" path="$2" cwd target
-    cwd=$(pid_cwd "$pid") || return 1
-    [ -n "$cwd" ] || return 1
-    target=$(canonical_existing_path "$path") || return 1
-    [ "$cwd" = "$target" ]
-}
-
-is_flock_process() {
-    local pid="$1" exe base
-    exe=$(pid_exe_path "$pid") || return 1
-    [ -n "$exe" ] || return 1
-    base=$(basename "${exe% (deleted)}")
-    [ "$base" = "flock" ]
-}
-
-find_server_pid_for_path() {
-    local path="$1" pid
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        same_cwd_as_path "$pid" "$path" || continue
-        if is_flock_process "$pid"; then
-            continue
-        fi
-        echo "$pid"
-        return 0
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
-    return 1
-}
-
-count_worktree_session_procs() {
-    local instance_path="$1" wt_root pid cwd count=0
-    wt_root="$instance_path/.claude/worktrees/"
-    # pgrep -c is not portable to macOS BSD pgrep, so count PID lines manually.
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        cwd=$(pid_cwd "$pid") || continue
-        case "$cwd" in
-            "$wt_root"*) count=$((count + 1)) ;;
-        esac
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
-    echo "$count"
 }
 
 normalized_instance_prefix() {
@@ -393,53 +209,6 @@ restart_gate() {
     return 2
 }
 
-start_server() {
-    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
-    local instance_dir lock_path log_path
-    instance_dir=$(instance_dir_for_path "$path")
-    lock_path="$instance_dir/lock"
-    log_path="$instance_dir/server.log"
-    mkdir -p "$instance_dir"
-    rotate_log_if_needed "$log_path"
-
-    # macOS does not ship setsid. The outer background subshell exits after
-    # spawning the inner one, so the server is re-parented and survives terminal,
-    # systemd oneshot (KillMode=process), and launchd agent exit. stdin/logs are
-    # detached, and SIGHUP is ignored before exec for terminal-close survival.
-    (
-        cd "$path" || exit 1
-        (
-            trap '' HUP
-            exec </dev/null >>"$log_path" 2>&1
-            if [ -n "$capacity" ]; then
-                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-                    flock -n "$lock_path" claude remote-control \
-                    --spawn "$spawn" \
-                    --permission-mode "$permission_mode" \
-                    --capacity "$capacity" \
-                    --no-create-session-in-dir
-            else
-                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-                    flock -n "$lock_path" claude remote-control \
-                    --spawn "$spawn" \
-                    --permission-mode "$permission_mode" \
-                    --no-create-session-in-dir
-            fi
-        ) &
-    ) &
-}
-
-wait_until_server_stops() {
-    local pid="$1"
-    for _ in 1 2 3 4 5 6 7 8 9 10; do
-        if ! kill -0 "$pid" 2>/dev/null; then
-            return 0
-        fi
-        sleep 1
-    done
-    return 1
-}
-
 restart_server() {
     local path="$1" spawn="$2" capacity="$3" permission_mode="$4" pid lock_path
     lock_path=$(lock_path_for_path "$path")
@@ -452,6 +221,9 @@ restart_server() {
 
     if ! lock_is_free "$lock_path"; then
         return 1
+    fi
+    if has_unmanaged_server_for_path "$path"; then
+        return 2
     fi
     start_server "$path" "$spawn" "$capacity" "$permission_mode"
     sleep 2
@@ -468,9 +240,8 @@ capture_started_version() {
 }
 
 process_instance() {
-    local path="$1" spawn="$2" capacity="$3" permission_mode="$4" source="$5"
-    local lock_path pid running_version action gate_rc started_version
-    : "$source"
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local lock_path pid running_version action gate_rc started_version restart_rc
 
     if [ ! -d "$path" ]; then
         action="path-missing"
@@ -498,6 +269,15 @@ process_instance() {
     ensure_instance_dir "$path"
     lock_path=$(lock_path_for_path "$path")
     if lock_is_free "$lock_path"; then
+        # A wrapper-bypassed plain CLI server in the same cwd does not hold our
+        # lock. Starting another server here permanently creates an undeletable
+        # ghost environment, so ensure must share the wrapper's cwd guard.
+        if has_unmanaged_server_for_path "$path"; then
+            action="unmanaged-server-present"
+            record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+            log_error "unmanaged same-cwd server present: $path"
+            return 1
+        fi
         start_server "$path" "$spawn" "$capacity" "$permission_mode"
         sleep 2
         if lock_is_free "$lock_path"; then
@@ -536,11 +316,19 @@ process_instance() {
         same-dir)
             # Live measurement confirmed same-dir spawned sessions reconnect to
             # the restarted server, so version drift can be corrected eagerly.
-            if restart_server "$path" "$spawn" "$capacity" "$permission_mode"; then
+            restart_rc=0
+            restart_server "$path" "$spawn" "$capacity" "$permission_mode" || restart_rc=$?
+            if [ "$restart_rc" -eq 0 ]; then
                 action="restarted-version-drift"
                 log_info "restarted same-dir drift: $path (${running_version} -> ${DESIRED_VERSION})"
                 record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
                 return 0
+            fi
+            if [ "$restart_rc" -eq 2 ]; then
+                action="unmanaged-server-present"
+                record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                log_error "unmanaged same-cwd server present after stop: $path"
+                return 1
             fi
             action="restart-failed"
             record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
@@ -551,11 +339,19 @@ process_instance() {
             restart_gate "$path" || gate_rc=$?
             case "$gate_rc" in
                 0)
-                    if restart_server "$path" "$spawn" "$capacity" "$permission_mode"; then
+                    restart_rc=0
+                    restart_server "$path" "$spawn" "$capacity" "$permission_mode" || restart_rc=$?
+                    if [ "$restart_rc" -eq 0 ]; then
                         action="restarted-version-drift"
                         log_info "restarted worktree drift: $path (${running_version} -> ${DESIRED_VERSION})"
                         record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
                         return 0
+                    fi
+                    if [ "$restart_rc" -eq 2 ]; then
+                        action="unmanaged-server-present"
+                        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                        log_error "unmanaged same-cwd server present after stop: $path"
+                        return 1
                     fi
                     action="restart-failed"
                     record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
@@ -589,7 +385,7 @@ process_instance() {
 }
 
 ensure_core() {
-    local entries rc path spawn capacity permission_mode source
+    local entries rc path spawn capacity permission_mode
     GLOBAL_ACTION="running"
 
     seed_declared_instances || return 1
@@ -610,10 +406,10 @@ ensure_core() {
     fi
 
     rc=0
-    while IFS=$'\t' read -r path spawn capacity permission_mode source; do
+    while IFS=$'\t' read -r path spawn capacity permission_mode; do
         [ -n "$path" ] || continue
         [ "$capacity" = "$TSV_NULL" ] && capacity=""
-        process_instance "$path" "$spawn" "$capacity" "$permission_mode" "$source" || rc=1
+        process_instance "$path" "$spawn" "$capacity" "$permission_mode" || rc=1
     done <<<"$entries"
 
     if [ "$rc" -eq 0 ]; then
@@ -668,7 +464,7 @@ failed_instance_summary() {
               | ["start-failed", "restart-failed", "no-server-process",
                  "running-version-unresolvable", "invalid-spawn",
                  "invalid-capacity", "invalid-permission-mode",
-                 "restart-gate-failed"] | index($action))
+                 "restart-gate-failed", "unmanaged-server-present"] | index($action))
           | "\(.path): \(.action)"
         ]
         | if length == 0 then "" else join("; ") end

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -256,16 +256,9 @@ capture_started_version() {
     fi
 }
 
-process_instance() {
+validate_instance_config() {
     local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
-    local lock_path pid running_version action gate_rc started_version restart_rc
-
-    if [ ! -d "$path" ]; then
-        action="path-missing"
-        log_info "path missing: $path"
-        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
-        return 0
-    fi
+    local action
 
     if ! validate_spawn "$spawn"; then
         action="invalid-spawn"
@@ -282,34 +275,38 @@ process_instance() {
         record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
         return 1
     fi
+}
 
-    ensure_instance_dir "$path"
+start_missing_instance() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local action lock_path started_version
     lock_path=$(lock_path_for_path "$path")
-    if lock_is_free "$lock_path"; then
-        # A wrapper-bypassed plain CLI server in the same cwd does not hold our
-        # lock. Starting another server here permanently creates an undeletable
-        # ghost environment, so ensure must share the wrapper's cwd guard.
-        if has_unmanaged_server_for_path "$path"; then
-            action="unmanaged-server-present"
-            record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
-            log_error "unmanaged same-cwd server present: $path"
-            return 1
-        fi
-        start_server "$path" "$spawn" "$capacity" "$permission_mode"
-        sleep 2
-        if lock_is_free "$lock_path"; then
-            action="start-failed"
-            record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
-            log_error "start failed: $path"
-            return 1
-        fi
-        started_version=$(capture_started_version "$path")
-        action="started"
-        record_instance_result "$path" "$started_version" "$DESIRED_VERSION" "$action"
-        log_info "started: $path"
-        return 0
+    # A wrapper-bypassed plain CLI server in the same cwd does not hold our
+    # lock. Starting another server here permanently creates an undeletable
+    # ghost environment, so ensure must share the wrapper's cwd guard.
+    if has_unmanaged_server_for_path "$path"; then
+        action="unmanaged-server-present"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        log_error "unmanaged same-cwd server present: $path"
+        return 1
     fi
+    start_server "$path" "$spawn" "$capacity" "$permission_mode"
+    sleep 2
+    if lock_is_free "$lock_path"; then
+        action="start-failed"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        log_error "start failed: $path"
+        return 1
+    fi
+    started_version=$(capture_started_version "$path")
+    action="started"
+    record_instance_result "$path" "$started_version" "$DESIRED_VERSION" "$action"
+    log_info "started: $path"
+}
 
+handle_running_instance() {
+    local path="$1" desired_spawn="$2" capacity="$3" permission_mode="$4"
+    local pid running_version action
     if ! pid=$(find_server_pid_for_path "$path"); then
         action="no-server-process"
         record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
@@ -329,12 +326,27 @@ process_instance() {
         return 0
     fi
 
-    case "$spawn" in
+    handle_drift "$path" "$desired_spawn" "$capacity" "$permission_mode" "$pid" "$running_version"
+}
+
+handle_drift() {
+    local path="$1" desired_spawn="$2" capacity="$3" permission_mode="$4" pid="$5" running_version="$6"
+    local effective_spawn gate_rc restart_rc action
+    # Registry spawn is desired state and may differ from the already-running
+    # server after declaration changes or temporary manual override starts.
+    # Restart safety depends on the effective mode of the running process. If
+    # argv parsing fails, apply the conservative worktree gate.
+    if ! effective_spawn=$(pid_spawn_mode "$pid"); then
+        effective_spawn="worktree"
+        log_info "running spawn unknown; applying worktree drift gate: $path"
+    fi
+
+    case "$effective_spawn" in
         same-dir)
             # Live measurement confirmed same-dir spawned sessions reconnect to
             # the restarted server, so version drift can be corrected eagerly.
             restart_rc=0
-            restart_server "$path" "$spawn" "$capacity" "$permission_mode" || restart_rc=$?
+            restart_server "$path" "$desired_spawn" "$capacity" "$permission_mode" || restart_rc=$?
             handle_restart_result "$path" "same-dir" "$running_version" "$restart_rc"
             ;;
         worktree)
@@ -343,7 +355,7 @@ process_instance() {
             case "$gate_rc" in
                 0)
                     restart_rc=0
-                    restart_server "$path" "$spawn" "$capacity" "$permission_mode" || restart_rc=$?
+                    restart_server "$path" "$desired_spawn" "$capacity" "$permission_mode" || restart_rc=$?
                     handle_restart_result "$path" "worktree" "$running_version" "$restart_rc"
                     ;;
                 1)
@@ -371,6 +383,28 @@ process_instance() {
             return 1
             ;;
     esac
+}
+
+process_instance() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local lock_path action
+
+    if [ ! -d "$path" ]; then
+        action="path-missing"
+        log_info "path missing: $path"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        return 0
+    fi
+
+    validate_instance_config "$path" "$spawn" "$capacity" "$permission_mode" || return 1
+
+    ensure_instance_dir "$path"
+    lock_path=$(lock_path_for_path "$path")
+    if lock_is_free "$lock_path"; then
+        start_missing_instance "$path" "$spawn" "$capacity" "$permission_mode"
+    else
+        handle_running_instance "$path" "$spawn" "$capacity" "$permission_mode"
+    fi
 }
 
 ensure_core() {

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -1,95 +1,269 @@
 #!/usr/bin/env bash
-# claude-rc-maint: Claude Code Remote Control bridge의 version-drift 감시 엔진.
+# claude-rc-maint: Claude Code Remote Control headless multi-instance ensure.
 #
-# 사용자 래퍼(claude-rc)와 책임을 분리한 maintenance 전용 스크립트로,
-# NixOS는 systemd timer(claude-rc-ensure), macOS는 launchd agent가 주기 실행한다.
-# codex-remote-control-maint.sh 골격 차용.
-#
-# 동작: 실행 중 bridge 바이너리(pid_exe_path — Linux /proc, macOS lsof)와 claude
-# launcher가 가리키는 최신 버전을 비교해 drift가 있으면 — 활성 원격 세션이 없을
-# 때만 — bridge를 재시작한다.
-# bridge 재시작은 활성 세션을 tombstone시키므로 idle 게이트가 핵심 안전장치다.
+# NixOS systemd timer and macOS launchd run `claude-rc-maint ensure`
+# periodically. The script seeds declared instances, starts dead servers, and
+# restarts version-drifted servers when that will not tombstone active worktree
+# sessions.
 set -euo pipefail
 
-#───────────────────────────────────────────────────────────────────────────────
-# env 파라미터 (systemd unit이 주입, 수동 실행 시 기본값)
-#───────────────────────────────────────────────────────────────────────────────
-CLAUDE_RC_BIN="${CLAUDE_RC_BIN:-$HOME/.local/bin/claude-rc}"
 CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
 STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
-TMUX_SESSION="${TMUX_SESSION:-claude-rc}"
+INSTANCES_FILE="$STATE_DIR/instances.json"
+INSTANCES_LOCK="$STATE_DIR/instances.json.lock"
 IDLE_THRESHOLD_MINUTES="${IDLE_THRESHOLD_MINUTES:-30}"
 MAINT_LOCK_TIMEOUT_SECONDS="${MAINT_LOCK_TIMEOUT_SECONDS:-120}"
 ALERT_COOLDOWN_SECONDS="${ALERT_COOLDOWN_SECONDS:-1800}"
 PUSHOVER_CRED_FILE="${PUSHOVER_CRED_FILE:-}"
 SERVICE_LIB="${SERVICE_LIB:-}"
-# bridge 시작 옵션 — 배선 모듈(NixOS homeserver.claudeRemoteControl.* / darwin
-# claude-remote-control.nix)이 주입한다. maint가 명시 전달하지 않으면 자동 재시작 시
-# 래퍼 기본값으로 조용히 되돌아가므로 (예: capacity 10 → 5) 반드시 전량 전달한다.
+CLAUDE_RC_DECLARED_INSTANCES="${CLAUDE_RC_DECLARED_INSTANCES:-}"
 CLAUDE_RC_PERMISSION_MODE="${CLAUDE_RC_PERMISSION_MODE:-bypassPermissions}"
-CLAUDE_RC_CAPACITY="${CLAUDE_RC_CAPACITY:-5}"
-CLAUDE_RC_NAME="${CLAUDE_RC_NAME:-minipc}"
-# 알림 메시지의 머신 식별자 (recovered 알림 본문에 사용)
-CLAUDE_RC_ALERT_HOST="${CLAUDE_RC_ALERT_HOST:-greenhead-minipc}"
+CLAUDE_RC_ALERT_HOST="${CLAUDE_RC_ALERT_HOST:-$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-rc)}"
 
-#───────────────────────────────────────────────────────────────────────────────
-# upstream 의존 selector — Claude Code CLI/spawn process shape 또는 transcript
-# 프로젝트 디렉토리 명명 규칙이 바뀌면 아래 3개를 함께 갱신한다.
-#───────────────────────────────────────────────────────────────────────────────
-BRIDGE_PROCESS_PATTERN='claude remote-control'
-# 스폰 세션의 argv[0]은 versions 디렉토리 절대경로라 "claude "가 나타나지 않는다
-# (실측: /home/.../claude/versions/2.1.169 --print --sdk-url ...). --sdk-url 자체로
-# 식별하되, ERE [-]로 시작해 pgrep이 패턴을 옵션으로 오해하지 않게 한다.
-BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
-# transcript 프로젝트 디렉토리 glob. 경로의 비영숫자([._/])는 하이픈으로
-# 정규화되어 저장되므로 underscore 변형은 나타나지 않는다 (실측 확인).
-BRIDGE_TRANSCRIPT_GLOBS=('*bridge-cse-*' '*bridge-session-*')
-
-VERSIONS_DIR="$HOME/.local/share/claude/versions"
+LOG_MAX_BYTES=$((5 * 1024 * 1024))
 PROJECTS_DIR="$HOME/.claude/projects"
+BRIDGE_PROCESS_PATTERN='claude remote-control'
+# Spawned session argv may be the versioned Claude binary path, so --sdk-url is
+# the stable selector. The leading [-] avoids pgrep treating the pattern as an
+# option.
+BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
+TSV_NULL='__CLAUDE_RC_NULL__'
 
-ACTION="none"
-RUNNING_VERSION=""
 DESIRED_VERSION=""
-RECENT_TRANSCRIPT_COUNT=0
+GLOBAL_ACTION="none"
+RESULTS_FILE=""
 
-log_info()  { echo "[claude-rc-maint] $*"; }
+log_info() { echo "[claude-rc-maint] $*"; }
 log_error() { echo "[claude-rc-maint] ERROR: $*" >&2; }
+
+iso_timestamp() {
+    local ts
+    ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
+    printf '%s:%s\n' "${ts%??}" "${ts: -2}"
+}
 
 #───────────────────────────────────────────────────────────────────────────────
 # flock 직렬화 (수동 실행과 timer의 동시 실행 방지)
 #───────────────────────────────────────────────────────────────────────────────
 with_lock() {
     mkdir -p "$STATE_DIR"
+    if ! command -v flock >/dev/null 2>&1; then
+        GLOBAL_ACTION="flock-missing"
+        log_error "required command not found in PATH: flock"
+        return 1
+    fi
     exec 9>"$STATE_DIR/ensure.lock"
     if ! flock --timeout "$MAINT_LOCK_TIMEOUT_SECONDS" 9; then
-        ACTION="lock-acquire-timeout"
+        GLOBAL_ACTION="lock-acquire-timeout"
         return 1
     fi
     # fd 9는 이 셸이 락을 유지하는 동안만 살아야 한다. 9>&- 없이 실행하면
-    # detach되는 tmux server/bridge가 fd 9를 상속해 락을 영구 점유하고
+    # detach되는 headless bridge가 fd 9를 상속해 락을 영구 점유하고
     # 이후 모든 타이머 실행이 lock-acquire-timeout으로 실패한다
     # (codex-remote-control-maint.sh의 PR #983과 동일 근거).
     "$@" 9>&-
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# bridge 세션/프로세스 판정
-#───────────────────────────────────────────────────────────────────────────────
-bridge_session_alive() {
-    tmux has-session -t "$TMUX_SESSION" 2>/dev/null || return 1
-    # 조회 실패(변수 없음 포함) = stale — 래퍼 is_session_stale과 동일 판정.
-    # systemd oneshot은 tmux 클라이언트 밖에서 실행되므로 -t 타깃 명시가 필수다.
-    local rc_active
-    rc_active=$(tmux show-environment -t "$TMUX_SESSION" CLAUDE_RC_ACTIVE 2>/dev/null) || return 1
-    [ "$rc_active" = "CLAUDE_RC_ACTIVE=1" ]
+with_instances_lock() {
+    mkdir -p "$STATE_DIR"
+    (
+        flock 8
+        "$@"
+    ) 8>"$INSTANCES_LOCK"
+}
+
+sha256_hex() {
+    local value="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
+        return
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$value" | sha256sum | awk '{print $1}'
+        return
+    fi
+    log_error "required command not found in PATH: shasum or sha256sum"
+    return 1
+}
+
+canonical_existing_path() {
+    local path="$1"
+    (cd "$path" 2>/dev/null && pwd -P)
+}
+
+slug_for_path() {
+    local path="$1" base digest
+    base=$(basename "$path")
+    digest=$(sha256_hex "$path")
+    printf '%s-%s\n' "$base" "${digest:0:8}"
+}
+
+instance_dir_for_path() {
+    local path="$1" slug
+    slug=$(slug_for_path "$path")
+    printf '%s/%s\n' "$STATE_DIR" "$slug"
+}
+
+lock_path_for_path() {
+    local path="$1"
+    printf '%s/lock\n' "$(instance_dir_for_path "$path")"
+}
+
+log_path_for_path() {
+    local path="$1"
+    printf '%s/server.log\n' "$(instance_dir_for_path "$path")"
+}
+
+ensure_instance_dir() {
+    local path="$1"
+    mkdir -p "$(instance_dir_for_path "$path")"
+}
+
+lock_is_free() {
+    local lock_path="$1"
+    flock -n "$lock_path" true
+}
+
+rotate_log_if_needed() {
+    local log_path="$1" size
+    if [ ! -f "$log_path" ]; then
+        return 0
+    fi
+    size=$(wc -c <"$log_path" | tr -d '[:space:]')
+    if [ "${size:-0}" -gt "$LOG_MAX_BYTES" ]; then
+        mv -f "$log_path" "$log_path.1"
+    fi
+}
+
+init_instances_file() {
+    mkdir -p "$STATE_DIR"
+    if [ ! -f "$INSTANCES_FILE" ]; then
+        printf '{"version":1,"instances":{}}\n' >"$INSTANCES_FILE"
+    fi
+}
+
+validate_permission_mode() {
+    case "$1" in
+        acceptEdits|bypassPermissions|default|dontAsk|plan) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_spawn() {
+    case "$1" in
+        worktree|same-dir) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+upsert_declared_if_absent_unlocked() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local tmp capacity_json registered_at
+    capacity_json="null"
+    if [ -n "$capacity" ]; then
+        capacity_json="$capacity"
+    fi
+    registered_at=$(iso_timestamp)
+    init_instances_file
+    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
+    jq \
+        --arg path "$path" \
+        --arg spawn "$spawn" \
+        --arg permissionMode "$permission_mode" \
+        --arg registeredAt "$registered_at" \
+        --argjson capacity "$capacity_json" \
+        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
+         | if (.instances | has($path)) then .
+           else .instances[$path] = {
+             spawn: $spawn,
+             capacity: $capacity,
+             permissionMode: $permissionMode,
+             registeredAt: $registeredAt,
+             source: "declared"
+           }
+           end' \
+        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$INSTANCES_FILE"
+}
+
+seed_declared_instances() {
+    local payload item path spawn capacity permission_mode
+    payload="$CLAUDE_RC_DECLARED_INSTANCES"
+    if [ -z "${payload//[[:space:]]/}" ]; then
+        return 0
+    fi
+    if ! jq -e 'type == "array"' >/dev/null 2>&1 <<<"$payload"; then
+        GLOBAL_ACTION="declared-instances-invalid"
+        log_error "CLAUDE_RC_DECLARED_INSTANCES must be a JSON array"
+        return 1
+    fi
+
+    while IFS= read -r item; do
+        [ -n "$item" ] || continue
+        path=$(jq -r '.path // empty' <<<"$item")
+        spawn=$(jq -r '.spawn // "worktree"' <<<"$item")
+        capacity=$(jq -r 'if (.capacity // null) == null then "" else (.capacity | tostring) end' <<<"$item")
+        permission_mode=$(jq -r --arg fallback "$CLAUDE_RC_PERMISSION_MODE" '.permissionMode // $fallback' <<<"$item")
+
+        if [ -z "$path" ] || [[ "$path" != /* ]]; then
+            GLOBAL_ACTION="declared-instances-invalid"
+            log_error "declared instance path must be absolute: ${path:-<empty>}"
+            return 1
+        fi
+        if [ -d "$path" ]; then
+            path=$(canonical_existing_path "$path")
+        fi
+        if ! validate_spawn "$spawn"; then
+            GLOBAL_ACTION="declared-instances-invalid"
+            log_error "invalid declared spawn for $path: $spawn"
+            return 1
+        fi
+        if [ -n "$capacity" ] && ! [[ "$capacity" =~ ^[0-9]+$ ]]; then
+            GLOBAL_ACTION="declared-instances-invalid"
+            log_error "invalid declared capacity for $path: $capacity"
+            return 1
+        fi
+        if ! validate_permission_mode "$permission_mode"; then
+            GLOBAL_ACTION="declared-instances-invalid"
+            log_error "invalid declared permissionMode for $path: $permission_mode"
+            return 1
+        fi
+        with_instances_lock upsert_declared_if_absent_unlocked "$path" "$spawn" "$capacity" "$permission_mode"
+    done < <(jq -c '.[]' <<<"$payload")
+}
+
+emit_instances_tsv_unlocked() {
+    init_instances_file
+    jq -r --arg tsv_null "$TSV_NULL" '
+        if (.version == 1 and (.instances | type) == "object") then .instances else {} end
+        | to_entries[]
+        | [
+            .key,
+            (.value.spawn // "worktree"),
+            (if (.value.capacity // null) == null then $tsv_null else (.value.capacity | tostring) end),
+            (.value.permissionMode // "bypassPermissions"),
+            (.value.source // "unknown")
+          ]
+        | @tsv
+    ' "$INSTANCES_FILE"
+}
+
+record_instance_result() {
+    local path="$1" running_version="$2" desired_version="$3" action="$4"
+    jq -n -c \
+        --arg path "$path" \
+        --arg runningVersion "$running_version" \
+        --arg desiredVersion "$desired_version" \
+        --arg action "$action" \
+        '{path: $path, runningVersion: $runningVersion, desiredVersion: $desiredVersion, action: $action}' \
+        >>"$RESULTS_FILE"
 }
 
 # 플랫폼별 실행 바이너리 경로 조회.
 # - Linux: /proc/PID/exe. 삭제된 바이너리는 " (deleted)" suffix가 붙는다.
 # - Darwin: /proc이 없어 lsof의 첫 txt(code segment) 항목을 쓴다. 실행 파일이
-#   항상 첫 txt로 나열되고(-F 필드 출력은 경로 공백 안전; 실측 work-MacBookPro),
-#   ps -o comm=은 argv[0] 기반이라 symlink 경유 실행 시 실경로를 잃는다.
+#   항상 첫 txt로 나열되고(-F 필드 출력은 경로 공백 안전; 실측), ps -o comm=은
+#   argv[0] 기반이라 symlink 경유 실행 시 실경로를 잃는다.
 #   삭제된 바이너리도 suffix 없이 원경로가 그대로 나오지만, 버전이 파일명이라
 #   desired와의 문자열 비교로 drift가 감지되므로 (deleted) 표식 없이도 충분하다.
 pid_exe_path() {
@@ -98,20 +272,6 @@ pid_exe_path() {
         Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
         *) readlink "/proc/$pid/exe" 2>/dev/null ;;
     esac
-}
-
-# 첫 번째 유효 bridge PID를 출력. 유효 = exe가 claude versions 디렉토리 아래.
-find_bridge_pid() {
-    local pid exe
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        exe=$(pid_exe_path "$pid") || continue
-        [ -n "$exe" ] || continue
-        case "${exe% (deleted)}" in
-            "$VERSIONS_DIR"/*) echo "$pid"; return 0 ;;
-        esac
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
-    return 1
 }
 
 # pid_exe_path 기준 실행 중 버전. 바이너리가 삭제된 구버전이면 "deleted"를 붙여
@@ -130,117 +290,362 @@ desired_claude_version() {
     basename "$(readlink -f "$CLAUDE_BIN")"
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# 활성 세션 판정 (restart 게이트)
-#───────────────────────────────────────────────────────────────────────────────
-# 허용 glob에 매치되는 transcript 프로젝트 디렉토리 수 (명명 규칙 유효성 신호)
-count_matching_transcript_dirs() {
-    local total=0 glob
-    [ -d "$PROJECTS_DIR" ] || { echo 0; return; }
-    for glob in "${BRIDGE_TRANSCRIPT_GLOBS[@]}"; do
-        total=$((total + $(find "$PROJECTS_DIR" -maxdepth 1 -type d -name "$glob" 2>/dev/null | wc -l)))
-    done
-    echo "$total"
+pid_cwd() {
+    local pid="$1"
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}'
 }
 
-# 최근 활동한 bridge transcript 파일 수. transcript file은 세션의 proxy이며
-# 측정 단위(파일)를 이름에 그대로 노출한다.
-count_recent_bridge_transcripts() {
-    local total=0 glob dir
-    [ -d "$PROJECTS_DIR" ] || { echo 0; return; }
-    for glob in "${BRIDGE_TRANSCRIPT_GLOBS[@]}"; do
-        while IFS= read -r dir; do
-            [ -n "$dir" ] || continue
-            total=$((total + $(find "$dir" -maxdepth 1 -name '*.jsonl' -mmin "-$IDLE_THRESHOLD_MINUTES" 2>/dev/null | wc -l)))
-        done < <(find "$PROJECTS_DIR" -maxdepth 1 -type d -name "$glob" 2>/dev/null)
-    done
-    echo "$total"
+same_cwd_as_path() {
+    local pid="$1" path="$2" cwd target
+    cwd=$(pid_cwd "$pid") || return 1
+    [ -n "$cwd" ] || return 1
+    target=$(canonical_existing_path "$path") || return 1
+    [ "$cwd" = "$target" ]
 }
 
-# bridge가 스폰한 세션 프로세스 수 (transcript 명명에 비의존인 2차 신호).
-# pgrep -c는 GNU procps 전용이라 macOS BSD pgrep에서 usage 에러(rc=2)가 난다
-# (실측) — PID 출력을 wc -l로 세는 플랫폼 중립 방식을 쓴다. 매치 0이면
-# pgrep rc=1 → pipefail로 대입이 실패하므로 실패 시 대입으로 0 처리한다.
-count_bridge_session_procs() {
-    local count
-    count=$(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null | wc -l) || count=0
+is_flock_process() {
+    local pid="$1" exe base
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
+    base=$(basename "${exe% (deleted)}")
+    [ "$base" = "flock" ]
+}
+
+find_server_pid_for_path() {
+    local path="$1" pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        same_cwd_as_path "$pid" "$path" || continue
+        if is_flock_process "$pid"; then
+            continue
+        fi
+        echo "$pid"
+        return 0
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
+    return 1
+}
+
+count_worktree_session_procs() {
+    local instance_path="$1" wt_root pid cwd count=0
+    wt_root="$instance_path/.claude/worktrees/"
+    # pgrep -c is not portable to macOS BSD pgrep, so count PID lines manually.
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        cwd=$(pid_cwd "$pid") || continue
+        case "$cwd" in
+            "$wt_root"*) count=$((count + 1)) ;;
+        esac
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
     echo "$count"
 }
 
-# 재시작이 안전한지 판정. 반환: 0=안전, 1=defer(활동 중), 2=defer(판정 불가)
-restart_gate() {
-    RECENT_TRANSCRIPT_COUNT=$(count_recent_bridge_transcripts)
-    local session_procs
-    session_procs=$(count_bridge_session_procs)
+normalized_instance_prefix() {
+    local path="$1"
+    printf '%s' "$path" | sed 's/[^[:alnum:]]/-/g'
+}
 
-    if [ "$RECENT_TRANSCRIPT_COUNT" -gt 0 ]; then
-        return 1 # 최근 활동 세션 존재 — 재시작하면 tombstone
+worktree_transcript_prefix() {
+    local instance_path="$1"
+    # Worktree spawn transcripts use the normalized absolute worktree path.
+    # Since spawned worktrees live under <instance>/.claude/worktrees/<name>,
+    # their project dirs always begin with:
+    # <normalized instance path>--claude-worktrees-
+    # Matching that prefix excludes the instance root transcript dir, which can
+    # be updated by unrelated local/same-dir sessions and must not defer a
+    # worktree drift restart.
+    printf '%s--claude-worktrees-' "$(normalized_instance_prefix "$instance_path")"
+}
+
+count_matching_transcript_dirs() {
+    local instance_path="$1" prefix
+    [ -d "$PROJECTS_DIR" ] || { echo 0; return; }
+    prefix=$(worktree_transcript_prefix "$instance_path")
+    find "$PROJECTS_DIR" -maxdepth 1 -type d -name "${prefix}*" 2>/dev/null | wc -l
+}
+
+count_recent_instance_transcripts() {
+    local instance_path="$1" prefix total=0 dir count
+    [ -d "$PROJECTS_DIR" ] || { echo 0; return; }
+    prefix=$(worktree_transcript_prefix "$instance_path")
+    while IFS= read -r dir; do
+        [ -n "$dir" ] || continue
+        count=$(find "$dir" -maxdepth 1 -name '*.jsonl' -mmin "-$IDLE_THRESHOLD_MINUTES" 2>/dev/null | wc -l)
+        total=$((total + count))
+    done < <(find "$PROJECTS_DIR" -maxdepth 1 -type d -name "${prefix}*" 2>/dev/null)
+    echo "$total"
+}
+
+restart_gate() {
+    local instance_path="$1" recent_count session_procs transcript_dir_count
+    recent_count=$(count_recent_instance_transcripts "$instance_path")
+    session_procs=$(count_worktree_session_procs "$instance_path")
+
+    if [ "$recent_count" -gt 0 ]; then
+        return 1
     fi
     if [ "$session_procs" -eq 0 ]; then
-        return 0 # 세션 프로세스 자체가 없음 — 재시작 안전
+        return 0
     fi
-    # 세션 프로세스는 있는데 최근 transcript가 없는 경우:
-    # 허용 glob 매치 디렉토리가 존재하면 명명 규칙이 현재도 유효하다는 증거이므로
-    # idle 세션으로 판단해 재시작하고, 매치가 0이면 upstream 명명 규칙 drift
-    # 가능성이 있어 보수적으로 유예한다 (tombstone 재시작 직행 방지).
-    if [ "$(count_matching_transcript_dirs)" -gt 0 ]; then
+    transcript_dir_count=$(count_matching_transcript_dirs "$instance_path")
+    if [ "$transcript_dir_count" -gt 0 ]; then
         return 0
     fi
     return 2
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# bridge 시작/재시작
-#───────────────────────────────────────────────────────────────────────────────
-# systemd LoadCredential의 CREDENTIALS_DIRECTORY와 Pushover env가 장기 실행
-# tmux server → bridge → 스폰 세션 트리로 상속되지 않도록 항상 env를 정리해 시작한다.
-start_bridge() {
-    env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-        "$CLAUDE_RC_BIN" --detach \
-        --permission-mode "$CLAUDE_RC_PERMISSION_MODE" \
-        --capacity "$CLAUDE_RC_CAPACITY" \
-        --name "$CLAUDE_RC_NAME"
-    # tmux server가 이 maint 유닛 환경에서 새로 떴을 경우 global env에 복사된
-    # credential 경로를 제거한다 (이미 없으면 no-op).
-    tmux set-environment -gu CREDENTIALS_DIRECTORY 2>/dev/null || true
-    tmux set-environment -gu PUSHOVER_CRED_FILE 2>/dev/null || true
+start_server() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local instance_dir lock_path log_path
+    instance_dir=$(instance_dir_for_path "$path")
+    lock_path="$instance_dir/lock"
+    log_path="$instance_dir/server.log"
+    mkdir -p "$instance_dir"
+    rotate_log_if_needed "$log_path"
+
+    # macOS does not ship setsid. The outer background subshell exits after
+    # spawning the inner one, so the server is re-parented and survives terminal,
+    # systemd oneshot (KillMode=process), and launchd agent exit. stdin/logs are
+    # detached, and SIGHUP is ignored before exec for terminal-close survival.
+    (
+        cd "$path" || exit 1
+        (
+            trap '' HUP
+            exec </dev/null >>"$log_path" 2>&1
+            if [ -n "$capacity" ]; then
+                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                    flock -n "$lock_path" claude remote-control \
+                    --spawn "$spawn" \
+                    --permission-mode "$permission_mode" \
+                    --capacity "$capacity" \
+                    --no-create-session-in-dir
+            else
+                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                    flock -n "$lock_path" claude remote-control \
+                    --spawn "$spawn" \
+                    --permission-mode "$permission_mode" \
+                    --no-create-session-in-dir
+            fi
+        ) &
+    ) &
 }
 
-restart_bridge() {
-    tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-    start_bridge
+wait_until_server_stops() {
+    local pid="$1"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# 상태 기록 + 알림
-#───────────────────────────────────────────────────────────────────────────────
+restart_server() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4" pid lock_path
+    lock_path=$(lock_path_for_path "$path")
+    if pid=$(find_server_pid_for_path "$path"); then
+        kill -TERM "$pid" 2>/dev/null || true
+        wait_until_server_stops "$pid" || return 1
+    elif ! lock_is_free "$lock_path"; then
+        return 1
+    fi
+
+    if ! lock_is_free "$lock_path"; then
+        return 1
+    fi
+    start_server "$path" "$spawn" "$capacity" "$permission_mode"
+    sleep 2
+    if lock_is_free "$lock_path"; then
+        return 1
+    fi
+}
+
+capture_started_version() {
+    local path="$1" pid
+    if pid=$(find_server_pid_for_path "$path"); then
+        pid_exe_version "$pid" 2>/dev/null || true
+    fi
+}
+
+process_instance() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4" source="$5"
+    local lock_path pid running_version action gate_rc started_version
+    : "$source"
+
+    if [ ! -d "$path" ]; then
+        action="path-missing"
+        log_info "path missing: $path"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        return 0
+    fi
+
+    if ! validate_spawn "$spawn"; then
+        action="invalid-spawn"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        return 1
+    fi
+    if [ -n "$capacity" ] && ! [[ "$capacity" =~ ^[0-9]+$ ]]; then
+        action="invalid-capacity"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        return 1
+    fi
+    if ! validate_permission_mode "$permission_mode"; then
+        action="invalid-permission-mode"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        return 1
+    fi
+
+    ensure_instance_dir "$path"
+    lock_path=$(lock_path_for_path "$path")
+    if lock_is_free "$lock_path"; then
+        start_server "$path" "$spawn" "$capacity" "$permission_mode"
+        sleep 2
+        if lock_is_free "$lock_path"; then
+            action="start-failed"
+            record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+            log_error "start failed: $path"
+            return 1
+        fi
+        started_version=$(capture_started_version "$path")
+        action="started"
+        record_instance_result "$path" "$started_version" "$DESIRED_VERSION" "$action"
+        log_info "started: $path"
+        return 0
+    fi
+
+    if ! pid=$(find_server_pid_for_path "$path"); then
+        action="no-server-process"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        log_error "lock held but server process not found: $path"
+        return 1
+    fi
+
+    if ! running_version=$(pid_exe_version "$pid"); then
+        action="running-version-unresolvable"
+        record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
+        return 1
+    fi
+
+    if [ "$running_version" = "$DESIRED_VERSION" ]; then
+        action="healthy"
+        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+        return 0
+    fi
+
+    case "$spawn" in
+        same-dir)
+            # Live measurement confirmed same-dir spawned sessions reconnect to
+            # the restarted server, so version drift can be corrected eagerly.
+            if restart_server "$path" "$spawn" "$capacity" "$permission_mode"; then
+                action="restarted-version-drift"
+                log_info "restarted same-dir drift: $path (${running_version} -> ${DESIRED_VERSION})"
+                record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                return 0
+            fi
+            action="restart-failed"
+            record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+            return 1
+            ;;
+        worktree)
+            gate_rc=0
+            restart_gate "$path" || gate_rc=$?
+            case "$gate_rc" in
+                0)
+                    if restart_server "$path" "$spawn" "$capacity" "$permission_mode"; then
+                        action="restarted-version-drift"
+                        log_info "restarted worktree drift: $path (${running_version} -> ${DESIRED_VERSION})"
+                        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                        return 0
+                    fi
+                    action="restart-failed"
+                    record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                    return 1
+                    ;;
+                1)
+                    action="deferred-active-sessions"
+                    record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                    log_info "deferred active worktree sessions: $path"
+                    return 0
+                    ;;
+                2)
+                    action="deferred-unknown-activity"
+                    record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                    log_info "deferred unknown worktree activity: $path"
+                    return 0
+                    ;;
+                *)
+                    action="restart-gate-failed"
+                    record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+                    return 1
+                    ;;
+            esac
+            ;;
+        *)
+            action="invalid-spawn"
+            record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+            return 1
+            ;;
+    esac
+}
+
+ensure_core() {
+    local entries rc path spawn capacity permission_mode source
+    GLOBAL_ACTION="running"
+
+    seed_declared_instances || return 1
+
+    if ! DESIRED_VERSION=$(desired_claude_version); then
+        GLOBAL_ACTION="desired-version-unresolvable"
+        return 1
+    fi
+
+    if ! entries=$(with_instances_lock emit_instances_tsv_unlocked); then
+        GLOBAL_ACTION="instances-read-failed"
+        return 1
+    fi
+    if [ -z "$entries" ]; then
+        GLOBAL_ACTION="no-instances"
+        log_info "no registered instances"
+        return 0
+    fi
+
+    rc=0
+    while IFS=$'\t' read -r path spawn capacity permission_mode source; do
+        [ -n "$path" ] || continue
+        [ "$capacity" = "$TSV_NULL" ] && capacity=""
+        process_instance "$path" "$spawn" "$capacity" "$permission_mode" "$source" || rc=1
+    done <<<"$entries"
+
+    if [ "$rc" -eq 0 ]; then
+        GLOBAL_ACTION="completed"
+    else
+        GLOBAL_ACTION="failed"
+    fi
+    return "$rc"
+}
+
 write_status() {
-    local exit_code="${1:-0}"
+    local exit_code="${1:-0}" tmp
     mkdir -p "$STATE_DIR"
-    local tmp
     tmp=$(mktemp "$STATE_DIR/status.XXXXXX") || return 1
-    jq -n \
-        --arg timestamp "$(date -Is)" \
-        --arg runningVersion "$RUNNING_VERSION" \
-        --arg desiredVersion "$DESIRED_VERSION" \
-        --arg action "$ACTION" \
-        --argjson recentTranscriptCount "$RECENT_TRANSCRIPT_COUNT" \
+    jq -s \
+        --arg timestamp "$(iso_timestamp)" \
+        --arg action "$GLOBAL_ACTION" \
         --argjson exitCode "$exit_code" \
         '{
           timestamp: $timestamp,
-          runningVersion: $runningVersion,
-          desiredVersion: $desiredVersion,
+          exitCode: $exitCode,
           action: $action,
-          recentTranscriptCount: $recentTranscriptCount,
-          exitCode: $exitCode
-        }' >"$tmp" || { rm -f "$tmp"; return 1; }
+          instances: .
+        }' "$RESULTS_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
     mv "$tmp" "$STATE_DIR/status.json"
 }
 
 load_alerting() {
     # shellcheck source=/dev/null
     [ -n "$SERVICE_LIB" ] && [ -f "$SERVICE_LIB" ] && source "$SERVICE_LIB"
-    local cred="$PUSHOVER_CRED_FILE"
+    local cred
+    cred="$PUSHOVER_CRED_FILE"
     if [ -z "$cred" ] && [ -n "${CREDENTIALS_DIRECTORY:-}" ]; then
         cred="$CREDENTIALS_DIRECTORY/pushover-system-monitor"
     fi
@@ -250,105 +655,77 @@ load_alerting() {
     fi
 }
 
+failed_instance_summary() {
+    if [ ! -s "$RESULTS_FILE" ]; then
+        printf 'action=%s' "$GLOBAL_ACTION"
+        return
+    fi
+    local summary
+    summary=$(jq -r '
+        [
+          .[]
+          | select(.action as $action
+              | ["start-failed", "restart-failed", "no-server-process",
+                 "running-version-unresolvable", "invalid-spawn",
+                 "invalid-capacity", "invalid-permission-mode",
+                 "restart-gate-failed"] | index($action))
+          | "\(.path): \(.action)"
+        ]
+        | if length == 0 then "" else join("; ") end
+    ' "$RESULTS_FILE")
+    if [ -n "$summary" ]; then
+        printf '%s' "$summary"
+    else
+        printf 'action=%s' "$GLOBAL_ACTION"
+    fi
+}
+
 send_alerts() {
     local exit_code="$1"
-    # graceful fallback: 크리덴셜/서비스 lib이 없는 호스트(예: work-MacBookPro는
-    # pushover-system-monitor.age가 minipcOnly 암호화라 복호화 불가)에서 수동
-    # 실행해도 알림만 스킵하고 ensure 본체는 정상 동작한다.
+    # graceful fallback: hosts without credentials or service-lib skip
+    # notification only; ensure itself still runs and records status.
     if ! command -v send_notification >/dev/null 2>&1 \
         || [ -z "${PUSHOVER_TOKEN:-}" ] || [ -z "${PUSHOVER_USER:-}" ]; then
         log_info "알림 스킵 (Pushover 크리덴셜/서비스 lib 없음)"
         return 0
     fi
 
-    local now state_file last_failure_file previous
+    local now state_file last_failure_file previous last summary
     now=$(date +%s)
     state_file="$STATE_DIR/last-health-state"
     last_failure_file="$STATE_DIR/last-failure-alert"
     previous="unknown"
-    [ -f "$state_file" ] && previous=$(cat "$state_file" 2>/dev/null || echo unknown)
+    if [ -f "$state_file" ]; then
+        previous=$(cat "$state_file" 2>/dev/null || echo unknown)
+    fi
 
     if [ "$exit_code" -eq 0 ]; then
         if [ "$previous" = "failed" ]; then
             send_notification "Claude RC Recovered" \
-                "${CLAUDE_RC_ALERT_HOST} claude-rc bridge is healthy (${RUNNING_VERSION:-unknown})." 0
+                "${CLAUDE_RC_ALERT_HOST} claude-rc ensure is healthy (desired=${DESIRED_VERSION:-unknown})." 0
         fi
         echo "healthy" >"$state_file"
         return 0
     fi
 
-    local last=0
-    [ -f "$last_failure_file" ] && last=$(cat "$last_failure_file" 2>/dev/null || echo 0)
+    last=0
+    if [ -f "$last_failure_file" ]; then
+        last=$(cat "$last_failure_file" 2>/dev/null || echo 0)
+    fi
     if [ $((now - last)) -ge "$ALERT_COOLDOWN_SECONDS" ]; then
+        summary=$(failed_instance_summary)
         send_notification "Claude RC Ensure Failed" \
-            "exit=${exit_code}, action=${ACTION}, running=${RUNNING_VERSION:-unknown}, desired=${DESIRED_VERSION:-unknown}" 0
+            "exit=${exit_code}, action=${GLOBAL_ACTION}, failed=${summary}, desired=${DESIRED_VERSION:-unknown}" 0
         echo "$now" >"$last_failure_file"
     fi
     echo "failed" >"$state_file"
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# ensure 본체 (조기 exit 없음 — action만 설정하고 cmd_ensure의 finalizer가 마무리)
-#───────────────────────────────────────────────────────────────────────────────
-ensure_core() {
-    DESIRED_VERSION=$(desired_claude_version) || {
-        ACTION="desired-version-unresolvable"
-        return 1
-    }
-
-    if ! bridge_session_alive; then
-        # tmux 세션 부재/stale — 부팅 후 자동 시작 겸 자가 복구
-        start_bridge
-        ACTION="started"
-        log_info "bridge 시작됨 (session absent/stale)"
-        return 0
-    fi
-
-    local pid
-    if ! pid=$(find_bridge_pid); then
-        # 세션은 살아있는데 bridge 프로세스가 없음 — 래퍼 루프가 backoff 재시작
-        # 중일 수 있으므로 maint는 개입하지 않는다 (다음 주기 재확인).
-        ACTION="no-bridge-process"
-        log_info "bridge 프로세스 없음 — 래퍼 루프에 위임 (다음 주기 재확인)"
-        return 0
-    fi
-
-    RUNNING_VERSION=$(pid_exe_version "$pid") || {
-        ACTION="running-version-unresolvable"
-        return 1
-    }
-
-    if [ "$RUNNING_VERSION" = "$DESIRED_VERSION" ]; then
-        ACTION="healthy"
-        return 0
-    fi
-
-    # version drift — 활성 세션 게이트 통과 시에만 재시작
-    local gate_rc=0
-    restart_gate || gate_rc=$?
-    case "$gate_rc" in
-        0)
-            restart_bridge
-            ACTION="restarted-version-drift"
-            log_info "재시작: ${RUNNING_VERSION} → ${DESIRED_VERSION}"
-            ;;
-        1)
-            ACTION="deferred-active-sessions"
-            log_info "drift 감지했으나 활성 세션 ${RECENT_TRANSCRIPT_COUNT}건 — 유예"
-            ;;
-        2)
-            ACTION="deferred-unknown-activity"
-            log_info "drift 감지했으나 활동 판정 불가 (transcript 명명 drift 의심) — 유예"
-            ;;
-    esac
-    return 0
-}
-
-#───────────────────────────────────────────────────────────────────────────────
-# 서브커맨드
-#───────────────────────────────────────────────────────────────────────────────
 cmd_ensure() {
-    local rc=0
+    local rc
+    rc=0
+    mkdir -p "$STATE_DIR"
+    RESULTS_FILE=$(mktemp "$STATE_DIR/results.XXXXXX") || return 1
     with_lock ensure_core || rc=$?
     # 단일 finalizer: 어떤 분기도 이 경로를 우회하지 않는다
     # (recovered/failure 알림 상태 전이가 모든 실행에서 평가되도록).
@@ -357,6 +734,7 @@ cmd_ensure() {
     # 마지막 명령이라 set -e 발동) finalizer가 send_alerts 전에 죽지 않게 guard.
     load_alerting || true
     send_alerts "$rc" || true
+    rm -f "$RESULTS_FILE"
     return "$rc"
 }
 
@@ -365,19 +743,24 @@ usage() {
 Usage: claude-rc-maint ensure
 
 env:
-  CLAUDE_RC_BIN, CLAUDE_BIN, STATE_DIR, TMUX_SESSION,
+  CLAUDE_BIN, STATE_DIR, CLAUDE_RC_DECLARED_INSTANCES,
   IDLE_THRESHOLD_MINUTES (default 30), MAINT_LOCK_TIMEOUT_SECONDS (default 120),
   ALERT_COOLDOWN_SECONDS (default 1800), PUSHOVER_CRED_FILE, SERVICE_LIB,
-  CLAUDE_RC_PERMISSION_MODE, CLAUDE_RC_CAPACITY, CLAUDE_RC_NAME, CLAUDE_RC_ALERT_HOST
+  CLAUDE_RC_PERMISSION_MODE, CLAUDE_RC_ALERT_HOST
 
-상태 확인: cat $STATE_DIR/status.json (기본 ~/.local/state/claude-rc/status.json)
+CLAUDE_RC_DECLARED_INSTANCES:
+  JSON array, for example:
+  [{"path":"/path/to/project","spawn":"worktree","capacity":null}]
+
+Status:
+  cat $STATE_DIR/status.json (default ~/.local/state/claude-rc/status.json)
 EOF
 }
 
 main() {
     case "${1:-}" in
         ensure) cmd_ensure ;;
-        -h | --help | help) usage ;;
+        -h|--help|help) usage ;;
         *)
             usage
             return 2

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -69,17 +69,13 @@ reconcile_declared_instance_unlocked() {
         --argjson capacity "$capacity_json" \
         'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
          | if (.instances | has($path)) then
-             if (.instances[$path].source // "manual") == "declared" then
-               .instances[$path] = (.instances[$path] + {
-                 spawn: $spawn,
-                 capacity: $capacity,
-                 permissionMode: $permissionMode,
-                 registeredAt: (.instances[$path].registeredAt // $registeredAt),
-                 source: "declared"
-               })
-             else
-               .
-             end
+             .instances[$path] = (.instances[$path] + {
+               spawn: $spawn,
+               capacity: $capacity,
+               permissionMode: $permissionMode,
+               registeredAt: (.instances[$path].registeredAt // $registeredAt),
+               source: "declared"
+             })
            else .instances[$path] = {
              spawn: $spawn,
              capacity: $capacity,
@@ -134,8 +130,10 @@ seed_declared_instances() {
             log_error "invalid declared permissionMode for $path: $permission_mode"
             return 1
         fi
-        # Manual registrations are user intent and win over declarations with
-        # the same path. Declared entries are reconciled to the current Nix env.
+        # Declared paths are authoritative desired state. If a manual start
+        # temporarily uses different options, the next ensure reconciles the
+        # registry back to the declaration and treats the manual change as an
+        # experiment.
         with_instances_lock reconcile_declared_instance_unlocked "$path" "$spawn" "$capacity" "$permission_mode"
     done < <(jq -c '.[]' <<<"$payload")
 }
@@ -232,6 +230,25 @@ restart_server() {
     fi
 }
 
+handle_restart_result() {
+    local path="$1" mode="$2" running_version="$3" restart_rc="$4" action
+    if [ "$restart_rc" -eq 0 ]; then
+        action="restarted-version-drift"
+        log_info "restarted ${mode} drift: $path (${running_version} -> ${DESIRED_VERSION})"
+        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+        return 0
+    fi
+    if [ "$restart_rc" -eq 2 ]; then
+        action="unmanaged-server-present"
+        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+        log_error "unmanaged same-cwd server present after stop: $path"
+        return 1
+    fi
+    action="restart-failed"
+    record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
+    return 1
+}
+
 capture_started_version() {
     local path="$1" pid
     if pid=$(find_server_pid_for_path "$path"); then
@@ -318,21 +335,7 @@ process_instance() {
             # the restarted server, so version drift can be corrected eagerly.
             restart_rc=0
             restart_server "$path" "$spawn" "$capacity" "$permission_mode" || restart_rc=$?
-            if [ "$restart_rc" -eq 0 ]; then
-                action="restarted-version-drift"
-                log_info "restarted same-dir drift: $path (${running_version} -> ${DESIRED_VERSION})"
-                record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
-                return 0
-            fi
-            if [ "$restart_rc" -eq 2 ]; then
-                action="unmanaged-server-present"
-                record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
-                log_error "unmanaged same-cwd server present after stop: $path"
-                return 1
-            fi
-            action="restart-failed"
-            record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
-            return 1
+            handle_restart_result "$path" "same-dir" "$running_version" "$restart_rc"
             ;;
         worktree)
             gate_rc=0
@@ -341,21 +344,7 @@ process_instance() {
                 0)
                     restart_rc=0
                     restart_server "$path" "$spawn" "$capacity" "$permission_mode" || restart_rc=$?
-                    if [ "$restart_rc" -eq 0 ]; then
-                        action="restarted-version-drift"
-                        log_info "restarted worktree drift: $path (${running_version} -> ${DESIRED_VERSION})"
-                        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
-                        return 0
-                    fi
-                    if [ "$restart_rc" -eq 2 ]; then
-                        action="unmanaged-server-present"
-                        record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
-                        log_error "unmanaged same-cwd server present after stop: $path"
-                        return 1
-                    fi
-                    action="restart-failed"
-                    record_instance_result "$path" "$running_version" "$DESIRED_VERSION" "$action"
-                    return 1
+                    handle_restart_result "$path" "worktree" "$running_version" "$restart_rc"
                     ;;
                 1)
                     action="deferred-active-sessions"
@@ -451,24 +440,35 @@ load_alerting() {
     fi
 }
 
+is_failure_action() {
+    case "$1" in
+        path-missing|started|healthy|restarted-version-drift|deferred-active-sessions|deferred-unknown-activity)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
 failed_instance_summary() {
     if [ ! -s "$RESULTS_FILE" ]; then
         printf 'action=%s' "$GLOBAL_ACTION"
         return
     fi
-    local summary
-    summary=$(jq -r '
-        [
-          .[]
-          | select(.action as $action
-              | ["start-failed", "restart-failed", "no-server-process",
-                 "running-version-unresolvable", "invalid-spawn",
-                 "invalid-capacity", "invalid-permission-mode",
-                 "restart-gate-failed", "unmanaged-server-present"] | index($action))
-          | "\(.path): \(.action)"
-        ]
-        | if length == 0 then "" else join("; ") end
-    ' "$RESULTS_FILE")
+    local summary line path action
+    summary=""
+    while IFS=$'\t' read -r path action; do
+        [ -n "$path" ] || continue
+        if is_failure_action "$action"; then
+            line="$path: $action"
+            if [ -n "$summary" ]; then
+                summary="${summary}; ${line}"
+            else
+                summary="$line"
+            fi
+        fi
+    done < <(jq -r '[.path, .action] | @tsv' "$RESULTS_FILE")
     if [ -n "$summary" ]; then
         printf '%s' "$summary"
     else
@@ -564,4 +564,6 @@ main() {
     esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/modules/nixos/scripts/claude-rc-lib.sh
+++ b/modules/nixos/scripts/claude-rc-lib.sh
@@ -1,0 +1,313 @@
+# claude-rc-lib.sh: shared lifecycle helpers for claude-rc and claude-rc-maint.
+# shellcheck shell=bash
+#
+# This file is definition-only. It is concatenated before the command-specific
+# script by the Nix package expressions, so it must not run command logic.
+
+STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
+INSTANCES_FILE="$STATE_DIR/instances.json"
+INSTANCES_LOCK="$STATE_DIR/instances.json.lock"
+LOG_MAX_BYTES=$((5 * 1024 * 1024))
+BRIDGE_PROCESS_PATTERN='claude remote-control'
+# Spawned session argv may be the versioned Claude binary path, so --sdk-url is
+# the stable selector. The leading [-] avoids pgrep treating the pattern as an
+# option.
+BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
+TSV_NULL='__CLAUDE_RC_NULL__'
+
+iso_timestamp() {
+    local ts
+    ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
+    printf '%s:%s\n' "${ts%??}" "${ts: -2}"
+}
+
+sha256_hex() {
+    local value="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
+        return
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$value" | sha256sum | awk '{print $1}'
+        return
+    fi
+    log_error "required command not found in PATH: shasum or sha256sum"
+    return 1
+}
+
+canonical_existing_path() {
+    local path="$1"
+    (cd "$path" 2>/dev/null && pwd -P)
+}
+
+slug_for_path() {
+    local path="$1" base digest
+    base=$(basename "$path")
+    digest=$(sha256_hex "$path")
+    printf '%s-%s\n' "$base" "${digest:0:8}"
+}
+
+instance_dir_for_path() {
+    local path="$1" slug
+    slug=$(slug_for_path "$path")
+    printf '%s/%s\n' "$STATE_DIR" "$slug"
+}
+
+lock_path_for_path() {
+    local path="$1"
+    printf '%s/lock\n' "$(instance_dir_for_path "$path")"
+}
+
+log_path_for_path() {
+    local path="$1"
+    printf '%s/server.log\n' "$(instance_dir_for_path "$path")"
+}
+
+ensure_instance_dir() {
+    local path="$1"
+    mkdir -p "$(instance_dir_for_path "$path")"
+}
+
+lock_is_free() {
+    local lock_path="$1"
+    flock -n "$lock_path" true
+}
+
+rotate_log_if_needed() {
+    local log_path="$1" size
+    if [ ! -f "$log_path" ]; then
+        return 0
+    fi
+    size=$(wc -c <"$log_path" | tr -d '[:space:]')
+    if [ "${size:-0}" -gt "$LOG_MAX_BYTES" ]; then
+        mv -f "$log_path" "$log_path.1"
+    fi
+}
+
+init_instances_file() {
+    mkdir -p "$STATE_DIR"
+    if [ ! -f "$INSTANCES_FILE" ]; then
+        printf '{"version":1,"instances":{}}\n' >"$INSTANCES_FILE"
+    fi
+}
+
+with_instances_lock() {
+    mkdir -p "$STATE_DIR"
+    (
+        flock 8
+        "$@"
+    ) 8>"$INSTANCES_LOCK"
+}
+
+upsert_instance_unlocked() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4" source="$5"
+    local tmp capacity_json registered_at
+    capacity_json="null"
+    if [ -n "$capacity" ]; then
+        capacity_json="$capacity"
+    fi
+    registered_at=$(iso_timestamp)
+    init_instances_file
+    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
+    jq \
+        --arg path "$path" \
+        --arg spawn "$spawn" \
+        --arg permissionMode "$permission_mode" \
+        --arg registeredAt "$registered_at" \
+        --arg source "$source" \
+        --argjson capacity "$capacity_json" \
+        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
+         | .instances[$path] = {
+             spawn: $spawn,
+             capacity: $capacity,
+             permissionMode: $permissionMode,
+             registeredAt: $registeredAt,
+             source: $source
+           }' \
+        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$INSTANCES_FILE"
+}
+
+upsert_instance() {
+    with_instances_lock upsert_instance_unlocked "$@"
+}
+
+remove_instance_unlocked() {
+    local path="$1" tmp
+    init_instances_file
+    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
+    jq --arg path "$path" \
+        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
+         | del(.instances[$path])' \
+        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$INSTANCES_FILE"
+}
+
+remove_instance() {
+    with_instances_lock remove_instance_unlocked "$@"
+}
+
+emit_instances_tsv_unlocked() {
+    init_instances_file
+    jq -r --arg tsv_null "$TSV_NULL" '
+        if (.version == 1 and (.instances | type) == "object") then .instances else {} end
+        | to_entries[]
+        | [
+            .key,
+            (.value.spawn // "worktree"),
+            (if (.value.capacity // null) == null then $tsv_null else (.value.capacity | tostring) end),
+            (.value.permissionMode // "bypassPermissions")
+          ]
+        | @tsv
+    ' "$INSTANCES_FILE"
+}
+
+validate_permission_mode() {
+    case "$1" in
+        acceptEdits|bypassPermissions|default|dontAsk|plan) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+validate_spawn() {
+    case "$1" in
+        worktree|same-dir) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+pid_cwd() {
+    local pid="$1"
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}'
+}
+
+# 플랫폼별 실행 바이너리 경로 조회.
+# - Linux: /proc/PID/exe. 삭제된 바이너리는 " (deleted)" suffix가 붙는다.
+# - Darwin: /proc이 없어 lsof의 첫 txt(code segment) 항목을 쓴다. 실행 파일이
+#   항상 첫 txt로 나열되고(-F 필드 출력은 경로 공백 안전; 실측), ps -o comm=은
+#   argv[0] 기반이라 symlink 경유 실행 시 실경로를 잃는다.
+#   삭제된 바이너리도 suffix 없이 원경로가 그대로 나오지만, 버전이 파일명이라
+#   desired와의 문자열 비교로 drift가 감지되므로 (deleted) 표식 없이도 충분하다.
+pid_exe_path() {
+    local pid="$1"
+    case "$(uname -s)" in
+        Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
+        *) readlink "/proc/$pid/exe" 2>/dev/null ;;
+    esac
+}
+
+# pid_exe_path 기준 실행 중 버전. 바이너리가 삭제된 구버전이면 "deleted"를 붙여
+# 호출측이 drift로 취급하게 한다 (Linux 전용 신호 — Darwin 주석은 pid_exe_path 참조).
+pid_exe_version() {
+    local pid="$1" exe
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
+    case "$exe" in
+        *" (deleted)") echo "$(basename "${exe% (deleted)}") (deleted)" ;;
+        *) basename "$exe" ;;
+    esac
+}
+
+same_cwd_as_path() {
+    local pid="$1" path="$2" cwd target
+    cwd=$(pid_cwd "$pid") || return 1
+    [ -n "$cwd" ] || return 1
+    target=$(canonical_existing_path "$path") || return 1
+    [ "$cwd" = "$target" ]
+}
+
+is_flock_process() {
+    local pid="$1" exe base
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
+    base=$(basename "${exe% (deleted)}")
+    [ "$base" = "flock" ]
+}
+
+find_server_pid_for_path() {
+    local path="$1" pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        same_cwd_as_path "$pid" "$path" || continue
+        if is_flock_process "$pid"; then
+            continue
+        fi
+        echo "$pid"
+        return 0
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
+    return 1
+}
+
+has_unmanaged_server_for_path() {
+    local path="$1" pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        same_cwd_as_path "$pid" "$path" || continue
+        if is_flock_process "$pid"; then
+            continue
+        fi
+        return 0
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
+    return 1
+}
+
+count_worktree_session_procs() {
+    local instance_path="$1" wt_root pid cwd count=0
+    wt_root="$instance_path/.claude/worktrees/"
+    # pgrep -c is not portable to macOS BSD pgrep, so count PID lines manually.
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        cwd=$(pid_cwd "$pid") || continue
+        case "$cwd" in
+            "$wt_root"*) count=$((count + 1)) ;;
+        esac
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
+    echo "$count"
+}
+
+start_server() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local instance_dir lock_path log_path
+    instance_dir=$(instance_dir_for_path "$path")
+    lock_path="$instance_dir/lock"
+    log_path="$instance_dir/server.log"
+    mkdir -p "$instance_dir"
+    rotate_log_if_needed "$log_path"
+
+    # macOS does not ship setsid. The outer background subshell exits after
+    # spawning the inner one, so the server is re-parented and survives terminal,
+    # systemd oneshot (KillMode=process), and launchd agent exit. stdin/logs are
+    # detached, and SIGHUP is ignored before exec for terminal-close survival.
+    (
+        cd "$path" || exit 1
+        (
+            trap '' HUP
+            exec </dev/null >>"$log_path" 2>&1
+            if [ -n "$capacity" ]; then
+                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                    flock -n "$lock_path" claude remote-control \
+                    --spawn "$spawn" \
+                    --permission-mode "$permission_mode" \
+                    --capacity "$capacity" \
+                    --no-create-session-in-dir
+            else
+                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                    flock -n "$lock_path" claude remote-control \
+                    --spawn "$spawn" \
+                    --permission-mode "$permission_mode" \
+                    --no-create-session-in-dir
+            fi
+        ) &
+    ) &
+}
+
+wait_until_server_stops() {
+    local pid="$1"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}

--- a/modules/nixos/scripts/claude-rc-lib.sh
+++ b/modules/nixos/scripts/claude-rc-lib.sh
@@ -208,6 +208,34 @@ pid_exe_version() {
     esac
 }
 
+pid_spawn_mode() {
+    local pid="$1" command mode i
+    local -a argv
+    command=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
+    [ -n "$command" ] || return 1
+    read -r -a argv <<<"$command"
+    for ((i = 0; i < ${#argv[@]}; i++)); do
+        case "${argv[$i]}" in
+            --spawn)
+                if [ $((i + 1)) -lt "${#argv[@]}" ]; then
+                    mode="${argv[$((i + 1))]}"
+                    validate_spawn "$mode" || return 1
+                    printf '%s\n' "$mode"
+                    return 0
+                fi
+                return 1
+                ;;
+            --spawn=*)
+                mode="${argv[$i]#--spawn=}"
+                validate_spawn "$mode" || return 1
+                printf '%s\n' "$mode"
+                return 0
+                ;;
+        esac
+    done
+    return 1
+}
+
 same_cwd_as_path() {
     local pid="$1" path="$2" cwd target
     cwd=$(pid_cwd "$pid") || return 1
@@ -239,16 +267,7 @@ find_server_pid_for_path() {
 }
 
 has_unmanaged_server_for_path() {
-    local path="$1" pid
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        same_cwd_as_path "$pid" "$path" || continue
-        if is_flock_process "$pid"; then
-            continue
-        fi
-        return 0
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
-    return 1
+    find_server_pid_for_path "$1" >/dev/null
 }
 
 count_worktree_session_procs() {
@@ -268,11 +287,17 @@ count_worktree_session_procs() {
 start_server() {
     local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
     local instance_dir lock_path log_path
+    local -a args
     instance_dir=$(instance_dir_for_path "$path")
     lock_path="$instance_dir/lock"
     log_path="$instance_dir/server.log"
     mkdir -p "$instance_dir"
     rotate_log_if_needed "$log_path"
+    args=(claude remote-control --spawn "$spawn" --permission-mode "$permission_mode")
+    if [ -n "$capacity" ]; then
+        args+=(--capacity "$capacity")
+    fi
+    args+=(--no-create-session-in-dir)
 
     # macOS does not ship setsid. The outer background subshell exits after
     # spawning the inner one, so the server is re-parented and survives terminal,
@@ -283,20 +308,8 @@ start_server() {
         (
             trap '' HUP
             exec </dev/null >>"$log_path" 2>&1
-            if [ -n "$capacity" ]; then
-                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-                    flock -n "$lock_path" claude remote-control \
-                    --spawn "$spawn" \
-                    --permission-mode "$permission_mode" \
-                    --capacity "$capacity" \
-                    --no-create-session-in-dir
-            else
-                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-                    flock -n "$lock_path" claude remote-control \
-                    --spawn "$spawn" \
-                    --permission-mode "$permission_mode" \
-                    --no-create-session-in-dir
-            fi
+            exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                flock -n "$lock_path" "${args[@]}"
         ) &
     ) &
 }

--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -109,6 +109,49 @@ warn_if_start_options_ignored() {
     fi
 }
 
+declared_instance_options_tsv() {
+    local path="$1"
+    [ -f "$INSTANCES_FILE" ] || return 0
+    jq -r --arg path "$path" --arg tsv_null "$TSV_NULL" '
+        if (.version == 1 and (.instances | type) == "object" and (.instances | has($path))
+            and (.instances[$path].source == "declared")) then
+          .instances[$path]
+          | [
+              (.spawn // "worktree"),
+              (if (.capacity // null) == null then $tsv_null else (.capacity | tostring) end),
+              (.permissionMode // "bypassPermissions")
+            ]
+          | @tsv
+        else
+          empty
+        end
+    ' "$INSTANCES_FILE"
+}
+
+warn_if_declared_start_options_differ() {
+    local declared="$1" declared_spawn declared_capacity declared_permission_mode
+    local -a diffs=()
+    [ -n "$declared" ] || return 0
+
+    IFS=$'\t' read -r declared_spawn declared_capacity declared_permission_mode <<<"$declared"
+    [ "$declared_capacity" = "$TSV_NULL" ] && declared_capacity=""
+
+    if [ "$RC_SPAWN_SET" = true ] && [ "$RC_SPAWN" != "$declared_spawn" ]; then
+        diffs+=("spawn: declared=${declared_spawn:-<unset>}, requested=$RC_SPAWN")
+    fi
+    if [ "$RC_CAPACITY_SET" = true ] && [ "$RC_CAPACITY" != "$declared_capacity" ]; then
+        diffs+=("capacity: declared=${declared_capacity:-<omitted>}, requested=$RC_CAPACITY")
+    fi
+    if [ "$RC_PERMISSION_MODE_SET" = true ] && [ "$RC_PERMISSION_MODE" != "$declared_permission_mode" ]; then
+        diffs+=("permission-mode: declared=${declared_permission_mode:-<unset>}, requested=$RC_PERMISSION_MODE")
+    fi
+
+    if [ "${#diffs[@]}" -gt 0 ]; then
+        log_warn "이 경로는 Nix 선언 관리 대상 — 다음 ensure에서 선언값으로 복원됨"
+        printf '[claude-rc] WARN: %s\n' "${diffs[@]}" >&2
+    fi
+}
+
 parse_args() {
     if [ $# -gt 0 ]; then
         case "$1" in
@@ -174,11 +217,12 @@ parse_args() {
 do_start() {
     require_common_cmds
     require_cmd claude
-    local instance_path lock_path log_path env_line
+    local instance_path lock_path log_path env_line declared_options
     instance_path=$(current_git_root)
     ensure_instance_dir "$instance_path"
     lock_path=$(lock_path_for_path "$instance_path")
     log_path=$(log_path_for_path "$instance_path")
+    declared_options=$(declared_instance_options_tsv "$instance_path")
 
     if ! lock_is_free "$lock_path"; then
         log_info "이미 실행 중: $instance_path"
@@ -196,6 +240,7 @@ do_start() {
         exit 1
     fi
 
+    warn_if_declared_start_options_differ "$declared_options"
     start_server "$instance_path" "$RC_SPAWN" "$RC_CAPACITY" "$RC_PERMISSION_MODE"
     sleep 2
 
@@ -207,7 +252,11 @@ do_start() {
         exit 1
     fi
 
-    upsert_instance "$instance_path" "$RC_SPAWN" "$RC_CAPACITY" "$RC_PERMISSION_MODE" "manual"
+    if [ -z "$declared_options" ]; then
+        upsert_instance "$instance_path" "$RC_SPAWN" "$RC_CAPACITY" "$RC_PERMISSION_MODE" "manual"
+    else
+        log_info "declared registry entry preserved: $instance_path"
+    fi
     log_info "서버 시작됨: $instance_path"
     log_info "log: $log_path"
     env_line=$(grep 'environment=' "$log_path" 2>/dev/null | tail -n 1 || true)
@@ -220,9 +269,10 @@ do_start() {
 
 do_stop() {
     require_common_cmds
-    local instance_path session_count pid
+    local instance_path session_count pid lock_path
     instance_path=$(current_git_root)
     ensure_instance_dir "$instance_path"
+    lock_path=$(lock_path_for_path "$instance_path")
 
     session_count=$(count_worktree_session_procs "$instance_path")
     if [ "$session_count" -gt 0 ] && [ "$FORCE" != true ]; then
@@ -240,6 +290,11 @@ do_stop() {
         fi
         log_info "서버 종료됨"
     else
+        if ! lock_is_free "$lock_path"; then
+            log_error "lock은 잡혔지만 cwd가 같은 서버 PID를 찾지 못함"
+            log_error "maint의 no-server-process와 같은 이상 상태이므로 등록을 보존함"
+            exit 1
+        fi
         log_info "서버가 이미 죽어 있음 — 등록만 해제"
     fi
 
@@ -341,4 +396,6 @@ main() {
     esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -15,6 +15,7 @@ RC_SPAWN_SET=false
 RC_CAPACITY_SET=false
 RC_PERMISSION_MODE_SET=false
 FORCE=false
+STOP_PATH=""
 
 log_info() { echo "[claude-rc] $*"; }
 log_warn() { echo "[claude-rc] WARN: $*" >&2; }
@@ -26,7 +27,7 @@ claude-rc: Claude Code Remote Control headless multi-instance wrapper
 
 Usage:
   claude-rc [start] [--spawn worktree|same-dir] [--capacity N] [--permission-mode MODE]
-  claude-rc stop [--force]
+  claude-rc stop [path] [--force]
   claude-rc ls
   claude-rc cleanup
   claude-rc --help
@@ -68,54 +69,29 @@ current_git_root() {
     printf '%s\n' "$root"
 }
 
-warn_if_start_options_ignored() {
-    local path="$1" registered reg_spawn reg_capacity reg_permission_mode
-    local -a diffs=()
-    if [ "$RC_SPAWN_SET" != true ] && [ "$RC_CAPACITY_SET" != true ] && [ "$RC_PERMISSION_MODE_SET" != true ]; then
-        return 0
+stop_target_path() {
+    if [ -z "$STOP_PATH" ]; then
+        current_git_root
+        return
     fi
-    [ -f "$INSTANCES_FILE" ] || return 0
-
-    registered=$(jq -r --arg path "$path" --arg tsv_null "$TSV_NULL" '
-        if (.version == 1 and (.instances | type) == "object" and (.instances | has($path))) then
-          .instances[$path]
-          | [
-              (.spawn // ""),
-              (if (.capacity // null) == null then $tsv_null else (.capacity | tostring) end),
-              (.permissionMode // "")
-            ]
-          | @tsv
-        else
-          empty
-        end
-    ' "$INSTANCES_FILE")
-    [ -n "$registered" ] || return 0
-
-    IFS=$'\t' read -r reg_spawn reg_capacity reg_permission_mode <<<"$registered"
-    [ "$reg_capacity" = "$TSV_NULL" ] && reg_capacity=""
-    if [ "$RC_SPAWN_SET" = true ] && [ "$RC_SPAWN" != "$reg_spawn" ]; then
-        diffs+=("spawn: running=${reg_spawn:-<unset>}, requested=$RC_SPAWN")
+    if [[ "$STOP_PATH" != /* ]]; then
+        log_error "stop path must be absolute: $STOP_PATH"
+        exit 1
     fi
-    if [ "$RC_CAPACITY_SET" = true ] && [ "$RC_CAPACITY" != "$reg_capacity" ]; then
-        diffs+=("capacity: running=${reg_capacity:-<omitted>}, requested=$RC_CAPACITY")
-    fi
-    if [ "$RC_PERMISSION_MODE_SET" = true ] && [ "$RC_PERMISSION_MODE" != "$reg_permission_mode" ]; then
-        diffs+=("permission-mode: running=${reg_permission_mode:-<unset>}, requested=$RC_PERMISSION_MODE")
-    fi
-
-    if [ "${#diffs[@]}" -gt 0 ]; then
-        log_warn "실행 중인 서버에는 반영되지 않음 — 변경하려면 claude-rc stop 후 재기동"
-        printf '[claude-rc] WARN: %s\n' "${diffs[@]}" >&2
+    if [ -d "$STOP_PATH" ]; then
+        canonical_existing_path "$STOP_PATH"
+    else
+        printf '%s\n' "$STOP_PATH"
     fi
 }
 
-declared_instance_options_tsv() {
-    local path="$1"
+instance_options_tsv() {
+    local path="$1" source_filter="${2:-}"
     [ -f "$INSTANCES_FILE" ] || return 0
-    jq -r --arg path "$path" --arg tsv_null "$TSV_NULL" '
-        if (.version == 1 and (.instances | type) == "object" and (.instances | has($path))
-            and (.instances[$path].source == "declared")) then
+    jq -r --arg path "$path" --arg sourceFilter "$source_filter" --arg tsv_null "$TSV_NULL" '
+        if (.version == 1 and (.instances | type) == "object" and (.instances | has($path))) then
           .instances[$path]
+          | select($sourceFilter == "" or (.source == $sourceFilter))
           | [
               (.spawn // "worktree"),
               (if (.capacity // null) == null then $tsv_null else (.capacity | tostring) end),
@@ -128,28 +104,53 @@ declared_instance_options_tsv() {
     ' "$INSTANCES_FILE"
 }
 
+start_option_diffs() {
+    local reference_label="$1" options_tsv="$2"
+    local ref_spawn ref_capacity ref_permission_mode
+    [ -n "$options_tsv" ] || return 0
+    IFS=$'\t' read -r ref_spawn ref_capacity ref_permission_mode <<<"$options_tsv"
+    [ "$ref_capacity" = "$TSV_NULL" ] && ref_capacity=""
+
+    if [ "$RC_SPAWN_SET" = true ] && [ "$RC_SPAWN" != "$ref_spawn" ]; then
+        printf 'spawn: %s=%s, requested=%s\n' "$reference_label" "${ref_spawn:-<unset>}" "$RC_SPAWN"
+    fi
+    if [ "$RC_CAPACITY_SET" = true ] && [ "$RC_CAPACITY" != "$ref_capacity" ]; then
+        printf 'capacity: %s=%s, requested=%s\n' "$reference_label" "${ref_capacity:-<omitted>}" "$RC_CAPACITY"
+    fi
+    if [ "$RC_PERMISSION_MODE_SET" = true ] && [ "$RC_PERMISSION_MODE" != "$ref_permission_mode" ]; then
+        printf 'permission-mode: %s=%s, requested=%s\n' "$reference_label" "${ref_permission_mode:-<unset>}" "$RC_PERMISSION_MODE"
+    fi
+}
+
+warn_for_start_option_diffs() {
+    local reference_label="$1" options_tsv="$2" message="$3"
+    local diffs line
+    if [ "$RC_SPAWN_SET" != true ] && [ "$RC_CAPACITY_SET" != true ] && [ "$RC_PERMISSION_MODE_SET" != true ]; then
+        return 0
+    fi
+    diffs=$(start_option_diffs "$reference_label" "$options_tsv")
+    [ -n "$diffs" ] || return 0
+    log_warn "$message"
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        printf '[claude-rc] WARN: %s\n' "$line" >&2
+    done <<<"$diffs"
+}
+
+warn_if_start_options_ignored() {
+    local registered
+    registered=$(instance_options_tsv "$1")
+    if [ -n "$registered" ]; then
+        warn_for_start_option_diffs "running" "$registered" "실행 중인 서버에는 반영되지 않음 — 변경하려면 claude-rc stop 후 재기동"
+    fi
+}
+
+declared_instance_options_tsv() {
+    instance_options_tsv "$1" "declared"
+}
+
 warn_if_declared_start_options_differ() {
-    local declared="$1" declared_spawn declared_capacity declared_permission_mode
-    local -a diffs=()
-    [ -n "$declared" ] || return 0
-
-    IFS=$'\t' read -r declared_spawn declared_capacity declared_permission_mode <<<"$declared"
-    [ "$declared_capacity" = "$TSV_NULL" ] && declared_capacity=""
-
-    if [ "$RC_SPAWN_SET" = true ] && [ "$RC_SPAWN" != "$declared_spawn" ]; then
-        diffs+=("spawn: declared=${declared_spawn:-<unset>}, requested=$RC_SPAWN")
-    fi
-    if [ "$RC_CAPACITY_SET" = true ] && [ "$RC_CAPACITY" != "$declared_capacity" ]; then
-        diffs+=("capacity: declared=${declared_capacity:-<omitted>}, requested=$RC_CAPACITY")
-    fi
-    if [ "$RC_PERMISSION_MODE_SET" = true ] && [ "$RC_PERMISSION_MODE" != "$declared_permission_mode" ]; then
-        diffs+=("permission-mode: declared=${declared_permission_mode:-<unset>}, requested=$RC_PERMISSION_MODE")
-    fi
-
-    if [ "${#diffs[@]}" -gt 0 ]; then
-        log_warn "이 경로는 Nix 선언 관리 대상 — 다음 ensure에서 선언값으로 복원됨"
-        printf '[claude-rc] WARN: %s\n' "${diffs[@]}" >&2
-    fi
+    warn_for_start_option_diffs "declared" "$1" "이 경로는 Nix 선언 관리 대상 — 다음 ensure에서 선언값으로 복원됨"
 }
 
 parse_args() {
@@ -206,9 +207,14 @@ parse_args() {
                 exit 0
                 ;;
             *)
-                log_error "Unknown option: $1"
-                usage
-                exit 1
+                if [ "$ACTION" = "stop" ] && [ -z "$STOP_PATH" ]; then
+                    STOP_PATH="$1"
+                    shift
+                else
+                    log_error "Unknown option: $1"
+                    usage
+                    exit 1
+                fi
                 ;;
         esac
     done
@@ -270,7 +276,7 @@ do_start() {
 do_stop() {
     require_common_cmds
     local instance_path session_count pid lock_path
-    instance_path=$(current_git_root)
+    instance_path=$(stop_target_path)
     ensure_instance_dir "$instance_path"
     lock_path=$(lock_path_for_path "$instance_path")
 

--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -1,22 +1,11 @@
 #!/usr/bin/env bash
 # claude-rc: Claude Code Remote Control headless multi-instance wrapper.
 #
-# Runtime dependencies are resolved from the user's PATH: claude, flock, git,
-# jq, lsof, pgrep, shasum or sha256sum. The wrapper intentionally has no Nix
-# runtimeInputs yet; the packaging changes are handled in the next phase.
+# This file is packaged by concatenating modules/nixos/scripts/claude-rc-lib.sh
+# before it. The Nix package provides flock/jq/lsof/pgrep/etc.; claude itself is
+# resolved from the caller's PATH tail so the user's launcher can self-update.
 
 set -euo pipefail
-
-STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
-INSTANCES_FILE="$STATE_DIR/instances.json"
-INSTANCES_LOCK="$STATE_DIR/instances.json.lock"
-LOG_MAX_BYTES=$((5 * 1024 * 1024))
-BRIDGE_PROCESS_PATTERN='claude remote-control'
-# Spawned session argv may be the versioned Claude binary path, so --sdk-url is
-# the stable selector. The leading [-] avoids pgrep treating the pattern as an
-# option.
-BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
-TSV_NULL='__CLAUDE_RC_NULL__'
 
 ACTION="start"
 RC_SPAWN="worktree"
@@ -30,12 +19,6 @@ FORCE=false
 log_info() { echo "[claude-rc] $*"; }
 log_warn() { echo "[claude-rc] WARN: $*" >&2; }
 log_error() { echo "[claude-rc] ERROR: $*" >&2; }
-
-iso_timestamp() {
-    local ts
-    ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
-    printf '%s:%s\n' "${ts%??}" "${ts: -2}"
-}
 
 usage() {
     cat <<'EOF'
@@ -76,20 +59,6 @@ require_common_cmds() {
     require_cmd pgrep
 }
 
-sha256_hex() {
-    local value="$1"
-    if command -v shasum >/dev/null 2>&1; then
-        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
-        return
-    fi
-    if command -v sha256sum >/dev/null 2>&1; then
-        printf '%s' "$value" | sha256sum | awk '{print $1}'
-        return
-    fi
-    log_error "required command not found in PATH: shasum or sha256sum"
-    exit 1
-}
-
 current_git_root() {
     local root
     if ! root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); then
@@ -97,117 +66,6 @@ current_git_root() {
         exit 1
     fi
     printf '%s\n' "$root"
-}
-
-canonical_existing_path() {
-    local path="$1"
-    (cd "$path" 2>/dev/null && pwd -P)
-}
-
-slug_for_path() {
-    local path="$1" base digest
-    base=$(basename "$path")
-    digest=$(sha256_hex "$path")
-    printf '%s-%s\n' "$base" "${digest:0:8}"
-}
-
-instance_dir_for_path() {
-    local path="$1" slug
-    slug=$(slug_for_path "$path")
-    printf '%s/%s\n' "$STATE_DIR" "$slug"
-}
-
-lock_path_for_path() {
-    local path="$1"
-    printf '%s/lock\n' "$(instance_dir_for_path "$path")"
-}
-
-log_path_for_path() {
-    local path="$1"
-    printf '%s/server.log\n' "$(instance_dir_for_path "$path")"
-}
-
-ensure_instance_dir() {
-    local path="$1"
-    mkdir -p "$(instance_dir_for_path "$path")"
-}
-
-lock_is_free() {
-    local lock_path="$1"
-    flock -n "$lock_path" true
-}
-
-rotate_log_if_needed() {
-    local log_path="$1" size
-    if [ ! -f "$log_path" ]; then
-        return 0
-    fi
-    size=$(wc -c <"$log_path" | tr -d '[:space:]')
-    if [ "${size:-0}" -gt "$LOG_MAX_BYTES" ]; then
-        mv -f "$log_path" "$log_path.1"
-    fi
-}
-
-init_instances_file() {
-    mkdir -p "$STATE_DIR"
-    if [ ! -f "$INSTANCES_FILE" ]; then
-        printf '{"version":1,"instances":{}}\n' >"$INSTANCES_FILE"
-    fi
-}
-
-with_instances_lock() {
-    mkdir -p "$STATE_DIR"
-    exec 8>"$INSTANCES_LOCK"
-    flock 8
-    "$@"
-}
-
-upsert_instance_unlocked() {
-    local path="$1" spawn="$2" capacity="$3" permission_mode="$4" source="$5"
-    local tmp capacity_json registered_at
-    capacity_json="null"
-    if [ -n "$capacity" ]; then
-        capacity_json="$capacity"
-    fi
-    registered_at=$(iso_timestamp)
-    init_instances_file
-    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
-    jq \
-        --arg path "$path" \
-        --arg spawn "$spawn" \
-        --arg permissionMode "$permission_mode" \
-        --arg registeredAt "$registered_at" \
-        --arg source "$source" \
-        --argjson capacity "$capacity_json" \
-        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
-         | .instances[$path] = {
-             spawn: $spawn,
-             capacity: $capacity,
-             permissionMode: $permissionMode,
-             registeredAt: $registeredAt,
-             source: $source
-           }' \
-        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
-    mv "$tmp" "$INSTANCES_FILE"
-}
-
-upsert_instance() {
-    with_instances_lock upsert_instance_unlocked "$@"
-}
-
-remove_instance_unlocked() {
-    local path="$1" tmp
-    init_instances_file
-    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
-    jq --arg path "$path" \
-        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
-         | del(.instances[$path])' \
-        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
-    mv "$tmp" "$INSTANCES_FILE"
-}
-
-remove_instance() {
-    with_instances_lock remove_instance_unlocked "$@"
 }
 
 warn_if_start_options_ignored() {
@@ -251,133 +109,6 @@ warn_if_start_options_ignored() {
     fi
 }
 
-pid_cwd() {
-    local pid="$1"
-    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}'
-}
-
-pid_exe_path() {
-    local pid="$1"
-    case "$(uname -s)" in
-        Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
-        *) readlink "/proc/$pid/exe" 2>/dev/null ;;
-    esac
-}
-
-pid_exe_version() {
-    local pid="$1" exe
-    exe=$(pid_exe_path "$pid") || return 1
-    [ -n "$exe" ] || return 1
-    case "$exe" in
-        *" (deleted)") echo "$(basename "${exe% (deleted)}") (deleted)" ;;
-        *) basename "$exe" ;;
-    esac
-}
-
-same_cwd_as_path() {
-    local pid="$1" path="$2" cwd target
-    cwd=$(pid_cwd "$pid") || return 1
-    [ -n "$cwd" ] || return 1
-    target=$(canonical_existing_path "$path") || return 1
-    [ "$cwd" = "$target" ]
-}
-
-is_flock_process() {
-    local pid="$1" exe base
-    exe=$(pid_exe_path "$pid") || return 1
-    [ -n "$exe" ] || return 1
-    base=$(basename "${exe% (deleted)}")
-    [ "$base" = "flock" ]
-}
-
-find_server_pid_for_path() {
-    local path="$1" pid
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        same_cwd_as_path "$pid" "$path" || continue
-        if is_flock_process "$pid"; then
-            continue
-        fi
-        echo "$pid"
-        return 0
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
-    return 1
-}
-
-has_unmanaged_server_for_path() {
-    local path="$1" pid
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        same_cwd_as_path "$pid" "$path" || continue
-        if is_flock_process "$pid"; then
-            continue
-        fi
-        return 0
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
-    return 1
-}
-
-count_worktree_session_procs() {
-    local instance_path="$1" wt_root pid cwd count=0
-    wt_root="$instance_path/.claude/worktrees/"
-    # pgrep -c is not portable to macOS BSD pgrep, so count PID lines manually.
-    while IFS= read -r pid; do
-        [ -n "$pid" ] || continue
-        cwd=$(pid_cwd "$pid") || continue
-        case "$cwd" in
-            "$wt_root"*) count=$((count + 1)) ;;
-        esac
-    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
-    echo "$count"
-}
-
-start_server() {
-    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
-    local instance_dir lock_path log_path
-    instance_dir=$(instance_dir_for_path "$path")
-    lock_path="$instance_dir/lock"
-    log_path="$instance_dir/server.log"
-    mkdir -p "$instance_dir"
-    rotate_log_if_needed "$log_path"
-
-    # macOS does not ship setsid. The outer background subshell exits after
-    # spawning the inner one, so the server is re-parented and survives terminal,
-    # systemd oneshot (KillMode=process), and launchd agent exit. stdin/logs are
-    # detached, and SIGHUP is ignored before exec for terminal-close survival.
-    (
-        cd "$path" || exit 1
-        (
-            trap '' HUP
-            exec </dev/null >>"$log_path" 2>&1
-            if [ -n "$capacity" ]; then
-                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-                    flock -n "$lock_path" claude remote-control \
-                    --spawn "$spawn" \
-                    --permission-mode "$permission_mode" \
-                    --capacity "$capacity" \
-                    --no-create-session-in-dir
-            else
-                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
-                    flock -n "$lock_path" claude remote-control \
-                    --spawn "$spawn" \
-                    --permission-mode "$permission_mode" \
-                    --no-create-session-in-dir
-            fi
-        ) &
-    ) &
-}
-
-wait_until_server_stops() {
-    local pid="$1"
-    for _ in 1 2 3 4 5 6 7 8 9 10; do
-        if ! kill -0 "$pid" 2>/dev/null; then
-            return 0
-        fi
-        sleep 1
-    done
-    return 1
-}
-
 parse_args() {
     if [ $# -gt 0 ]; then
         case "$1" in
@@ -404,10 +135,7 @@ parse_args() {
         case "$1" in
             --spawn)
                 [ $# -ge 2 ] || { log_error "$1 requires an argument"; exit 1; }
-                case "$2" in
-                    worktree|same-dir) ;;
-                    *) log_error "Invalid spawn mode: $2"; exit 1 ;;
-                esac
+                validate_spawn "$2" || { log_error "Invalid spawn mode: $2"; exit 1; }
                 RC_SPAWN="$2"
                 RC_SPAWN_SET=true
                 shift 2
@@ -421,10 +149,7 @@ parse_args() {
                 ;;
             --permission-mode)
                 [ $# -ge 2 ] || { log_error "$1 requires an argument"; exit 1; }
-                case "$2" in
-                    acceptEdits|bypassPermissions|default|dontAsk|plan) ;;
-                    *) log_error "Invalid permission mode: $2"; exit 1 ;;
-                esac
+                validate_permission_mode "$2" || { log_error "Invalid permission mode: $2"; exit 1; }
                 RC_PERMISSION_MODE="$2"
                 RC_PERMISSION_MODE_SET=true
                 shift 2

--- a/modules/nixos/scripts/claude-rc.sh
+++ b/modules/nixos/scripts/claude-rc.sh
@@ -1,147 +1,442 @@
 #!/usr/bin/env bash
-# claude-rc: Claude Code Remote Control tmux wrapper
+# claude-rc: Claude Code Remote Control headless multi-instance wrapper.
 #
-# 사용법:
-#   claude-rc                              # 서버 시작 (tmux attach)
-#   claude-rc --detach                     # 서버 시작 (백그라운드)
-#   claude-rc --attach                     # 기존 세션 접속
-#   claude-rc --stop                       # 서버 종료
-#   claude-rc --permission-mode default    # 권한 모드 오버라이드
-#   claude-rc --capacity 10               # 동시 세션 수 오버라이드
-#   claude-rc --name "NixOS HQ"           # 세션 이름 변경
+# Runtime dependencies are resolved from the user's PATH: claude, flock, git,
+# jq, lsof, pgrep, shasum or sha256sum. The wrapper intentionally has no Nix
+# runtimeInputs yet; the packaging changes are handled in the next phase.
 
 set -euo pipefail
 
-#───────────────────────────────────────────────────────────────────────────────
-# 기본값
-#───────────────────────────────────────────────────────────────────────────────
-WORK_DIR="@flakePath@"
-TMUX_SESSION="claude-rc"
-RC_NAME="@defaultName@"
-RC_PERMISSION_MODE="bypassPermissions"
+STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
+INSTANCES_FILE="$STATE_DIR/instances.json"
+INSTANCES_LOCK="$STATE_DIR/instances.json.lock"
+LOG_MAX_BYTES=$((5 * 1024 * 1024))
+BRIDGE_PROCESS_PATTERN='claude remote-control'
+# Spawned session argv may be the versioned Claude binary path, so --sdk-url is
+# the stable selector. The leading [-] avoids pgrep treating the pattern as an
+# option.
+BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
+TSV_NULL='__CLAUDE_RC_NULL__'
+
+ACTION="start"
 RC_SPAWN="worktree"
-RC_CAPACITY=5
+RC_CAPACITY=""
+RC_PERMISSION_MODE="bypassPermissions"
+RC_SPAWN_SET=false
+RC_CAPACITY_SET=false
+RC_PERMISSION_MODE_SET=false
+FORCE=false
 
-# 재시작 전략
-MAX_QUICK_FAILURES=30
-QUICK_FAIL_THRESHOLD=30  # seconds
-BACKOFF_INITIAL=2
-BACKOFF_MAX=60
-
-#───────────────────────────────────────────────────────────────────────────────
-# 유틸리티
-#───────────────────────────────────────────────────────────────────────────────
-log_info()  { echo "[claude-rc] $*"; }
+log_info() { echo "[claude-rc] $*"; }
+log_warn() { echo "[claude-rc] WARN: $*" >&2; }
 log_error() { echo "[claude-rc] ERROR: $*" >&2; }
+
+iso_timestamp() {
+    local ts
+    ts=$(date '+%Y-%m-%dT%H:%M:%S%z')
+    printf '%s:%s\n' "${ts%??}" "${ts: -2}"
+}
 
 usage() {
     cat <<'EOF'
-claude-rc: Claude Code Remote Control tmux wrapper
+claude-rc: Claude Code Remote Control headless multi-instance wrapper
 
-Claude 모바일 앱/claude.ai에서 이 머신의 Claude Code 세션을 원격 조종하는
-bridge 서버(`claude remote-control`)를 tmux 세션 안에서 상시 구동한다.
-구조: tmux 세션 "claude-rc" → 이 래퍼의 재시작 루프(backoff) → claude remote-control
+Usage:
+  claude-rc [start] [--spawn worktree|same-dir] [--capacity N] [--permission-mode MODE]
+  claude-rc stop [--force]
+  claude-rc ls
+  claude-rc cleanup
+  claude-rc --help
 
-사용법:
-  claude-rc                              서버 시작 (tmux attach)
-  claude-rc --detach                     서버 시작 (백그라운드)
-  claude-rc --attach                     기존 세션 접속
-  claude-rc --stop                       서버 종료 (아래 "세션 수명주기 경고" 참조)
-  claude-rc --cleanup                    zombie 세션 + stale worktree 정리
-
-옵션:
-  --permission-mode <mode>   스폰 세션 권한 모드 (default: bypassPermissions)
-                             acceptEdits|bypassPermissions|default|dontAsk|plan
-  --capacity <N>             동시 세션 수 (default: 5)
-  --name <name>              claude.ai/앱에 표시되는 이름 (default: @defaultName@)
-  --help                     이 도움말 출력
-
-세션 수명주기 경고 (--stop / 재시작 시):
-  bridge가 죽으면 활성 원격 세션은 모바일 앱에서 이어쓸 수 없게 된다
-  (기록은 보이지만 프롬프트가 무시되는 tombstone 상태).
-  대화 기록 자체는 보존된다:
-    - 로컬 transcript: ~/.claude/projects/<프로젝트 디렉토리>/<uuid>.jsonl
-    - 재개: 해당 worktree에서 `claude --resume <uuid>`,
-      또는 (claude 2.1.200+) `claude remote-control --session-id <cse_...>`
-
---cleanup 배경 (upstream workaround):
-  upstream의 "disconnect ≠ end session" 설계로 세션 프로세스가 종료되지 않아
-  capacity 슬롯이 영구 점유될 수 있다. 세션 revoke(#28917)와 idle timeout(#32050)
-  요청은 모두 미구현 상태로 종결되어 이 workaround는 계속 필요하다.
-
-자동 재시작 (버전 drift 감시):
-  NixOS는 systemd timer, macOS는 launchd agent(모두 claude-rc-ensure)가 30분마다
-  claude-rc-maint를 실행해 bridge 바이너리가 구버전이면 idle 시점에 자동 재시작한다.
-  상태 확인: cat ~/.local/state/claude-rc/status.json
-  상세: .claude/skills/managing-claude-rc/SKILL.md
+Options:
+  --spawn <mode>             worktree|same-dir (default: worktree)
+  --capacity <N>             Optional capacity. Omitted by default, so upstream uses its default.
+  --permission-mode <mode>   acceptEdits|bypassPermissions|default|dontAsk|plan
+                             (default: bypassPermissions)
+  --force                    Allow stop while worktree sessions exist.
 EOF
+    printf '\nState:\n'
+    printf '  %s/instances.json records managed instances.\n' "$STATE_DIR"
+    printf '  %s/<slug>/server.log stores each server'\''s stdout/stderr.\n' "$STATE_DIR"
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# tmux 세션 내부 감지
-#───────────────────────────────────────────────────────────────────────────────
-inside_rc_session() {
-    [[ "${CLAUDE_RC_INSIDE:-}" == "1" ]] && return 0
-    # env var 없이도 감지: claude-rc 세션의 idle pane에서 직접 재실행 시
-    # 다른 pane에서 실행 + wrapper 활성 중이면 false → do_start_outer가 "이미 실행 중" 처리
-    if [[ -n "${TMUX:-}" ]]; then
-        local current_session
-        current_session=$(tmux display-message -p '#{session_name}' 2>/dev/null) || return 1
-        [[ "$current_session" == "$TMUX_SESSION" ]] && is_session_stale && return 0
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        log_error "required command not found in PATH: $cmd"
+        exit 1
     fi
+}
+
+require_common_cmds() {
+    require_cmd flock
+    require_cmd git
+    require_cmd jq
+    require_cmd lsof
+    require_cmd pgrep
+}
+
+sha256_hex() {
+    local value="$1"
+    if command -v shasum >/dev/null 2>&1; then
+        printf '%s' "$value" | shasum -a 256 | awk '{print $1}'
+        return
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+        printf '%s' "$value" | sha256sum | awk '{print $1}'
+        return
+    fi
+    log_error "required command not found in PATH: shasum or sha256sum"
+    exit 1
+}
+
+current_git_root() {
+    local root
+    if ! root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); then
+        log_error "git repo가 아님"
+        exit 1
+    fi
+    printf '%s\n' "$root"
+}
+
+canonical_existing_path() {
+    local path="$1"
+    (cd "$path" 2>/dev/null && pwd -P)
+}
+
+slug_for_path() {
+    local path="$1" base digest
+    base=$(basename "$path")
+    digest=$(sha256_hex "$path")
+    printf '%s-%s\n' "$base" "${digest:0:8}"
+}
+
+instance_dir_for_path() {
+    local path="$1" slug
+    slug=$(slug_for_path "$path")
+    printf '%s/%s\n' "$STATE_DIR" "$slug"
+}
+
+lock_path_for_path() {
+    local path="$1"
+    printf '%s/lock\n' "$(instance_dir_for_path "$path")"
+}
+
+log_path_for_path() {
+    local path="$1"
+    printf '%s/server.log\n' "$(instance_dir_for_path "$path")"
+}
+
+ensure_instance_dir() {
+    local path="$1"
+    mkdir -p "$(instance_dir_for_path "$path")"
+}
+
+lock_is_free() {
+    local lock_path="$1"
+    flock -n "$lock_path" true
+}
+
+rotate_log_if_needed() {
+    local log_path="$1" size
+    if [ ! -f "$log_path" ]; then
+        return 0
+    fi
+    size=$(wc -c <"$log_path" | tr -d '[:space:]')
+    if [ "${size:-0}" -gt "$LOG_MAX_BYTES" ]; then
+        mv -f "$log_path" "$log_path.1"
+    fi
+}
+
+init_instances_file() {
+    mkdir -p "$STATE_DIR"
+    if [ ! -f "$INSTANCES_FILE" ]; then
+        printf '{"version":1,"instances":{}}\n' >"$INSTANCES_FILE"
+    fi
+}
+
+with_instances_lock() {
+    mkdir -p "$STATE_DIR"
+    exec 8>"$INSTANCES_LOCK"
+    flock 8
+    "$@"
+}
+
+upsert_instance_unlocked() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4" source="$5"
+    local tmp capacity_json registered_at
+    capacity_json="null"
+    if [ -n "$capacity" ]; then
+        capacity_json="$capacity"
+    fi
+    registered_at=$(iso_timestamp)
+    init_instances_file
+    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
+    jq \
+        --arg path "$path" \
+        --arg spawn "$spawn" \
+        --arg permissionMode "$permission_mode" \
+        --arg registeredAt "$registered_at" \
+        --arg source "$source" \
+        --argjson capacity "$capacity_json" \
+        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
+         | .instances[$path] = {
+             spawn: $spawn,
+             capacity: $capacity,
+             permissionMode: $permissionMode,
+             registeredAt: $registeredAt,
+             source: $source
+           }' \
+        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$INSTANCES_FILE"
+}
+
+upsert_instance() {
+    with_instances_lock upsert_instance_unlocked "$@"
+}
+
+remove_instance_unlocked() {
+    local path="$1" tmp
+    init_instances_file
+    tmp=$(mktemp "$STATE_DIR/instances.XXXXXX") || return 1
+    jq --arg path "$path" \
+        'if (.version == 1 and (.instances | type) == "object") then . else {version: 1, instances: {}} end
+         | del(.instances[$path])' \
+        "$INSTANCES_FILE" >"$tmp" || { rm -f "$tmp"; return 1; }
+    mv "$tmp" "$INSTANCES_FILE"
+}
+
+remove_instance() {
+    with_instances_lock remove_instance_unlocked "$@"
+}
+
+warn_if_start_options_ignored() {
+    local path="$1" registered reg_spawn reg_capacity reg_permission_mode
+    local -a diffs=()
+    if [ "$RC_SPAWN_SET" != true ] && [ "$RC_CAPACITY_SET" != true ] && [ "$RC_PERMISSION_MODE_SET" != true ]; then
+        return 0
+    fi
+    [ -f "$INSTANCES_FILE" ] || return 0
+
+    registered=$(jq -r --arg path "$path" --arg tsv_null "$TSV_NULL" '
+        if (.version == 1 and (.instances | type) == "object" and (.instances | has($path))) then
+          .instances[$path]
+          | [
+              (.spawn // ""),
+              (if (.capacity // null) == null then $tsv_null else (.capacity | tostring) end),
+              (.permissionMode // "")
+            ]
+          | @tsv
+        else
+          empty
+        end
+    ' "$INSTANCES_FILE")
+    [ -n "$registered" ] || return 0
+
+    IFS=$'\t' read -r reg_spawn reg_capacity reg_permission_mode <<<"$registered"
+    [ "$reg_capacity" = "$TSV_NULL" ] && reg_capacity=""
+    if [ "$RC_SPAWN_SET" = true ] && [ "$RC_SPAWN" != "$reg_spawn" ]; then
+        diffs+=("spawn: running=${reg_spawn:-<unset>}, requested=$RC_SPAWN")
+    fi
+    if [ "$RC_CAPACITY_SET" = true ] && [ "$RC_CAPACITY" != "$reg_capacity" ]; then
+        diffs+=("capacity: running=${reg_capacity:-<omitted>}, requested=$RC_CAPACITY")
+    fi
+    if [ "$RC_PERMISSION_MODE_SET" = true ] && [ "$RC_PERMISSION_MODE" != "$reg_permission_mode" ]; then
+        diffs+=("permission-mode: running=${reg_permission_mode:-<unset>}, requested=$RC_PERMISSION_MODE")
+    fi
+
+    if [ "${#diffs[@]}" -gt 0 ]; then
+        log_warn "실행 중인 서버에는 반영되지 않음 — 변경하려면 claude-rc stop 후 재기동"
+        printf '[claude-rc] WARN: %s\n' "${diffs[@]}" >&2
+    fi
+}
+
+pid_cwd() {
+    local pid="$1"
+    lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}'
+}
+
+pid_exe_path() {
+    local pid="$1"
+    case "$(uname -s)" in
+        Darwin) lsof -a -p "$pid" -d txt -Fn 2>/dev/null | awk '/^n/ {print substr($0, 2); exit}' ;;
+        *) readlink "/proc/$pid/exe" 2>/dev/null ;;
+    esac
+}
+
+pid_exe_version() {
+    local pid="$1" exe
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
+    case "$exe" in
+        *" (deleted)") echo "$(basename "${exe% (deleted)}") (deleted)" ;;
+        *) basename "$exe" ;;
+    esac
+}
+
+same_cwd_as_path() {
+    local pid="$1" path="$2" cwd target
+    cwd=$(pid_cwd "$pid") || return 1
+    [ -n "$cwd" ] || return 1
+    target=$(canonical_existing_path "$path") || return 1
+    [ "$cwd" = "$target" ]
+}
+
+is_flock_process() {
+    local pid="$1" exe base
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
+    base=$(basename "${exe% (deleted)}")
+    [ "$base" = "flock" ]
+}
+
+find_server_pid_for_path() {
+    local path="$1" pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        same_cwd_as_path "$pid" "$path" || continue
+        if is_flock_process "$pid"; then
+            continue
+        fi
+        echo "$pid"
+        return 0
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
     return 1
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# stale 세션 감지: foreground가 shell이면 stale
-#───────────────────────────────────────────────────────────────────────────────
-is_session_stale() {
-    # tmux 환경변수로 wrapper 활성 여부 판별 (pane command보다 정확)
-    local rc_active
-    rc_active=$(tmux show-environment -t "$TMUX_SESSION" CLAUDE_RC_ACTIVE 2>/dev/null) || return 0
-    # CLAUDE_RC_ACTIVE=1 → active, 그 외 → stale
-    [[ "$rc_active" != "CLAUDE_RC_ACTIVE=1" ]]
+has_unmanaged_server_for_path() {
+    local path="$1" pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        same_cwd_as_path "$pid" "$path" || continue
+        if is_flock_process "$pid"; then
+            continue
+        fi
+        return 0
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
+    return 1
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# tmux attach/switch (nested 방지)
-#───────────────────────────────────────────────────────────────────────────────
-attach_session() {
-    if [[ -n "${TMUX:-}" ]]; then
-        tmux switch-client -t "$TMUX_SESSION"
-    else
-        exec tmux attach-session -t "$TMUX_SESSION"
-    fi
+count_worktree_session_procs() {
+    local instance_path="$1" wt_root pid cwd count=0
+    wt_root="$instance_path/.claude/worktrees/"
+    # pgrep -c is not portable to macOS BSD pgrep, so count PID lines manually.
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        cwd=$(pid_cwd "$pid") || continue
+        case "$cwd" in
+            "$wt_root"*) count=$((count + 1)) ;;
+        esac
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
+    echo "$count"
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# 인자 파싱
-#───────────────────────────────────────────────────────────────────────────────
-ACTION="start"
-DETACH=false
+start_server() {
+    local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
+    local instance_dir lock_path log_path
+    instance_dir=$(instance_dir_for_path "$path")
+    lock_path="$instance_dir/lock"
+    log_path="$instance_dir/server.log"
+    mkdir -p "$instance_dir"
+    rotate_log_if_needed "$log_path"
+
+    # macOS does not ship setsid. The outer background subshell exits after
+    # spawning the inner one, so the server is re-parented and survives terminal,
+    # systemd oneshot (KillMode=process), and launchd agent exit. stdin/logs are
+    # detached, and SIGHUP is ignored before exec for terminal-close survival.
+    (
+        cd "$path" || exit 1
+        (
+            trap '' HUP
+            exec </dev/null >>"$log_path" 2>&1
+            if [ -n "$capacity" ]; then
+                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                    flock -n "$lock_path" claude remote-control \
+                    --spawn "$spawn" \
+                    --permission-mode "$permission_mode" \
+                    --capacity "$capacity" \
+                    --no-create-session-in-dir
+            else
+                exec env -u CREDENTIALS_DIRECTORY -u PUSHOVER_CRED_FILE -u PUSHOVER_TOKEN -u PUSHOVER_USER -u SERVICE_LIB \
+                    flock -n "$lock_path" claude remote-control \
+                    --spawn "$spawn" \
+                    --permission-mode "$permission_mode" \
+                    --no-create-session-in-dir
+            fi
+        ) &
+    ) &
+}
+
+wait_until_server_stops() {
+    local pid="$1"
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
 
 parse_args() {
-    while [[ $# -gt 0 ]]; do
+    if [ $# -gt 0 ]; then
         case "$1" in
-            --stop)    ACTION="stop"; shift ;;
-            --cleanup) ACTION="cleanup"; shift ;;
-            --attach)  ACTION="attach"; shift ;;
-            --detach)  DETACH=true; shift ;;
-            --help|-h) usage; exit 0 ;;
+            start|stop|ls|cleanup)
+                ACTION="$1"
+                shift
+                ;;
+            --stop)
+                ACTION="stop"
+                shift
+                ;;
+            --cleanup)
+                ACTION="cleanup"
+                shift
+                ;;
+            --help|-h|help)
+                usage
+                exit 0
+                ;;
+        esac
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --spawn)
+                [ $# -ge 2 ] || { log_error "$1 requires an argument"; exit 1; }
+                case "$2" in
+                    worktree|same-dir) ;;
+                    *) log_error "Invalid spawn mode: $2"; exit 1 ;;
+                esac
+                RC_SPAWN="$2"
+                RC_SPAWN_SET=true
+                shift 2
+                ;;
+            --capacity)
+                [ $# -ge 2 ] || { log_error "$1 requires an argument"; exit 1; }
+                [[ "$2" =~ ^[0-9]+$ ]] || { log_error "capacity must be a number: $2"; exit 1; }
+                RC_CAPACITY="$2"
+                RC_CAPACITY_SET=true
+                shift 2
+                ;;
             --permission-mode)
-                [[ $# -ge 2 ]] || { log_error "$1 requires an argument"; exit 1; }
+                [ $# -ge 2 ] || { log_error "$1 requires an argument"; exit 1; }
                 case "$2" in
                     acceptEdits|bypassPermissions|default|dontAsk|plan) ;;
                     *) log_error "Invalid permission mode: $2"; exit 1 ;;
                 esac
-                RC_PERMISSION_MODE="$2"; shift 2 ;;
-            --capacity)
-                [[ $# -ge 2 ]] || { log_error "$1 requires an argument"; exit 1; }
-                [[ "$2" =~ ^[0-9]+$ ]] || { log_error "capacity must be a number: $2"; exit 1; }
-                RC_CAPACITY="$2"; shift 2 ;;
-            --name)
-                [[ $# -ge 2 ]] || { log_error "$1 requires an argument"; exit 1; }
-                RC_NAME="$2"; shift 2 ;;
+                RC_PERMISSION_MODE="$2"
+                RC_PERMISSION_MODE_SET=true
+                shift 2
+                ;;
+            --force)
+                FORCE=true
+                shift
+                ;;
+            --help|-h|help)
+                usage
+                exit 0
+                ;;
             *)
                 log_error "Unknown option: $1"
                 usage
@@ -151,218 +446,174 @@ parse_args() {
     done
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# 서브커맨드: stop
-#───────────────────────────────────────────────────────────────────────────────
-do_stop() {
-    if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-        tmux kill-session -t "$TMUX_SESSION"
-        log_info "서버 종료됨"
-    else
-        log_info "실행 중인 세션 없음"
-    fi
-}
+do_start() {
+    require_common_cmds
+    require_cmd claude
+    local instance_path lock_path log_path env_line
+    instance_path=$(current_git_root)
+    ensure_instance_dir "$instance_path"
+    lock_path=$(lock_path_for_path "$instance_path")
+    log_path=$(log_path_for_path "$instance_path")
 
-#───────────────────────────────────────────────────────────────────────────────
-# 서브커맨드: attach
-#───────────────────────────────────────────────────────────────────────────────
-do_attach() {
-    if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-        attach_session
-    else
-        log_error "실행 중인 세션 없음 (claude-rc로 시작하세요)"
+    if ! lock_is_free "$lock_path"; then
+        log_info "이미 실행 중: $instance_path"
+        warn_if_start_options_ignored "$instance_path"
+        log_info "log: $log_path"
+        exit 0
+    fi
+
+    # Wrapper-bypassed plain CLI servers do not hold this flock. Starting a
+    # second server in the same cwd permanently creates an undeletable ghost
+    # environment, so cwd-based process detection is a hard safety gate.
+    if has_unmanaged_server_for_path "$instance_path"; then
+        log_error "same-dir claude remote-control process already exists outside claude-rc"
+        log_error "refusing duplicate start for: $instance_path"
         exit 1
     fi
+
+    start_server "$instance_path" "$RC_SPAWN" "$RC_CAPACITY" "$RC_PERMISSION_MODE"
+    sleep 2
+
+    if lock_is_free "$lock_path"; then
+        log_error "server failed to start: $instance_path"
+        if [ -f "$log_path" ]; then
+            tail -n 30 "$log_path" >&2 || true
+        fi
+        exit 1
+    fi
+
+    upsert_instance "$instance_path" "$RC_SPAWN" "$RC_CAPACITY" "$RC_PERMISSION_MODE" "manual"
+    log_info "서버 시작됨: $instance_path"
+    log_info "log: $log_path"
+    env_line=$(grep 'environment=' "$log_path" 2>/dev/null | tail -n 1 || true)
+    if [ -n "$env_line" ]; then
+        log_info "$env_line"
+    else
+        log_info "접속 URL은 server.log의 environment= 라인을 확인하세요."
+    fi
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# 서브커맨드: cleanup
-#
-# Workaround: claude remote-control의 disconnect ≠ end session 설계로 인해
-# bridge 프로세스가 종료되지 않아 capacity 슬롯이 영구 점유되는 문제.
-# upstream에서 세션 revoke(#28917) 또는 idle timeout(#32050)이 구현되면
-# 이 서브커맨드는 불필요해질 수 있다 — 그때 제거를 검토할 것.
-# refs: https://github.com/anthropics/claude-code/issues/28917
-#       https://github.com/anthropics/claude-code/issues/32050
-#───────────────────────────────────────────────────────────────────────────────
+do_stop() {
+    require_common_cmds
+    local instance_path session_count pid
+    instance_path=$(current_git_root)
+    ensure_instance_dir "$instance_path"
+
+    session_count=$(count_worktree_session_procs "$instance_path")
+    if [ "$session_count" -gt 0 ] && [ "$FORCE" != true ]; then
+        log_error "재시작 불가(tombstone) 세션 ${session_count}개 존재"
+        log_error "정말 종료하려면: claude-rc stop --force"
+        exit 1
+    fi
+
+    if pid=$(find_server_pid_for_path "$instance_path"); then
+        log_info "SIGTERM: pid=$pid"
+        kill -TERM "$pid" 2>/dev/null || true
+        if ! wait_until_server_stops "$pid"; then
+            log_error "server did not exit within 10s: pid=$pid"
+            exit 1
+        fi
+        log_info "서버 종료됨"
+    else
+        log_info "서버가 이미 죽어 있음 — 등록만 해제"
+    fi
+
+    remove_instance "$instance_path"
+}
+
+do_ls() {
+    require_common_cmds
+    init_instances_file
+    printf '%-7s %-8s %-10s %-8s %-12s %-16s %s\n' "RUNNING" "PID" "VERSION" "SPAWN" "SOURCE" "LOG" "PATH"
+    jq -r '
+        if (.version == 1 and (.instances | type) == "object") then .instances else {} end
+        | to_entries[]
+        | [.key, .value.spawn, (.value.source // "unknown")]
+        | @tsv
+    ' "$INSTANCES_FILE" | while IFS=$'\t' read -r path spawn source; do
+        [ -n "$path" ] || continue
+        local lock_path log_path running pid version
+        ensure_instance_dir "$path"
+        lock_path=$(lock_path_for_path "$path")
+        log_path=$(log_path_for_path "$path")
+        running="no"
+        pid="-"
+        version="-"
+        if ! lock_is_free "$lock_path"; then
+            running="yes"
+            if pid=$(find_server_pid_for_path "$path"); then
+                version=$(pid_exe_version "$pid" 2>/dev/null || echo unknown)
+            else
+                pid="?"
+                version="unknown"
+            fi
+        fi
+        printf '%-7s %-8s %-10s %-8s %-12s %-16s %s\n' "$running" "$pid" "$version" "$spawn" "$source" "$log_path" "$path"
+    done
+}
+
 do_cleanup() {
-    # 세션 내부 실행 감지: do_stop이 현재 셸을 kill하므로 cleanup을 먼저 수행
-    local inside=false
-    if [[ -n "${TMUX:-}" ]]; then
-        local current_session
-        current_session=$(tmux display-message -p '#{session_name}' 2>/dev/null) || true
-        [[ "$current_session" == "$TMUX_SESSION" ]] && inside=true
-    fi
+    require_common_cmds
+    local instance_path wt_dir prune_output porcelain_output dir canonical
+    local -a live_worktrees=()
+    instance_path=$(current_git_root)
 
-    # 1단계: 서버 종료 (외부 실행 시만 — 내부 실행 시 마지막에 처리)
-    if [[ "$inside" == false ]]; then
-        do_stop
+    if ! prune_output=$(git -C "$instance_path" worktree prune --expire=now --verbose 2>&1); then
+        log_error "git worktree prune 실패"
+        echo "$prune_output" >&2
+        exit 1
     fi
-
-    # 2단계: git worktree prune
-    cd "$WORK_DIR" || exit 1
-    local prune_output
-    prune_output=$(git worktree prune --expire=now --verbose 2>&1) || true
-    if [[ -n "$prune_output" ]]; then
+    if [ -n "$prune_output" ]; then
         log_info "worktree prune:"
         echo "$prune_output"
     fi
 
-    # 3단계: orphan worktree 디렉토리 정리
-    local wt_dir="${WORK_DIR}/.claude/worktrees"
-    if [[ -d "$wt_dir" ]]; then
-        # prune 후 git worktree list에 등록된 경로 수집
-        local porcelain_output
-        if ! porcelain_output=$(git worktree list --porcelain 2>&1); then
-            log_error "git worktree list 실패 — orphan sweep 건너뜀"
-        else
-            local -a live_worktrees=()
-            while IFS= read -r line; do
-                [[ "$line" == worktree\ * ]] && live_worktrees+=("${line#worktree }")
-            done <<< "$porcelain_output"
-
-            for dir in "$wt_dir"/*/; do
-                [[ -d "$dir" ]] || continue
-                local canonical
-                canonical=$(realpath "$dir")
-                local is_live=false
-                for live in "${live_worktrees[@]}"; do
-                    [[ "$(realpath "$live" 2>/dev/null)" == "$canonical" ]] && { is_live=true; break; }
-                done
-                if [[ "$is_live" == false ]]; then
-                    log_info "orphan 디렉토리 삭제: $(basename "$dir")"
-                    rm -rf "$dir"
-                fi
-            done
-        fi
-    fi
-
-    # 세션 내부: cleanup 완료 후 세션 종료 (이 셸도 함께 종료됨)
-    if [[ "$inside" == true ]]; then
-        log_info "정리 완료 — 세션 종료 중..."
-        tmux kill-session -t "$TMUX_SESSION"
-    else
-        log_info "정리 완료 — claude-rc 또는 claude-rc --detach 로 서버 재시작"
-    fi
-}
-
-#───────────────────────────────────────────────────────────────────────────────
-# 서브커맨드: start (외부에서)
-#───────────────────────────────────────────────────────────────────────────────
-do_start_outer() {
-    # 기존 세션 확인
-    if tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-        if is_session_stale; then
-            log_info "stale 세션 감지 → 재생성"
-            tmux kill-session -t "$TMUX_SESSION"
-        else
-            log_info "서버 이미 실행 중"
-            if [[ "$DETACH" == true ]]; then
-                return 0
-            fi
-            attach_session
-            return 0
-        fi
-    fi
-
-    # 새 tmux 세션 생성
-    tmux new-session -d -s "$TMUX_SESSION"
-
-    # shell-escaped 인자로 self 재호출
-    local cmd
-    cmd="CLAUDE_RC_INSIDE=1 $(printf '%q ' "$0" \
-        --permission-mode "$RC_PERMISSION_MODE" \
-        --capacity "$RC_CAPACITY" \
-        --name "$RC_NAME")"
-    tmux send-keys -t "$TMUX_SESSION" "$cmd" Enter
-
-    log_info "서버 시작됨 (세션: ${TMUX_SESSION})"
-
-    if [[ "$DETACH" == true ]]; then
-        log_info "백그라운드 실행 중 — claude-rc --attach 로 접속"
+    wt_dir="$instance_path/.claude/worktrees"
+    if [ ! -d "$wt_dir" ]; then
+        log_info "정리할 worktree 디렉토리 없음"
         return 0
     fi
 
-    attach_session
-}
+    if ! porcelain_output=$(git -C "$instance_path" worktree list --porcelain 2>&1); then
+        log_error "git worktree list 실패 — orphan sweep 건너뜀"
+        echo "$porcelain_output" >&2
+        exit 1
+    fi
 
-#───────────────────────────────────────────────────────────────────────────────
-# 내부 루프 (tmux 세션 안에서)
-#───────────────────────────────────────────────────────────────────────────────
-do_start_inner() {
-    cd "$WORK_DIR" || exit 1
-
-    # wrapper 활성 표시 (stale 감지용, 종료 시 해제)
-    tmux set-environment -t "$TMUX_SESSION" CLAUDE_RC_ACTIVE 1
-    trap 'tmux set-environment -t "$TMUX_SESSION" -u CLAUDE_RC_ACTIVE 2>/dev/null' EXIT
-
-    local failure_count=0
-    local backoff=$BACKOFF_INITIAL
-
-    log_info "Remote Control 시작: name=${RC_NAME}, mode=${RC_PERMISSION_MODE}, spawn=${RC_SPAWN}, capacity=${RC_CAPACITY}"
-
-    while true; do
-        local start_time=$SECONDS
-
-        # claude remote-control 실행
-        local rc=0
-        claude remote-control \
-            --name "$RC_NAME" \
-            --permission-mode "$RC_PERMISSION_MODE" \
-            --spawn "$RC_SPAWN" \
-            --capacity "$RC_CAPACITY" \
-            --no-create-session-in-dir || rc=$?
-
-        # 정상 종료
-        if [[ $rc -eq 0 ]]; then
-            log_info "정상 종료"
-            break
+    while IFS= read -r line; do
+        if [[ "$line" == worktree\ * ]]; then
+            live_worktrees+=("${line#worktree }")
         fi
+    done <<<"$porcelain_output"
 
-        local elapsed=$(( SECONDS - start_time ))
-
-        if [[ $elapsed -ge $QUICK_FAIL_THRESHOLD ]]; then
-            # Transient: 충분히 실행된 후 종료 → 일시적 장애
-            failure_count=0
-            backoff=$BACKOFF_INITIAL
-            log_info "일시적 장애 (${elapsed}s 실행 후 종료, exit=${rc}) → 즉시 재시작"
-        else
-            # Fatal 후보: 빠른 종료
-            failure_count=$((failure_count + 1))
-            log_info "빠른 종료 (${elapsed}s, exit=${rc}) → 실패 ${failure_count}/${MAX_QUICK_FAILURES}"
-
-            if [[ $failure_count -ge $MAX_QUICK_FAILURES ]]; then
-                log_error "연속 ${MAX_QUICK_FAILURES}회 빠른 실패 — 루프 종료"
-                log_error "수동 확인 후 claude-rc로 재시작하세요"
+    for dir in "$wt_dir"/*/; do
+        [ -d "$dir" ] || continue
+        canonical=$(canonical_existing_path "$dir") || continue
+        local is_live=false live canonical_live
+        for live in "${live_worktrees[@]}"; do
+            canonical_live=$(canonical_existing_path "$live" 2>/dev/null || true)
+            if [ -n "$canonical_live" ] && [ "$canonical_live" = "$canonical" ]; then
+                is_live=true
                 break
             fi
-
-            log_info "${backoff}s 후 재시작..."
-            sleep "$backoff"
-
-            # Exponential backoff (cap at max)
-            backoff=$(( backoff * 2 ))
-            if [[ $backoff -gt $BACKOFF_MAX ]]; then
-                backoff=$BACKOFF_MAX
-            fi
+        done
+        if [ "$is_live" = false ]; then
+            log_info "orphan 디렉토리 삭제: $(basename "$dir")"
+            rm -rf "$dir"
         fi
     done
+    log_info "정리 완료"
 }
 
-#───────────────────────────────────────────────────────────────────────────────
-# 메인
-#───────────────────────────────────────────────────────────────────────────────
-parse_args "$@"
+main() {
+    parse_args "$@"
+    case "$ACTION" in
+        start) do_start ;;
+        stop) do_stop ;;
+        ls) do_ls ;;
+        cleanup) do_cleanup ;;
+        *) usage; exit 2 ;;
+    esac
+}
 
-case "$ACTION" in
-    stop)    do_stop ;;
-    attach)  do_attach ;;
-    cleanup) do_cleanup ;;
-    start)
-        if inside_rc_session; then
-            do_start_inner
-        else
-            do_start_outer
-        fi
-        ;;
-esac
+main "$@"

--- a/modules/shared/programs/shell/nixos.nix
+++ b/modules/shared/programs/shell/nixos.nix
@@ -4,7 +4,6 @@
   pkgs,
   lib,
   username,
-  nixosConfigDefaultPath,
   ...
 }:
 
@@ -46,14 +45,12 @@ in
     executable = true;
   };
 
-  # store 패키지로 배선 — NixOS systemd 모듈(claude-remote-control.nix)의
-  # claude-rc-maint가 같은 표현식을 같은 인자로 평가해 동일 산출물을 CLAUDE_RC_BIN
-  # 절대경로로 호출한다 (HM activation 산출물에 시스템 서비스가 의존하지 않도록).
+  # store 패키지로 배선 — 래퍼는 flock/jq/lsof 등 runtimeInputs가 필요하므로
+  # Home Manager activation 산출물이 아니라 패키지 산출물을 ~/.local/bin에 링크한다.
   home.file.".local/bin/claude-rc" = {
     source = "${
       import ../../../nixos/lib/claude-rc-package.nix {
         inherit pkgs;
-        flakePath = nixosConfigDefaultPath;
       }
     }/bin/claude-rc";
   };

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# SC2034: REPO_ROOT/FIXTURE_DIR/TEST_TMP_FILE는 source된 스위트가 사용. SC1090: 스위트 동적 디스커버리.
-# shellcheck disable=SC2034,SC1090
+# SC2034: REPO_ROOT/FIXTURE_DIR/TEST_TMP_FILE는 source된 스위트가 사용. SC1090/SC1091: 동적/상대 source.
+# shellcheck disable=SC2034,SC1090,SC1091
 # tests/shell-script-tests.sh
 # 배포 레이아웃 기준 shell script fixture 테스트
 set -euo pipefail
@@ -68,6 +68,17 @@ run_test "wt cleanup removes exact Claude local plugin manifest entries" test_wt
 run_test "wt cleanup stops when plugin manifest cleanup fails" test_wt_cleanup_stops_when_plugin_manifest_cleanup_fails
 run_test "wt plugin manifest missing and invalid inputs are safe" test_wt_plugin_manifest_missing_and_invalid_are_safe
 run_test "codex activation .agents symlink guard static" test_codex_activation_agents_symlink_guard_static
+run_test "claude remote-control start requires git repo" test_claude_remote_control_start_requires_git_repo
+run_test "claude remote-control start registers manual instance" test_claude_remote_control_start_registers_manual_instance
+run_test "claude remote-control start warns on ignored options" test_claude_remote_control_start_warns_when_running_options_differ
+run_test "claude remote-control rejects unmanaged same-cwd server" test_claude_remote_control_start_rejects_unmanaged_same_cwd_server
+run_test "claude remote-control stop gates worktree sessions" test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters
+run_test "claude remote-control slug separates same basenames" test_claude_remote_control_slug_uses_hash_for_same_basename
+run_test "claude remote-control cleanup removes only orphan worktrees" test_claude_remote_control_cleanup_removes_only_orphan_worktrees
+run_test "claude remote-control maint seeds declarations" test_claude_remote_control_maint_seeds_declared_instances_without_overwrite
+run_test "claude remote-control maint rejects invalid declarations" test_claude_remote_control_maint_rejects_invalid_declared_instances
+run_test "claude remote-control transcript gate scopes to worktrees" test_claude_remote_control_transcript_gate_scopes_to_worktree_dirs
+run_test "claude remote-control maint writes status schema" test_claude_remote_control_maint_status_schema
 if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control probe parses daemon JSON" test_codex_remote_control_probe_parses_daemon_json
   run_test "codex remote-control probe marks malformed daemon JSON" test_codex_remote_control_probe_marks_malformed_daemon_json

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -71,9 +71,11 @@ run_test "codex activation .agents symlink guard static" test_codex_activation_a
 run_test "claude remote-control start requires git repo" test_claude_remote_control_start_requires_git_repo
 run_test "claude remote-control start registers manual instance" test_claude_remote_control_start_registers_manual_instance
 run_test "claude remote-control start warns on ignored options" test_claude_remote_control_start_warns_when_running_options_differ
+run_test "claude remote-control start preserves declared registry" test_claude_remote_control_start_warns_and_preserves_declared_registry
 run_test "claude remote-control rejects unmanaged same-cwd server" test_claude_remote_control_start_rejects_unmanaged_same_cwd_server
 run_test "claude remote-control maint rejects unmanaged same-cwd server" test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server
 run_test "claude remote-control stop gates worktree sessions" test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters
+run_test "claude remote-control stop preserves held-lock registration" test_claude_remote_control_stop_preserves_registration_when_lock_held_without_pid
 run_test "claude remote-control slug separates same basenames" test_claude_remote_control_slug_uses_hash_for_same_basename
 run_test "claude remote-control cleanup removes only orphan worktrees" test_claude_remote_control_cleanup_removes_only_orphan_worktrees
 run_test "claude remote-control maint reconciles declarations" test_claude_remote_control_maint_reconciles_declared_instances

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -76,9 +76,11 @@ run_test "claude remote-control rejects unmanaged same-cwd server" test_claude_r
 run_test "claude remote-control maint rejects unmanaged same-cwd server" test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server
 run_test "claude remote-control stop gates worktree sessions" test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters
 run_test "claude remote-control stop preserves held-lock registration" test_claude_remote_control_stop_preserves_registration_when_lock_held_without_pid
+run_test "claude remote-control stop path removes stale registration" test_claude_remote_control_stop_path_removes_missing_registered_instance
 run_test "claude remote-control slug separates same basenames" test_claude_remote_control_slug_uses_hash_for_same_basename
 run_test "claude remote-control cleanup removes only orphan worktrees" test_claude_remote_control_cleanup_removes_only_orphan_worktrees
 run_test "claude remote-control maint reconciles declarations" test_claude_remote_control_maint_reconciles_declared_instances
+run_test "claude remote-control maint gates drift by effective spawn" test_claude_remote_control_maint_uses_effective_spawn_for_drift_gate
 run_test "claude remote-control maint rejects invalid declarations" test_claude_remote_control_maint_rejects_invalid_declared_instances
 run_test "claude remote-control transcript gate scopes to worktrees" test_claude_remote_control_transcript_gate_scopes_to_worktree_dirs
 run_test "claude remote-control maint writes status schema" test_claude_remote_control_maint_status_schema

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -72,10 +72,11 @@ run_test "claude remote-control start requires git repo" test_claude_remote_cont
 run_test "claude remote-control start registers manual instance" test_claude_remote_control_start_registers_manual_instance
 run_test "claude remote-control start warns on ignored options" test_claude_remote_control_start_warns_when_running_options_differ
 run_test "claude remote-control rejects unmanaged same-cwd server" test_claude_remote_control_start_rejects_unmanaged_same_cwd_server
+run_test "claude remote-control maint rejects unmanaged same-cwd server" test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server
 run_test "claude remote-control stop gates worktree sessions" test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters
 run_test "claude remote-control slug separates same basenames" test_claude_remote_control_slug_uses_hash_for_same_basename
 run_test "claude remote-control cleanup removes only orphan worktrees" test_claude_remote_control_cleanup_removes_only_orphan_worktrees
-run_test "claude remote-control maint seeds declarations" test_claude_remote_control_maint_seeds_declared_instances_without_overwrite
+run_test "claude remote-control maint reconciles declarations" test_claude_remote_control_maint_reconciles_declared_instances
 run_test "claude remote-control maint rejects invalid declarations" test_claude_remote_control_maint_rejects_invalid_declared_instances
 run_test "claude remote-control transcript gate scopes to worktrees" test_claude_remote_control_transcript_gate_scopes_to_worktree_dirs
 run_test "claude remote-control maint writes status schema" test_claude_remote_control_maint_status_schema

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -1,0 +1,539 @@
+# tests/suites/claude-remote-control.sh — Claude remote-control headless fixtures
+# shellcheck shell=bash
+# shellcheck disable=SC2154,SC2164
+
+_claude_rc_wrapper_script() {
+  printf '%s\n' "$REPO_ROOT/modules/nixos/scripts/claude-rc.sh"
+}
+
+_claude_rc_maint_script() {
+  printf '%s\n' "$REPO_ROOT/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh"
+}
+
+_claude_rc_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  else
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  fi
+}
+
+_claude_rc_slug() {
+  local path="$1" base digest
+  base="$(basename "$path")"
+  digest="$(_claude_rc_sha256 "$path")"
+  printf '%s-%s\n' "$base" "${digest:0:8}"
+}
+
+_claude_rc_new_sandbox() {
+  local sandbox
+  sandbox="$(new_sandbox)"
+  (cd "$sandbox" && pwd -P)
+}
+
+_claude_rc_make_repo() {
+  local repo="$1"
+  local home="$2"
+  mkdir -p "$repo" "$home"
+  (
+    cd "$repo"
+    HOME="$home" \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_NOSYSTEM=1 \
+      git -c init.templateDir= init >/dev/null 2>&1
+  )
+}
+
+_claude_rc_make_fake_claude() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  cat > "$bin_dir/claude" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\t%s\n' "$PWD" "$*" >> "${FAKE_CLAUDE_LOG:-/dev/null}"
+if [ "${FAKE_CLAUDE_RC:-0}" != "0" ]; then
+  echo "${FAKE_CLAUDE_ERR:-fake claude failure}" >&2
+  exit "$FAKE_CLAUDE_RC"
+fi
+echo "environment=https://example.invalid/claude-rc-test"
+if [ -n "${FAKE_CLAUDE_HOLD_FILE:-}" ]; then
+  while [ -e "$FAKE_CLAUDE_HOLD_FILE" ]; do
+    sleep 0.1
+  done
+fi
+EOS
+  chmod +x "$bin_dir/claude"
+}
+
+_claude_rc_make_fake_readlink() {
+  local bin_dir="$1"
+  cat > "$bin_dir/readlink" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-f" ]; then
+  shift
+  case "${1:-}" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$PWD" "$1" ;;
+  esac
+  exit 0
+fi
+exit 1
+EOS
+  chmod +x "$bin_dir/readlink"
+}
+
+_claude_rc_find_tool() {
+  local name="$1" found
+  if found="$(command -v "$name" 2>/dev/null)"; then
+    printf '%s\n' "$found"
+    return 0
+  fi
+  found="$(find /nix/store -maxdepth 3 -type f -path "*/bin/$name" 2>/dev/null | head -n 1)"
+  [ -n "$found" ] || return 1
+  printf '%s\n' "$found"
+}
+
+_claude_rc_link_tool_if_missing() {
+  local name="$1" found
+  command -v "$name" >/dev/null 2>&1 && return 0
+  found="$(_claude_rc_find_tool "$name")" || fail "required test tool not found: $name"
+  ln -sf "$found" "$CLAUDE_RC_FAKE_BIN/$name"
+}
+
+_claude_rc_setup() {
+  local sandbox="$1"
+  CLAUDE_RC_HOME="$sandbox/home"
+  CLAUDE_RC_STATE="$sandbox/state"
+  CLAUDE_RC_FAKE_BIN="$sandbox/fake-bin"
+  CLAUDE_RC_LOG="$sandbox/claude.log"
+  CLAUDE_RC_HOLD_FILE="$sandbox/hold-server"
+  mkdir -p "$CLAUDE_RC_HOME" "$CLAUDE_RC_STATE" "$CLAUDE_RC_FAKE_BIN"
+  _claude_rc_make_fake_claude "$CLAUDE_RC_FAKE_BIN"
+  _claude_rc_link_tool_if_missing flock
+}
+
+_claude_rc_run() {
+  local cwd="$1"
+  shift
+  (
+    cd "$cwd"
+    env \
+      HOME="$CLAUDE_RC_HOME" \
+      STATE_DIR="$CLAUDE_RC_STATE" \
+      PATH="$CLAUDE_RC_FAKE_BIN:$PATH" \
+      FAKE_CLAUDE_LOG="$CLAUDE_RC_LOG" \
+      FAKE_CLAUDE_HOLD_FILE="${CLAUDE_RC_HOLD_FILE:-}" \
+      FAKE_UNMANAGED_CWD="${FAKE_UNMANAGED_CWD:-}" \
+      FAKE_UNMANAGED_EXE="${FAKE_UNMANAGED_EXE:-}" \
+      FAKE_CHILD_CWD="${FAKE_CHILD_CWD:-}" \
+      "$@"
+  )
+}
+
+_claude_rc_run_maint() {
+  local cwd="$1"
+  shift
+  (
+    cd "$cwd"
+    env \
+      HOME="$CLAUDE_RC_HOME" \
+      STATE_DIR="$CLAUDE_RC_STATE" \
+      CLAUDE_BIN="$CLAUDE_RC_FAKE_BIN/claude-new" \
+      PATH="$CLAUDE_RC_FAKE_BIN:$PATH" \
+      FAKE_CLAUDE_LOG="$CLAUDE_RC_LOG" \
+      FAKE_CLAUDE_HOLD_FILE="${CLAUDE_RC_HOLD_FILE:-}" \
+      "$@"
+  )
+}
+
+_claude_rc_wait_lock_free() {
+  local lock_path="$1"
+  local _i
+  for _i in {1..60}; do
+    if "$CLAUDE_RC_FAKE_BIN/flock" -n "$lock_path" true; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+_claude_rc_release_server() {
+  local repo="$1"
+  local lock_path
+  lock_path="$CLAUDE_RC_STATE/$(_claude_rc_slug "$repo")/lock"
+  rm -f "$CLAUDE_RC_HOLD_FILE"
+  _claude_rc_wait_lock_free "$lock_path" || fail "server lock remained held: $lock_path"
+}
+
+_claude_rc_write_instance() {
+  local path="$1" spawn="$2" capacity_json="$3" permission_mode="$4" source="$5"
+  mkdir -p "$CLAUDE_RC_STATE"
+  jq -n \
+    --arg path "$path" \
+    --arg spawn "$spawn" \
+    --arg permissionMode "$permission_mode" \
+    --arg source "$source" \
+    --argjson capacity "$capacity_json" \
+    '{version: 1, instances: {($path): {
+      spawn: $spawn,
+      capacity: $capacity,
+      permissionMode: $permissionMode,
+      registeredAt: "2026-07-08T00:00:00+09:00",
+      source: $source
+    }}}' > "$CLAUDE_RC_STATE/instances.json"
+}
+
+_claude_rc_install_unmanaged_process_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
+#!/usr/bin/env bash
+case "$*" in
+  *"claude remote-control"*) echo 4242 ;;
+  *) exit 1 ;;
+esac
+EOS
+  cat > "$CLAUDE_RC_FAKE_BIN/lsof" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+args=" $* "
+case "$args" in
+  *"cwd"*)
+    printf 'p4242\nn%s\n' "$FAKE_UNMANAGED_CWD"
+    ;;
+  *"txt"*)
+    printf 'p4242\nn%s\n' "$FAKE_UNMANAGED_EXE"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOS
+  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof"
+}
+
+_claude_rc_install_child_process_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
+#!/usr/bin/env bash
+case "$*" in
+  *"[-]-sdk-url"*) echo 5252 ;;
+  *) exit 1 ;;
+esac
+EOS
+  cat > "$CLAUDE_RC_FAKE_BIN/lsof" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+args=" $* "
+case "$args" in
+  *"cwd"*)
+    printf 'p5252\nn%s\n' "$FAKE_CHILD_CWD"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOS
+  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof"
+}
+
+test_claude_remote_control_start_requires_git_repo() {
+  local sandbox out rc
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  mkdir -p "$sandbox/not-repo"
+
+  rc=0
+  out="$(_claude_rc_run "$sandbox/not-repo" bash "$(_claude_rc_wrapper_script)" start 2>&1)" || rc=$?
+  [ "$rc" -eq 1 ] || fail "start outside git repo should exit 1, got $rc: $out"
+  assert_contains "$out" "git repo가 아님"
+}
+
+test_claude_remote_control_start_registers_manual_instance() {
+  local sandbox repo lock_path status
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start >/dev/null
+  lock_path="$CLAUDE_RC_STATE/$(_claude_rc_slug "$repo")/lock"
+  if "$CLAUDE_RC_FAKE_BIN/flock" -n "$lock_path" true; then
+    fail "server lock should be held after successful start"
+  fi
+
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$repo" '
+    .version == 1
+    and .instances[$path].spawn == "worktree"
+    and .instances[$path].capacity == null
+    and .instances[$path].permissionMode == "bypassPermissions"
+    and .instances[$path].source == "manual"
+  ' <<<"$status" >/dev/null || fail "manual instance schema mismatch: $status"
+
+  _claude_rc_release_server "$repo"
+}
+
+test_claude_remote_control_start_warns_when_running_options_differ() {
+  local sandbox repo err out
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start >/dev/null
+  out="$sandbox/start.out"
+  err="$sandbox/start.err"
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start \
+    --spawn same-dir --capacity 7 --permission-mode plan > "$out" 2> "$err"
+
+  assert_contains "$(cat "$out")" "이미 실행 중"
+  assert_contains "$(cat "$err")" "실행 중인 서버에는 반영되지 않음"
+  assert_contains "$(cat "$err")" "spawn: running=worktree, requested=same-dir"
+  assert_contains "$(cat "$err")" "capacity: running=<omitted>, requested=7"
+  assert_contains "$(cat "$err")" "permission-mode: running=bypassPermissions, requested=plan"
+
+  _claude_rc_release_server "$repo"
+}
+
+test_claude_remote_control_start_rejects_unmanaged_same_cwd_server() {
+  local sandbox repo out rc
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  _claude_rc_install_unmanaged_process_mocks
+
+  rc=0
+  FAKE_UNMANAGED_CWD="$repo"
+  FAKE_UNMANAGED_EXE="$sandbox/bin/claude"
+  out="$(_claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start 2>&1)" || rc=$?
+  unset FAKE_UNMANAGED_CWD FAKE_UNMANAGED_EXE
+  [ "$rc" -eq 1 ] || fail "unmanaged same-cwd server should be rejected, got $rc: $out"
+  assert_contains "$out" "refusing duplicate start"
+  [ ! -f "$CLAUDE_RC_STATE/instances.json" ] || fail "unmanaged rejection must not register instance"
+}
+
+test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters() {
+  local sandbox repo child_dir out rc status dead_repo
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  child_dir="$repo/.claude/worktrees/session-one"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  mkdir -p "$child_dir"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "manual"
+  _claude_rc_install_child_process_mocks
+
+  rc=0
+  FAKE_CHILD_CWD="$child_dir"
+  out="$(_claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" stop 2>&1)" || rc=$?
+  unset FAKE_CHILD_CWD
+  [ "$rc" -eq 1 ] || fail "stop should fail while worktree sessions exist, got $rc: $out"
+  assert_contains "$out" "재시작 불가(tombstone) 세션 1개 존재"
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$repo" '.instances | has($path)' <<<"$status" >/dev/null \
+    || fail "failed stop should preserve registration: $status"
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  : > "$CLAUDE_RC_HOLD_FILE"
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start >/dev/null
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" stop --force >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$repo" '(.instances | has($path)) | not' <<<"$status" >/dev/null \
+    || fail "force stop should unregister instance: $status"
+  rm -f "$CLAUDE_RC_HOLD_FILE"
+
+  dead_repo="$sandbox/dead-repo"
+  _claude_rc_make_repo "$dead_repo" "$CLAUDE_RC_HOME"
+  _claude_rc_write_instance "$dead_repo" "worktree" "null" "bypassPermissions" "manual"
+  _claude_rc_run "$dead_repo" bash "$(_claude_rc_wrapper_script)" stop --force >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$dead_repo" '(.instances | has($path)) | not' <<<"$status" >/dev/null \
+    || fail "dead server stop should only unregister: $status"
+}
+
+test_claude_remote_control_slug_uses_hash_for_same_basename() {
+  local sandbox repo_a repo_b slug_a slug_b status
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo_a="$sandbox/a/project"
+  repo_b="$sandbox/b/project"
+  _claude_rc_make_repo "$repo_a" "$CLAUDE_RC_HOME"
+  _claude_rc_make_repo "$repo_b" "$CLAUDE_RC_HOME"
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  _claude_rc_run "$repo_a" bash "$(_claude_rc_wrapper_script)" start >/dev/null
+  _claude_rc_run "$repo_b" bash "$(_claude_rc_wrapper_script)" start >/dev/null
+  slug_a="$(_claude_rc_slug "$repo_a")"
+  slug_b="$(_claude_rc_slug "$repo_b")"
+  [ "$slug_a" != "$slug_b" ] || fail "same basename paths should produce distinct slugs"
+  [ -d "$CLAUDE_RC_STATE/$slug_a" ] || fail "missing state dir for $repo_a"
+  [ -d "$CLAUDE_RC_STATE/$slug_b" ] || fail "missing state dir for $repo_b"
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg a "$repo_a" --arg b "$repo_b" '.instances | has($a) and has($b)' <<<"$status" >/dev/null \
+    || fail "both same-basename repos should be registered: $status"
+
+  rm -f "$CLAUDE_RC_HOLD_FILE"
+  _claude_rc_wait_lock_free "$CLAUDE_RC_STATE/$slug_a/lock" || fail "repo_a lock remained held"
+  _claude_rc_wait_lock_free "$CLAUDE_RC_STATE/$slug_b/lock" || fail "repo_b lock remained held"
+}
+
+test_claude_remote_control_cleanup_removes_only_orphan_worktrees() {
+  local sandbox repo live_dir orphan_dir
+  sandbox="$(_claude_rc_new_sandbox)"
+  repo="$sandbox/repo"
+  create_git_fixture_repo "$repo"
+  _claude_rc_setup "$sandbox"
+  live_dir="$repo/.claude/worktrees/feature_one"
+  orphan_dir="$repo/.claude/worktrees/orphan_one"
+  mkdir -p "$orphan_dir"
+
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" cleanup >/dev/null
+  [ -d "$live_dir" ] || fail "registered worktree should be preserved"
+  [ ! -e "$orphan_dir" ] || fail "orphan worktree dir should be removed"
+}
+
+test_claude_remote_control_maint_seeds_declared_instances_without_overwrite() {
+  local sandbox declared_path payload status
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  declared_path="$sandbox/missing-project"
+  payload="$(jq -n -c --arg path "$declared_path" '[{path: $path, spawn: "worktree", capacity: null, permissionMode: "bypassPermissions"}]')"
+
+  CLAUDE_RC_DECLARED_INSTANCES="$payload" _claude_rc_run_maint "$sandbox" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$declared_path" '
+    .instances[$path].source == "declared"
+    and .instances[$path].spawn == "worktree"
+    and .instances[$path].capacity == null
+    and .instances[$path].permissionMode == "bypassPermissions"
+  ' <<<"$status" >/dev/null || fail "declared seed schema mismatch: $status"
+
+  payload="$(jq -n -c --arg path "$declared_path" '[{path: $path, spawn: "same-dir", capacity: 9, permissionMode: "plan"}]')"
+  CLAUDE_RC_DECLARED_INSTANCES="$payload" _claude_rc_run_maint "$sandbox" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$declared_path" '
+    .instances[$path].source == "declared"
+    and .instances[$path].spawn == "worktree"
+    and .instances[$path].capacity == null
+    and .instances[$path].permissionMode == "bypassPermissions"
+  ' <<<"$status" >/dev/null || fail "declared seed should not overwrite existing instance: $status"
+}
+
+test_claude_remote_control_maint_rejects_invalid_declared_instances() {
+  local sandbox repo payload status rc
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  rc=0
+  CLAUDE_RC_DECLARED_INSTANCES='{"path":"/path/to/project"}' \
+    _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "non-array declared instances should fail"
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '.action == "declared-instances-invalid" and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "non-array invalid status mismatch: $status"
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  payload='[{"path":"relative/project","spawn":"worktree","capacity":null}]'
+  rc=0
+  CLAUDE_RC_DECLARED_INSTANCES="$payload" \
+    _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "relative declared path should fail"
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '.action == "declared-instances-invalid" and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "relative path invalid status mismatch: $status"
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  payload="$(jq -n -c --arg path "$repo" '[{path: $path, spawn: "bad-spawn", capacity: null}]')"
+  rc=0
+  CLAUDE_RC_DECLARED_INSTANCES="$payload" \
+    _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null 2>&1 || rc=$?
+  [ "$rc" -ne 0 ] || fail "invalid declared spawn should fail"
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '.action == "declared-instances-invalid" and .exitCode != 0' <<<"$status" >/dev/null \
+    || fail "invalid spawn status mismatch: $status"
+}
+
+test_claude_remote_control_transcript_gate_scopes_to_worktree_dirs() {
+  local sandbox repo copy out
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  copy="$sandbox/maint-sourceable.sh"
+  sed '$d' "$(_claude_rc_maint_script)" > "$copy"
+  cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
+#!/usr/bin/env bash
+exit 1
+EOS
+  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep"
+
+  out="$(
+    HOME="$CLAUDE_RC_HOME" STATE_DIR="$CLAUDE_RC_STATE" PATH="$CLAUDE_RC_FAKE_BIN:$PATH" \
+      bash -c '
+        set -euo pipefail
+        # shellcheck source=/dev/null
+        . "$1"
+        repo="$2"
+        prefix="$(normalized_instance_prefix "$repo")"
+        mkdir -p "$PROJECTS_DIR/$prefix"
+        : > "$PROJECTS_DIR/$prefix/root.jsonl"
+        root_count="$(count_recent_instance_transcripts "$repo")"
+        root_gate=0
+        restart_gate "$repo" || root_gate=$?
+        mkdir -p "$PROJECTS_DIR/${prefix}--claude-worktrees-bridge-cse-1"
+        : > "$PROJECTS_DIR/${prefix}--claude-worktrees-bridge-cse-1/worktree.jsonl"
+        worktree_count="$(count_recent_instance_transcripts "$repo")"
+        worktree_gate=0
+        restart_gate "$repo" || worktree_gate=$?
+        printf "root_count=%s root_gate=%s worktree_count=%s worktree_gate=%s\n" \
+          "$root_count" "$root_gate" "$worktree_count" "$worktree_gate"
+      ' _ "$copy" "$repo"
+  )"
+  [ "$out" = "root_count=0 root_gate=0 worktree_count=1 worktree_gate=1" ] \
+    || fail "transcript gate scope mismatch: $out"
+}
+
+test_claude_remote_control_maint_status_schema() {
+  local sandbox repo status log
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "manual"
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '
+    (.timestamp | type == "string")
+    and (.exitCode | type == "number")
+    and (.action | type == "string")
+    and (.instances | type == "array")
+    and (.instances[0].action == "started")
+  ' <<<"$status" >/dev/null || fail "status schema mismatch: $status"
+
+  log="$(cat "$CLAUDE_RC_LOG")"
+  assert_contains "$log" "remote-control --spawn worktree --permission-mode bypassPermissions --no-create-session-in-dir"
+  assert_not_contains "$log" "--capacity"
+
+  _claude_rc_release_server "$repo"
+}

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -76,10 +76,17 @@ EOS
   chmod +x "$bin_dir/claude"
 }
 
+# fake readlink는 desired_claude_version의 `readlink -f`만 조작한다. 그 외 호출은
+# 실제 도구로 passthrough해야 한다 — Linux의 pid_exe_path는 `readlink /proc/PID/exe`
+# (옵션 없음)를 쓰므로, 여기서 exit 1로 막으면 Linux에서만 실행 버전 조회가 실패해
+# running-version-unresolvable 오탐이 난다 (macOS는 lsof 경로라 안 걸리는 플랫폼 비대칭).
 _claude_rc_make_fake_readlink() {
-  local bin_dir="$1"
-  cat > "$bin_dir/readlink" <<'EOS'
-#!/usr/bin/env bash
+  local bin_dir="$1" real_readlink
+  # 생성 시점 PATH에는 fake-bin이 없으므로 실제 readlink가 잡힌다.
+  real_readlink="$(command -v readlink)" || fail "required test tool not found: readlink"
+  {
+    printf '#!/usr/bin/env bash\nREAL_READLINK=%q\n' "$real_readlink"
+    cat <<'EOS'
 set -euo pipefail
 if [ "${1:-}" = "-f" ]; then
   shift
@@ -89,8 +96,9 @@ if [ "${1:-}" = "-f" ]; then
   esac
   exit 0
 fi
-exit 1
+exec "$REAL_READLINK" "$@"
 EOS
+  } > "$bin_dir/readlink"
   chmod +x "$bin_dir/readlink"
 }
 

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -273,6 +273,15 @@ EOS
 }
 
 _claude_rc_install_running_server_mocks() {
+  # 이 mock 세트는 실존하지 않는 가짜 pid(6262)를 서버로 흉내낸다. 실행 바이너리
+  # 조회의 Linux 분기(readlink /proc/PID/exe)는 커널 경로라 mock이 불가능하므로,
+  # fake uname으로 Darwin 분기(lsof — 아래 mock이 커버)를 강제해 이 mock 세트가
+  # 플랫폼과 무관하게 동작하게 한다. 없으면 Linux CI에서만 실행 버전 조회가
+  # 실패해 running-version-unresolvable 오탐이 난다.
+  cat > "$CLAUDE_RC_FAKE_BIN/uname" <<'EOS'
+#!/usr/bin/env bash
+echo Darwin
+EOS
   cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
 #!/usr/bin/env bash
 case "$*" in
@@ -300,7 +309,7 @@ EOS
 #!/usr/bin/env bash
 printf '%s\n' "${FAKE_SERVER_COMMAND:-claude remote-control}"
 EOS
-  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof" "$CLAUDE_RC_FAKE_BIN/ps"
+  chmod +x "$CLAUDE_RC_FAKE_BIN/uname" "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof" "$CLAUDE_RC_FAKE_BIN/ps"
 }
 
 _claude_rc_make_recent_worktree_transcript() {

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -105,9 +105,13 @@ _claude_rc_find_tool() {
   printf '%s\n' "$found"
 }
 
-_claude_rc_link_tool_if_missing() {
+# fake-bin은 테스트가 절대경로("$CLAUDE_RC_FAKE_BIN/<tool>")로 참조하는 자기완결
+# 도구 디렉토리다. PATH에 도구가 있어도 링크를 생략하면(구현 초기 버그) macOS
+# devShell(flock 부재 → 링크 생성)에서는 통과하고 Linux CI(util-linux flock이
+# PATH에 존재 → 링크 미생성)에서만 "No such file or directory"로 깨진다.
+# 따라서 발견 경로와 무관하게 항상 링크한다.
+_claude_rc_link_tool() {
   local name="$1" found
-  command -v "$name" >/dev/null 2>&1 && return 0
   found="$(_claude_rc_find_tool "$name")" || fail "required test tool not found: $name"
   ln -sf "$found" "$CLAUDE_RC_FAKE_BIN/$name"
 }
@@ -121,7 +125,7 @@ _claude_rc_setup() {
   CLAUDE_RC_HOLD_FILE="$sandbox/hold-server"
   mkdir -p "$CLAUDE_RC_HOME" "$CLAUDE_RC_STATE" "$CLAUDE_RC_FAKE_BIN"
   _claude_rc_make_fake_claude "$CLAUDE_RC_FAKE_BIN"
-  _claude_rc_link_tool_if_missing flock
+  _claude_rc_link_tool flock
 }
 
 _claude_rc_run() {

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -249,6 +249,14 @@ EOS
   chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof"
 }
 
+_claude_rc_install_no_process_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
+#!/usr/bin/env bash
+exit 1
+EOS
+  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep"
+}
+
 test_claude_remote_control_start_requires_git_repo() {
   local sandbox out rc
   sandbox="$(_claude_rc_new_sandbox)"
@@ -306,6 +314,37 @@ test_claude_remote_control_start_warns_when_running_options_differ() {
   assert_contains "$(cat "$err")" "spawn: running=worktree, requested=same-dir"
   assert_contains "$(cat "$err")" "capacity: running=<omitted>, requested=7"
   assert_contains "$(cat "$err")" "permission-mode: running=bypassPermissions, requested=plan"
+
+  _claude_rc_release_server "$repo"
+}
+
+test_claude_remote_control_start_warns_and_preserves_declared_registry() {
+  local sandbox repo err status log
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "declared"
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  err="$sandbox/start.err"
+  _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start \
+    --spawn same-dir --capacity 7 --permission-mode plan >/dev/null 2> "$err"
+
+  assert_contains "$(cat "$err")" "이 경로는 Nix 선언 관리 대상"
+  assert_contains "$(cat "$err")" "spawn: declared=worktree, requested=same-dir"
+  assert_contains "$(cat "$err")" "capacity: declared=<omitted>, requested=7"
+  assert_contains "$(cat "$err")" "permission-mode: declared=bypassPermissions, requested=plan"
+
+  log="$(cat "$CLAUDE_RC_LOG")"
+  assert_contains "$log" "remote-control --spawn same-dir --permission-mode plan --capacity 7 --no-create-session-in-dir"
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$repo" '
+    .instances[$path].source == "declared"
+    and .instances[$path].spawn == "worktree"
+    and .instances[$path].capacity == null
+    and .instances[$path].permissionMode == "bypassPermissions"
+  ' <<<"$status" >/dev/null || fail "declared start should preserve registry entry: $status"
 
   _claude_rc_release_server "$repo"
 }
@@ -395,6 +434,43 @@ test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters()
     || fail "dead server stop should only unregister: $status"
 }
 
+test_claude_remote_control_stop_preserves_registration_when_lock_held_without_pid() {
+  local sandbox repo slug lock_path lock_pid out rc status
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_install_no_process_mocks
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "manual"
+  slug="$(_claude_rc_slug "$repo")"
+  mkdir -p "$CLAUDE_RC_STATE/$slug"
+  lock_path="$CLAUDE_RC_STATE/$slug/lock"
+
+  "$CLAUDE_RC_FAKE_BIN/flock" "$lock_path" sleep 30 &
+  lock_pid=$!
+  for _ in {1..30}; do
+    if ! "$CLAUDE_RC_FAKE_BIN/flock" -n "$lock_path" true; then
+      break
+    fi
+    sleep 0.1
+  done
+  if "$CLAUDE_RC_FAKE_BIN/flock" -n "$lock_path" true; then
+    kill "$lock_pid" 2>/dev/null || true
+    wait "$lock_pid" 2>/dev/null || true
+    fail "test failed to acquire synthetic lock"
+  fi
+
+  rc=0
+  out="$(_claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" stop --force 2>&1)" || rc=$?
+  kill "$lock_pid" 2>/dev/null || true
+  wait "$lock_pid" 2>/dev/null || true
+  [ "$rc" -eq 1 ] || fail "stop should fail on held lock without PID, got $rc: $out"
+  assert_contains "$out" "no-server-process"
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$repo" '.instances | has($path)' <<<"$status" >/dev/null \
+    || fail "held-lock stop must preserve registration: $status"
+}
+
 test_claude_remote_control_slug_uses_hash_for_same_basename() {
   local sandbox repo_a repo_b slug_a slug_b status
   sandbox="$(_claude_rc_new_sandbox)"
@@ -469,16 +545,33 @@ test_claude_remote_control_maint_reconciles_declared_instances() {
   _claude_rc_setup "$sandbox"
   _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
   manual_path="$sandbox/manual-project"
-  _claude_rc_write_instance "$manual_path" "worktree" "null" "bypassPermissions" "manual"
-  payload="$(jq -n -c --arg path "$manual_path" '[{path: $path, spawn: "same-dir", capacity: 9, permissionMode: "plan"}]')"
+  _claude_rc_write_instance "$manual_path" "same-dir" "9" "plan" "manual"
+  payload="$(jq -n -c --arg path "$manual_path" '[{path: $path, spawn: "worktree", capacity: null, permissionMode: "bypassPermissions"}]')"
   CLAUDE_RC_DECLARED_INSTANCES="$payload" _claude_rc_run_maint "$sandbox" bash "$(_claude_rc_maint_script)" ensure >/dev/null
   status="$(cat "$CLAUDE_RC_STATE/instances.json")"
   jq -e --arg path "$manual_path" '
-    .instances[$path].source == "manual"
+    .instances[$path].source == "declared"
     and .instances[$path].spawn == "worktree"
     and .instances[$path].capacity == null
     and .instances[$path].permissionMode == "bypassPermissions"
-  ' <<<"$status" >/dev/null || fail "manual instance should win over declaration: $status"
+  ' <<<"$status" >/dev/null || fail "declared path should override manual registry entry: $status"
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  manual_path="$sandbox/manual-project"
+  declared_path="$sandbox/declared-project"
+  _claude_rc_write_instance "$manual_path" "same-dir" "9" "plan" "manual"
+  payload="$(jq -n -c --arg path "$declared_path" '[{path: $path, spawn: "worktree", capacity: null, permissionMode: "bypassPermissions"}]')"
+  CLAUDE_RC_DECLARED_INSTANCES="$payload" _claude_rc_run_maint "$sandbox" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$manual_path" --arg declared "$declared_path" '
+    .instances[$path].source == "manual"
+    and .instances[$path].spawn == "same-dir"
+    and .instances[$path].capacity == 9
+    and .instances[$path].permissionMode == "plan"
+    and .instances[$declared].source == "declared"
+  ' <<<"$status" >/dev/null || fail "undeclared manual instance should remain untouched: $status"
 }
 
 test_claude_remote_control_maint_rejects_invalid_declared_instances() {
@@ -532,8 +625,7 @@ test_claude_remote_control_transcript_gate_scopes_to_worktree_dirs() {
   _claude_rc_setup "$sandbox"
   repo="$sandbox/repo"
   _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
-  copy="$sandbox/maint-sourceable.sh"
-  sed '$d' "$(_claude_rc_maint_script)" > "$copy"
+  copy="$(_claude_rc_maint_script)"
   cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
 #!/usr/bin/env bash
 exit 1

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -156,6 +156,9 @@ _claude_rc_run_maint() {
       FAKE_CLAUDE_HOLD_FILE="${CLAUDE_RC_HOLD_FILE:-}" \
       FAKE_UNMANAGED_CWD="${FAKE_UNMANAGED_CWD:-}" \
       FAKE_UNMANAGED_EXE="${FAKE_UNMANAGED_EXE:-}" \
+      FAKE_SERVER_CWD="${FAKE_SERVER_CWD:-}" \
+      FAKE_SERVER_EXE="${FAKE_SERVER_EXE:-}" \
+      FAKE_SERVER_COMMAND="${FAKE_SERVER_COMMAND:-}" \
       "$@"
   )
 }
@@ -255,6 +258,44 @@ _claude_rc_install_no_process_mocks() {
 exit 1
 EOS
   chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep"
+}
+
+_claude_rc_install_running_server_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
+#!/usr/bin/env bash
+case "$*" in
+  *"claude remote-control"*) echo 6262 ;;
+  *) exit 1 ;;
+esac
+EOS
+  cat > "$CLAUDE_RC_FAKE_BIN/lsof" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+args=" $* "
+case "$args" in
+  *"cwd"*)
+    printf 'p6262\nn%s\n' "$FAKE_SERVER_CWD"
+    ;;
+  *"txt"*)
+    printf 'p6262\nn%s\n' "$FAKE_SERVER_EXE"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOS
+  cat > "$CLAUDE_RC_FAKE_BIN/ps" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_SERVER_COMMAND:-claude remote-control}"
+EOS
+  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof" "$CLAUDE_RC_FAKE_BIN/ps"
+}
+
+_claude_rc_make_recent_worktree_transcript() {
+  local repo="$1" prefix
+  prefix="$(printf '%s' "$repo" | sed 's/[^[:alnum:]]/-/g')"
+  mkdir -p "$CLAUDE_RC_HOME/.claude/projects/${prefix}--claude-worktrees-bridge-cse-1"
+  : > "$CLAUDE_RC_HOME/.claude/projects/${prefix}--claude-worktrees-bridge-cse-1/session.jsonl"
 }
 
 test_claude_remote_control_start_requires_git_repo() {
@@ -471,6 +512,20 @@ test_claude_remote_control_stop_preserves_registration_when_lock_held_without_pi
     || fail "held-lock stop must preserve registration: $status"
 }
 
+test_claude_remote_control_stop_path_removes_missing_registered_instance() {
+  local sandbox stale_path status
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_install_no_process_mocks
+  stale_path="$sandbox/missing-project"
+  _claude_rc_write_instance "$stale_path" "worktree" "null" "bypassPermissions" "manual"
+
+  _claude_rc_run "$sandbox" bash "$(_claude_rc_wrapper_script)" stop "$stale_path" >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$stale_path" '(.instances | has($path)) | not' <<<"$status" >/dev/null \
+    || fail "stop <path> should remove missing stale registration: $status"
+}
+
 test_claude_remote_control_slug_uses_hash_for_same_basename() {
   local sandbox repo_a repo_b slug_a slug_b status
   sandbox="$(_claude_rc_new_sandbox)"
@@ -572,6 +627,53 @@ test_claude_remote_control_maint_reconciles_declared_instances() {
     and .instances[$path].permissionMode == "plan"
     and .instances[$declared].source == "declared"
   ' <<<"$status" >/dev/null || fail "undeclared manual instance should remain untouched: $status"
+}
+
+test_claude_remote_control_maint_uses_effective_spawn_for_drift_gate() {
+  local sandbox repo slug lock_path lock_pid status command
+
+  for command in \
+    "claude remote-control --spawn worktree --permission-mode bypassPermissions" \
+    "claude remote-control --permission-mode bypassPermissions"
+  do
+    sandbox="$(_claude_rc_new_sandbox)"
+    _claude_rc_setup "$sandbox"
+    _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+    _claude_rc_install_running_server_mocks
+    repo="$sandbox/repo"
+    _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+    _claude_rc_write_instance "$repo" "same-dir" "null" "bypassPermissions" "manual"
+    _claude_rc_make_recent_worktree_transcript "$repo"
+    slug="$(_claude_rc_slug "$repo")"
+    mkdir -p "$CLAUDE_RC_STATE/$slug"
+    lock_path="$CLAUDE_RC_STATE/$slug/lock"
+
+    "$CLAUDE_RC_FAKE_BIN/flock" "$lock_path" sleep 30 &
+    lock_pid=$!
+    for _ in {1..30}; do
+      if ! "$CLAUDE_RC_FAKE_BIN/flock" -n "$lock_path" true; then
+        break
+      fi
+      sleep 0.1
+    done
+    if "$CLAUDE_RC_FAKE_BIN/flock" -n "$lock_path" true; then
+      kill "$lock_pid" 2>/dev/null || true
+      wait "$lock_pid" 2>/dev/null || true
+      fail "test failed to acquire synthetic lock"
+    fi
+
+    FAKE_SERVER_CWD="$repo" \
+    FAKE_SERVER_EXE="$CLAUDE_RC_FAKE_BIN/claude-old" \
+    FAKE_SERVER_COMMAND="$command" \
+      _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+    kill "$lock_pid" 2>/dev/null || true
+    wait "$lock_pid" 2>/dev/null || true
+    status="$(cat "$CLAUDE_RC_STATE/status.json")"
+    jq -e '
+      .action == "completed"
+      and .instances[0].action == "deferred-active-sessions"
+    ' <<<"$status" >/dev/null || fail "effective spawn drift gate mismatch for [$command]: $status"
+  done
 }
 
 test_claude_remote_control_maint_rejects_invalid_declared_instances() {

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -3,11 +3,22 @@
 # shellcheck disable=SC2154,SC2164
 
 _claude_rc_wrapper_script() {
-  printf '%s\n' "$REPO_ROOT/modules/nixos/scripts/claude-rc.sh"
+  _claude_rc_concat_script "$REPO_ROOT/modules/nixos/scripts/claude-rc.sh"
 }
 
 _claude_rc_maint_script() {
-  printf '%s\n' "$REPO_ROOT/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh"
+  _claude_rc_concat_script "$REPO_ROOT/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh"
+}
+
+_claude_rc_concat_script() {
+  local body="$1" sandbox out
+  sandbox="$(new_sandbox)"
+  out="$sandbox/$(basename "$body")"
+  cat "$REPO_ROOT/modules/nixos/scripts/claude-rc-lib.sh" > "$out"
+  printf '\n' >> "$out"
+  cat "$body" >> "$out"
+  chmod +x "$out"
+  printf '%s\n' "$out"
 }
 
 _claude_rc_sha256() {
@@ -143,6 +154,8 @@ _claude_rc_run_maint() {
       PATH="$CLAUDE_RC_FAKE_BIN:$PATH" \
       FAKE_CLAUDE_LOG="$CLAUDE_RC_LOG" \
       FAKE_CLAUDE_HOLD_FILE="${CLAUDE_RC_HOLD_FILE:-}" \
+      FAKE_UNMANAGED_CWD="${FAKE_UNMANAGED_CWD:-}" \
+      FAKE_UNMANAGED_EXE="${FAKE_UNMANAGED_EXE:-}" \
       "$@"
   )
 }
@@ -315,6 +328,31 @@ test_claude_remote_control_start_rejects_unmanaged_same_cwd_server() {
   [ ! -f "$CLAUDE_RC_STATE/instances.json" ] || fail "unmanaged rejection must not register instance"
 }
 
+test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server() {
+  local sandbox repo status rc
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "manual"
+  _claude_rc_install_unmanaged_process_mocks
+
+  rc=0
+  FAKE_UNMANAGED_CWD="$repo"
+  FAKE_UNMANAGED_EXE="$CLAUDE_RC_FAKE_BIN/claude"
+  _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null 2>&1 || rc=$?
+  unset FAKE_UNMANAGED_CWD FAKE_UNMANAGED_EXE
+  [ "$rc" -ne 0 ] || fail "maint should fail when unmanaged same-cwd server exists"
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '
+    .action == "failed"
+    and .exitCode != 0
+    and .instances[0].action == "unmanaged-server-present"
+  ' <<<"$status" >/dev/null || fail "unmanaged status mismatch: $status"
+  [ ! -s "$CLAUDE_RC_LOG" ] || fail "maint unmanaged guard must not start claude: $(cat "$CLAUDE_RC_LOG")"
+}
+
 test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters() {
   local sandbox repo child_dir out rc status dead_repo
   sandbox="$(_claude_rc_new_sandbox)"
@@ -398,8 +436,8 @@ test_claude_remote_control_cleanup_removes_only_orphan_worktrees() {
   [ ! -e "$orphan_dir" ] || fail "orphan worktree dir should be removed"
 }
 
-test_claude_remote_control_maint_seeds_declared_instances_without_overwrite() {
-  local sandbox declared_path payload status
+test_claude_remote_control_maint_reconciles_declared_instances() {
+  local sandbox declared_path manual_path payload status registered_at
   sandbox="$(_claude_rc_new_sandbox)"
   _claude_rc_setup "$sandbox"
   _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
@@ -414,16 +452,33 @@ test_claude_remote_control_maint_seeds_declared_instances_without_overwrite() {
     and .instances[$path].capacity == null
     and .instances[$path].permissionMode == "bypassPermissions"
   ' <<<"$status" >/dev/null || fail "declared seed schema mismatch: $status"
+  registered_at="$(jq -r --arg path "$declared_path" '.instances[$path].registeredAt' <<<"$status")"
 
   payload="$(jq -n -c --arg path "$declared_path" '[{path: $path, spawn: "same-dir", capacity: 9, permissionMode: "plan"}]')"
   CLAUDE_RC_DECLARED_INSTANCES="$payload" _claude_rc_run_maint "$sandbox" bash "$(_claude_rc_maint_script)" ensure >/dev/null
   status="$(cat "$CLAUDE_RC_STATE/instances.json")"
-  jq -e --arg path "$declared_path" '
+  jq -e --arg path "$declared_path" --arg registeredAt "$registered_at" '
     .instances[$path].source == "declared"
+    and .instances[$path].spawn == "same-dir"
+    and .instances[$path].capacity == 9
+    and .instances[$path].permissionMode == "plan"
+    and .instances[$path].registeredAt == $registeredAt
+  ' <<<"$status" >/dev/null || fail "declared instance should reconcile to current declaration: $status"
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  manual_path="$sandbox/manual-project"
+  _claude_rc_write_instance "$manual_path" "worktree" "null" "bypassPermissions" "manual"
+  payload="$(jq -n -c --arg path "$manual_path" '[{path: $path, spawn: "same-dir", capacity: 9, permissionMode: "plan"}]')"
+  CLAUDE_RC_DECLARED_INSTANCES="$payload" _claude_rc_run_maint "$sandbox" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$manual_path" '
+    .instances[$path].source == "manual"
     and .instances[$path].spawn == "worktree"
     and .instances[$path].capacity == null
     and .instances[$path].permissionMode == "bypassPermissions"
-  ' <<<"$status" >/dev/null || fail "declared seed should not overwrite existing instance: $status"
+  ' <<<"$status" >/dev/null || fail "manual instance should win over declaration: $status"
 }
 
 test_claude_remote_control_maint_rejects_invalid_declared_instances() {


### PR DESCRIPTION
## Summary

- `claude-rc`를 tmux 단일 bridge에서 **디렉토리 단위 headless multi-instance** 스택으로 재설계한다 — upstream의 실제 모델(디렉토리 = claude.ai 환경)과 정합.
- lock을 서버 프로세스에 상속시키는 flock 설계로 생사 오판을 구조적으로 제거하고, 중복 기동(=삭제 불가능한 유령 환경 생성)을 2중 가드로 방어한다.
- 동적 등록(`instances.json`) + 선언 시드(reconcile)로 "한 번 띄우면 ensure가 유지, 명시적 stop이 해제"의 수명주기를 제공한다.

Closes #1051

## 기존 문제/배경

현행 래퍼는 tmux 세션 이름(`claude-rc`)과 작업 디렉토리(`@flakePath@` 빌드타임 치환)를 고정해 머신당 bridge를 1개만, nixos-config 전용으로 띄울 수 있다. 다른 프로젝트 디렉토리에서 실행하면 "서버 이미 실행 중"으로 차단되고 전달한 옵션도 조용히 무시된다.

이는 최초 요구(#208: 단일 프로젝트 상시 관제)의 명세가 macOS 이식(#1007) 때 재검토 없이 승계된 결과다. 라이브 실측(claude v2.1.204)으로 upstream 동작을 전수 검증한 결과, 단일 인스턴스 제약은 upstream에 없고 래퍼가 만든 것임이 확정됐다 (상세 근거는 #1051).

## CIR (Change Intent Record)

- **v1** (#208 → PR #226): MiniPC에서 nixos-config 관제용 단일 tmux bridge. "이미 실행 중이면 attach"가 당시 승인 기준이었다.
- **v2** (PR #228, #1005): capacity 슬롯 workaround(`--cleanup`), 버전 drift 자동 재시작(maint 분리), 운영 옵션의 Nix 선언 승격.
- **v3** (PR #1008): macOS 이식 — 단일 프로젝트 가정이 검토 없이 함께 이식됨.
- **v4** (이번 변경): 실측으로 upstream 모델(디렉토리=환경, 환경 보존·회수, same-dir 세션 자동 재연결, 앱의 세션 종료 UI)을 확정하고 v1의 단일 인스턴스 명세를 의도적으로 번복. tmux 계층(stale 감지·backoff 루프)은 flock 상속 설계로 대체 — lock 생사가 곧 서버 생사라 stale 중간 상태가 구조적으로 없다. `--name` 제거(환경 표시명은 호스트명+디렉토리 basename으로 upstream이 결정함을 실측), capacity는 upstream 기본 위임(nullable), `--cleanup`의 capacity workaround 서술 제거(앱 세션 종료 UI 실측 확인).
- 구현 중 정련: (a) 래퍼/maint에 중복되던 lifecycle 엔진을 `claude-rc-lib.sh` 공유 lib로 추출(패키징 concat), (b) maint 자동 기동 경로에도 unmanaged same-cwd 가드 적용(유령 환경 방어를 자동화 경로까지 확장), (c) 선언 경로는 선언이 항상 authority(수동 override는 다음 ensure에서 선언값 복원 — 선언적 관리 철학), (d) drift 재시작 안전성 판정은 registry의 desired spawn이 아니라 실행 중 서버 argv의 effective spawn 실측으로 분기(파싱 실패 시 보수적 worktree 게이트).

**trade-off**: 재시작 루프가 없어 crash 후 다음 ensure까지 최대 30분 공백이 생기지만, 실사망 원인 1위(머신 sleep)는 wake 시 ensure가 처리하므로 실효 격차가 작다. 공백이 실측으로 아프면 주기 단축 → transient unit 순으로 증분 확장한다 (flock 구조가 그대로 전제).

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| tmux 래퍼 multi-instance 확장 | 세션 N개 + stale 감지 유지 | attach로 라이브 TUI, 검증된 스택 | stale 감지가 env var 프록시라 오판 여지, 세션 관리 코드 증가 | ❌ |
| headless + flock 상속 | lock을 서버 프로세스가 직접 보유 | 생사 오판 구조적 불가, 코드 최소, 로그 영속 | crash 후 최대 30분 부활 공백 | ✅ |
| 프로젝트별 launchd/systemd 서비스 | OS가 KeepAlive로 직접 관리 | 즉시 재시작 | 인스턴스 목록이 머신 로컬 가변 정보라 정적 선언 불가, macOS 동적 plist 관리 복잡 | ❌ (필요 시 증분 추가) |
| 인스턴스 목록 Nix 선언 전용 | 모든 인스턴스를 선언으로 관리 | 완전 선언적 | 프로젝트 추가마다 rebuild, 머신 로컬 정보의 repo 유입 | ❌ (nixos-config만 선언 시드) |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/scripts/claude-rc-lib.sh` | 신설 | 공유 lifecycle lib — slug/lock/log 경로, instances.json 접근, pid 실측(cwd/exe/spawn), 서버 기동(flock 상속 + double-fork detach) |
| `modules/nixos/scripts/claude-rc.sh` | 재작성 | start/stop/ls/cleanup — 중복 기동 2중 가드, 동적 등록, worktree 세션 tombstone 가드(`--force`), stale 등록 제거(`stop [path]`) |
| `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh` | 재작성 | 선언 시드 reconcile + 인스턴스 순회 ensure — 부활, drift 시 effective spawn 실측 게이트, 인스턴스 스코프 transcript 판정, Pushover 승계 |
| `modules/nixos/lib/claude-rc-package.nix` | 재작성 | `writeShellApplication` 전환 (runtimeInputs: flock/jq/lsof 등 플랫폼 분기, lib concat) |
| `modules/nixos/lib/claude-rc-maint-package.nix` | 수정 | tmux 제거, Linux lsof 추가, lib concat |
| `modules/nixos/programs/claude-remote-control.nix` | 수정 | env 계약 교체 — `CLAUDE_RC_DECLARED_INSTANCES` JSON 주입 |
| `modules/darwin/programs/claude-remote-control.nix` | 수정 | 동일 + `AbandonProcessGroup = true` (ensure job 종료가 방금 스폰한 서버를 죽이지 않도록) |
| `modules/nixos/options/homeserver.nix` | 수정 | `name` 제거, `spawn` 추가, `capacity` nullable |
| `.claude/skills/managing-claude-rc/SKILL.md` | 전면 개정 | 실측 반영 — tombstone은 worktree 스폰 세션 한정, 환경 보존·회수 모델, legacy tmux 마이그레이션 절차 |
| `tests/suites/claude-remote-control.sh` | 신설 | fixture 테스트 스위트 (가드·등록·reconcile·게이트·상태 스키마) |

### 핵심 코드

```bash
# lock을 서버 프로세스에 상속 — lock 생사 = 서버 생사 (stale 중간 상태 없음)
flock -n "$STATE_DIR/<slug>/lock" claude remote-control \
  --spawn "$spawn" --permission-mode "$pm" --no-create-session-in-dir

# drift 재시작 안전성은 registry(desired)가 아니라 실행 중 프로세스의 실제 모드가 결정
if ! effective_spawn=$(pid_spawn_mode "$pid"); then
    effective_spawn="worktree"   # 파싱 실패 시 보수적 게이트
fi
```

## 참고 레퍼런스

- Issue #1051 — 재설계 결정 기록 + 실측 검증 전문 (환경 모델, 세션 수명주기, 유령 환경 기전)
- Issue #208 / PR #226 — 최초 도입 (단일 프로젝트 명세의 출처, 본 PR이 의도적으로 번복)
- PR #228 — `--cleanup` capacity workaround (근거 소멸로 축소)
- PR #1005 — maint 분리·선언 승격 (분리 구조와 flock fd 규칙은 승계)
- PR #1008 — macOS 이식 (플랫폼 분기 승계)
- [Remote Control 공식 문서](https://code.claude.com/docs/en/remote-control.md) — 디렉토리 단위 서버 모델, 네트워크 10분 자기 종료

## Human Test Plan

### 정상 동작 검증

1. `nrs` 적용 후 임의 git 프로젝트에서 `claude-rc`를 실행한다.
   - **기대**: 서버가 headless로 기동되고 `claude-rc ls`에 등록·실행 상태가 보인다. claude.ai/모바일 앱 환경 목록에 해당 디렉토리 환경이 나타난다.
   - **실패 시**: `~/.local/state/claude-rc/<slug>/server.log` 확인.
2. 두 번째 프로젝트에서도 `claude-rc`를 실행한다.
   - **기대**: 기존 서버와 동시에 기동된다 (구버전의 "서버 이미 실행 중" 차단 없음).
3. 같은 프로젝트에서 `claude-rc`를 다시 실행한다.
   - **기대**: "이미 실행 중" 멱등 종료. 다른 옵션을 명시하면 반영되지 않는다는 경고가 출력된다.
4. `claude-rc stop` 후 재기동한다.
   - **기대**: claude.ai 환경 목록에 같은 환경이 유지된다 (중복 환경 생성 없음 — 환경 회수 실측 근거는 #1051).

### 자동화 검증

5. macOS: `launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"` / NixOS: `systemctl start claude-rc-ensure` 후 `cat ~/.local/state/claude-rc/status.json`.
   - **기대**: 선언 인스턴스(nixos-config)가 시드·기동되고 인스턴스별 action이 기록된다.
   - **실패 시**: ensure 로그(`~/Library/Logs/claude-rc-ensure.log` 또는 journalctl)와 스킬 문서의 status action 표 대조.
6. 서버를 `kill`로 죽이고 다음 ensure를 기다린다(또는 수동 kickstart).
   - **기대**: 부활 후 같은 환경 회수.

### Negative / 마이그레이션 검증

7. 구 tmux bridge가 떠 있는 상태에서 ensure를 실행한다.
   - **기대**: 기동하지 않고 `unmanaged-server-present`로 기록 (유령 환경 생성 없음). 스킬 문서의 마이그레이션 절차(구 tmux 세션 종료 → 재기동)로 전환.
8. 순정 `claude remote-control`을 직접 띄운 디렉토리에서 `claude-rc`를 실행한다.
   - **기대**: 중복 기동 거부 (같은 디렉토리 2서버 = 유령 환경 방지 가드).
9. `--name`·`--attach`·`--detach` 등 제거된 옵션이 usage에 없음을 확인한다 (Negative).
10. 인접 기능 regression: `wt ls`, `wt cleanup` 등 worktree 도구가 정상 동작하는지 확인한다 (cleanup은 git 미등록 orphan만 삭제).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless multi-instance management for remote-control sessions, including declared-instance syncing, status reporting, and safer start/stop behavior.
  * Introduced support for per-instance spawn modes and optional capacity settings.

* **Bug Fixes**
  * Prevents duplicate or unmanaged same-directory sessions from starting.
  * Improves cleanup of stale registrations, orphan worktree folders, and drifted sessions.

* **Tests**
  * Expanded shell coverage with new scenarios for registration, reconciliation, gating, and recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->