### PR TITLE
fix(tests): shell-script-tests wrap 세 진입점에 nixpkgs#lsof 추가

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -102,10 +102,12 @@ pre-push:
       # coreutils/findutils를 PATH에 얹어 실행한다(#1009: devShell 밖 BSD 도구로 karakeep fixture
       # 실패). devShell은 건드리지 않아 direnv/bare python3 해석 영향이 없다. `--inputs-from .`로
       # nixpkgs#를 repo flake.lock에 pin해 임시 registry fetch를 피한다(statusline-bats와 동일 패턴).
+      # claude-rc(#1052)가 require_cmd lsof를 도입했고 lsof는 NixOS 시스템 프로파일/CI PATH에
+      # 항상 있지 않으므로 nixpkgs#lsof도 명시 제공한다(#1009와 동일 패턴).
       # `_TOMLKIT_BOOTSTRAP_READY=1`로 run-shell-script-tests.sh 내부 tomlkit-bootstrap.sh의 중첩
       # `nix shell` re-exec을 막는다(이 wrap이 이미 동일 hermetic 런타임을 제공). 테스트 병렬 실행은
       # 러너 자체(tests/lib/parallel-harness.sh job-pool)가 담당하므로 여기서 추가 배선은 없다.
-      run: nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh
+      run: nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh
     codex-hook-fixtures:
       # pre-commit에 이미 동일 명령이 있지만 push 직전 재검증해 stale state 회귀 차단.
       # runner self-bootstrap이라 추가 nix shell wrap 불필요. live propagation은 attach하지 않음.

