### PR TITLE
fix(claude-rc): pid 판정 강화 — exe 경계 복원 + SIGKILL 고아 정리

### DIFF
--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -292,7 +292,7 @@ validate_instance_config() {
 
 start_missing_instance() {
     local path="$1" spawn="$2" capacity="$3" permission_mode="$4"
-    local action lock_path started_version
+    local action lock_path reaped started_version
     lock_path=$(lock_path_for_path "$path")
     # A wrapper-bypassed plain CLI server in the same cwd does not hold our
     # lock. Starting another server here permanently creates an undeletable
@@ -302,6 +302,14 @@ start_missing_instance() {
         record_instance_result "$path" "" "$DESIRED_VERSION" "$action"
         log_error "unmanaged same-cwd server present: $path"
         return 1
+    fi
+    # SIGKILLed servers can leave --sdk-url session children re-parented to
+    # init. They are not remote-control servers and do not match the unmanaged
+    # server guard above; preserving them only keeps broken, unreachable
+    # sessions around, so reap them before the replacement server starts.
+    reaped=$(reap_orphan_session_procs_for_path "$path") || reaped=0
+    if [ "$reaped" -gt 0 ]; then
+        log_info "reaped ${reaped} orphan session process(es): $path"
     fi
     start_server "$path" "$spawn" "$capacity" "$permission_mode"
     sleep 2

--- a/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
+++ b/modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh
@@ -595,6 +595,7 @@ Usage: claude-rc-maint ensure
 
 env:
   CLAUDE_BIN, STATE_DIR, CLAUDE_RC_DECLARED_INSTANCES,
+  VERSIONS_DIR (default ~/.local/share/claude/versions; exe boundary for server/session PID detection),
   IDLE_THRESHOLD_MINUTES (default 30), MAINT_LOCK_TIMEOUT_SECONDS (default 120),
   ALERT_COOLDOWN_SECONDS (default 1800), PUSHOVER_CRED_FILE, SERVICE_LIB,
   CLAUDE_RC_PERMISSION_MODE, CLAUDE_RC_ALERT_HOST

--- a/modules/nixos/scripts/claude-rc-lib.sh
+++ b/modules/nixos/scripts/claude-rc-lib.sh
@@ -314,6 +314,8 @@ session_cwd_is_in_instance_scope() {
     [ -n "$cwd" ] || return 1
     target=$(canonical_existing_path "$instance_path") || return 1
     wt_root="$target/.claude/worktrees/"
+    # The instance root itself is in scope because same-dir spawned sessions
+    # run at the instance root; only worktree sessions live under wt_root.
     [ "$cwd" = "$target" ] && return 0
     case "$cwd" in
         "$wt_root"*) return 0 ;;
@@ -321,8 +323,21 @@ session_cwd_is_in_instance_scope() {
     return 1
 }
 
+pid_is_session_proc() {
+    local pid="$1" command
+    command=$(ps -o command= -p "$pid" 2>/dev/null) || return 1
+    case "$command" in
+        *--sdk-url*) return 0 ;;
+    esac
+    return 1
+}
+
 is_orphan_session_proc_for_path() {
     local pid="$1" instance_path="$2" ppid
+    # The --sdk-url argv selector is rechecked here (not only at pgrep
+    # discovery) so a recycled PID that is no longer a session process fails
+    # this predicate before any signal is sent.
+    pid_is_session_proc "$pid" || return 1
     # Spawned session processes run as the versioned Claude binary. Keep the
     # same executable boundary as server PID detection so an unrelated
     # --sdk-url argv match is never a reap target.

--- a/modules/nixos/scripts/claude-rc-lib.sh
+++ b/modules/nixos/scripts/claude-rc-lib.sh
@@ -14,6 +14,8 @@ BRIDGE_PROCESS_PATTERN='claude remote-control'
 # the stable selector. The leading [-] avoids pgrep treating the pattern as an
 # option.
 BRIDGE_CHILD_PROCESS_PATTERN='[-]-sdk-url'
+ORPHAN_REAP_TERM_ATTEMPTS=5
+ORPHAN_REAP_TERM_SLEEP_SECONDS=0.2
 TSV_NULL='__CLAUDE_RC_NULL__'
 
 iso_timestamp() {
@@ -321,14 +323,20 @@ session_cwd_is_in_instance_scope() {
 
 is_orphan_session_proc_for_path() {
     local pid="$1" instance_path="$2" ppid
+    # Spawned session processes run as the versioned Claude binary. Keep the
+    # same executable boundary as server PID detection so an unrelated
+    # --sdk-url argv match is never a reap target.
+    is_claude_versions_exe_process "$pid" || return 1
     session_cwd_is_in_instance_scope "$pid" "$instance_path" || return 1
     ppid=$(pid_parent_pid "$pid") || return 1
     case "$ppid" in
         ''|*[!0-9]*) return 1 ;;
     esac
+    # The confirmed orphan shape is SIGKILL re-parenting to init. A ppid > 1
+    # non-server parent is not proven orphaned, so do not broaden this helper
+    # beyond the case its name describes.
     [ "$ppid" -le 1 ] && return 0
-    is_claude_versions_exe_process "$ppid" && return 1
-    return 0
+    return 1
 }
 
 find_orphan_session_pids_for_path() {
@@ -342,8 +350,8 @@ find_orphan_session_pids_for_path() {
 }
 
 reap_orphan_session_procs_for_path() {
-    local instance_path="$1" pid initial_count _
-    local -a pids remaining
+    local instance_path="$1" pid initial_count attempt
+    local -a pids term_pids remaining
     pids=()
     while IFS= read -r pid; do
         [ -n "$pid" ] || continue
@@ -355,25 +363,41 @@ reap_orphan_session_procs_for_path() {
         return 0
     fi
 
-    initial_count="${#pids[@]}"
+    term_pids=()
     for pid in "${pids[@]}"; do
+        # PIDs can exit and be reused between discovery and signal delivery;
+        # kill -0 only proves existence, not that this is still the same
+        # orphan session, so re-run the full predicate before signaling.
+        is_orphan_session_proc_for_path "$pid" "$instance_path" || continue
         kill -TERM "$pid" 2>/dev/null || true
+        term_pids+=("$pid")
     done
 
-    remaining=("${pids[@]}")
-    for _ in 1 2 3 4 5; do
+    if [ "${#term_pids[@]}" -eq 0 ]; then
+        echo 0
+        return 0
+    fi
+
+    initial_count="${#term_pids[@]}"
+    remaining=("${term_pids[@]}")
+    # Give cooperative session processes about 1s to handle SIGTERM before
+    # escalating to SIGKILL.
+    for ((attempt = 0; attempt < ORPHAN_REAP_TERM_ATTEMPTS; attempt++)); do
         remaining=()
-        for pid in "${pids[@]}"; do
+        for pid in "${term_pids[@]}"; do
             if kill -0 "$pid" 2>/dev/null; then
                 remaining+=("$pid")
             fi
         done
         [ "${#remaining[@]}" -gt 0 ] || break
-        pids=("${remaining[@]}")
-        sleep 0.2
+        term_pids=("${remaining[@]}")
+        sleep "$ORPHAN_REAP_TERM_SLEEP_SECONDS"
     done
 
     for pid in "${remaining[@]}"; do
+        # Revalidate again after the grace window; a recycled PID must not
+        # receive the terminal SIGKILL.
+        is_orphan_session_proc_for_path "$pid" "$instance_path" || continue
         kill -KILL "$pid" 2>/dev/null || true
     done
 

--- a/modules/nixos/scripts/claude-rc-lib.sh
+++ b/modules/nixos/scripts/claude-rc-lib.sh
@@ -5,6 +5,7 @@
 # script by the Nix package expressions, so it must not run command logic.
 
 STATE_DIR="${STATE_DIR:-$HOME/.local/state/claude-rc}"
+VERSIONS_DIR="${VERSIONS_DIR:-$HOME/.local/share/claude/versions}"
 INSTANCES_FILE="$STATE_DIR/instances.json"
 INSTANCES_LOCK="$STATE_DIR/instances.json.lock"
 LOG_MAX_BYTES=$((5 * 1024 * 1024))
@@ -252,6 +253,18 @@ is_flock_process() {
     [ "$base" = "flock" ]
 }
 
+is_claude_versions_exe_process() {
+    local pid="$1" exe versions_dir
+    exe=$(pid_exe_path "$pid") || return 1
+    [ -n "$exe" ] || return 1
+    versions_dir="${VERSIONS_DIR%/}"
+    [ -n "$versions_dir" ] || return 1
+    case "${exe% (deleted)}" in
+        "$versions_dir"/*) return 0 ;;
+    esac
+    return 1
+}
+
 find_server_pid_for_path() {
     local path="$1" pid
     while IFS= read -r pid; do
@@ -260,6 +273,10 @@ find_server_pid_for_path() {
         if is_flock_process "$pid"; then
             continue
         fi
+        # pgrep -f is only argv substring matching. A long-lived unrelated
+        # script can contain "claude remote-control" in argv and share the cwd,
+        # so require the actual executable to be the versioned Claude binary.
+        is_claude_versions_exe_process "$pid" || continue
         echo "$pid"
         return 0
     done < <(pgrep -u "$(id -u)" -f "$BRIDGE_PROCESS_PATTERN" 2>/dev/null || true)
@@ -282,6 +299,85 @@ count_worktree_session_procs() {
         esac
     done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
     echo "$count"
+}
+
+pid_parent_pid() {
+    local pid="$1"
+    ps -o ppid= -p "$pid" 2>/dev/null | awk '{print $1; exit}'
+}
+
+session_cwd_is_in_instance_scope() {
+    local pid="$1" instance_path="$2" cwd target wt_root
+    cwd=$(pid_cwd "$pid") || return 1
+    [ -n "$cwd" ] || return 1
+    target=$(canonical_existing_path "$instance_path") || return 1
+    wt_root="$target/.claude/worktrees/"
+    [ "$cwd" = "$target" ] && return 0
+    case "$cwd" in
+        "$wt_root"*) return 0 ;;
+    esac
+    return 1
+}
+
+is_orphan_session_proc_for_path() {
+    local pid="$1" instance_path="$2" ppid
+    session_cwd_is_in_instance_scope "$pid" "$instance_path" || return 1
+    ppid=$(pid_parent_pid "$pid") || return 1
+    case "$ppid" in
+        ''|*[!0-9]*) return 1 ;;
+    esac
+    [ "$ppid" -le 1 ] && return 0
+    is_claude_versions_exe_process "$ppid" && return 1
+    return 0
+}
+
+find_orphan_session_pids_for_path() {
+    local instance_path="$1" pid
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        if is_orphan_session_proc_for_path "$pid" "$instance_path"; then
+            echo "$pid"
+        fi
+    done < <(pgrep -u "$(id -u)" -f "$BRIDGE_CHILD_PROCESS_PATTERN" 2>/dev/null || true)
+}
+
+reap_orphan_session_procs_for_path() {
+    local instance_path="$1" pid initial_count _
+    local -a pids remaining
+    pids=()
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        pids+=("$pid")
+    done < <(find_orphan_session_pids_for_path "$instance_path")
+
+    if [ "${#pids[@]}" -eq 0 ]; then
+        echo 0
+        return 0
+    fi
+
+    initial_count="${#pids[@]}"
+    for pid in "${pids[@]}"; do
+        kill -TERM "$pid" 2>/dev/null || true
+    done
+
+    remaining=("${pids[@]}")
+    for _ in 1 2 3 4 5; do
+        remaining=()
+        for pid in "${pids[@]}"; do
+            if kill -0 "$pid" 2>/dev/null; then
+                remaining+=("$pid")
+            fi
+        done
+        [ "${#remaining[@]}" -gt 0 ] || break
+        pids=("${remaining[@]}")
+        sleep 0.2
+    done
+
+    for pid in "${remaining[@]}"; do
+        kill -KILL "$pid" 2>/dev/null || true
+    done
+
+    echo "$initial_count"
 }
 
 start_server() {

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -73,6 +73,7 @@ run_test "claude remote-control start registers manual instance" test_claude_rem
 run_test "claude remote-control start warns on ignored options" test_claude_remote_control_start_warns_when_running_options_differ
 run_test "claude remote-control start preserves declared registry" test_claude_remote_control_start_warns_and_preserves_declared_registry
 run_test "claude remote-control rejects unmanaged same-cwd server" test_claude_remote_control_start_rejects_unmanaged_same_cwd_server
+run_test "claude remote-control ignores argv-only remote-control match" test_claude_remote_control_ignores_argv_only_remote_control_match
 run_test "claude remote-control maint rejects unmanaged same-cwd server" test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server
 run_test "claude remote-control stop gates worktree sessions" test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters
 run_test "claude remote-control stop preserves held-lock registration" test_claude_remote_control_stop_preserves_registration_when_lock_held_without_pid
@@ -83,6 +84,7 @@ run_test "claude remote-control maint reconciles declarations" test_claude_remot
 run_test "claude remote-control maint gates drift by effective spawn" test_claude_remote_control_maint_uses_effective_spawn_for_drift_gate
 run_test "claude remote-control maint rejects invalid declarations" test_claude_remote_control_maint_rejects_invalid_declared_instances
 run_test "claude remote-control transcript gate scopes to worktrees" test_claude_remote_control_transcript_gate_scopes_to_worktree_dirs
+run_test "claude remote-control maint reaps orphan sessions before start" test_claude_remote_control_maint_reaps_orphan_sessions_before_start
 run_test "claude remote-control maint writes status schema" test_claude_remote_control_maint_status_schema
 if [ "$(uname -s)" = "Linux" ]; then
   run_test "codex remote-control probe parses daemon JSON" test_codex_remote_control_probe_parses_daemon_json

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -56,10 +56,14 @@ _claude_rc_make_repo() {
 }
 
 _claude_rc_make_fake_claude() {
-  local bin_dir="$1"
-  mkdir -p "$bin_dir"
-  cat > "$bin_dir/claude" <<'EOS'
-#!/usr/bin/env bash
+  local bin_dir="$1" versions_dir="$2" bash_bin
+  mkdir -p "$bin_dir" "$versions_dir"
+  bash_bin="$versions_dir/bash"
+  cp "$(command -v bash)" "$bash_bin" || fail "failed to copy bash into fake VERSIONS_DIR"
+  chmod +x "$bash_bin"
+  {
+    printf '#!%s\n' "$bash_bin"
+    cat <<'EOS'
 set -euo pipefail
 printf '%s\t%s\n' "$PWD" "$*" >> "${FAKE_CLAUDE_LOG:-/dev/null}"
 if [ "${FAKE_CLAUDE_RC:-0}" != "0" ]; then
@@ -73,6 +77,7 @@ if [ -n "${FAKE_CLAUDE_HOLD_FILE:-}" ]; then
   done
 fi
 EOS
+  } > "$bin_dir/claude"
   chmod +x "$bin_dir/claude"
 }
 
@@ -129,10 +134,13 @@ _claude_rc_setup() {
   CLAUDE_RC_HOME="$sandbox/home"
   CLAUDE_RC_STATE="$sandbox/state"
   CLAUDE_RC_FAKE_BIN="$sandbox/fake-bin"
+  CLAUDE_RC_VERSIONS="$sandbox/versions"
+  CLAUDE_RC_SERVER_EXE="$CLAUDE_RC_VERSIONS/claude-server"
   CLAUDE_RC_LOG="$sandbox/claude.log"
   CLAUDE_RC_HOLD_FILE="$sandbox/hold-server"
-  mkdir -p "$CLAUDE_RC_HOME" "$CLAUDE_RC_STATE" "$CLAUDE_RC_FAKE_BIN"
-  _claude_rc_make_fake_claude "$CLAUDE_RC_FAKE_BIN"
+  mkdir -p "$CLAUDE_RC_HOME" "$CLAUDE_RC_STATE" "$CLAUDE_RC_FAKE_BIN" "$CLAUDE_RC_VERSIONS"
+  _claude_rc_make_fake_claude "$CLAUDE_RC_FAKE_BIN" "$CLAUDE_RC_VERSIONS"
+  cp "$CLAUDE_RC_VERSIONS/bash" "$CLAUDE_RC_SERVER_EXE"
   _claude_rc_link_tool flock
 }
 
@@ -144,6 +152,7 @@ _claude_rc_run() {
     env \
       HOME="$CLAUDE_RC_HOME" \
       STATE_DIR="$CLAUDE_RC_STATE" \
+      VERSIONS_DIR="$CLAUDE_RC_VERSIONS" \
       PATH="$CLAUDE_RC_FAKE_BIN:$PATH" \
       FAKE_CLAUDE_LOG="$CLAUDE_RC_LOG" \
       FAKE_CLAUDE_HOLD_FILE="${CLAUDE_RC_HOLD_FILE:-}" \
@@ -162,6 +171,7 @@ _claude_rc_run_maint() {
     env \
       HOME="$CLAUDE_RC_HOME" \
       STATE_DIR="$CLAUDE_RC_STATE" \
+      VERSIONS_DIR="$CLAUDE_RC_VERSIONS" \
       CLAUDE_BIN="$CLAUDE_RC_FAKE_BIN/claude-new" \
       PATH="$CLAUDE_RC_FAKE_BIN:$PATH" \
       FAKE_CLAUDE_LOG="$CLAUDE_RC_LOG" \
@@ -171,6 +181,9 @@ _claude_rc_run_maint() {
       FAKE_SERVER_CWD="${FAKE_SERVER_CWD:-}" \
       FAKE_SERVER_EXE="${FAKE_SERVER_EXE:-}" \
       FAKE_SERVER_COMMAND="${FAKE_SERVER_COMMAND:-}" \
+      FAKE_ORPHAN_PID="${FAKE_ORPHAN_PID:-}" \
+      FAKE_ORPHAN_CWD="${FAKE_ORPHAN_CWD:-}" \
+      FAKE_ORPHAN_PPID="${FAKE_ORPHAN_PPID:-}" \
       "$@"
   )
 }
@@ -195,6 +208,17 @@ _claude_rc_release_server() {
   _claude_rc_wait_lock_free "$lock_path" || fail "server lock remained held: $lock_path"
 }
 
+_claude_rc_wait_fake_claude_log() {
+  local needle="${1:-remote-control}" _i
+  for _i in {1..50}; do
+    if [ -f "$CLAUDE_RC_LOG" ] && grep -F -- "$needle" "$CLAUDE_RC_LOG" >/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
 _claude_rc_write_instance() {
   local path="$1" spawn="$2" capacity_json="$3" permission_mode="$4" source="$5"
   mkdir -p "$CLAUDE_RC_STATE"
@@ -214,6 +238,10 @@ _claude_rc_write_instance() {
 }
 
 _claude_rc_install_unmanaged_process_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/uname" <<'EOS'
+#!/usr/bin/env bash
+echo Darwin
+EOS
   cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
 #!/usr/bin/env bash
 case "$*" in
@@ -237,7 +265,7 @@ case "$args" in
     ;;
 esac
 EOS
-  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof"
+  chmod +x "$CLAUDE_RC_FAKE_BIN/uname" "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof"
 }
 
 _claude_rc_install_child_process_mocks() {
@@ -262,6 +290,40 @@ case "$args" in
 esac
 EOS
   chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof"
+}
+
+_claude_rc_install_orphan_session_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
+#!/usr/bin/env bash
+case "$*" in
+  *"[-]-sdk-url"*)
+    [ -n "${FAKE_ORPHAN_PID:-}" ] || exit 1
+    echo "$FAKE_ORPHAN_PID"
+    ;;
+  *) exit 1 ;;
+esac
+EOS
+  cat > "$CLAUDE_RC_FAKE_BIN/lsof" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+args=" $* "
+case "$args" in
+  *" -p ${FAKE_ORPHAN_PID:-__none__} "*"cwd"*)
+    printf 'p%s\nn%s\n' "$FAKE_ORPHAN_PID" "$FAKE_ORPHAN_CWD"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOS
+  cat > "$CLAUDE_RC_FAKE_BIN/ps" <<'EOS'
+#!/usr/bin/env bash
+case "$*" in
+  *"ppid="*) echo "${FAKE_ORPHAN_PPID:-1}" ;;
+  *) exit 1 ;;
+esac
+EOS
+  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof" "$CLAUDE_RC_FAKE_BIN/ps"
 }
 
 _claude_rc_install_no_process_mocks() {
@@ -392,6 +454,8 @@ test_claude_remote_control_start_warns_and_preserves_declared_registry() {
   err="$sandbox/start.err"
   _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start \
     --spawn same-dir --capacity 7 --permission-mode plan >/dev/null 2> "$err"
+  _claude_rc_wait_fake_claude_log "remote-control --spawn same-dir" \
+    || fail "fake claude log did not appear before assertion"
 
   assert_contains "$(cat "$err")" "이 경로는 Nix 선언 관리 대상"
   assert_contains "$(cat "$err")" "spawn: declared=worktree, requested=same-dir"
@@ -421,12 +485,46 @@ test_claude_remote_control_start_rejects_unmanaged_same_cwd_server() {
 
   rc=0
   FAKE_UNMANAGED_CWD="$repo"
-  FAKE_UNMANAGED_EXE="$sandbox/bin/claude"
+  FAKE_UNMANAGED_EXE="$CLAUDE_RC_SERVER_EXE"
   out="$(_claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start 2>&1)" || rc=$?
   unset FAKE_UNMANAGED_CWD FAKE_UNMANAGED_EXE
   [ "$rc" -eq 1 ] || fail "unmanaged same-cwd server should be rejected, got $rc: $out"
   assert_contains "$out" "refusing duplicate start"
   [ ! -f "$CLAUDE_RC_STATE/instances.json" ] || fail "unmanaged rejection must not register instance"
+}
+
+test_claude_remote_control_ignores_argv_only_remote_control_match() {
+  local sandbox repo copy out rc status
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  repo="$sandbox/repo"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  _claude_rc_install_unmanaged_process_mocks
+  copy="$(_claude_rc_wrapper_script)"
+
+  rc=0
+  FAKE_UNMANAGED_CWD="$repo" \
+  FAKE_UNMANAGED_EXE="$sandbox/outside/rogue" \
+    out="$(_claude_rc_run "$repo" bash -c '
+      set -euo pipefail
+      # shellcheck source=/dev/null
+      . "$1"
+      find_server_pid_for_path "$2"
+    ' _ "$copy" "$repo" 2>&1)" || rc=$?
+  [ "$rc" -eq 1 ] || fail "argv-only remote-control match should not resolve as server, got rc=$rc out=$out"
+
+  : > "$CLAUDE_RC_HOLD_FILE"
+  rc=0
+  FAKE_UNMANAGED_CWD="$repo" \
+  FAKE_UNMANAGED_EXE="$sandbox/outside/rogue" \
+    out="$(_claude_rc_run "$repo" bash "$copy" start 2>&1)" || rc=$?
+  [ "$rc" -eq 0 ] || fail "argv-only remote-control match should not trip unmanaged guard, got $rc: $out"
+  assert_contains "$out" "서버 시작됨"
+  status="$(cat "$CLAUDE_RC_STATE/instances.json")"
+  jq -e --arg path "$repo" '.instances | has($path)' <<<"$status" >/dev/null \
+    || fail "start should register when only argv matches remote-control: $status"
+
+  _claude_rc_release_server "$repo"
 }
 
 test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server() {
@@ -441,7 +539,7 @@ test_claude_remote_control_maint_rejects_unmanaged_same_cwd_server() {
 
   rc=0
   FAKE_UNMANAGED_CWD="$repo"
-  FAKE_UNMANAGED_EXE="$CLAUDE_RC_FAKE_BIN/claude"
+  FAKE_UNMANAGED_EXE="$CLAUDE_RC_SERVER_EXE"
   _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null 2>&1 || rc=$?
   unset FAKE_UNMANAGED_CWD FAKE_UNMANAGED_EXE
   [ "$rc" -ne 0 ] || fail "maint should fail when unmanaged same-cwd server exists"
@@ -481,6 +579,8 @@ test_claude_remote_control_stop_blocks_worktree_sessions_and_force_unregisters()
   _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
   : > "$CLAUDE_RC_HOLD_FILE"
   _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" start >/dev/null
+  _claude_rc_wait_fake_claude_log "remote-control --spawn worktree" \
+    || fail "fake claude log did not appear before stop"
   _claude_rc_run "$repo" bash "$(_claude_rc_wrapper_script)" stop --force >/dev/null
   status="$(cat "$CLAUDE_RC_STATE/instances.json")"
   jq -e --arg path "$repo" '(.instances | has($path)) | not' <<<"$status" >/dev/null \
@@ -684,7 +784,7 @@ test_claude_remote_control_maint_uses_effective_spawn_for_drift_gate() {
     fi
 
     FAKE_SERVER_CWD="$repo" \
-    FAKE_SERVER_EXE="$CLAUDE_RC_FAKE_BIN/claude-old" \
+    FAKE_SERVER_EXE="$CLAUDE_RC_VERSIONS/claude-old" \
     FAKE_SERVER_COMMAND="$command" \
       _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null
     kill "$lock_pid" 2>/dev/null || true
@@ -781,6 +881,53 @@ EOS
     || fail "transcript gate scope mismatch: $out"
 }
 
+test_claude_remote_control_maint_reaps_orphan_sessions_before_start() {
+  local sandbox repo orphan_dir term_mark orphan_pid out status rc
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  orphan_dir="$repo/.claude/worktrees/orphan-session"
+  term_mark="$sandbox/orphan.term"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  mkdir -p "$orphan_dir"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "manual"
+  _claude_rc_install_orphan_session_mocks
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  bash -c '
+    set -euo pipefail
+    cd "$1"
+    trap '\''printf term >"$2"; exit 0'\'' TERM
+    while :; do sleep 0.1; done
+  ' _ "$orphan_dir" "$term_mark" &
+  orphan_pid=$!
+
+  rc=0
+  FAKE_ORPHAN_PID="$orphan_pid" \
+  FAKE_ORPHAN_CWD="$orphan_dir" \
+  FAKE_ORPHAN_PPID=1 \
+    out="$(_claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure 2>&1)" || rc=$?
+
+  for _ in {1..20}; do
+    [ -f "$term_mark" ] && break
+    sleep 0.1
+  done
+  kill "$orphan_pid" 2>/dev/null || true
+  wait "$orphan_pid" 2>/dev/null || true
+
+  [ "$rc" -eq 0 ] || fail "maint should continue after orphan reap, got $rc: $out"
+  assert_contains "$out" "reaped 1 orphan session process(es)"
+  [ -f "$term_mark" ] || fail "orphan session did not receive SIGTERM before start"
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '
+    .action == "completed"
+    and .instances[0].action == "started"
+  ' <<<"$status" >/dev/null || fail "orphan reap should continue into started status: $status"
+
+  _claude_rc_release_server "$repo"
+}
+
 test_claude_remote_control_maint_status_schema() {
   local sandbox repo status log
   sandbox="$(_claude_rc_new_sandbox)"
@@ -792,6 +939,8 @@ test_claude_remote_control_maint_status_schema() {
   : > "$CLAUDE_RC_HOLD_FILE"
 
   _claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure >/dev/null
+  _claude_rc_wait_fake_claude_log "remote-control --spawn worktree" \
+    || fail "fake claude log did not appear before status assertion"
   status="$(cat "$CLAUDE_RC_STATE/status.json")"
   jq -e '
     (.timestamp | type == "string")

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -183,6 +183,7 @@ _claude_rc_run_maint() {
       FAKE_SERVER_COMMAND="${FAKE_SERVER_COMMAND:-}" \
       FAKE_ORPHAN_PID="${FAKE_ORPHAN_PID:-}" \
       FAKE_ORPHAN_CWD="${FAKE_ORPHAN_CWD:-}" \
+      FAKE_ORPHAN_EXE="${FAKE_ORPHAN_EXE:-}" \
       FAKE_ORPHAN_PPID="${FAKE_ORPHAN_PPID:-}" \
       "$@"
   )
@@ -238,6 +239,8 @@ _claude_rc_write_instance() {
 }
 
 _claude_rc_install_unmanaged_process_mocks() {
+  # Force the Darwin pid_exe_path branch so this fake PID's txt path is fully
+  # controlled by the lsof mock, matching the running-server mock strategy.
   cat > "$CLAUDE_RC_FAKE_BIN/uname" <<'EOS'
 #!/usr/bin/env bash
 echo Darwin
@@ -293,6 +296,10 @@ EOS
 }
 
 _claude_rc_install_orphan_session_mocks() {
+  cat > "$CLAUDE_RC_FAKE_BIN/uname" <<'EOS'
+#!/usr/bin/env bash
+echo Darwin
+EOS
   cat > "$CLAUDE_RC_FAKE_BIN/pgrep" <<'EOS'
 #!/usr/bin/env bash
 case "$*" in
@@ -308,6 +315,10 @@ EOS
 set -euo pipefail
 args=" $* "
 case "$args" in
+  *" -p ${FAKE_ORPHAN_PID:-__none__} "*"txt"*)
+    [ -n "${FAKE_ORPHAN_EXE:-}" ] || exit 1
+    printf 'p%s\nn%s\n' "$FAKE_ORPHAN_PID" "$FAKE_ORPHAN_EXE"
+    ;;
   *" -p ${FAKE_ORPHAN_PID:-__none__} "*"cwd"*)
     printf 'p%s\nn%s\n' "$FAKE_ORPHAN_PID" "$FAKE_ORPHAN_CWD"
     ;;
@@ -323,7 +334,7 @@ case "$*" in
   *) exit 1 ;;
 esac
 EOS
-  chmod +x "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof" "$CLAUDE_RC_FAKE_BIN/ps"
+  chmod +x "$CLAUDE_RC_FAKE_BIN/uname" "$CLAUDE_RC_FAKE_BIN/pgrep" "$CLAUDE_RC_FAKE_BIN/lsof" "$CLAUDE_RC_FAKE_BIN/ps"
 }
 
 _claude_rc_install_no_process_mocks() {
@@ -882,7 +893,7 @@ EOS
 }
 
 test_claude_remote_control_maint_reaps_orphan_sessions_before_start() {
-  local sandbox repo orphan_dir term_mark orphan_pid out status rc
+  local sandbox repo orphan_dir term_mark orphan_pid out status rc non_versioned_reaped
   sandbox="$(_claude_rc_new_sandbox)"
   _claude_rc_setup "$sandbox"
   _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
@@ -906,6 +917,7 @@ test_claude_remote_control_maint_reaps_orphan_sessions_before_start() {
   rc=0
   FAKE_ORPHAN_PID="$orphan_pid" \
   FAKE_ORPHAN_CWD="$orphan_dir" \
+  FAKE_ORPHAN_EXE="$CLAUDE_RC_VERSIONS/claude-session" \
   FAKE_ORPHAN_PPID=1 \
     out="$(_claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure 2>&1)" || rc=$?
 
@@ -924,6 +936,50 @@ test_claude_remote_control_maint_reaps_orphan_sessions_before_start() {
     .action == "completed"
     and .instances[0].action == "started"
   ' <<<"$status" >/dev/null || fail "orphan reap should continue into started status: $status"
+
+  _claude_rc_release_server "$repo"
+
+  sandbox="$(_claude_rc_new_sandbox)"
+  _claude_rc_setup "$sandbox"
+  _claude_rc_make_fake_readlink "$CLAUDE_RC_FAKE_BIN"
+  repo="$sandbox/repo"
+  orphan_dir="$repo/.claude/worktrees/non-versioned-session"
+  term_mark="$sandbox/non-versioned.term"
+  _claude_rc_make_repo "$repo" "$CLAUDE_RC_HOME"
+  mkdir -p "$orphan_dir"
+  _claude_rc_write_instance "$repo" "worktree" "null" "bypassPermissions" "manual"
+  _claude_rc_install_orphan_session_mocks
+  : > "$CLAUDE_RC_HOLD_FILE"
+
+  bash -c '
+    set -euo pipefail
+    cd "$1"
+    trap '\''printf term >"$2"; exit 0'\'' TERM
+    while :; do sleep 0.1; done
+  ' _ "$orphan_dir" "$term_mark" &
+  orphan_pid=$!
+
+  rc=0
+  FAKE_ORPHAN_PID="$orphan_pid" \
+  FAKE_ORPHAN_CWD="$orphan_dir" \
+  FAKE_ORPHAN_EXE="$sandbox/outside/not-claude" \
+  FAKE_ORPHAN_PPID=1 \
+    out="$(_claude_rc_run_maint "$repo" bash "$(_claude_rc_maint_script)" ensure 2>&1)" || rc=$?
+
+  sleep 0.3
+  non_versioned_reaped=false
+  [ -f "$term_mark" ] && non_versioned_reaped=true
+  kill "$orphan_pid" 2>/dev/null || true
+  wait "$orphan_pid" 2>/dev/null || true
+
+  [ "$rc" -eq 0 ] || fail "maint should continue when non-versioned sdk-url process is ignored, got $rc: $out"
+  assert_not_contains "$out" "reaped"
+  [ "$non_versioned_reaped" = false ] || fail "non-versioned --sdk-url process must not be reaped"
+  status="$(cat "$CLAUDE_RC_STATE/status.json")"
+  jq -e '
+    .action == "completed"
+    and .instances[0].action == "started"
+  ' <<<"$status" >/dev/null || fail "ignored non-versioned process should still allow start: $status"
 
   _claude_rc_release_server "$repo"
 }

--- a/tests/suites/claude-remote-control.sh
+++ b/tests/suites/claude-remote-control.sh
@@ -185,6 +185,7 @@ _claude_rc_run_maint() {
       FAKE_ORPHAN_CWD="${FAKE_ORPHAN_CWD:-}" \
       FAKE_ORPHAN_EXE="${FAKE_ORPHAN_EXE:-}" \
       FAKE_ORPHAN_PPID="${FAKE_ORPHAN_PPID:-}" \
+      FAKE_ORPHAN_COMMAND="${FAKE_ORPHAN_COMMAND:-}" \
       "$@"
   )
 }
@@ -331,6 +332,8 @@ EOS
 #!/usr/bin/env bash
 case "$*" in
   *"ppid="*) echo "${FAKE_ORPHAN_PPID:-1}" ;;
+  # pid_is_session_proc의 signal 직전 argv 재확인이 조회하는 command= 응답.
+  *"command="*) echo "${FAKE_ORPHAN_COMMAND:-/path/to/versions/2.0.0 --print --sdk-url https://example.invalid}" ;;
   *) exit 1 ;;
 esac
 EOS


### PR DESCRIPTION
## Summary

- claude-rc의 프로세스 판정을 강화한다: 서버/unmanaged 판정에 실행 바이너리 경계(claude versions 경로)를 복원하고, SIGKILL로 죽은 서버가 남긴 고아 세션 프로세스를 ensure가 기동 직전에 정리한다.

Closes #1060
Closes #1061

## 기존 문제/배경

- 서버 판정이 `pgrep -f`(argv 문자열 매칭) + cwd + flock 제외뿐이라, 감지 패턴을 argv에 가진 무관한 장수 프로세스를 서버로 오탐하는 사례가 실측됐다 (`unmanaged-server-present` 오탐 → 부활 지연 + 불필요 알림). 구 스택(#1005)의 `find_bridge_pid`에 있던 exe 검증이 재설계(#1052)에서 느슨해진 부분이다.
- 서버가 SIGKILL(OOM 킬 등)로 죽으면 스폰 세션 자식(`--sdk-url`)이 ppid=1 고아로 잔존함이 실측됐다 (SIGTERM 경로만 자식 정리). 고아는 재연결 불능 상태로 리소스를 점유하고 다음 기동 시 새 서버와 공존한다.

## CIR (Change Intent Record)

- v1 (#1005): `find_bridge_pid`가 "유효 = exe가 claude versions 디렉토리"로 검증.
- v2 (#1052): headless 재설계에서 판정이 argv+cwd로 재구현되며 exe 검증이 누락됨.
- v3 (이번 변경): exe 검증 복원 + 같은 경계를 고아 reap 대상에도 적용. 리뷰 과정에서 reap 경계를 3중으로 강화 — (a) reap 대상 자식에도 versions exe 검증, (b) orphan 판정을 실측 확정 범위(ppid≤1)로 축소(비서버 부모 분기는 근거 없는 과광 판정이라 제거), (c) TERM/KILL 직전 predicate 재검증 + `--sdk-url` argv 재확인(pid 재사용 레이스 방어).

**trade-off**: exe 경계는 `VERSIONS_DIR`(기본 `~/.local/share/claude/versions`) 가정을 도입한다 — 커스텀 launcher 배포는 env로 오버라이드 가능하며 usage에 문서화했다 (nix 배선은 기본 경로 사용이라 불필요).

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| exe 경계 검증 (versions 경로) | pid의 실행 바이너리 위치로 판정 | 구현 단순, argv 오탐 원천 차단, 구 스택 검증의 복원 | VERSIONS_DIR 가정 (env 오버라이드로 완화) | ✅ |
| argv 정밀 파싱 강화 | 커맨드라인 구조 분석 | env 가정 없음 | 여전히 argv 위조/우연 일치에 취약 | ❌ |
| 고아 방치 (reap 없음) | SIGKILL 잔재를 그대로 둠 | 코드 없음 | 리소스 점유 + 새 서버와 공존 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/nixos/scripts/claude-rc-lib.sh` | 수정 | `VERSIONS_DIR` 상수 + exe 경계 검증(`is_claude_versions_exe_process`)을 서버 판정·orphan 판정에 결합, 고아 감지(`--sdk-url` + 인스턴스 스코프 cwd + ppid≤1)·정리(TERM grace 상수화 → KILL, 각 signal 직전 재검증) helper |
| `modules/nixos/programs/claude-remote-control/files/claude-rc-maint.sh` | 수정 | 기동 직전 고아 reap 배선 + 로그, usage에 `VERSIONS_DIR` 계약 문서화 |
| `tests/suites/claude-remote-control.sh` | 수정 | 오탐 회귀(argv만 일치하는 프로세스 무시)·고아 reap fixture, VERSIONS_DIR sandbox 주입 |

## 참고 레퍼런스

- Issue #1060 — argv 오탐 실측 기록
- Issue #1061 — SIGKILL 고아 실측 기록
- PR #1052 — 재설계 본체 (exe 검증 누락 지점)
- #1005 — 구 스택의 exe 검증 선례

## Human Test Plan

1. 정상 서버 운영 중 ensure 실행 (`launchctl kickstart ...` / `systemctl start claude-rc-ensure`).
   - **기대**: `healthy` — exe 경계 추가가 실서버 판정을 깨지 않음 (regression).
2. 인스턴스 디렉토리에서 argv에 'claude remote-control' 문자열을 가진 장수 스크립트를 띄우고(서버는 정지 상태) ensure 실행.
   - **기대**: 오탐 없이 정상 기동 (구버전이라면 `unmanaged-server-present` 오탐).
3. 서버를 `kill -9`로 죽인 후 ensure 실행.
   - **기대**: `reaped N orphan session process(es)` 로그 후 정상 기동, 고아 프로세스 소멸.
   - **실패 시**: `<slug>/server.log` 및 ensure 로그 확인.
4. Negative: `--sdk-url` argv를 가졌지만 exe가 versions 밖인 프로세스는 reap되지 않음 (테스트 fixture로 자동 검증됨).
