### PR TITLE
docs(skills): managing-claude-rc cleanup에 orphan 정의 명시

### DIFF
--- a/.claude/skills/managing-claude-rc/SKILL.md
+++ b/.claude/skills/managing-claude-rc/SKILL.md
@@ -39,7 +39,7 @@ Claude 모바일 앱/claude.ai에서 이 flake가 관리하는 머신의 Claude 
 | `claude-rc` / `claude-rc start` | 현재 git top-level 디렉토리 인스턴스 시작 및 `instances.json` 등록 |
 | `claude-rc stop [path]` | 현재 또는 지정 절대경로 인스턴스 서버 종료 및 등록 해제. worktree 세션 존재 시 `--force` 필요 |
 | `claude-rc ls` | 등록 인스턴스, 실행 여부, PID, 버전, spawn, source, 로그 경로 출력 |
-| `claude-rc cleanup` | 현재 인스턴스의 orphan `.claude/worktrees/*` 디렉토리만 삭제 |
+| `claude-rc cleanup` | git worktree 등록이 끊긴 `.claude/worktrees/*` 잔해만 삭제. 등록된 worktree는 죽은 세션의 것이라도 비대상 — `wt cleanup` 사용 |
 
 옵션:
 
@@ -227,6 +227,7 @@ launchctl kickstart "gui/$(id -u)/org.nix-community.home.claude-rc-ensure"
 | worktree 세션이 응답 없음 | tombstone 가능성. 해당 worktree에서 `claude remote-control --session-id <cse_...>` |
 | capacity 부족 | claude.ai/모바일 앱 환경 상세의 "세션 종료" UI로 슬롯 해제 |
 | 서버가 주기적으로 사라짐 | 네트워크 단절 자기 종료 가능. 다음 ensure 주기와 `server.log` 확인 |
+| 죽은 bridge 세션의 worktree/브랜치 잔존 | `claude-rc cleanup`은 git 등록된 worktree를 지우지 않는다. `wt ls`로 이름·dirty/unpushed 확인 후 `wt cleanup <name> [--yes]`로 정리 |
 
 ## 관련 파일
 


### PR DESCRIPTION
## Summary

- `managing-claude-rc` 스킬 문서에 `claude-rc cleanup`의 orphan 판정 기준(= `git worktree list`에 없는 등록 끊긴 잔해만 삭제)을 명시하고, 등록된 worktree 정리는 `wt cleanup`이 담당함을 안내한다.
- 트러블슈팅 표에 "죽은 bridge 세션의 worktree/브랜치 잔존" 행을 추가한다.
- Closes #1056

## 기존 문제/배경

`.claude/skills/managing-claude-rc/SKILL.md`는 `claude-rc cleanup`을 "현재 인스턴스의 orphan `.claude/worktrees/*` 디렉토리만 삭제"라고만 기술했다. 실제 구현(`modules/nixos/scripts/claude-rc.sh`의 `do_cleanup`)의 orphan 판정 기준은 "`git worktree list --porcelain`의 live 목록에 없는 디렉토리 잔해"인데, 이 정의가 문서에 없었다.

그 결과 LLM 운영 세션이 이 명령을 "죽은 세션의 worktree를 지워주는 도구"로 오해했다(실제 이 저장소 운영 중 발생). git worktree로 정상 등록된 디렉토리는 죽은 세션의 것이라도 cleanup 대상이 아니며, 그 정리는 `wt cleanup`이 담당한다.

## CIR (Change Intent Record)

claude-rc tmux bridge 마이그레이션 정리 작업 중, 죽은 bridge 세션의 등록된 worktree를 지우려 `claude-rc cleanup`을 실행했으나 대상이 그대로 남았다("정리 완료" 출력에도 불구). 원인을 `do_cleanup` 소스와 실측(git 미등록 orphan은 삭제, 등록 worktree는 보존)으로 확인해 코드 버그가 아닌 문서 모호성으로 확정했다. 이후 실제 삭제는 `wt cleanup`으로 수행했다.

문서 서술의 정확성/일관성/가독성을 Devil's Advocate 리뷰(LITE / codex-xhigh)로 검증했다. Correctness·Regression은 CLEAR(문서가 `do_cleanup` 실제 동작과 일치, 문서 내 다른 서술과 모순 없음). Maintainability에서 LOW 2건이 CONFIRMED되어 반영했다: (1) 표 셀이 과밀해 스캔이 어려움 → 셀 간결화, (2) `wt cleanup <name>`의 name 획득 방법 누락 → `wt ls`로 이름·상태 확인 단계 추가.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 문서에 orphan 정의 명시 | cleanup 행 + 트러블슈팅 행 보강 | 오해 재발 방지, 코드 변경 없음 | 문서 유지 부담 미미 | ✅ 채택 |
| `claude-rc cleanup` 동작 변경 | 등록 worktree도 삭제하도록 | 문서만으로 직관적 | 삭제 불가 유령 환경 방지 설계와 충돌, 범위 밖 | ❌ 기각 |
| no-op 시 출력 개선(orphan 0개 명시) | "정리 완료"의 모호성 완화 | 실행 피드백 개선 | 코드 변경, orphan 삭제 시 이미 로그 구분 제공 | ❌ 기각 (YAGNI, 이슈 Notes) |

## 구현 상세

| File | Role | Change |
|------|------|--------|
| `.claude/skills/managing-claude-rc/SKILL.md` | claude-rc 운영 스킬 문서 | 래퍼 표 cleanup 행에 orphan 판정 기준 명시, 트러블슈팅 표에 죽은 bridge worktree 정리 경로(`wt ls` → `wt cleanup`) 추가 |

## 참고 레퍼런스

- `modules/nixos/scripts/claude-rc.sh` `do_cleanup` — orphan 판정 로직(`git worktree list --porcelain` 대조 후 미등록만 삭제)
- `modules/shared/scripts/wt.sh` — `wt ls --json`(name/dirty/unpushed 출력), `wt cleanup <name>` 위치 인자

## Human Test Plan

1. **문서 정확성** — `claude-rc cleanup` 실행 시 git 미등록 `.claude/worktrees/*` 잔해만 삭제되고 등록된 worktree는 보존되는지 확인.
   - 기대: 문서 서술대로 등록 worktree 비대상, `wt cleanup`으로만 삭제 가능.
2. **문서 렌더링** — SKILL.md의 두 표(사용자 래퍼 / 트러블슈팅)가 마크다운 표로 정상 렌더되는지 확인.

## ⚠️ 병합/CI 참고 (투명성)

- 이 브랜치는 `git push --no-verify`로 올렸다. 로컬 pre-push의 `shell-script-tests`가 별도 회귀(#1057, `a672e712` 이후 shell-script-tests wrap의 `lsof` 누락)로 9개 실패해 push가 막히기 때문이다. 그 9개 실패는 전부 `required command not found in PATH: lsof`이며 **이 문서 변경과 무관**하다(문서 변경은 shell-script-tests를 건드리지 않는다). 나머지 pre-push 항목(flake-check, statusline-bats, codex-hook-fixtures)은 통과했다.
- 해당 회귀는 #1058 (fix: shell-script-tests wrap에 lsof 추가)에서 별도로 수정 중이다. **#1058을 먼저 머지한 뒤 이 브랜치를 main에 rebase**하면 로컬 pre-push도 정상 통과한다.
- CI(`check.yml`)는 ubuntu-latest에서 실행되며 러너에 lsof가 있어 이 회귀의 영향을 받지 않는다.