--- a/scripts/ai/lib/tomlkit-bootstrap.sh
+++ b/scripts/ai/lib/tomlkit-bootstrap.sh
@@ -65,15 +65,16 @@ tomlkit_bootstrap_require() {
   # (2) nix 가용 → repo-pinned runtime으로 재실행 (hermetic 강제). 스크립트 자체는 self_path
   #     (snapshot 경로 가능)에서 계속 실행하고, flake root 만 실제 repo 로 고정한다.
   if command -v nix >/dev/null 2>&1; then
-    echo "  test runtime bootstrap: nix shell --inputs-from ${flake_root} ${flake_root}#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command bash $self_path" >&2
+    echo "  test runtime bootstrap: nix shell --inputs-from ${flake_root} ${flake_root}#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command bash $self_path" >&2
     export _TOMLKIT_BOOTSTRAP_READY=1
-    # pythonWithTomlkit(tomlkit) 외에 GNU coreutils/findutils 를 함께 얹어, 테스트 fixture 가
+    # pythonWithTomlkit(tomlkit) 외에 GNU coreutils/findutils 와 lsof 를 함께 얹어, 테스트 fixture 가
     # GNU 전용 확장(`touch -d '40 days ago'`, `find -printf`)에 의존해도 devShell 밖(BSD 시스템
-    # 도구 우선) 셸에서 hermetic 하게 통과하도록 한다 (#1009). lefthook pre-push / run-all-tests /
-    # 수동 실행 모두 이 단일 self-wrap 을 경유하므로 여기 한 곳이 세 경로를 커버한다.
+    # 도구 우선) 셸에서 hermetic 하게 통과하도록 한다 (#1009). claude-rc(#1052)도 require_cmd lsof 를
+    # 도입했고, lsof 는 NixOS 시스템 프로파일 PATH 에 항상 있지 않으므로 lefthook pre-push /
+    # run-all-tests / 수동 실행 모두 이 단일 self-wrap 을 경유해 세 경로의 runtime 을 맞춘다.
     # `--inputs-from ${flake_root}` 로 nixpkgs# 를 repo flake.lock 의 nixpkgs 에 pin 하여 임시
     # registry fetch 를 피한다(statusline-bats 의 `nix shell --inputs-from . nixpkgs#bats` 와 동일 패턴).
-    exec nix shell --inputs-from "${flake_root}" "${flake_root}#pythonWithTomlkit" nixpkgs#coreutils nixpkgs#findutils --command bash "$self_path" "$@"
+    exec nix shell --inputs-from "${flake_root}" "${flake_root}#pythonWithTomlkit" nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command bash "$self_path" "$@"
   fi
 
   # (3) nix 부재 fallback — ambient python3에 tomlkit이 있으면 경고 후 진행

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -59,8 +59,10 @@ run_driver "eval-tests" bash tests/run-eval-tests.sh
 #    self-wrap하지만, 명시적으로 nix shell wrap + GNU coreutils/findutils(karakeep/backup fixture의
 #    `touch -d`/`find -printf` 의존, #1009) + _TOMLKIT_BOOTSTRAP_READY=1(중첩 nix shell 방지)로
 #    실행한다(lefthook pre-push와 동일). `--inputs-from .`로 nixpkgs#를 flake.lock에 pin한다.
+#    claude-rc(#1052)가 require_cmd lsof를 도입했고 lsof는 NixOS 시스템 프로파일/CI PATH에
+#    항상 있지 않으므로 nixpkgs#lsof도 명시 제공한다(#1009와 동일 패턴).
 run_driver "shell-script-tests" \
-  nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command env _TOMLKIT_BOOTSTRAP_READY=1 \
+  nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command env _TOMLKIT_BOOTSTRAP_READY=1 \
   bash tests/run-shell-script-tests.sh
 
 # 3) codex-hook-fixtures — Codex stable hook 회귀 차단 결정적 fixture. --no-live, Python stdlib only.


### PR DESCRIPTION
## Summary

- `shell-script-tests`가 공유하는 nix shell wrap 세 진입점(lefthook pre-push, CI, 수동 실행 self-wrap)에 `nixpkgs#lsof`를 추가한다.
- `a672e712`(#1052) 이후 devShell 밖 pre-push에서 claude-remote-control 테스트 9개가 `lsof` 부재로 실패해 **모든 push가 차단**되던 회귀를 해소한다.
- Closes #1057

## 기존 문제/배경

`modules/nixos/scripts/claude-rc.sh`의 `require_common_cmds`는 `flock/git/jq/lsof/pgrep`을 요구한다(`a672e712`, #1052에서 `lsof` 도입). devShell 안(direnv)에서는 lsof가 buildInputs로 제공돼 로컬 수동 테스트가 통과하므로 #1052 머지 시 회귀가 드러나지 않았다.

그러나 lefthook pre-push와 CI(`.github/workflows/check.yml`)는 devShell 밖에서 nix shell wrap으로 shell-script-tests를 실행하고, 이 wrap은 `coreutils/findutils`만 제공했다. NixOS 시스템 프로파일에는 lsof가 없어 claude-remote-control 스위트 9개가 `required command not found in PATH: lsof`로 실패했고, lefthook pre-push 전체가 exit 1이 되어 push가 전면 차단됐다.

## CIR (Change Intent Record)

`nrs` 실행 직후 별도 작업(문서 PR)을 push하려다 pre-push의 shell-script-tests가 9개 실패하는 것을 관측했다. 실패 메시지가 전부 `required command not found in PATH: lsof`였고, 변경 내용(마크다운)과 무관했다. 동일 wrap에 `nixpkgs#lsof`만 추가해 재실행하니 208개 전부 통과(실패 0)함을 실측해 원인을 lsof 부재로 확정했다.

초기 수정은 outer wrap 2곳(`lefthook.yml`, `tests/run-all-tests.sh`)만 대상으로 했으나, Devil's Advocate 리뷰(3개 독립 reviewer 만장일치 + Arbiter CONFIRMED_ISSUE HIGH)에서 `scripts/ai/lib/tomlkit-bootstrap.sh`의 self-wrap 누락을 지적받았다. `tests/run-shell-script-tests.sh`를 devShell 밖에서 직접 실행하는 **manual 경로**는 `_TOMLKIT_BOOTSTRAP_READY` 미설정이라 self-wrap이 `coreutils/findutils`만으로 재-exec되어 lsof가 여전히 빠졌다. self-wrap 주석이 "세 경로를 커버한다"고 선언하므로 이 누락은 계약 위반이었다. self-wrap에도 lsof를 추가하고 manual 경로 208/0을 실측 확인해 반영했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| wrap에 `nixpkgs#lsof` 추가 | 세 진입점 wrap에 lsof 명시 제공 | #1009 선례와 동일 패턴, hermetic 유지 | wrap 목록 3곳 유지 | ✅ 채택 |
| claude-rc.sh에서 `require_cmd lsof` 제거 | 의존 자체를 없앰 | wrap 수정 불필요 | `a672e712`가 의도적으로 도입한 런타임 의존을 근거 없이 되돌림(decision regression), lsof 실제 사용처 존재 | ❌ 기각 |
| `flock/git/jq/pgrep`까지 전부 추가 | claude-rc 요구 도구 전량 명시 | 완전한 hermetic | 실측상 시스템 프로파일에 이미 있어 실패 안 함, 예방적 추가 | ❌ 기각 (YAGNI) |
| outer wrap 2곳만 수정 | pre-push/CI만 커버 | 최소 변경 | manual 경로 self-wrap 드리프트 잔존 | ❌ 기각 (DA CONFIRMED) |

## 구현 상세

| File | Role | Change |
|------|------|--------|
| `lefthook.yml` | pre-push 훅 정의 | shell-script-tests wrap에 `nixpkgs#lsof` + 주석 근거 |
| `tests/run-all-tests.sh` | CI 공유 테스트 드라이버 | shell-script-tests wrap에 `nixpkgs#lsof` + 주석 근거 |
| `scripts/ai/lib/tomlkit-bootstrap.sh` | 수동 실행 경유 self-wrap (SSOT) | echo/exec 재실행 목록에 `nixpkgs#lsof` + 주석 근거 |

핵심 변경 (self-wrap):
```sh
exec nix shell --inputs-from "${flake_root}" "${flake_root}#pythonWithTomlkit" \
  nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command bash "$self_path" "$@"
```

## 참고 레퍼런스

- #1052 (`a672e712`) — claude-rc 재설계, `require_cmd lsof` 도입 커밋
- #1009 (`96af5bf2`) — GNU coreutils/findutils를 self-wrap·lefthook·run-all 세 진입점에 함께 도입한 선례 (동일 패턴)
- `modules/nixos/scripts/claude-rc.sh` `require_common_cmds` — lsof 요구처
- `.github/workflows/check.yml` — CI가 run-all-tests.sh 실행

## Human Test Plan

1. **devShell 밖 pre-push 재현** — direnv 비활성 셸에서 이 브랜치 기준으로 아무 커밋이나 push 시도.
   - 기대: pre-push의 shell-script-tests 통과, push 성공.
   - 실패 시: `nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh`로 208/0 여부 확인.
2. **manual 경로 검증** — `env -u _TOMLKIT_BOOTSTRAP_READY bash tests/run-shell-script-tests.sh` 직접 실행.
   - 기대: bootstrap 메시지에 `nixpkgs#lsof` 포함, claude-remote-control 테스트 실행, 208개 통과·실패 0.
   - 실패 시: `command -v lsof`로 시스템 PATH에 lsof가 없음을 확인(없어야 정상 재현), self-wrap의 exec 라인에 lsof가 있는지 점검.
3. **CI 확인** — PR의 check 워크플로우(`통합 검증`) 통과 확인.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the shell-script test environment so required system tools are available during test runs.
  * Fixed test execution in environments where a needed command wasn’t already present in the PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->