### PR TITLE
fix(lefthook): auto-sync가 staged-config guard를 지우는 회귀 차단

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ NixOS 홈서버 서비스는 `homeserver.*` 옵션으로 선언적으로 활성�
 **통합 검증 (push 전 / 온보딩 시 권장)**: [`bash tests/run-all-tests.sh`](./tests/run-all-tests.sh) — eval-tests · shell-script-tests · codex-hook-fixtures · codex-exec-supervised · flake-check · statusline-bats · precommit-staged-snapshot를 한 번에 순차 실행하고 통과/SKIP/실패를 구분 요약한다(하나라도 실패 시 non-zero). 로컬 훅을 우회(`git commit --no-verify` / `LEFTHOOK=0`)했거나 fresh clone에서 훅 설치 전이라도, 이 명령으로 pre-push 게이트와 테스트 드라이버를 재검증할 수 있다. 단 pre-commit의 staged 스냅샷 정책(`gitleaks` · `nixfmt` · `shellcheck` · skill-noise)은 staged index 기준이라 working-tree 러너 범위 밖이며 커밋 시점 게이트로 별도 적용된다.
 
 **pre-commit** (병렬):
-- `lefthook-guard-self-check` — 메인 repo `.git/hooks/pre-commit`에 staged-config guard marker 부재 시 commit fail-fast (인접 worktree의 lefthook install 덮어쓰기 회귀 방지 layer)
+- `lefthook-guard-self-check` — 설치된 hook에서 (1) `.git/hooks/pre-commit`의 staged-config guard marker, (2) 세 hook(`pre-commit`/`commit-msg`/`pre-push`) lefthook 호출부의 `--no-auto-install` 플래그가 사라지면 commit fail-fast. lefthook의 암묵 auto-sync(`lefthook.yml` 변경 후 첫 실행)와 인접 worktree의 `lefthook install` 덮어쓰기, 두 회귀 경로를 함께 막는다
 - `ai-skills-consistency` — staged snapshot 기준 `.claude/skills`, `.agents/skills`, `modules/shared/programs/codex` 구조 일관성
 - `gitleaks` — staged policy/config 기준 시크릿 유출 방지
 - `nixfmt` — Nix 포매팅 검증
@@ -102,7 +102,7 @@ NixOS 홈서버 서비스는 `homeserver.*` 옵션으로 선언적으로 활성�
 pre-commit 정책:
 - whole-repo / whole-corpus hook은 [`scripts/ai/run-staged-snapshot.sh`](./scripts/ai/run-staged-snapshot.sh)를 통해 staged index snapshot에서 실행한다.
 - `gitleaks`는 [`scripts/ai/run-gitleaks-staged-policy.sh`](./scripts/ai/run-gitleaks-staged-policy.sh)를 통해 copied temp index, staged snapshot worktree, staged `.gitleaks.toml` / `.gitleaksignore`만 사용한다.
-- installed `git commit` 경로는 [`scripts/ai/install-lefthook-hooks.sh`](./scripts/ai/install-lefthook-hooks.sh)가 메인 repo에서는 git default hook path(`.git/hooks`)에, 워크트리에서는 worktree-local hook path(`.git/worktrees/<name>/hooks`)에 pre-Lefthook guard를 주입한다. 이 guard는 `lefthook.yml`과 repo-local hook scripts의 index/working-tree drift, unsupported Lefthook merged config surface, `LEFTHOOK_CONFIG` / `LEFTHOOK_BIN` / `LEFTHOOK_EXCLUDE`를 차단한다. 인접 worktree의 `lefthook install`이 메인 hook을 덮어써서 guard가 사라지는 경우는 `lefthook-guard-self-check` command가 commit-time에 fail-fast로 차단한다.
+- installed `git commit` 경로는 [`scripts/ai/install-lefthook-hooks.sh`](./scripts/ai/install-lefthook-hooks.sh)가 메인 repo에서는 git default hook path(`.git/hooks`)에, 워크트리에서는 worktree-local hook path(`.git/worktrees/<name>/hooks`)에 pre-Lefthook guard를 주입한다. 이 guard는 `lefthook.yml`과 repo-local hook scripts의 index/working-tree drift, unsupported Lefthook merged config surface, `LEFTHOOK_CONFIG` / `LEFTHOOK_BIN` / `LEFTHOOK_EXCLUDE`를 차단한다. 같은 스크립트가 설치된 모든 hook의 lefthook 호출부에 `--no-auto-install`을 주입한다 — `lefthook run`은 `lefthook.checksum`이 stale하면 hook을 암묵 재설치(`sync hooks`)하면서 이 guard를 지우기 때문이다(그래서 `lefthook.yml`을 바꾼 뒤 첫 commit이 실패했다). hook checksum 갱신은 이 스크립트의 `lefthook install`이 전담하므로 자동 재설치를 잃어도 손해가 없다. guard 블록이나 플래그가 사라지는 경우(암묵 auto-sync, 또는 인접 worktree의 `lefthook install` 덮어쓰기)는 `lefthook-guard-self-check` command가 commit-time에 fail-fast로 차단한다.
 - 표준 우회인 `git commit --no-verify`와 `LEFTHOOK=0`은 여전히 hook을 실행하지 않는다.
 - 직접 스크립트 실행은 pre-commit staged snapshot 경로와 동일하지 않다.
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ NixOS 홈서버 서비스는 `homeserver.*` 옵션으로 선언적으로 활성�
 
 ## 검증 / 훅
 
-[`lefthook.yml`](./lefthook.yml)로 pre-commit/pre-push 훅 관리.
+[`lefthook.yml`](./lefthook.yml)로 pre-commit/commit-msg/pre-push 훅 관리.
 
 **통합 검증 (push 전 / 온보딩 시 권장)**: [`bash tests/run-all-tests.sh`](./tests/run-all-tests.sh) — eval-tests · shell-script-tests · codex-hook-fixtures · codex-exec-supervised · flake-check · statusline-bats · precommit-staged-snapshot를 한 번에 순차 실행하고 통과/SKIP/실패를 구분 요약한다(하나라도 실패 시 non-zero). 로컬 훅을 우회(`git commit --no-verify` / `LEFTHOOK=0`)했거나 fresh clone에서 훅 설치 전이라도, 이 명령으로 pre-push 게이트와 테스트 드라이버를 재검증할 수 있다. 단 pre-commit의 staged 스냅샷 정책(`gitleaks` · `nixfmt` · `shellcheck` · skill-noise)은 staged index 기준이라 working-tree 러너 범위 밖이며 커밋 시점 게이트로 별도 적용된다.
 
 **pre-commit** (병렬):
-- `lefthook-guard-self-check` — 설치된 hook에서 (1) `.git/hooks/pre-commit`의 staged-config guard marker, (2) 세 hook(`pre-commit`/`commit-msg`/`pre-push`) lefthook 호출부의 `--no-auto-install` 플래그가 사라지면 commit fail-fast. lefthook의 암묵 auto-sync(`lefthook.yml` 변경 후 첫 실행)와 인접 worktree의 `lefthook install` 덮어쓰기, 두 회귀 경로를 함께 막는다
+- `lefthook-guard-self-check` — 현재 worktree에서 Git이 해석한 hooks 경로(`git rev-parse --git-path hooks`)를 기준으로, (1) `pre-commit`의 staged-config guard marker, (2) 세 hook(`pre-commit`/`commit-msg`/`pre-push`)의 설치 여부와 lefthook 호출부의 `--no-auto-install` 플래그가 사라지면 commit fail-fast. lefthook의 암묵 auto-sync(`lefthook.yml` 변경 후 첫 실행)와 인접 worktree의 `lefthook install` 덮어쓰기, 두 회귀 경로를 함께 막는다
 - `ai-skills-consistency` — staged snapshot 기준 `.claude/skills`, `.agents/skills`, `modules/shared/programs/codex` 구조 일관성
 - `gitleaks` — staged policy/config 기준 시크릿 유출 방지
 - `nixfmt` — Nix 포매팅 검증
@@ -107,6 +107,7 @@ pre-commit 정책:
 - 직접 스크립트 실행은 pre-commit staged snapshot 경로와 동일하지 않다.
 
 **commit-msg**:
+- `lefthook-guard-self-check` — pre-commit self-check의 복제. `git commit --allow-empty`처럼 staged files가 0이라 pre-commit command가 skip되는 경로까지 차단한다
 - `pinning` — commit message LLM 박제 패턴 감지 (warn-only) ([`scripts/ai/commit-msg-pinning.sh`](./scripts/ai/commit-msg-pinning.sh))
 
 **LLM durable-output pinning guard layers**:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,8 +21,9 @@ pre-commit:
           for hook_name in pre-commit commit-msg pre-push; do
             hook_path="$hooks_dir/$hook_name"
             [ -f "$hook_path" ] || continue
-            if ! grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '; then
-              problem="--no-auto-install missing from the lefthook call in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
+            expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
+            if ! grep -Fxq -- "$expected_call" "$hook_path"; then
+              problem="expected exact lefthook call [$expected_call] in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
               break
             fi
           done
@@ -102,8 +103,9 @@ commit-msg:
           for hook_name in pre-commit commit-msg pre-push; do
             hook_path="$hooks_dir/$hook_name"
             [ -f "$hook_path" ] || continue
-            if ! grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '; then
-              problem="--no-auto-install missing from the lefthook call in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
+            expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
+            if ! grep -Fxq -- "$expected_call" "$hook_path"; then
+              problem="expected exact lefthook call [$expected_call] in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
               break
             fi
           done

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,19 +2,36 @@ pre-commit:
   parallel: true
   commands:
     lefthook-guard-self-check:
-      # 회귀 방지 layer: 인접 worktree의 `lefthook install`이 (worktree-local 격리 없이)
-      # 메인 .git/hooks/pre-commit을 덮어쓰면서 staged-config guard를 silently 제거하는
-      # 시나리오를 commit-time에 fail-fast로 잡는다. install-lefthook-hooks.sh가
-      # 호출되는 worktree는 자기 worktree-local hook에 격리되어 안전하지만, 메인 repo
-      # hook은 8개 inline shellHook worktree(NG-1)의 매 direnv 진입으로 덮어써질 수
-      # 있다. 본 check가 메인에서 commit 시도 시 guard 부재를 발견하고 차단한다.
+      # 회귀 방지 layer: install-lefthook-hooks.sh가 hook에 주입한 두 가지가 살아있는지
+      # commit-time에 fail-fast로 확인한다.
+      #   (1) staged-config guard 블록 (pre-commit)
+      #   (2) lefthook 호출부의 --no-auto-install 플래그 (설치된 모든 hook)
+      # 둘이 사라지는 경로는 두 가지다. 첫째, `lefthook run`은 lefthook.checksum이 stale하면
+      # hook 전체를 암묵 재설치해(sync hooks) guard를 지운다 — (2)가 이 경로를 원천 차단하므로
+      # (2)의 부재는 곧 다음 commit의 guard 소실을 뜻해 여기서 함께 막는다. 둘째, 인접
+      # worktree의 raw `lefthook install`이 worktree-local 격리 없이 공유 hook을 덮어쓴다.
       # parallel: true이지만 어느 command든 fail이면 commit이 차단되므로 순서는 무관.
       run: |
-        hook_path="$(git rev-parse --path-format=absolute --git-path hooks/pre-commit)"
-        if [ ! -f "$hook_path" ] || ! grep -Fq "# BEGIN nixos-config lefthook staged-config guard" "$hook_path"; then
-          echo "lefthook-guard-self-check: staged-config guard missing from $hook_path." >&2
-          echo "  Cause: another worktree's 'lefthook install' likely overwrote the shared hook." >&2
-          echo "  Fix:   re-run 'direnv reload' or 'bash scripts/ai/install-lefthook-hooks.sh' in the current worktree." >&2
+        hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
+        pre_commit="$hooks_dir/pre-commit"
+        problem=""
+        if [ ! -f "$pre_commit" ] || ! grep -Fq "# BEGIN nixos-config lefthook staged-config guard" "$pre_commit"; then
+          problem="staged-config guard block missing from $pre_commit"
+        else
+          for hook_name in pre-commit commit-msg pre-push; do
+            hook_path="$hooks_dir/$hook_name"
+            [ -f "$hook_path" ] || continue
+            if ! grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '; then
+              problem="--no-auto-install missing from the lefthook call in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
+              break
+            fi
+          done
+        fi
+        if [ -n "$problem" ]; then
+          echo "lefthook-guard-self-check: $problem" >&2
+          echo "  Cause: lefthook's implicit auto-sync regenerated the hooks (happens on the first run after lefthook.yml changes)," >&2
+          echo "         or another worktree's raw 'lefthook install' overwrote the shared hook." >&2
+          echo "  Fix:   bash scripts/ai/install-lefthook-hooks.sh   (or 'direnv reload') in the current worktree, then retry." >&2
           exit 1
         fi
     ai-skills-consistency:
@@ -76,11 +93,26 @@ commit-msg:
       # staged files"로 무력화한다. commit-msg hook은 staged files와 무관하게 항상
       # 실행되므로, 이 layer가 staged-files-가-0인 경로의 우회 시나리오까지 차단한다.
       run: |
-        hook_path="$(git rev-parse --path-format=absolute --git-path hooks/pre-commit)"
-        if [ ! -f "$hook_path" ] || ! grep -Fq "# BEGIN nixos-config lefthook staged-config guard" "$hook_path"; then
-          echo "lefthook-guard-self-check (commit-msg): staged-config guard missing from $hook_path." >&2
-          echo "  Cause: another worktree's 'lefthook install' likely overwrote the shared hook." >&2
-          echo "  Fix:   re-run 'direnv reload' or 'bash scripts/ai/install-lefthook-hooks.sh' in the current worktree." >&2
+        hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
+        pre_commit="$hooks_dir/pre-commit"
+        problem=""
+        if [ ! -f "$pre_commit" ] || ! grep -Fq "# BEGIN nixos-config lefthook staged-config guard" "$pre_commit"; then
+          problem="staged-config guard block missing from $pre_commit"
+        else
+          for hook_name in pre-commit commit-msg pre-push; do
+            hook_path="$hooks_dir/$hook_name"
+            [ -f "$hook_path" ] || continue
+            if ! grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '; then
+              problem="--no-auto-install missing from the lefthook call in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
+              break
+            fi
+          done
+        fi
+        if [ -n "$problem" ]; then
+          echo "lefthook-guard-self-check (commit-msg): $problem" >&2
+          echo "  Cause: lefthook's implicit auto-sync regenerated the hooks (happens on the first run after lefthook.yml changes)," >&2
+          echo "         or another worktree's raw 'lefthook install' overwrote the shared hook." >&2
+          echo "  Fix:   bash scripts/ai/install-lefthook-hooks.sh   (or 'direnv reload') in the current worktree, then retry." >&2
           exit 1
         fi
     pinning:
@@ -103,11 +135,13 @@ pre-push:
       # 실패). devShell은 건드리지 않아 direnv/bare python3 해석 영향이 없다. `--inputs-from .`로
       # nixpkgs#를 repo flake.lock에 pin해 임시 registry fetch를 피한다(statusline-bats와 동일 패턴).
       # claude-rc(#1052)가 require_cmd lsof를 도입했고 lsof는 NixOS 시스템 프로파일/CI PATH에
-      # 항상 있지 않으므로 nixpkgs#lsof도 명시 제공한다(#1009와 동일 패턴).
+      # 항상 있지 않으므로 nixpkgs#lsof도 명시 제공한다(#1009와 동일 패턴). lefthook auto-sync
+      # end-to-end 테스트는 stub이 아닌 실제 lefthook을 요구하는데, hook이 lefthook을 nix store
+      # 절대경로로 호출하면 자식 PATH에 lefthook이 없다. 같은 이유로 nixpkgs#lefthook도 얹는다.
       # `_TOMLKIT_BOOTSTRAP_READY=1`로 run-shell-script-tests.sh 내부 tomlkit-bootstrap.sh의 중첩
       # `nix shell` re-exec을 막는다(이 wrap이 이미 동일 hermetic 런타임을 제공). 테스트 병렬 실행은
       # 러너 자체(tests/lib/parallel-harness.sh job-pool)가 담당하므로 여기서 추가 배선은 없다.
-      run: nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh
+      run: nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof nixpkgs#lefthook --command env _TOMLKIT_BOOTSTRAP_READY=1 bash ./tests/run-shell-script-tests.sh
     codex-hook-fixtures:
       # pre-commit에 이미 동일 명령이 있지만 push 직전 재검증해 stale state 회귀 차단.
       # runner self-bootstrap이라 추가 nix shell wrap 불필요. live propagation은 attach하지 않음.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,11 +5,13 @@ pre-commit:
       # 회귀 방지 layer: install-lefthook-hooks.sh가 hook에 주입한 두 가지가 살아있는지
       # commit-time에 fail-fast로 확인한다.
       #   (1) staged-config guard 블록 (pre-commit)
-      #   (2) lefthook 호출부의 --no-auto-install 플래그 (설치된 모든 hook)
+      #   (2) 설치된 hook 세 개의 존재와, 각 lefthook 호출부의 --no-auto-install 플래그
       # 둘이 사라지는 경로는 두 가지다. 첫째, `lefthook run`은 lefthook.checksum이 stale하면
       # hook 전체를 암묵 재설치해(sync hooks) guard를 지운다 — (2)가 이 경로를 원천 차단하므로
       # (2)의 부재는 곧 다음 commit의 guard 소실을 뜻해 여기서 함께 막는다. 둘째, 인접
       # worktree의 raw `lefthook install`이 worktree-local 격리 없이 공유 hook을 덮어쓴다.
+      # auto-install을 끈 이상 hook 파일이 없어도 lefthook이 되살려 주지 않는다. 없는 hook을
+      # 건너뛰면 그 hook의 게이트가 조용히 사라지므로, 누락 자체를 fail-fast로 잡는다.
       # parallel: true이지만 어느 command든 fail이면 commit이 차단되므로 순서는 무관.
       run: |
         hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
@@ -20,7 +22,12 @@ pre-commit:
         else
           for hook_name in pre-commit commit-msg pre-push; do
             hook_path="$hooks_dir/$hook_name"
-            [ -f "$hook_path" ] || continue
+            if [ ! -f "$hook_path" ]; then
+              problem="hook file missing: $hook_path (auto-install is disabled, so lefthook will not recreate it)"
+              break
+            fi
+            # `"$@"`는 이 sh 블록에서 인자가 없어 빈 문자열로 확장된다. 기대 라인 전체를
+            # 작은따옴표로 조립해 리터럴 `"$@"`를 보존한다.
             expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
             if ! grep -Fxq -- "$expected_call" "$hook_path"; then
               problem="expected exact lefthook call [$expected_call] in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
@@ -102,7 +109,12 @@ commit-msg:
         else
           for hook_name in pre-commit commit-msg pre-push; do
             hook_path="$hooks_dir/$hook_name"
-            [ -f "$hook_path" ] || continue
+            if [ ! -f "$hook_path" ]; then
+              problem="hook file missing: $hook_path (auto-install is disabled, so lefthook will not recreate it)"
+              break
+            fi
+            # `"$@"`는 이 sh 블록에서 인자가 없어 빈 문자열로 확장된다. 기대 라인 전체를
+            # 작은따옴표로 조립해 리터럴 `"$@"`를 보존한다.
             expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
             if ! grep -Fxq -- "$expected_call" "$hook_path"; then
               problem="expected exact lefthook call [$expected_call] in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -87,11 +87,26 @@ pre-commit:
   commands:
     lefthook-guard-self-check:
       run: |
-        hook_path="$(git rev-parse --path-format=absolute --git-path hooks/pre-commit)"
-        if [ ! -f "$hook_path" ] || ! grep -Fq "# BEGIN nixos-config lefthook staged-config guard" "$hook_path"; then
-          echo "lefthook-guard-self-check: staged-config guard missing from $hook_path." >&2
-          echo "  Cause: another worktree's 'lefthook install' likely overwrote the shared hook." >&2
-          echo "  Fix:   re-run 'direnv reload' or 'bash scripts/ai/install-lefthook-hooks.sh' in the current worktree." >&2
+        hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
+        pre_commit="$hooks_dir/pre-commit"
+        problem=""
+        if [ ! -f "$pre_commit" ] || ! grep -Fq "# BEGIN nixos-config lefthook staged-config guard" "$pre_commit"; then
+          problem="staged-config guard block missing from $pre_commit"
+        else
+          for hook_name in pre-commit commit-msg pre-push; do
+            hook_path="$hooks_dir/$hook_name"
+            [ -f "$hook_path" ] || continue
+            if ! grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '; then
+              problem="--no-auto-install missing from the lefthook call in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
+              break
+            fi
+          done
+        fi
+        if [ -n "$problem" ]; then
+          echo "lefthook-guard-self-check: $problem" >&2
+          echo "  Cause: lefthook's implicit auto-sync regenerated the hooks (happens on the first run after lefthook.yml changes)," >&2
+          echo "         or another worktree's raw 'lefthook install' overwrote the shared hook." >&2
+          echo "  Fix:   bash scripts/ai/install-lefthook-hooks.sh   (or 'direnv reload') in the current worktree, then retry." >&2
           exit 1
         fi
     ai-skills-consistency:

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -96,8 +96,9 @@ pre-commit:
           for hook_name in pre-commit commit-msg pre-push; do
             hook_path="$hooks_dir/$hook_name"
             [ -f "$hook_path" ] || continue
-            if ! grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '; then
-              problem="--no-auto-install missing from the lefthook call in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
+            expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
+            if ! grep -Fxq -- "$expected_call" "$hook_path"; then
+              problem="expected exact lefthook call [$expected_call] in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"
               break
             fi
           done
@@ -165,6 +166,10 @@ repo_scripts=(
   "tests/run-eval-tests.sh"
   "tests/test-codex-hook-fixtures.sh"
   "scripts/ai/check-skill-noise.sh"
+  # lefthook-guard-self-check가 검사하는 `--no-auto-install` 주입은 이 installer가 수행한다.
+  # hook 설정과 allowlist만 staged되고 installer 변경이 빠지면 그 계약이 조용히 깨지므로,
+  # PR #750의 helper script drift 경계를 installer까지 넓힌다.
+  "scripts/ai/install-lefthook-hooks.sh"
 )
 
 for path in "${repo_scripts[@]}"; do

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -95,7 +95,10 @@ pre-commit:
         else
           for hook_name in pre-commit commit-msg pre-push; do
             hook_path="$hooks_dir/$hook_name"
-            [ -f "$hook_path" ] || continue
+            if [ ! -f "$hook_path" ]; then
+              problem="hook file missing: $hook_path (auto-install is disabled, so lefthook will not recreate it)"
+              break
+            fi
             expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
             if ! grep -Fxq -- "$expected_call" "$hook_path"; then
               problem="expected exact lefthook call [$expected_call] in $hook_path (lefthook's next auto-sync would silently drop the staged-config guard)"

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -49,6 +49,11 @@ END_MARKER="# END nixos-config lefthook staged-config guard"
 # 플래그 존재 재확인: `lefthook run --help | grep -- --no-auto-install` (lefthook 2.1.5 기준).
 NO_AUTO_INSTALL_FLAG="--no-auto-install"
 
+# git이 인정하는 hook 이름. configured_hooks가 lefthook.yml의 top-level 키에서 hook만 골라낼 때
+# 쓴다 (전역 옵션 키를 hook으로 오인하지 않도록). 목록 출처: `man githooks` (git 2.x).
+# 한 줄로 유지한다 — tests/suites/lefthook.sh가 sed로 추출해 실제 hook 이름 판별에 재사용한다.
+GIT_HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit pre-merge-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-push pre-receive update proc-receive post-receive post-update reference-transaction push-to-checkout pre-auto-gc post-rewrite sendemail-validate fsmonitor-watchman p4-changelist p4-prepare-changelist p4-post-changelist p4-pre-submit post-index-change"
+
 
 # 30 minutes — install itself runs in ~150ms; this guards against hung child
 # processes (NFS lock issues, OS bugs) rather than normal contention. Matches the
@@ -441,11 +446,20 @@ require_canonical_lefthook_config() {
 }
 
 configured_hooks() {
-  # lefthook.yml이 정의한 top-level hook 이름. 파싱 방식은 check-lefthook-staged-config.sh의
-  # allowed_top_level 검사와 같다. 설정 파일이 없으면 아무것도 출력하지 않는다.
+  # lefthook.yml이 정의한 top-level 키 중 실제 git hook 이름만 고른다. lefthook config의
+  # top-level에는 hook 외에 전역 옵션(`colors`, `skip_output`, `min_version`, `remotes` 등)도
+  # 올 수 있는데, 그것을 hook으로 오인하면 아래 호출부가 `.git/hooks/colors`를 찾다가
+  # "expected hook not installed"로 install을 막아 버린다 (실측: `colors: false` 한 줄로 재현).
+  # 현재 저장소는 세 hook만 쓰지만, 전역 옵션을 추가하는 순간 direnv 진입이 깨지는 잠복 결함이었다.
   # require_canonical_lefthook_config가 LEFTHOOK_CONFIG를 이 파일로 고정해 둔다.
   [ -f "$repo_root/lefthook.yml" ] || return 0
-  awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' "$repo_root/lefthook.yml"
+  awk -v known=" $GIT_HOOK_NAMES " '
+    /^[A-Za-z0-9_.-]+:/ {
+      name = $1
+      sub(/:$/, "", name)
+      if (index(known, " " name " ") > 0) print name
+    }
+  ' "$repo_root/lefthook.yml"
 }
 
 refuse_symlinked_hooks() {

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -33,6 +33,18 @@ set -euo pipefail
 BEGIN_MARKER="# BEGIN nixos-config lefthook staged-config guard"
 END_MARKER="# END nixos-config lefthook staged-config guard"
 
+# `lefthook run`은 lefthook.checksum(해시 + config mtime)이 현재 lefthook.yml과
+# 어긋나면 hook 파일 전체를 암묵적으로 재설치한다 ("sync hooks: ✔️ (...)"). 그 재설치는
+# 순수 lefthook 템플릿을 쓰므로 inject_staged_guard가 넣은 guard 블록이 조용히 사라지고,
+# 바로 그 실행의 lefthook-guard-self-check가 자기가 방금 잃은 guard를 발견해 commit을
+# 차단한다 (= lefthook.yml이 바뀐 뒤 첫 commit은 항상 실패). hook 하나에서 sync가 나면
+# pre-commit/commit-msg/pre-push가 한꺼번에 재생성되므로 세 hook 모두 차단해야 한다.
+# LEFTHOOK_* env로는 끌 수 없고 `lefthook run --no-auto-install`이 유일한 차단 수단이라,
+# 설치된 모든 hook의 lefthook 호출부에 이 플래그를 주입한다. checksum 최신화는 아래
+# run_lefthook_install이 전담하므로 자동 재설치를 잃어도 손해가 없다.
+# 플래그 존재 재확인: `lefthook run --help | grep -- --no-auto-install` (lefthook 2.1.5 기준).
+NO_AUTO_INSTALL_FLAG="--no-auto-install"
+
 # 30 minutes — install itself runs in ~150ms; this guards against hung child
 # processes (NFS lock issues, OS bugs) rather than normal contention. Matches the
 # convention from modules/shared/scripts/lib/rebuild/locks.sh:198.
@@ -289,6 +301,80 @@ PY
   fi
 }
 
+disable_lefthook_auto_install() {
+  # 설치된 모든 lefthook hook의 `call_lefthook run "<hook>" "$@"` 호출부에
+  # NO_AUTO_INSTALL_FLAG를 주입한다 (배경은 상수 정의부 주석 참조).
+  #
+  # `--git-path hooks`는 core.hooksPath를 반영하므로 lefthook이 실제로 hook을 쓴 위치와
+  # 일치한다 ($git_dir/hooks와 다를 수 있다 — 사용자가 core.hooksPath를 재정의한 경우).
+  # inject_staged_guard가 hook을 찾는 방식과 같은 해석 경로를 쓴다.
+  local hook_file resolved_hooks_dir
+  resolved_hooks_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks)"
+  local -a hook_files=()
+  for hook_file in "$resolved_hooks_dir"/*; do
+    [ -f "$hook_file" ] || continue
+    # lefthook이 기존 hook을 밀어낼 때 남기는 백업본은 실행되지 않으므로 건드리지 않는다.
+    case "$hook_file" in *.old) continue ;; esac
+    grep -Fq 'call_lefthook run ' "$hook_file" || continue
+    hook_files+=("$hook_file")
+  done
+  if [ "${#hook_files[@]}" -eq 0 ]; then
+    fail "no lefthook-generated hooks found under $resolved_hooks_dir"
+  fi
+
+  # 200>&- closes the lock fd in the python child (same reason as run_lefthook_install).
+  python3 - "$NO_AUTO_INSTALL_FLAG" "${hook_files[@]}" 200>&- <<'PY'
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import sys
+import tempfile
+
+flag = sys.argv[1]
+call_prefix = 'call_lefthook run "'
+call_suffix = '"$@"'
+
+for raw_path in sys.argv[2:]:
+    hook_path = Path(raw_path)
+    lines = hook_path.read_text(encoding="utf-8").splitlines()
+
+    changed = False
+    patched: list[str] = []
+    for line in lines:
+        if line.startswith(call_prefix) and line.endswith(call_suffix) and flag not in line:
+            line = f"{line[: -len(call_suffix)]}{flag} {call_suffix}"
+            changed = True
+        patched.append(line)
+
+    if not changed:
+        continue
+
+    # Atomic replace: a hook process already executing this file keeps reading the
+    # old inode. An in-place truncate+write would corrupt a running `sh` mid-read.
+    mode = hook_path.stat().st_mode
+    fd, tmp_name = tempfile.mkstemp(dir=str(hook_path.parent), prefix=f"{hook_path.name}.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(patched) + "\n")
+        os.chmod(tmp_name, mode)
+        os.replace(tmp_name, hook_path)
+    except BaseException:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+        raise
+PY
+
+  # Defense in depth: lefthook이 hook 템플릿의 호출부 형태를 바꾸면 위 치환이 조용히
+  # no-op가 되고, 다음 auto-sync가 guard를 다시 지운다. 그 실패를 install 시점으로 당긴다.
+  for hook_file in "${hook_files[@]}"; do
+    bash -n "$hook_file"
+    if ! grep -F -- "$NO_AUTO_INSTALL_FLAG" "$hook_file" | grep -Fq 'call_lefthook run '; then
+      fail "auto-install suppression failed: $NO_AUTO_INSTALL_FLAG missing from lefthook call in $hook_file"
+    fi
+  done
+}
+
 if is_main_repo; then
   cleanup_main_redundant_hooks_path
 else
@@ -297,3 +383,4 @@ fi
 acquire_install_lock
 run_lefthook_install
 inject_staged_guard
+disable_lefthook_auto_install

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -47,6 +47,7 @@ END_MARKER="# END nixos-config lefthook staged-config guard"
 # 플래그 존재 재확인: `lefthook run --help | grep -- --no-auto-install` (lefthook 2.1.5 기준).
 NO_AUTO_INSTALL_FLAG="--no-auto-install"
 
+
 # 30 minutes — install itself runs in ~150ms; this guards against hung child
 # processes (NFS lock issues, OS bugs) rather than normal contention. Matches the
 # convention from modules/shared/scripts/lib/rebuild/locks.sh:198.
@@ -187,8 +188,17 @@ run_lefthook_install() {
 
 inject_staged_guard() {
   local hook_path
-  hook_path="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks/pre-commit)"
+  # `--git-path hooks/pre-commit`은 마지막 구성요소의 symlink까지 해석해 target 경로를 돌려준다
+  # (실측). 그 경로로는 아래 `-L` 검사가 무력해지고 python도 target을 직접 연다. 디렉토리만
+  # 해석시키고 파일명을 직접 붙여 symlink를 보존한다 — disable_lefthook_auto_install과 같은 방식.
+  hook_path="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks)/pre-commit"
   [ -f "$hook_path" ] || fail "generated pre-commit hook not found: $hook_path"
+  # 아래 python은 write_text로 제자리 갱신하므로 symlink를 만나면 그 target을 따라 쓴다.
+  # disable_lefthook_auto_install이 같은 이유로 symlink를 거부하는데, 이쪽이 먼저 실행되므로
+  # 여기서도 막지 않으면 방어가 반쪽이 된다.
+  if [ -L "$hook_path" ]; then
+    fail "refusing to patch symlinked hook (write would follow the link): $hook_path"
+  fi
 
   # 200>&- closes the lock fd in the python child for the same reason as run_lefthook_install.
   python3 - "$hook_path" "$BEGIN_MARKER" "$END_MARKER" 200>&- <<'PY'
@@ -396,6 +406,19 @@ PY
       fail "auto-install suppression failed: expected exact call line [$expected_call] in $hook_file"
     fi
   done
+
+  # lefthook.yml이 정의한 hook이 하나라도 설치되지 않았다면, auto-install을 끈 지금은 아무도
+  # 되살려 주지 않는다. commit-time self-check가 같은 목록을 fail-fast로 확인하므로, 그 실패를
+  # install 시점으로 당겨 원인을 분명히 남긴다. 기대 목록은 대상 repo의 lefthook.yml에서
+  # 도출한다 — 하드코딩하면 다른 hook 집합을 쓰는 저장소/픽스처에서 거짓 실패가 난다.
+  # top-level 키 파싱은 check-lefthook-staged-config.sh의 allowed_top_level 검사와 같은 방식이다.
+  if [ -f "$repo_root/lefthook.yml" ]; then
+    for hook_name in $(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' "$repo_root/lefthook.yml"); do
+      if [ ! -f "$resolved_hooks_dir/$hook_name" ]; then
+        fail "expected hook not installed: $resolved_hooks_dir/$hook_name (lefthook.yml defines it; check 'lefthook install' output)"
+      fi
+    done
+  fi
 }
 
 if is_main_repo; then

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -21,11 +21,13 @@
 #
 # Source-of-truth scope: this script governs lefthook install + guard injection for
 # the main repo and every worktree whose flake.nix shellHook calls
-# `bash ./scripts/ai/install-lefthook-hooks.sh`. Worktrees with inline shellHook
-# implementations (`.claude/worktrees/issue_587/flake.nix` 등 8개) are outside this
-# scope and tracked as NG-1 (follow-up consolidation candidate). The lefthook.yml
-# `lefthook-guard-self-check` job is a second-layer regression defense that catches
-# silent guard removal by any worktree at commit-time.
+# `bash ./scripts/ai/install-lefthook-hooks.sh`. Worktrees whose shellHook still calls
+# `lefthook install` inline are outside this scope and tracked as NG-1 (issue #789).
+# Enumerate the current ones instead of trusting a hard-coded count — that number went
+# stale before:
+#   rg -l 'git config --unset-all --local core\.hooksPath' .claude/worktrees/*/flake.nix
+# The lefthook.yml `lefthook-guard-self-check` job is a second-layer regression defense
+# that catches silent guard removal by any worktree at commit-time.
 set -euo pipefail
 
 # Marker constants — kept on dedicated lines so tests/shell-script-tests.sh can
@@ -316,6 +318,12 @@ disable_lefthook_auto_install() {
     # lefthook이 기존 hook을 밀어낼 때 남기는 백업본은 실행되지 않으므로 건드리지 않는다.
     case "$hook_file" in *.old) continue ;; esac
     grep -Fq 'call_lefthook run ' "$hook_file" || continue
+    # 아래 python 블록은 rename으로 교체하므로 symlink였다면 링크 자체가 일반 파일로 바뀐다
+    # (다른 레이어가 hook을 symlink로 관리한다면 그 경계가 조용히 끊긴다). lefthook install은
+    # 일반 파일을 쓰므로 여기서 symlink를 만나는 것은 예상 밖 상태다 — 삼키지 말고 세운다.
+    if [ -L "$hook_file" ]; then
+      fail "refusing to patch symlinked hook (rename would replace the link): $hook_file"
+    fi
     hook_files+=("$hook_file")
   done
   if [ "${#hook_files[@]}" -eq 0 ]; then
@@ -337,6 +345,12 @@ call_suffix = '"$@"'
 
 for raw_path in sys.argv[2:]:
     hook_path = Path(raw_path)
+    # 호출부의 symlink 검사와 여기 사이의 TOCTOU를 좁힌다. rename은 링크를 따라가지 않고
+    # directory entry를 갈아끼우므로, symlink를 만나면 교체하지 않고 세운다.
+    st = hook_path.lstat()
+    if os.path.islink(hook_path):
+        raise SystemExit(f"install-lefthook-hooks: refusing to patch symlinked hook: {hook_path}")
+
     lines = hook_path.read_text(encoding="utf-8").splitlines()
 
     changed = False
@@ -352,12 +366,14 @@ for raw_path in sys.argv[2:]:
 
     # Atomic replace: a hook process already executing this file keeps reading the
     # old inode. An in-place truncate+write would corrupt a running `sh` mid-read.
-    mode = hook_path.stat().st_mode
+    # mkstemp는 0600 + 현재 uid/gid로 만들므로 원본의 mode와 owner를 명시적으로 옮긴다.
+    # 소유자가 달라 chown할 권한이 없으면 조용히 owner를 바꾸지 말고 실패한다.
     fd, tmp_name = tempfile.mkstemp(dir=str(hook_path.parent), prefix=f"{hook_path.name}.")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write("\n".join(patched) + "\n")
-        os.chmod(tmp_name, mode)
+        os.chmod(tmp_name, st.st_mode)
+        os.chown(tmp_name, st.st_uid, st.st_gid)
         os.replace(tmp_name, hook_path)
     except BaseException:
         if os.path.exists(tmp_name):
@@ -367,10 +383,17 @@ PY
 
   # Defense in depth: lefthook이 hook 템플릿의 호출부 형태를 바꾸면 위 치환이 조용히
   # no-op가 되고, 다음 auto-sync가 guard를 다시 지운다. 그 실패를 install 시점으로 당긴다.
+  #
+  # 실행 라인을 통째로 정확히 대조한다. "플래그가 파일 어딘가에 있다"는 느슨한 검사는
+  # 주석 한 줄이 두 문자열을 함께 담기만 해도 통과해, 정작 실행 호출부에 플래그가 없는
+  # 상태를 미탐한다. 패턴 안의 `"$@"`가 확장되지 않도록 작은따옴표로 감싼다.
+  local hook_name expected_call
   for hook_file in "${hook_files[@]}"; do
     bash -n "$hook_file"
-    if ! grep -F -- "$NO_AUTO_INSTALL_FLAG" "$hook_file" | grep -Fq 'call_lefthook run '; then
-      fail "auto-install suppression failed: $NO_AUTO_INSTALL_FLAG missing from lefthook call in $hook_file"
+    hook_name="$(basename "$hook_file")"
+    expected_call='call_lefthook run "'"$hook_name"'" '"$NO_AUTO_INSTALL_FLAG"' "$@"'
+    if ! grep -Fxq -- "$expected_call" "$hook_file"; then
+      fail "auto-install suppression failed: expected exact call line [$expected_call] in $hook_file"
     fi
   done
 }

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -411,14 +411,33 @@ PY
   # 되살려 주지 않는다. commit-time self-check가 같은 목록을 fail-fast로 확인하므로, 그 실패를
   # install 시점으로 당겨 원인을 분명히 남긴다. 기대 목록은 대상 repo의 lefthook.yml에서
   # 도출한다 — 하드코딩하면 다른 hook 집합을 쓰는 저장소/픽스처에서 거짓 실패가 난다.
-  # top-level 키 파싱은 check-lefthook-staged-config.sh의 allowed_top_level 검사와 같은 방식이다.
-  if [ -f "$repo_root/lefthook.yml" ]; then
-    for hook_name in $(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' "$repo_root/lefthook.yml"); do
-      if [ ! -f "$resolved_hooks_dir/$hook_name" ]; then
-        fail "expected hook not installed: $resolved_hooks_dir/$hook_name (lefthook.yml defines it; check 'lefthook install' output)"
-      fi
-    done
-  fi
+  for hook_name in $(configured_hooks); do
+    if [ ! -f "$resolved_hooks_dir/$hook_name" ]; then
+      fail "expected hook not installed: $resolved_hooks_dir/$hook_name (lefthook.yml defines it; check 'lefthook install' output)"
+    fi
+  done
+}
+
+configured_hooks() {
+  # lefthook.yml이 정의한 top-level hook 이름. 파싱 방식은 check-lefthook-staged-config.sh의
+  # allowed_top_level 검사와 같다. 설정 파일이 없으면 아무것도 출력하지 않는다.
+  [ -f "$repo_root/lefthook.yml" ] || return 0
+  awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' "$repo_root/lefthook.yml"
+}
+
+refuse_symlinked_hooks() {
+  # `lefthook install`은 configured hook을 `>` 리다이렉션처럼 제자리에 쓰므로 symlink를 만나면
+  # 링크를 따라가 외부 target을 덮어쓴다. 그 뒤의 inject_staged_guard / disable_lefthook_auto_install
+  # 거부는 이미 늦다. install 전에 세워서 남의 파일을 건드리지 않는다.
+  # (install 이후의 거부는 TOCTOU 방어로 그대로 유지한다.)
+  local hooks_dir_now hook_name
+  hooks_dir_now="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks)"
+  [ -d "$hooks_dir_now" ] || return 0
+  for hook_name in $(configured_hooks); do
+    if [ -L "$hooks_dir_now/$hook_name" ]; then
+      fail "refusing to install over a symlinked hook (lefthook install would write through the link): $hooks_dir_now/$hook_name"
+    fi
+  done
 }
 
 if is_main_repo; then
@@ -427,6 +446,7 @@ else
   apply_worktree_local_hooks_config
 fi
 acquire_install_lock
+refuse_symlinked_hooks
 run_lefthook_install
 inject_staged_guard
 disable_lefthook_auto_install

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Install Lefthook (worktree-local in worktrees, default in main) and inject the staged-config guard.
+# Install Lefthook (worktree-local in worktrees, default in main), refuse symlinked hooks before
+# `lefthook install` can write through them, inject the staged-config guard, and suppress
+# lefthook's implicit auto-install on every configured hook.
 #
 # Design split — main repo vs. worktree (preserves PR #750's worktree-local design):
 #
@@ -320,24 +322,30 @@ disable_lefthook_auto_install() {
   # `--git-path hooks`는 core.hooksPath를 반영하므로 lefthook이 실제로 hook을 쓴 위치와
   # 일치한다 ($git_dir/hooks와 다를 수 있다 — 사용자가 core.hooksPath를 재정의한 경우).
   # inject_staged_guard가 hook을 찾는 방식과 같은 해석 경로를 쓴다.
-  local hook_file resolved_hooks_dir
+  # 패치 대상은 lefthook.yml이 정의한 hook뿐이다. 디렉토리를 훑어 `call_lefthook run`이 든 파일을
+  # 전부 편입하면, 설정에 없는 남의 hook까지 우리 관리 대상으로 끌어들이고 basename 기반 검증이
+  # 그 파일에서 실패해 install 전체를 막는다. preflight·패치·검증이 같은 집합을 본다.
+  local hook_file hook_name resolved_hooks_dir
   resolved_hooks_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks)"
   local -a hook_files=()
-  for hook_file in "$resolved_hooks_dir"/*; do
-    [ -f "$hook_file" ] || continue
-    # lefthook이 기존 hook을 밀어낼 때 남기는 백업본은 실행되지 않으므로 건드리지 않는다.
-    case "$hook_file" in *.old) continue ;; esac
-    grep -Fq 'call_lefthook run ' "$hook_file" || continue
+  for hook_name in $(configured_hooks); do
+    hook_file="$resolved_hooks_dir/$hook_name"
+    # lefthook.yml이 정의한 hook이 하나라도 설치되지 않았다면, auto-install을 끈 지금은 아무도
+    # 되살려 주지 않는다. commit-time self-check가 같은 목록을 fail-fast로 확인하므로, 그 실패를
+    # install 시점으로 당겨 원인을 분명히 남긴다.
+    if [ ! -f "$hook_file" ]; then
+      fail "expected hook not installed: $hook_file (lefthook.yml defines it; check 'lefthook install' output)"
+    fi
     # 아래 python 블록은 rename으로 교체하므로 symlink였다면 링크 자체가 일반 파일로 바뀐다
-    # (다른 레이어가 hook을 symlink로 관리한다면 그 경계가 조용히 끊긴다). lefthook install은
-    # 일반 파일을 쓰므로 여기서 symlink를 만나는 것은 예상 밖 상태다 — 삼키지 말고 세운다.
+    # (다른 레이어가 hook을 symlink로 관리한다면 그 경계가 조용히 끊긴다). install 전 preflight가
+    # 이미 걸렀어야 하지만, 그 사이의 TOCTOU를 여기서 한 번 더 막는다.
     if [ -L "$hook_file" ]; then
       fail "refusing to patch symlinked hook (rename would replace the link): $hook_file"
     fi
     hook_files+=("$hook_file")
   done
   if [ "${#hook_files[@]}" -eq 0 ]; then
-    fail "no lefthook-generated hooks found under $resolved_hooks_dir"
+    fail "no hooks configured in $repo_root/lefthook.yml"
   fi
 
   # 200>&- closes the lock fd in the python child (same reason as run_lefthook_install).
@@ -394,33 +402,48 @@ PY
   # Defense in depth: lefthook이 hook 템플릿의 호출부 형태를 바꾸면 위 치환이 조용히
   # no-op가 되고, 다음 auto-sync가 guard를 다시 지운다. 그 실패를 install 시점으로 당긴다.
   #
-  # 실행 라인을 통째로 정확히 대조한다. "플래그가 파일 어딘가에 있다"는 느슨한 검사는
-  # 주석 한 줄이 두 문자열을 함께 담기만 해도 통과해, 정작 실행 호출부에 플래그가 없는
-  # 상태를 미탐한다. 패턴 안의 `"$@"`가 확장되지 않도록 작은따옴표로 감싼다.
-  local hook_name expected_call
+  # 두 가지를 함께 본다. (1) `call_lefthook run` 호출부가 정확히 하나여야 한다 — 기대 라인의
+  # 존재만 확인하면, 같은 hook에 패치되지 않은 두 번째 호출(들여쓰기·후행 구문 등)이 남아 있어도
+  # 통과해 그 경로에서 auto-install이 계속 살아 있다. (2) 그 한 줄이 기대값과 완전히 같아야 한다 —
+  # "플래그가 파일 어딘가에 있다"는 느슨한 검사는 주석 한 줄만으로 통과한다.
+  # 패턴 안의 `"$@"`가 확장되지 않도록 작은따옴표로 감싼다.
+  local expected_call call_count
   for hook_file in "${hook_files[@]}"; do
     bash -n "$hook_file"
     hook_name="$(basename "$hook_file")"
+    call_count="$(grep -Fc 'call_lefthook run ' "$hook_file" || true)"
+    if [ "$call_count" != "1" ]; then
+      fail "auto-install suppression failed: expected exactly one 'call_lefthook run' line in $hook_file, found $call_count"
+    fi
     expected_call='call_lefthook run "'"$hook_name"'" '"$NO_AUTO_INSTALL_FLAG"' "$@"'
     if ! grep -Fxq -- "$expected_call" "$hook_file"; then
       fail "auto-install suppression failed: expected exact call line [$expected_call] in $hook_file"
     fi
   done
+}
 
-  # lefthook.yml이 정의한 hook이 하나라도 설치되지 않았다면, auto-install을 끈 지금은 아무도
-  # 되살려 주지 않는다. commit-time self-check가 같은 목록을 fail-fast로 확인하므로, 그 실패를
-  # install 시점으로 당겨 원인을 분명히 남긴다. 기대 목록은 대상 repo의 lefthook.yml에서
-  # 도출한다 — 하드코딩하면 다른 hook 집합을 쓰는 저장소/픽스처에서 거짓 실패가 난다.
-  for hook_name in $(configured_hooks); do
-    if [ ! -f "$resolved_hooks_dir/$hook_name" ]; then
-      fail "expected hook not installed: $resolved_hooks_dir/$hook_name (lefthook.yml defines it; check 'lefthook install' output)"
-    fi
-  done
+require_canonical_lefthook_config() {
+  # `lefthook install`은 LEFTHOOK_CONFIG가 가리키는 설정을 쓴다. 반면 아래 configured_hooks와
+  # symlink preflight는 저장소의 lefthook.yml만 읽는다. 둘이 갈라지면 대체 설정에만 있는 hook이
+  # 사전 검사를 통과하지 못한 채 install 대상이 되어, 그 hook이 symlink일 때 외부 target을
+  # 덮어쓴다. 상태를 바꾸기 전에 두 경로가 같은 설정을 보게 강제한다.
+  # (hook 실행 시점의 동일한 차단은 inject_staged_guard가 주입하는 guard 블록이 담당한다.)
+  [ -n "${LEFTHOOK_CONFIG:-}" ] || return 0
+  local expected config_dir config_base config_abs
+  expected="$(cd "$repo_root" && pwd -P)/lefthook.yml"
+  config_dir="$(dirname "$LEFTHOOK_CONFIG")"
+  config_base="$(basename "$LEFTHOOK_CONFIG")"
+  config_abs="$(cd "$config_dir" 2>/dev/null && pwd -P)/$config_base" \
+    || fail "invalid LEFTHOOK_CONFIG: $LEFTHOOK_CONFIG"
+  if [ "$config_abs" != "$expected" ]; then
+    fail "LEFTHOOK_CONFIG must point to $expected (got $config_abs); the installer's preflight only knows the canonical config"
+  fi
 }
 
 configured_hooks() {
   # lefthook.yml이 정의한 top-level hook 이름. 파싱 방식은 check-lefthook-staged-config.sh의
   # allowed_top_level 검사와 같다. 설정 파일이 없으면 아무것도 출력하지 않는다.
+  # require_canonical_lefthook_config가 LEFTHOOK_CONFIG를 이 파일로 고정해 둔다.
   [ -f "$repo_root/lefthook.yml" ] || return 0
   awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' "$repo_root/lefthook.yml"
 }
@@ -446,6 +469,7 @@ else
   apply_worktree_local_hooks_config
 fi
 acquire_install_lock
+require_canonical_lefthook_config
 refuse_symlinked_hooks
 run_lefthook_install
 inject_staged_guard

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -54,7 +54,6 @@ NO_AUTO_INSTALL_FLAG="--no-auto-install"
 # 한 줄로 유지한다 — tests/suites/lefthook.sh가 sed로 추출해 실제 hook 이름 판별에 재사용한다.
 GIT_HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit pre-merge-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-push pre-receive update proc-receive post-receive post-update reference-transaction push-to-checkout pre-auto-gc post-rewrite sendemail-validate fsmonitor-watchman p4-changelist p4-prepare-changelist p4-post-changelist p4-pre-submit post-index-change"
 
-
 # 30 minutes — install itself runs in ~150ms; this guards against hung child
 # processes (NFS lock issues, OS bugs) rather than normal contention. Matches the
 # convention from modules/shared/scripts/lib/rebuild/locks.sh:198.

--- a/scripts/ai/lib/tomlkit-bootstrap.sh
+++ b/scripts/ai/lib/tomlkit-bootstrap.sh
@@ -65,16 +65,18 @@ tomlkit_bootstrap_require() {
   # (2) nix 가용 → repo-pinned runtime으로 재실행 (hermetic 강제). 스크립트 자체는 self_path
   #     (snapshot 경로 가능)에서 계속 실행하고, flake root 만 실제 repo 로 고정한다.
   if command -v nix >/dev/null 2>&1; then
-    echo "  test runtime bootstrap: nix shell --inputs-from ${flake_root} ${flake_root}#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command bash $self_path" >&2
+    echo "  test runtime bootstrap: nix shell --inputs-from ${flake_root} ${flake_root}#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof nixpkgs#lefthook --command bash $self_path" >&2
     export _TOMLKIT_BOOTSTRAP_READY=1
     # pythonWithTomlkit(tomlkit) 외에 GNU coreutils/findutils 와 lsof 를 함께 얹어, 테스트 fixture 가
     # GNU 전용 확장(`touch -d '40 days ago'`, `find -printf`)에 의존해도 devShell 밖(BSD 시스템
     # 도구 우선) 셸에서 hermetic 하게 통과하도록 한다 (#1009). claude-rc(#1052)도 require_cmd lsof 를
     # 도입했고, lsof 는 NixOS 시스템 프로파일 PATH 에 항상 있지 않으므로 lefthook pre-push /
     # run-all-tests / 수동 실행 모두 이 단일 self-wrap 을 경유해 세 경로의 runtime 을 맞춘다.
+    # lefthook auto-sync end-to-end 테스트는 stub 이 아닌 실제 lefthook 을 요구하는데, hook 이
+    # lefthook 을 nix store 절대경로로 호출하면 자식 PATH 에 lefthook 이 없다 — nixpkgs#lefthook 도 얹는다.
     # `--inputs-from ${flake_root}` 로 nixpkgs# 를 repo flake.lock 의 nixpkgs 에 pin 하여 임시
     # registry fetch 를 피한다(statusline-bats 의 `nix shell --inputs-from . nixpkgs#bats` 와 동일 패턴).
-    exec nix shell --inputs-from "${flake_root}" "${flake_root}#pythonWithTomlkit" nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command bash "$self_path" "$@"
+    exec nix shell --inputs-from "${flake_root}" "${flake_root}#pythonWithTomlkit" nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof nixpkgs#lefthook --command bash "$self_path" "$@"
   fi
 
   # (3) nix 부재 fallback — ambient python3에 tomlkit이 있으면 경고 후 진행

--- a/scripts/ai/lib/tomlkit-bootstrap.sh
+++ b/scripts/ai/lib/tomlkit-bootstrap.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
 # scripts/ai/lib/tomlkit-bootstrap.sh
 #
-# tomlkit 포함 Python interpreter + GNU coreutils/findutils 테스트 런타임 부트스트랩 helper.
-# verifier/test runner가 source한 뒤 `tomlkit_bootstrap_require` 를 호출한다. 같은 파일을 여러
-# 진입점이 재사용하므로 재진입 guard env var와 nix shell re-exec 정책을 한 곳에만 둔다.
+# tomlkit 포함 Python interpreter + GNU coreutils/findutils + lsof + lefthook 테스트 런타임
+# 부트스트랩 helper. verifier/test runner가 source한 뒤 `tomlkit_bootstrap_require` 를 호출한다.
+# 같은 파일을 여러 진입점이 재사용하므로 재진입 guard env var와 nix shell re-exec 정책을 한 곳에만 둔다.
 # (함수/파일명은 역사적 이유로 tomlkit_* 유지 — 실제 책임은 테스트 hermetic runtime 전반이다.)
 #
 # 정책:
 #   1) 이미 `_TOMLKIT_BOOTSTRAP_READY=1` 이면 추가 검사 없이 즉시 반환한다.
 #      lefthook pre-push가 `nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils
-#      nixpkgs#findutils --command ...`로 이미 감쌌거나, 자체 스크립트가 이전에 self-wrap으로
-#      재진입한 경우다.
+#      nixpkgs#findutils nixpkgs#lsof nixpkgs#lefthook --command ...`로 이미 감쌌거나, 자체
+#      스크립트가 이전에 self-wrap으로 재진입한 경우다.
 #   2) 아니면 ambient `python3`/GNU 도구 유무와 **무관하게** 항상 repo-pinned `nix shell
-#      --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils --command bash
-#      "$0" ...`로 재실행한다. host 에 우연히 tomlkit 이 있거나 GNU 도구가 없더라도 pre-push 와
-#      동일한 store path 의 interpreter + GNU coreutils/findutils(karakeep/backup fixture 의
-#      `touch -d`/`find -printf` 의존, #1009)를 쓰게 만들어 hermetic 속성을 유지한다.
+#      --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof
+#      nixpkgs#lefthook --command bash "$0" ...`로 재실행한다. host 에 우연히 tomlkit 이 있거나
+#      GNU 도구가 없더라도 pre-push 와 동일한 store path 의 interpreter + GNU coreutils/findutils
+#      (karakeep/backup fixture 의 `touch -d`/`find -printf` 의존, #1009) + lsof(claude-rc #1052)
+#      + lefthook(auto-sync end-to-end 테스트)을 쓰게 만들어 hermetic 속성을 유지한다.
 #   3) nix가 없으면 마지막 fallback으로 ambient python3 tomlkit import를 체크해 있으면 그대로
 #      진행(경고 출력), 없으면 hard fail. 개발자가 직접 nix shell을 띄운 상태라면 (1)으로 빠진다.
 #

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -61,9 +61,10 @@ run_driver "eval-tests" bash tests/run-eval-tests.sh
 #    `touch -d`/`find -printf` 의존, #1009) + _TOMLKIT_BOOTSTRAP_READY=1(중첩 nix shell 방지)로
 #    실행한다(lefthook pre-push와 동일). `--inputs-from .`로 nixpkgs#를 flake.lock에 pin한다.
 #    claude-rc(#1052)가 require_cmd lsof를 도입했고 lsof는 NixOS 시스템 프로파일/CI PATH에
-#    항상 있지 않으므로 nixpkgs#lsof도 명시 제공한다(#1009와 동일 패턴).
+#    항상 있지 않으므로 nixpkgs#lsof도 명시 제공한다(#1009와 동일 패턴). lefthook auto-sync
+#    end-to-end 테스트는 stub이 아닌 실제 lefthook을 요구하므로 nixpkgs#lefthook도 얹는다.
 run_driver "shell-script-tests" \
-  nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof --command env _TOMLKIT_BOOTSTRAP_READY=1 \
+  nix shell --inputs-from . .#pythonWithTomlkit nixpkgs#coreutils nixpkgs#findutils nixpkgs#lsof nixpkgs#lefthook --command env _TOMLKIT_BOOTSTRAP_READY=1 \
   bash tests/run-shell-script-tests.sh
 
 # 3) codex-hook-fixtures — Codex stable hook 회귀 차단 결정적 fixture. --no-live, Python stdlib only.

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -177,6 +177,9 @@ run_test "install-lefthook --no-auto-install injection is idempotent" test_insta
 run_test "install-lefthook leaves .old backup hooks untouched" test_install_lefthook_leaves_old_backup_hooks_untouched
 run_test "install-lefthook fails when lefthook call shape changes" test_install_lefthook_fails_when_lefthook_call_shape_changes
 run_test "install-lefthook refuses to patch a symlinked hook" test_install_lefthook_refuses_symlinked_hook
+run_test "install-lefthook refuses to patch a symlinked pre-commit" test_install_lefthook_refuses_symlinked_pre_commit
+run_test "lefthook.yml self-check hook list matches config" test_lefthook_self_check_hook_list_matches_config
+run_test "lefthook.yml self-check bodies stay in sync" test_lefthook_self_check_bodies_stay_in_sync
 run_test "lefthook auto-sync cannot drop the staged-config guard" test_lefthook_auto_sync_cannot_drop_guard_end_to_end
 run_test "webhook-bridge crawled payload sends notification" test_webhook_bridge_crawled_payload_sends_notification
 run_test "webhook-bridge non-crawled payload skips notification" test_webhook_bridge_non_crawled_payload_skips_notification

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -176,6 +176,7 @@ run_test "install-lefthook injects --no-auto-install into every hook" test_insta
 run_test "install-lefthook --no-auto-install injection is idempotent" test_install_lefthook_no_auto_install_injection_is_idempotent
 run_test "install-lefthook leaves .old backup hooks untouched" test_install_lefthook_leaves_old_backup_hooks_untouched
 run_test "install-lefthook fails when lefthook call shape changes" test_install_lefthook_fails_when_lefthook_call_shape_changes
+run_test "install-lefthook refuses to patch a symlinked hook" test_install_lefthook_refuses_symlinked_hook
 run_test "lefthook auto-sync cannot drop the staged-config guard" test_lefthook_auto_sync_cannot_drop_guard_end_to_end
 run_test "webhook-bridge crawled payload sends notification" test_webhook_bridge_crawled_payload_sends_notification
 run_test "webhook-bridge non-crawled payload skips notification" test_webhook_bridge_non_crawled_payload_skips_notification

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -172,6 +172,11 @@ run_test "install-lefthook preserves custom local core.hooksPath" test_install_l
 run_test "install-lefthook is silent on clean state" test_install_lefthook_silent_on_clean_state
 run_test "install-lefthook serializes concurrent invocations" test_install_lefthook_concurrent_install_serializes
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
+run_test "install-lefthook injects --no-auto-install into every hook" test_install_lefthook_injects_no_auto_install_into_every_hook
+run_test "install-lefthook --no-auto-install injection is idempotent" test_install_lefthook_no_auto_install_injection_is_idempotent
+run_test "install-lefthook leaves .old backup hooks untouched" test_install_lefthook_leaves_old_backup_hooks_untouched
+run_test "install-lefthook fails when lefthook call shape changes" test_install_lefthook_fails_when_lefthook_call_shape_changes
+run_test "lefthook auto-sync cannot drop the staged-config guard" test_lefthook_auto_sync_cannot_drop_guard_end_to_end
 run_test "webhook-bridge crawled payload sends notification" test_webhook_bridge_crawled_payload_sends_notification
 run_test "webhook-bridge non-crawled payload skips notification" test_webhook_bridge_non_crawled_payload_skips_notification
 run_test "webhook-bridge invalid JSON keeps 200 without notification" test_webhook_bridge_invalid_json_keeps_200_without_notification

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -176,8 +176,10 @@ run_test "install-lefthook injects --no-auto-install into every hook" test_insta
 run_test "install-lefthook --no-auto-install injection is idempotent" test_install_lefthook_no_auto_install_injection_is_idempotent
 run_test "install-lefthook leaves .old backup hooks untouched" test_install_lefthook_leaves_old_backup_hooks_untouched
 run_test "install-lefthook fails when lefthook call shape changes" test_install_lefthook_fails_when_lefthook_call_shape_changes
-run_test "install-lefthook refuses to patch a symlinked hook" test_install_lefthook_refuses_symlinked_hook
-run_test "install-lefthook refuses to patch a symlinked pre-commit" test_install_lefthook_refuses_symlinked_pre_commit
+run_test "install-lefthook fails on an unpatched second lefthook call" test_install_lefthook_fails_on_unpatched_second_call
+run_test "install-lefthook rejects a foreign LEFTHOOK_CONFIG" test_install_lefthook_rejects_foreign_lefthook_config
+run_test "install-lefthook refuses to install over a symlinked hook" test_install_lefthook_refuses_symlinked_hook
+run_test "install-lefthook refuses to install over a symlinked pre-commit" test_install_lefthook_refuses_symlinked_pre_commit
 run_test "lefthook.yml self-check hook list matches config" test_lefthook_self_check_hook_list_matches_config
 run_test "lefthook.yml self-check bodies stay in sync" test_lefthook_self_check_bodies_stay_in_sync
 run_test "lefthook auto-sync cannot drop the staged-config guard" test_lefthook_auto_sync_cannot_drop_guard_end_to_end

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -180,6 +180,7 @@ run_test "install-lefthook fails on an unpatched second lefthook call" test_inst
 run_test "install-lefthook rejects a foreign LEFTHOOK_CONFIG" test_install_lefthook_rejects_foreign_lefthook_config
 run_test "install-lefthook refuses to install over a symlinked hook" test_install_lefthook_refuses_symlinked_hook
 run_test "install-lefthook refuses to install over a symlinked pre-commit" test_install_lefthook_refuses_symlinked_pre_commit
+run_test "install-lefthook ignores global lefthook.yml config keys" test_install_lefthook_ignores_global_config_keys
 run_test "lefthook.yml self-check hook list matches config" test_lefthook_self_check_hook_list_matches_config
 run_test "lefthook.yml self-check bodies stay in sync" test_lefthook_self_check_bodies_stay_in_sync
 run_test "lefthook auto-sync cannot drop the staged-config guard" test_lefthook_auto_sync_cannot_drop_guard_end_to_end

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -3,11 +3,14 @@
 # SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
 # shellcheck disable=SC2154,SC2164
 # ─── install-lefthook-hooks fixture helpers ───
-# 실제 lefthook은 stub으로 대체한다. 우리 검증 대상은 install-lefthook-hooks.sh의
+# 대부분의 테스트에서 실제 lefthook은 stub으로 대체한다. 우리 검증 대상은 install-lefthook-hooks.sh의
 # cleanup_main_redundant_hooks_path / apply_worktree_local_hooks_config /
-# acquire_install_lock / run_lefthook_install / inject_staged_guard 동작이고,
-# lefthook 자체의 install 로직은 별도 신뢰 영역이다. stub은 install 명령 호출 시
-# `call_lefthook run "pre-commit" "$@"` 라인을 포함한 minimal pre-commit 파일만 작성한다.
+# acquire_install_lock / run_lefthook_install / inject_staged_guard /
+# disable_lefthook_auto_install 동작이고, lefthook 자체의 install 로직은 별도 신뢰 영역이다.
+# stub은 install 명령 호출 시 설정된 hook(pre-commit/commit-msg/pre-push)을 모두 생성하며,
+# 각 파일은 `call_lefthook run "<hook>" "$@"` 라인을 포함한다.
+# 예외: test_lefthook_auto_sync_cannot_drop_guard_end_to_end는 auto-sync 동작 자체를 확인해야
+# 하므로 stub 없이 실제 lefthook 바이너리를 사용한다.
 
 # Marker 리터럴을 install-lefthook-hooks.sh에서 한 번만 정의하고 테스트가
 # 그 정의를 sed로 추출해 사용한다. install 스크립트에서 marker를 바꿔도
@@ -390,6 +393,10 @@ test_install_lefthook_leaves_old_backup_hooks_untouched() {
 test_install_lefthook_fails_when_lefthook_call_shape_changes() {
   # 상류 lefthook이 hook 템플릿의 호출부 형태를 바꾸면 플래그 주입이 조용한 no-op가 되고,
   # 다음 auto-sync가 guard를 다시 지운다. 그 실패를 install 시점으로 당겼는지 검증한다.
+  #
+  # 이 fixture의 hook에는 플래그와 `call_lefthook run `을 한 줄에 모두 담은 decoy 주석이 있다.
+  # "파일 어딘가에 플래그가 있는가" 식의 느슨한 검사는 이 주석만으로 통과해버리므로, 검증이
+  # 실행 라인 자체를 정확히 대조하는지까지 함께 못박는다.
   local sandbox repo_root stub_dir
   sandbox=$(new_sandbox)
   repo_root="$sandbox/repo"
@@ -405,7 +412,11 @@ case "${1:-}" in
     cd "$(git rev-parse --show-toplevel)"
     hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
     mkdir -p "$hooks_dir"
-    printf '#!/bin/sh\ncall_lefthook run "pre-commit" "$@" # upstream template drift\n' > "$hooks_dir/pre-commit"
+    {
+      printf '#!/bin/sh\n'
+      printf '# decoy: call_lefthook run "pre-commit" --no-auto-install "$@"\n'
+      printf 'call_lefthook run "pre-commit" "$@" # upstream template drift\n'
+    } > "$hooks_dir/pre-commit"
     chmod +x "$hooks_dir/pre-commit"
     ;;
   *)
@@ -419,6 +430,34 @@ STUB
   run_install_lefthook_capture "$repo_root" "$stub_dir"
   [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail when the lefthook call shape changes; output: $INSTALL_LEFTHOOK_OUTPUT"
   assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "auto-install suppression failed"
+}
+
+test_install_lefthook_refuses_symlinked_hook() {
+  # 패치는 rename으로 교체하므로 symlink hook을 만나면 링크 자체가 일반 파일로 바뀌어
+  # 다른 레이어의 관리 경계가 조용히 끊긴다. 삼키지 말고 세우는지 확인한다.
+  local sandbox repo_root stub_dir hooks_dir target
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  # warm-up으로 hook을 만든 뒤 pre-push만 외부 파일을 가리키는 symlink로 바꾼다. stub의
+  # `> "$hooks_dir/pre-push"`는 symlink를 따라가 target에 쓰므로 링크 자체는 살아남고,
+  # 그 상태로 다음 install이 돌면 disable_lefthook_auto_install이 symlink를 만난다.
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "warm-up install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  hooks_dir="$repo_root/.git/hooks"
+  target="$sandbox/external-pre-push"
+  printf '#!/bin/sh\ncall_lefthook run "pre-push" "$@"\n' > "$target"
+  chmod +x "$target"
+  rm -f "$hooks_dir/pre-push"
+  ln -s "$target" "$hooks_dir/pre-push"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail on a symlinked hook; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "refusing to patch symlinked hook"
+  [[ -L "$hooks_dir/pre-push" ]] || fail "symlinked hook must be left in place, not replaced"
 }
 
 lefthook_make_checksum_stale() {

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -75,6 +75,56 @@ install_lefthook_isolated_git() {
     "$@"
 }
 
+write_install_lefthook_fixture_config() {
+  # installer는 lefthook.yml의 top-level 키에서 기대 hook 목록을 도출한다. 실제 저장소와 같은
+  # 세 hook을 정의해, "설정된 hook이 전부 설치됐는가" 검증이 fixture에서도 성립하게 한다.
+  cat > "$1/lefthook.yml" <<'YML'
+pre-commit:
+  jobs:
+    - name: noop
+      run: "true"
+commit-msg:
+  jobs:
+    - name: noop
+      run: "true"
+pre-push:
+  jobs:
+    - name: noop
+      run: "true"
+YML
+}
+
+write_install_lefthook_stub() {
+  # 두 fixture 생성기가 공유하는 lefthook stub. install 동작을 한 곳에서만 정의해
+  # 호출 형태나 hook 집합을 바꿀 때 한쪽만 고치는 사고를 막는다.
+  cat > "$1/lefthook" <<'STUB'
+#!/usr/bin/env bash
+# stub for install-lefthook-hooks shell tests: emulate `lefthook install` by writing every
+# hook configured in lefthook.yml, each containing the `call_lefthook run "<hook>" "$@"`
+# marker expected by inject_staged_guard and disable_lefthook_auto_install. Hook names come
+# from the config (like the real CLI), so fixtures and assertions cannot drift apart.
+# The stub also tolerates --force (worktree mode passes it). Silent on success to mirror
+# the real CLI output we strip.
+set -euo pipefail
+case "${1:-}" in
+  install)
+    cd "$(git rev-parse --show-toplevel)"
+    hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
+    mkdir -p "$hooks_dir"
+    for hook in $(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' lefthook.yml); do
+      printf '#!/bin/sh\ncall_lefthook run "%s" "$@"\n' "$hook" > "$hooks_dir/$hook"
+      chmod +x "$hooks_dir/$hook"
+    done
+    ;;
+  *)
+    echo "stub lefthook: unsupported command: ${1:-}" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$1/lefthook"
+}
+
 create_install_lefthook_fixture() {
   # 메인 repo 모드 fixture: git init된 단일 repo (git_dir == git_common_dir).
   # is_main_repo가 true로 평가되어 cleanup_main_redundant_hooks_path 분기 검증.
@@ -86,42 +136,11 @@ create_install_lefthook_fixture() {
   install_lefthook_isolated_git "$repo_root" init >/dev/null 2>&1
   install_lefthook_isolated_git "$repo_root" config user.name "Test User"
   install_lefthook_isolated_git "$repo_root" config user.email "test@example.com"
-  cat > "$repo_root/lefthook.yml" <<'YML'
-pre-commit:
-  jobs:
-    - name: noop
-      run: "true"
-YML
+  write_install_lefthook_fixture_config "$repo_root"
   install_lefthook_isolated_git "$repo_root" add lefthook.yml
   install_lefthook_isolated_git "$repo_root" commit -m "initial" >/dev/null 2>&1
 
-  cat > "$stub_dir/lefthook" <<'STUB'
-#!/usr/bin/env bash
-# stub for install-lefthook-hooks shell tests: emulate `lefthook install` by writing
-# every configured hook (pre-commit/commit-msg/pre-push), each containing the
-# `call_lefthook run "<hook>" "$@"` marker expected by inject_staged_guard and
-# disable_lefthook_auto_install. The stub also tolerates --force (worktree mode
-# passes it). Silent on success to mirror the real CLI output we strip.
-set -euo pipefail
-case "${1:-}" in
-  install)
-    cd "$(git rev-parse --show-toplevel)"
-    hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
-    mkdir -p "$hooks_dir"
-    # 실제 lefthook처럼 install 한 번에 설정된 hook을 모두(재)생성한다. disable_lefthook_auto_install이
-    # pre-commit뿐 아니라 commit-msg/pre-push의 호출부까지 패치하는지 검증하려면 셋 다 필요하다.
-    for hook in pre-commit commit-msg pre-push; do
-      printf '#!/bin/sh\ncall_lefthook run "%s" "$@"\n' "$hook" > "$hooks_dir/$hook"
-      chmod +x "$hooks_dir/$hook"
-    done
-    ;;
-  *)
-    echo "stub lefthook: unsupported command: ${1:-}" >&2
-    exit 1
-    ;;
-esac
-STUB
-  chmod +x "$stub_dir/lefthook"
+  write_install_lefthook_stub "$stub_dir"
 }
 
 create_install_lefthook_worktree_fixture() {
@@ -136,38 +155,12 @@ create_install_lefthook_worktree_fixture() {
   install_lefthook_isolated_git "$main_root" init -b main >/dev/null 2>&1
   install_lefthook_isolated_git "$main_root" config user.name "Test User"
   install_lefthook_isolated_git "$main_root" config user.email "test@example.com"
-  cat > "$main_root/lefthook.yml" <<'YML'
-pre-commit:
-  jobs:
-    - name: noop
-      run: "true"
-YML
+  write_install_lefthook_fixture_config "$main_root"
   install_lefthook_isolated_git "$main_root" add lefthook.yml
   install_lefthook_isolated_git "$main_root" commit -m "initial" >/dev/null 2>&1
   install_lefthook_isolated_git "$main_root" worktree add -b feature "$worktree_root" >/dev/null 2>&1
 
-  cat > "$stub_dir/lefthook" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-case "${1:-}" in
-  install)
-    cd "$(git rev-parse --show-toplevel)"
-    hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
-    mkdir -p "$hooks_dir"
-    # 실제 lefthook처럼 install 한 번에 설정된 hook을 모두(재)생성한다. disable_lefthook_auto_install이
-    # pre-commit뿐 아니라 commit-msg/pre-push의 호출부까지 패치하는지 검증하려면 셋 다 필요하다.
-    for hook in pre-commit commit-msg pre-push; do
-      printf '#!/bin/sh\ncall_lefthook run "%s" "$@"\n' "$hook" > "$hooks_dir/$hook"
-      chmod +x "$hooks_dir/$hook"
-    done
-    ;;
-  *)
-    echo "stub lefthook: unsupported command: ${1:-}" >&2
-    exit 1
-    ;;
-esac
-STUB
-  chmod +x "$stub_dir/lefthook"
+  write_install_lefthook_stub "$stub_dir"
 }
 
 run_install_lefthook_capture() {
@@ -447,59 +440,53 @@ STUB
   assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "auto-install suppression failed"
 }
 
+assert_symlinked_hook_refused_before_install() {
+  # symlink hook은 `lefthook install`이 링크를 따라가 외부 target을 덮어쓰기 전에 거부되어야
+  # 한다. target에는 stub이 쓸 내용과 다른 sentinel을 넣어, 선행 write가 있었다면 반드시
+  # 드러나게 한다 (내용이 우연히 같으면 이 검증은 아무것도 잡지 못한다).
+  local sandbox="$1" repo_root="$2" stub_dir="$3" hook_name="$4"
+  local hooks_dir target sentinel
+  hooks_dir="$repo_root/.git/hooks"
+  target="$sandbox/external-$hook_name"
+  sentinel="SENTINEL_${hook_name}_must_survive"
+  printf '#!/bin/sh\n# %s\nexit 0\n' "$sentinel" > "$target"
+  chmod +x "$target"
+  mkdir -p "$hooks_dir"
+  rm -f "$hooks_dir/$hook_name"
+  ln -s "$target" "$hooks_dir/$hook_name"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail on a symlinked $hook_name; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "refusing to install over a symlinked hook"
+  [[ -L "$hooks_dir/$hook_name" ]] || fail "symlinked $hook_name must be left in place, not replaced"
+  grep -Fq "$sentinel" "$target" || fail "external symlink target was written through before the refusal: $target"
+}
+
 test_install_lefthook_refuses_symlinked_hook() {
-  # 패치는 rename으로 교체하므로 symlink hook을 만나면 링크 자체가 일반 파일로 바뀌어
-  # 다른 레이어의 관리 경계가 조용히 끊긴다. 삼키지 말고 세우는지 확인한다.
-  local sandbox repo_root stub_dir hooks_dir target
+  # `lefthook install`은 configured hook을 제자리에 쓰므로 symlink를 만나면 링크를 따라
+  # 외부 target을 덮어쓴다. install 전 preflight가 이를 막는지 확인한다.
+  local sandbox repo_root stub_dir
   sandbox=$(new_sandbox)
   repo_root="$sandbox/repo"
   stub_dir="$sandbox/stubs"
   create_install_lefthook_fixture "$repo_root" "$stub_dir"
 
-  # warm-up으로 hook을 만든 뒤 pre-push만 외부 파일을 가리키는 symlink로 바꾼다. stub의
-  # `> "$hooks_dir/pre-push"`는 symlink를 따라가 target에 쓰므로 링크 자체는 살아남고,
-  # 그 상태로 다음 install이 돌면 disable_lefthook_auto_install이 symlink를 만난다.
-  run_install_lefthook_capture "$repo_root" "$stub_dir"
-  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "warm-up install failed: $INSTALL_LEFTHOOK_OUTPUT"
-
-  hooks_dir="$repo_root/.git/hooks"
-  target="$sandbox/external-pre-push"
-  printf '#!/bin/sh\ncall_lefthook run "pre-push" "$@"\n' > "$target"
-  chmod +x "$target"
-  rm -f "$hooks_dir/pre-push"
-  ln -s "$target" "$hooks_dir/pre-push"
-
-  run_install_lefthook_capture "$repo_root" "$stub_dir"
-  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail on a symlinked hook; output: $INSTALL_LEFTHOOK_OUTPUT"
-  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "refusing to patch symlinked hook"
-  [[ -L "$hooks_dir/pre-push" ]] || fail "symlinked hook must be left in place, not replaced"
+  assert_symlinked_hook_refused_before_install "$sandbox" "$repo_root" "$stub_dir" "pre-push"
 }
 
 test_install_lefthook_refuses_symlinked_pre_commit() {
-  # pre-commit은 disable_lefthook_auto_install보다 먼저 도는 inject_staged_guard가 in-place로
-  # 다시 쓴다. 그쪽 경로에서도 symlink target을 따라 쓰지 않고 거부하는지 확인한다.
-  local sandbox repo_root stub_dir hooks_dir target before
+  # pre-commit은 inject_staged_guard가 in-place로 다시 쓰는 경로이기도 하다. preflight가
+  # install 전에 세우므로 guard 주입도 외부 target에 닿지 않아야 한다.
+  local sandbox repo_root stub_dir
   sandbox=$(new_sandbox)
   repo_root="$sandbox/repo"
   stub_dir="$sandbox/stubs"
   create_install_lefthook_fixture "$repo_root" "$stub_dir"
 
-  run_install_lefthook_capture "$repo_root" "$stub_dir"
-  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "warm-up install failed: $INSTALL_LEFTHOOK_OUTPUT"
-
-  hooks_dir="$repo_root/.git/hooks"
-  target="$sandbox/external-pre-commit"
-  printf '#!/bin/sh\ncall_lefthook run "pre-commit" "$@"\n' > "$target"
-  chmod +x "$target"
-  before=$(cat "$target")
-  rm -f "$hooks_dir/pre-commit"
-  ln -s "$target" "$hooks_dir/pre-commit"
-
-  run_install_lefthook_capture "$repo_root" "$stub_dir"
-  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail on a symlinked pre-commit; output: $INSTALL_LEFTHOOK_OUTPUT"
-  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "refusing to patch symlinked hook"
-  [[ -L "$hooks_dir/pre-commit" ]] || fail "symlinked pre-commit must be left in place, not replaced"
-  [[ "$(cat "$target")" == "$before" ]] || fail "external symlink target must not be modified"
+  assert_symlinked_hook_refused_before_install "$sandbox" "$repo_root" "$stub_dir" "pre-commit"
+  if grep -Fq "$LEFTHOOK_GUARD_BEGIN_MARKER" "$sandbox/external-pre-commit"; then
+    fail "staged-config guard must not be injected into the external symlink target"
+  fi
 }
 
 test_lefthook_self_check_hook_list_matches_config() {

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -22,6 +22,20 @@ LEFTHOOK_NO_AUTO_INSTALL_FLAG=$(sed -n 's/^NO_AUTO_INSTALL_FLAG="\(.*\)"$/\1/p' 
 [[ -n "$LEFTHOOK_GUARD_END_MARKER" ]] || fail "could not extract END_MARKER from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_NO_AUTO_INSTALL_FLAG" ]] || fail "could not extract NO_AUTO_INSTALL_FLAG from install-lefthook-hooks.sh"
 
+extract_self_check_run_body() {
+  # lefthook.yml의 <top-level hook>.commands.lefthook-guard-self-check 의 `run: |` 본문만 뽑는다.
+  local top="$1"
+  awk -v want="${top}:" '
+    $0 == want { in_top = 1; next }
+    in_top && /^[^[:space:]#]/ { exit }
+    in_top && /^    lefthook-guard-self-check:$/ { in_cmd = 1; next }
+    in_cmd && /^    [^[:space:]]/ { exit }
+    in_cmd && /^      run: \|$/ { in_run = 1; next }
+    in_run && /^      [^[:space:]]/ { exit }
+    in_run { print }
+  ' "$REPO_ROOT/lefthook.yml"
+}
+
 assert_hook_call_line() {
   # 설치된 hook의 lefthook 호출부가 정확히 기대 형태인지 확인한다. 완전 일치로 비교하므로
   # 플래그 누락뿐 아니라 중복 주입(비-idempotent 회귀)도 함께 잡힌다.
@@ -84,9 +98,10 @@ YML
   cat > "$stub_dir/lefthook" <<'STUB'
 #!/usr/bin/env bash
 # stub for install-lefthook-hooks shell tests: emulate `lefthook install` by writing
-# a minimal pre-commit hook that contains the `call_lefthook run "pre-commit" "$@"`
-# marker expected by inject_staged_guard. The stub also tolerates --force (worktree
-# mode passes it). Silent on success to mirror the real CLI output we strip.
+# every configured hook (pre-commit/commit-msg/pre-push), each containing the
+# `call_lefthook run "<hook>" "$@"` marker expected by inject_staged_guard and
+# disable_lefthook_auto_install. The stub also tolerates --force (worktree mode
+# passes it). Silent on success to mirror the real CLI output we strip.
 set -euo pipefail
 case "${1:-}" in
   install)
@@ -458,6 +473,61 @@ test_install_lefthook_refuses_symlinked_hook() {
   [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail on a symlinked hook; output: $INSTALL_LEFTHOOK_OUTPUT"
   assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "refusing to patch symlinked hook"
   [[ -L "$hooks_dir/pre-push" ]] || fail "symlinked hook must be left in place, not replaced"
+}
+
+test_install_lefthook_refuses_symlinked_pre_commit() {
+  # pre-commit은 disable_lefthook_auto_install보다 먼저 도는 inject_staged_guard가 in-place로
+  # 다시 쓴다. 그쪽 경로에서도 symlink target을 따라 쓰지 않고 거부하는지 확인한다.
+  local sandbox repo_root stub_dir hooks_dir target before
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "warm-up install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  hooks_dir="$repo_root/.git/hooks"
+  target="$sandbox/external-pre-commit"
+  printf '#!/bin/sh\ncall_lefthook run "pre-commit" "$@"\n' > "$target"
+  chmod +x "$target"
+  before=$(cat "$target")
+  rm -f "$hooks_dir/pre-commit"
+  ln -s "$target" "$hooks_dir/pre-commit"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail on a symlinked pre-commit; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "refusing to patch symlinked hook"
+  [[ -L "$hooks_dir/pre-commit" ]] || fail "symlinked pre-commit must be left in place, not replaced"
+  [[ "$(cat "$target")" == "$before" ]] || fail "external symlink target must not be modified"
+}
+
+test_lefthook_self_check_hook_list_matches_config() {
+  # self-check가 순회하는 hook 목록은 lefthook.yml이 정의한 hook 집합과 같아야 한다.
+  # auto-install을 껐으므로 목록이 어긋나면 설치되지 않은 hook의 게이트가 조용히 사라진다.
+  local from_config from_self_check
+  from_config=$(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); printf "%s%s", sep, $1; sep = " " }' "$REPO_ROOT/lefthook.yml")
+  from_self_check=$(extract_self_check_run_body "pre-commit" | sed -n 's/^ *for hook_name in \(.*\); do$/\1/p')
+
+  [[ -n "$from_self_check" ]] || fail "could not extract the hook list from lefthook.yml self-check"
+  [[ "$from_config" == "$from_self_check" ]] \
+    || fail "hook list drift: lefthook.yml self-check iterates [$from_self_check], but lefthook.yml defines [$from_config]"
+}
+
+test_lefthook_self_check_bodies_stay_in_sync() {
+  # commit-msg의 self-check는 pre-commit 본문의 수동 복제다 (staged files가 0인 --allow-empty
+  # 경로를 막기 위해 존재). 두 본문이 의도치 않게 갈라지면 한쪽 게이트만 강화되는 사고가 나므로,
+  # 유일하게 허용된 차이(에러 prefix의 " (commit-msg)")만 정규화한 뒤 완전 일치를 요구한다.
+  local pre_body msg_body
+  pre_body=$(extract_self_check_run_body "pre-commit")
+  msg_body=$(extract_self_check_run_body "commit-msg" | sed 's/lefthook-guard-self-check (commit-msg):/lefthook-guard-self-check:/')
+
+  [[ -n "$pre_body" ]] || fail "could not extract pre-commit lefthook-guard-self-check run body"
+  [[ -n "$msg_body" ]] || fail "could not extract commit-msg lefthook-guard-self-check run body"
+  if [[ "$pre_body" != "$msg_body" ]]; then
+    fail "lefthook.yml self-check bodies diverged (only the ' (commit-msg)' error prefix may differ):
+$(diff <(printf '%s\n' "$pre_body") <(printf '%s\n' "$msg_body") || true)"
+  fi
 }
 
 lefthook_make_checksum_stale() {

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -5,8 +5,9 @@
 # ─── install-lefthook-hooks fixture helpers ───
 # 대부분의 테스트에서 실제 lefthook은 stub으로 대체한다. 우리 검증 대상은 install-lefthook-hooks.sh의
 # cleanup_main_redundant_hooks_path / apply_worktree_local_hooks_config /
-# acquire_install_lock / run_lefthook_install / inject_staged_guard /
-# disable_lefthook_auto_install 동작이고, lefthook 자체의 install 로직은 별도 신뢰 영역이다.
+# acquire_install_lock / require_canonical_lefthook_config / refuse_symlinked_hooks /
+# run_lefthook_install / inject_staged_guard / disable_lefthook_auto_install 동작이고,
+# lefthook 자체의 install 로직은 별도 신뢰 영역이다.
 # stub은 install 명령 호출 시 설정된 hook(pre-commit/commit-msg/pre-push)을 모두 생성하며,
 # 각 파일은 `call_lefthook run "<hook>" "$@"` 라인을 포함한다.
 # 예외: test_lefthook_auto_sync_cannot_drop_guard_end_to_end는 auto-sync 동작 자체를 확인해야
@@ -398,6 +399,36 @@ test_install_lefthook_leaves_old_backup_hooks_untouched() {
   [[ "$before" == "$after" ]] || fail "expected $backup to stay untouched; got: $after"
 }
 
+write_drifting_lefthook_stub() {
+  # 정상 stub과 같은 hook 집합을 만들되, pre-commit만 body_file 내용으로 덮어써 호출부를
+  # 흐트러뜨린다. 나머지 hook은 정상이라 검증이 pre-commit에서만 걸린다.
+  # body를 stub 소스에 리터럴로 심으면 stub 실행 시 `"$@"`/`${VAR}`가 확장돼 버리므로,
+  # 파일 경로만 넘기고 그대로 복사한다.
+  local stub_dir="$1" body_file="$2"
+  cat > "$stub_dir/lefthook" <<STUB
+#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-}" in
+  install)
+    cd "\$(git rev-parse --show-toplevel)"
+    hooks_dir="\$(git rev-parse --path-format=absolute --git-path hooks)"
+    mkdir -p "\$hooks_dir"
+    for hook in \$(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:\$/, "", \$1); print \$1 }' lefthook.yml); do
+      printf '#!/bin/sh\ncall_lefthook run "%s" "\$@"\n' "\$hook" > "\$hooks_dir/\$hook"
+      chmod +x "\$hooks_dir/\$hook"
+    done
+    cp "$body_file" "\$hooks_dir/pre-commit"
+    chmod +x "\$hooks_dir/pre-commit"
+    ;;
+  *)
+    echo "stub lefthook: unsupported command: \${1:-}" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$stub_dir/lefthook"
+}
+
 test_install_lefthook_fails_when_lefthook_call_shape_changes() {
   # 상류 lefthook이 hook 템플릿의 호출부 형태를 바꾸면 플래그 주입이 조용한 no-op가 되고,
   # 다음 auto-sync가 guard를 다시 지운다. 그 실패를 install 시점으로 당겼는지 검증한다.
@@ -411,33 +442,70 @@ test_install_lefthook_fails_when_lefthook_call_shape_changes() {
   stub_dir="$sandbox/stubs"
   create_install_lefthook_fixture "$repo_root" "$stub_dir"
 
-  # inject_staged_guard의 부분 문자열 매칭은 통과하지만 호출부가 `"$@"`로 끝나지 않는 형태.
-  cat > "$stub_dir/lefthook" <<'STUB'
-#!/usr/bin/env bash
-set -euo pipefail
-case "${1:-}" in
-  install)
-    cd "$(git rev-parse --show-toplevel)"
-    hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
-    mkdir -p "$hooks_dir"
-    {
-      printf '#!/bin/sh\n'
-      printf '# decoy: call_lefthook run "pre-commit" --no-auto-install "$@"\n'
-      printf 'call_lefthook run "pre-commit" "$@" # upstream template drift\n'
-    } > "$hooks_dir/pre-commit"
-    chmod +x "$hooks_dir/pre-commit"
-    ;;
-  *)
-    echo "stub lefthook: unsupported command: ${1:-}" >&2
-    exit 1
-    ;;
-esac
-STUB
-  chmod +x "$stub_dir/lefthook"
+  # 호출부는 하나지만 `"$@"`로 끝나지 않아 주입이 no-op가 된다. decoy 주석에는 플래그만 있어
+  # "파일 어딘가에 플래그가 있는가" 식의 느슨한 검사라면 통과해버린다.
+  cat > "$sandbox/drift-body" <<'BODY'
+#!/bin/sh
+# decoy: --no-auto-install appears here, but not on the call line
+call_lefthook run "pre-commit" "$@" # upstream template drift
+BODY
+  write_drifting_lefthook_stub "$stub_dir" "$sandbox/drift-body"
 
   run_install_lefthook_capture "$repo_root" "$stub_dir"
   [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail when the lefthook call shape changes; output: $INSTALL_LEFTHOOK_OUTPUT"
-  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "auto-install suppression failed"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "expected exact call line"
+}
+
+test_install_lefthook_fails_on_unpatched_second_call() {
+  # 기대 라인 하나의 존재만 확인하면, 같은 hook에 패치되지 않은 두 번째 호출이 남아 있어도
+  # 통과해 그 경로에서 auto-install이 계속 살아 있다. 호출부가 정확히 하나인지도 세는지 본다.
+  local sandbox repo_root stub_dir
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  # 첫 호출은 column 0이라 패치되지만, 들여쓴 둘째 호출은 주입 대상이 아니라 그대로 남는다.
+  cat > "$sandbox/second-call-body" <<'BODY'
+#!/bin/sh
+call_lefthook run "pre-commit" "$@"
+if [ -n "${EXTRA:-}" ]; then
+  call_lefthook run "pre-commit" "$@"
+fi
+BODY
+  write_drifting_lefthook_stub "$stub_dir" "$sandbox/second-call-body"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail when a second, unpatched lefthook call remains; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "expected exactly one 'call_lefthook run' line"
+}
+
+test_install_lefthook_rejects_foreign_lefthook_config() {
+  # `lefthook install`은 LEFTHOOK_CONFIG가 가리키는 설정을 쓰는데 preflight는 저장소의
+  # lefthook.yml만 읽는다. 두 경로가 갈라진 채 상태를 바꾸지 않는지 확인한다.
+  local sandbox repo_root stub_dir home_dir rc out
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  home_dir="$sandbox/home"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+  printf 'post-commit:\n  jobs:\n    - name: noop\n      run: "true"\n' > "$sandbox/other-lefthook.yml"
+
+  rc=0
+  out=$(
+    cd "$repo_root"
+    export HOME="$home_dir"
+    export XDG_CONFIG_HOME="$home_dir/.config"
+    export GIT_CONFIG_GLOBAL=/dev/null
+    export GIT_CONFIG_NOSYSTEM=1
+    export PATH="$stub_dir:$PATH"
+    export LEFTHOOK_CONFIG="$sandbox/other-lefthook.yml"
+    bash "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh" 2>&1
+  ) || rc=$?
+
+  [[ "$rc" != "0" ]] || fail "expected install to fail with a foreign LEFTHOOK_CONFIG; output: $out"
+  assert_contains "$out" "LEFTHOOK_CONFIG must point to"
+  [[ ! -f "$repo_root/.git/hooks/pre-commit" ]] || fail "no hook should be written when LEFTHOOK_CONFIG is rejected"
 }
 
 assert_symlinked_hook_refused_before_install() {

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -19,9 +19,23 @@
 LEFTHOOK_GUARD_BEGIN_MARKER=$(sed -n 's/^BEGIN_MARKER="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 LEFTHOOK_GUARD_END_MARKER=$(sed -n 's/^END_MARKER="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 LEFTHOOK_NO_AUTO_INSTALL_FLAG=$(sed -n 's/^NO_AUTO_INSTALL_FLAG="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
+LEFTHOOK_GIT_HOOK_NAMES=$(sed -n 's/^GIT_HOOK_NAMES="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 [[ -n "$LEFTHOOK_GUARD_BEGIN_MARKER" ]] || fail "could not extract BEGIN_MARKER from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_GUARD_END_MARKER" ]] || fail "could not extract END_MARKER from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_NO_AUTO_INSTALL_FLAG" ]] || fail "could not extract NO_AUTO_INSTALL_FLAG from install-lefthook-hooks.sh"
+[[ -n "$LEFTHOOK_GIT_HOOK_NAMES" ]] || fail "could not extract GIT_HOOK_NAMES from install-lefthook-hooks.sh"
+
+lefthook_config_hook_names() {
+  # installer의 configured_hooks와 같은 방식으로 lefthook.yml에서 hook 이름만 뽑는다
+  # (전역 옵션 키 제외). GIT_HOOK_NAMES는 installer에서 추출해 재사용한다.
+  awk -v known=" $LEFTHOOK_GIT_HOOK_NAMES " '
+    /^[A-Za-z0-9_.-]+:/ {
+      name = $1
+      sub(/:$/, "", name)
+      if (index(known, " " name " ") > 0) { printf "%s%s", sep, name; sep = " " }
+    }
+  ' "$1"
+}
 
 extract_self_check_run_body() {
   # lefthook.yml의 <top-level hook>.commands.lefthook-guard-self-check 의 `run: |` 본문만 뽑는다.
@@ -98,27 +112,29 @@ YML
 write_install_lefthook_stub() {
   # 두 fixture 생성기가 공유하는 lefthook stub. install 동작을 한 곳에서만 정의해
   # 호출 형태나 hook 집합을 바꿀 때 한쪽만 고치는 사고를 막는다.
-  cat > "$1/lefthook" <<'STUB'
+  # 실제 CLI처럼 lefthook.yml에서 hook 이름을 읽되, 전역 옵션 키(`colors` 등)는 건너뛴다.
+  cat > "$1/lefthook" <<STUB
 #!/usr/bin/env bash
-# stub for install-lefthook-hooks shell tests: emulate `lefthook install` by writing every
-# hook configured in lefthook.yml, each containing the `call_lefthook run "<hook>" "$@"`
+# stub for install-lefthook-hooks shell tests: emulate \`lefthook install\` by writing every
+# hook configured in lefthook.yml, each containing the \`call_lefthook run "<hook>" "\$@"\`
 # marker expected by inject_staged_guard and disable_lefthook_auto_install. Hook names come
-# from the config (like the real CLI), so fixtures and assertions cannot drift apart.
-# The stub also tolerates --force (worktree mode passes it). Silent on success to mirror
-# the real CLI output we strip.
+# from the config (like the real CLI) and global option keys are skipped, so fixtures and
+# assertions cannot drift apart. The stub also tolerates --force (worktree mode passes it).
+# Silent on success to mirror the real CLI output we strip.
 set -euo pipefail
-case "${1:-}" in
+known=" $LEFTHOOK_GIT_HOOK_NAMES "
+case "\${1:-}" in
   install)
-    cd "$(git rev-parse --show-toplevel)"
-    hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
-    mkdir -p "$hooks_dir"
-    for hook in $(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); print $1 }' lefthook.yml); do
-      printf '#!/bin/sh\ncall_lefthook run "%s" "$@"\n' "$hook" > "$hooks_dir/$hook"
-      chmod +x "$hooks_dir/$hook"
+    cd "\$(git rev-parse --show-toplevel)"
+    hooks_dir="\$(git rev-parse --path-format=absolute --git-path hooks)"
+    mkdir -p "\$hooks_dir"
+    for hook in \$(awk -v known="\$known" '/^[A-Za-z0-9_.-]+:/ { name = \$1; sub(/:\$/, "", name); if (index(known, " " name " ") > 0) print name }' lefthook.yml); do
+      printf '#!/bin/sh\ncall_lefthook run "%s" "\$@"\n' "\$hook" > "\$hooks_dir/\$hook"
+      chmod +x "\$hooks_dir/\$hook"
     done
     ;;
   *)
-    echo "stub lefthook: unsupported command: ${1:-}" >&2
+    echo "stub lefthook: unsupported command: \${1:-}" >&2
     exit 1
     ;;
 esac
@@ -561,12 +577,35 @@ test_lefthook_self_check_hook_list_matches_config() {
   # self-check가 순회하는 hook 목록은 lefthook.yml이 정의한 hook 집합과 같아야 한다.
   # auto-install을 껐으므로 목록이 어긋나면 설치되지 않은 hook의 게이트가 조용히 사라진다.
   local from_config from_self_check
-  from_config=$(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:$/, "", $1); printf "%s%s", sep, $1; sep = " " }' "$REPO_ROOT/lefthook.yml")
+  from_config=$(lefthook_config_hook_names "$REPO_ROOT/lefthook.yml")
   from_self_check=$(extract_self_check_run_body "pre-commit" | sed -n 's/^ *for hook_name in \(.*\); do$/\1/p')
 
   [[ -n "$from_self_check" ]] || fail "could not extract the hook list from lefthook.yml self-check"
   [[ "$from_config" == "$from_self_check" ]] \
     || fail "hook list drift: lefthook.yml self-check iterates [$from_self_check], but lefthook.yml defines [$from_config]"
+}
+
+test_install_lefthook_ignores_global_config_keys() {
+  # lefthook.yml의 top-level에는 hook 외에 전역 옵션(`colors`, `skip_output` 등)도 올 수 있다.
+  # 그것을 hook 이름으로 오인하면 `.git/hooks/colors`를 찾다가 install이 막힌다.
+  local sandbox repo_root stub_dir
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  # 기존 fixture config 앞에 전역 옵션 키를 얹는다.
+  {
+    printf 'colors: false\nmin_version: 2.0.0\nskip_output:\n  - meta\n'
+    cat "$repo_root/lefthook.yml"
+  } > "$repo_root/lefthook.yml.new"
+  mv "$repo_root/lefthook.yml.new" "$repo_root/lefthook.yml"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] \
+    || fail "global lefthook.yml keys must not be treated as hooks; output: $INSTALL_LEFTHOOK_OUTPUT"
+  [[ ! -e "$repo_root/.git/hooks/colors" ]] || fail "a global config key was installed as a hook file"
+  assert_hook_call_line "$repo_root/.git/hooks/pre-commit" "pre-commit"
 }
 
 test_lefthook_self_check_bodies_stay_in_sync() {

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -14,8 +14,19 @@
 # 테스트가 그 변경을 자동으로 따라간다 (silent fail 방지).
 LEFTHOOK_GUARD_BEGIN_MARKER=$(sed -n 's/^BEGIN_MARKER="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 LEFTHOOK_GUARD_END_MARKER=$(sed -n 's/^END_MARKER="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
+LEFTHOOK_NO_AUTO_INSTALL_FLAG=$(sed -n 's/^NO_AUTO_INSTALL_FLAG="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 [[ -n "$LEFTHOOK_GUARD_BEGIN_MARKER" ]] || fail "could not extract BEGIN_MARKER from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_GUARD_END_MARKER" ]] || fail "could not extract END_MARKER from install-lefthook-hooks.sh"
+[[ -n "$LEFTHOOK_NO_AUTO_INSTALL_FLAG" ]] || fail "could not extract NO_AUTO_INSTALL_FLAG from install-lefthook-hooks.sh"
+
+assert_hook_call_line() {
+  # 설치된 hook의 lefthook 호출부가 정확히 기대 형태인지 확인한다. 완전 일치로 비교하므로
+  # 플래그 누락뿐 아니라 중복 주입(비-idempotent 회귀)도 함께 잡힌다.
+  local hook_path="$1" hook_name="$2" expected actual
+  expected="call_lefthook run \"${hook_name}\" ${LEFTHOOK_NO_AUTO_INSTALL_FLAG} \"\$@\""
+  actual=$(grep -F 'call_lefthook run ' "$hook_path" || true)
+  [[ "$actual" == "$expected" ]] || fail "hook $hook_path: expected call line [$expected], got [$actual]"
+}
 
 install_lefthook_git_isolation() {
   # skill_noise_git의 7개 격리 옵션과 동일하게 사용자 시스템 git/global config 영향 차단:
@@ -79,11 +90,12 @@ case "${1:-}" in
     cd "$(git rev-parse --show-toplevel)"
     hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
     mkdir -p "$hooks_dir"
-    cat > "$hooks_dir/pre-commit" <<'HOOK'
-#!/bin/sh
-call_lefthook run "pre-commit" "$@"
-HOOK
-    chmod +x "$hooks_dir/pre-commit"
+    # 실제 lefthook처럼 install 한 번에 설정된 hook을 모두(재)생성한다. disable_lefthook_auto_install이
+    # pre-commit뿐 아니라 commit-msg/pre-push의 호출부까지 패치하는지 검증하려면 셋 다 필요하다.
+    for hook in pre-commit commit-msg pre-push; do
+      printf '#!/bin/sh\ncall_lefthook run "%s" "$@"\n' "$hook" > "$hooks_dir/$hook"
+      chmod +x "$hooks_dir/$hook"
+    done
     ;;
   *)
     echo "stub lefthook: unsupported command: ${1:-}" >&2
@@ -124,11 +136,12 @@ case "${1:-}" in
     cd "$(git rev-parse --show-toplevel)"
     hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
     mkdir -p "$hooks_dir"
-    cat > "$hooks_dir/pre-commit" <<'HOOK'
-#!/bin/sh
-call_lefthook run "pre-commit" "$@"
-HOOK
-    chmod +x "$hooks_dir/pre-commit"
+    # 실제 lefthook처럼 install 한 번에 설정된 hook을 모두(재)생성한다. disable_lefthook_auto_install이
+    # pre-commit뿐 아니라 commit-msg/pre-push의 호출부까지 패치하는지 검증하려면 셋 다 필요하다.
+    for hook in pre-commit commit-msg pre-push; do
+      printf '#!/bin/sh\ncall_lefthook run "%s" "$@"\n' "$hook" > "$hooks_dir/$hook"
+      chmod +x "$hooks_dir/$hook"
+    done
     ;;
   *)
     echo "stub lefthook: unsupported command: ${1:-}" >&2
@@ -309,4 +322,176 @@ test_install_lefthook_worktree_mode_pins_local_hooks_path() {
 
   # 격리 검증 (content level): 메인 pre-commit의 sentinel이 그대로 보존되어야 함
   grep -Fq "$sentinel" "$main_hooks/pre-commit" || fail "main repo hooks should be isolated from worktree install; sentinel '$sentinel' missing from $main_hooks/pre-commit"
+}
+
+test_install_lefthook_injects_no_auto_install_into_every_hook() {
+  # `lefthook run`의 암묵 auto-sync는 hook 하나에서 발동해도 설치된 hook을 모두 재생성하며
+  # staged-config guard를 지운다. 따라서 guard가 없는 commit-msg/pre-push도 차단해야 한다.
+  local sandbox repo_root stub_dir hooks_dir hook_name
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  hooks_dir="$repo_root/.git/hooks"
+  for hook_name in pre-commit commit-msg pre-push; do
+    assert_hook_call_line "$hooks_dir/$hook_name" "$hook_name"
+  done
+
+  # guard 블록 자체는 pre-commit 전용 — 다른 hook으로 새지 않아야 한다.
+  grep -Fq "$LEFTHOOK_GUARD_BEGIN_MARKER" "$hooks_dir/pre-commit" || fail "guard marker missing from pre-commit"
+  for hook_name in commit-msg pre-push; do
+    ! grep -Fq "$LEFTHOOK_GUARD_BEGIN_MARKER" "$hooks_dir/$hook_name" \
+      || fail "guard marker unexpectedly injected into $hook_name"
+  done
+}
+
+test_install_lefthook_no_auto_install_injection_is_idempotent() {
+  # 매 direnv 진입마다 재실행되므로 플래그가 누적되면 안 된다. assert_hook_call_line은
+  # 완전 일치 비교라 중복 주입(`--no-auto-install --no-auto-install`)을 잡는다.
+  local sandbox repo_root stub_dir
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "first install failed: $INSTALL_LEFTHOOK_OUTPUT"
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "second install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  assert_hook_call_line "$repo_root/.git/hooks/pre-commit" "pre-commit"
+}
+
+test_install_lefthook_leaves_old_backup_hooks_untouched() {
+  # lefthook은 밀려난 기존 hook을 `<name>.old`로 남긴다. 실행되지 않는 파일이므로
+  # 패치 대상에서 제외한다 (되살렸을 때 원본 그대로여야 한다).
+  local sandbox repo_root stub_dir backup before after
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  mkdir -p "$repo_root/.git/hooks"
+  backup="$repo_root/.git/hooks/pre-commit.old"
+  printf '#!/bin/sh\ncall_lefthook run "pre-commit" "$@"\n' > "$backup"
+  before=$(cat "$backup")
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  after=$(cat "$backup")
+  [[ "$before" == "$after" ]] || fail "expected $backup to stay untouched; got: $after"
+}
+
+test_install_lefthook_fails_when_lefthook_call_shape_changes() {
+  # 상류 lefthook이 hook 템플릿의 호출부 형태를 바꾸면 플래그 주입이 조용한 no-op가 되고,
+  # 다음 auto-sync가 guard를 다시 지운다. 그 실패를 install 시점으로 당겼는지 검증한다.
+  local sandbox repo_root stub_dir
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  # inject_staged_guard의 부분 문자열 매칭은 통과하지만 호출부가 `"$@"`로 끝나지 않는 형태.
+  cat > "$stub_dir/lefthook" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  install)
+    cd "$(git rev-parse --show-toplevel)"
+    hooks_dir="$(git rev-parse --path-format=absolute --git-path hooks)"
+    mkdir -p "$hooks_dir"
+    printf '#!/bin/sh\ncall_lefthook run "pre-commit" "$@" # upstream template drift\n' > "$hooks_dir/pre-commit"
+    chmod +x "$hooks_dir/pre-commit"
+    ;;
+  *)
+    echo "stub lefthook: unsupported command: ${1:-}" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$stub_dir/lefthook"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] || fail "expected install to fail when the lefthook call shape changes; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "auto-install suppression failed"
+}
+
+lefthook_make_checksum_stale() {
+  # 실측(lefthook 2.1.5): auto-sync는 저장된 해시가 현재 config와 다르고 **동시에** config
+  # mtime이 저장된 timestamp보다 새로울 때만 발동한다. 둘 중 하나만으로는 재설치되지 않는다.
+  local repo_root="$1" checksum
+  checksum="$repo_root/.git/info/lefthook.checksum"
+  [[ -f "$checksum" ]] || fail "expected lefthook.checksum to exist after install: $checksum"
+  printf 'deadbeefdeadbeefdeadbeefdeadbeef 1\n' > "$checksum"
+  touch "$repo_root/lefthook.yml"
+}
+
+lefthook_exec_hook() {
+  # 실제 hook 파일을 git이 실행하듯 돌린다. `lefthook run`을 직접 부르면 우리가 hook에 주입한
+  # --no-auto-install을 우회하게 되어 검증이 성립하지 않는다.
+  local repo_root="$1" hook_path="$2" home_dir
+  home_dir="$(dirname "$repo_root")/home"
+  (
+    cd "$repo_root"
+    export HOME="$home_dir"
+    export XDG_CONFIG_HOME="$home_dir/.config"
+    export GIT_CONFIG_GLOBAL=/dev/null
+    export GIT_CONFIG_NOSYSTEM=1
+    sh "$hook_path"
+  ) >/dev/null 2>&1
+}
+
+test_lefthook_auto_sync_cannot_drop_guard_end_to_end() {
+  # stub이 아닌 실제 lefthook으로, checksum이 stale한 상태에서 hook을 실행해도 guard가
+  # 살아남는지 확인한다. 대조군(플래그를 뗀 hook)이 실제로 guard를 잃는 것도 함께 보여,
+  # 이 테스트가 "lefthook이 원래 sync를 안 해서" 통과하는 착시가 아님을 보장한다.
+  # 수동 재현: `git commit` 직후 `.git/hooks/pre-commit`에서 guard 마커가 사라지는지 확인.
+  local sandbox repo_root stub_dir hook_path tmp_hook
+  if ! command -v lefthook >/dev/null 2>&1; then
+    fail "real lefthook binary not found on PATH; this suite runs inside the nix devShell"
+  fi
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"  # stub_dir는 PATH에 넣지 않는다
+
+  lefthook_install_real() {
+    (
+      cd "$repo_root"
+      export HOME="$sandbox/home"
+      export XDG_CONFIG_HOME="$sandbox/home/.config"
+      export GIT_CONFIG_GLOBAL=/dev/null
+      export GIT_CONFIG_NOSYSTEM=1
+      bash "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh"
+    ) >/dev/null 2>&1 || fail "real-lefthook install failed"
+  }
+
+  hook_path="$repo_root/.git/hooks/pre-commit"
+
+  # ── 대조군: 플래그를 제거하면 auto-sync가 guard를 지운다 ──
+  lefthook_install_real
+  grep -Fq "$LEFTHOOK_GUARD_BEGIN_MARKER" "$hook_path" || fail "guard missing right after install"
+  tmp_hook="$sandbox/hook.stripped"
+  sed "s| ${LEFTHOOK_NO_AUTO_INSTALL_FLAG} | |" "$hook_path" > "$tmp_hook"
+  cat "$tmp_hook" > "$hook_path"
+  chmod +x "$hook_path"
+  lefthook_make_checksum_stale "$repo_root"
+  lefthook_exec_hook "$repo_root" "$hook_path"
+  if grep -Fq "$LEFTHOOK_GUARD_BEGIN_MARKER" "$hook_path"; then
+    fail "control group: lefthook no longer auto-syncs on a stale checksum — the --no-auto-install injection may now be unnecessary; re-verify with 'lefthook run --help'"
+  fi
+
+  # ── 실험군: 플래그가 붙은 정상 hook은 같은 조건에서 guard를 지키다 ──
+  lefthook_install_real
+  assert_hook_call_line "$hook_path" "pre-commit"
+  lefthook_make_checksum_stale "$repo_root"
+  lefthook_exec_hook "$repo_root" "$hook_path"
+  grep -Fq "$LEFTHOOK_GUARD_BEGIN_MARKER" "$hook_path" \
+    || fail "auto-sync dropped the staged-config guard despite $LEFTHOOK_NO_AUTO_INSTALL_FLAG"
+  assert_hook_call_line "$hook_path" "pre-commit"
 }


### PR DESCRIPTION
## Summary

- `lefthook run`이 `lefthook.checksum`을 stale로 판단하면 hook 파일 전체를 암묵적으로 재설치(`sync hooks`)하면서 `install-lefthook-hooks.sh`가 주입한 staged-config guard를 지운다. 그리고 **같은 실행**의 `lefthook-guard-self-check`가 방금 잃은 guard를 발견해 commit을 차단한다 — 결과적으로 `lefthook.yml`을 바꾼 뒤의 첫 commit은 항상 실패했다.
- `LEFTHOOK_*` 환경변수로는 이 auto-install을 끌 수 없다. 설치된 모든 hook의 lefthook 호출부에 `--no-auto-install`을 주입해 원천 차단하고, commit-time self-check가 guard 블록·hook 설치 여부·플래그 잔존을 함께 검사한다.
- checksum 갱신은 `install-lefthook-hooks.sh`의 `lefthook install`이 전담하므로 자동 재설치를 잃어도 손해가 없다.

## 기존 문제/배경

`lefthook.yml`이 바뀐 직후 `git commit`을 하면 다음과 같이 실패했다.

```
┃  lefthook-guard-self-check ❯

lefthook-guard-self-check: staged-config guard missing from .../.git/hooks/pre-commit.
  Cause: another worktree's 'lefthook install' likely overwrote the shared hook.
  Fix:   re-run 'direnv reload' or 'bash scripts/ai/install-lefthook-hooks.sh' in the current worktree.
```

메시지는 "다른 worktree가 덮어썼다"고 지목하지만, 실제 범인은 lefthook 자신이었다. lefthook 2.1.5 기준 실측:

1. `lefthook run`은 `.git/info/lefthook.checksum`(형식 `<hash> <config-mtime-epoch>`)과 현재 `lefthook.yml`을 비교해, **해시 불일치 AND config mtime > 저장된 timestamp** 두 조건이 모두 성립할 때만 hook 파일 전체를 암묵 재설치한다(`sync hooks: ✔️ (pre-commit, commit-msg, pre-push)`). 한 조건만으로는 재설치되지 않는다.
2. 그 재설치는 lefthook 기본 템플릿을 쓰므로 guard 블록이 사라진다. hook 하나(예: `commit-msg`)에서 sync가 발동해도 세 hook이 함께 재생성된다.
3. `lefthook --help`가 문서화한 환경변수는 `LEFTHOOK`, `LEFTHOOK_CONFIG`, `LEFTHOOK_OUTPUT`, `LEFTHOOK_VERBOSE`뿐이다. auto-install을 끄는 env는 없고, `lefthook run --no-auto-install`("do not implicitly install hooks")이 유일한 차단 수단이다.

A/B로 확인했다. 플래그가 주입된 hook은 stale checksum에서도 sync가 발동하지 않고 guard가 살아남았다. 플래그를 제거하면 동일 조건에서 sync가 발동해 guard가 사라졌다.

이 경로는 이미 알려진 미검증 항목이었다. Issue #789의 Remaining work 4번이 *"EnterWorktree 또는 delegated worktree에서 `lefthook.checksum` mismatch로 auto-install이 guard를 지우는 경로가 남는지 별도 검증한다"* 로 기록해 두었다.

## CIR (Change Intent Record)

- **v1** (PR #750): staged snapshot 기반 pre-commit 검증 도입. `install-lefthook-hooks.sh`가 worktree-local hook을 설치하고 생성된 pre-commit hook에 staged-config guard를 주입한다. 이 guard는 `LEFTHOOK_CONFIG`/`LEFTHOOK_BIN`/`LEFTHOOK_EXCLUDE` 우회와 helper script drift를 차단하는 신뢰 경계다.
- **v2** (PR #788): 메인/워크트리 자동 분기로 재설계. "메인 + 호출 worktree 모두 cleanup" 대안은 인접 inline shellHook worktree의 `lefthook install`이 공유 메인 hook을 덮어써 guard를 제거하는 cross-worktree 회귀를 **실측 확인**해 기각했고, worktree-local 격리를 보존했다. 2차 방어층으로 `pre-commit`과 `commit-msg` 두 hook에 `lefthook-guard-self-check`를 추가했다(`commit-msg` 사본은 `git commit --allow-empty`처럼 staged files가 0이라 pre-commit command가 skip되는 경로를 담당).
- **v3** (이번 변경): guard가 사라지는 **세 번째 경로**를 차단한다. lefthook 자신의 암묵 auto-install이다. v2가 확인한 "인접 worktree overwrite" 원인은 여전히 실재하므로 **부정하지 않고**, self-check 메시지에 두 원인을 병기한다.
  - 처음에는 self-check가 guard 부재를 감지하면 스스로 installer를 호출해 복구하는 self-heal을 검토했으나, 실행 중인 hook 파일을 그 hook 안에서 다시 쓰는 구조라 기각했다.
  - `.envrc`에 `watch_file lefthook.yml`을 추가해 direnv가 installer를 재실행하게 하는 안도 검토했으나, pull 직후 새 셸 없이 commit하는 경로를 못 막아 기각했다.
  - 방어를 추가하는 과정에서 두 가지 자체 결함을 실측으로 발견해 함께 고쳤다. 첫째, `git rev-parse --path-format=absolute --git-path hooks/pre-commit`은 마지막 구성요소의 symlink까지 해석해 target 절대경로를 돌려준다. 그 경로에 건 `[ -L ]` 검사는 항상 거짓이라 symlink 방어가 무력했다. 둘째, `lefthook install`은 configured hook을 제자리에 쓰므로, 설치 이후에 symlink를 거부하면 이미 외부 target을 덮어쓴 뒤다.

**trade-off**: auto-install을 끄면 `lefthook.yml`에 새 hook 종류를 추가했을 때 lefthook이 그 hook 파일을 자동으로 만들어 주지 않는다. 대신 installer가 "설정된 hook이 전부 설치됐는가"를 install 시점에 확인하고, commit-time self-check가 같은 목록을 fail-fast로 검사한다. installer는 devShell shellHook에서 direnv 진입마다 호출되므로 실사용 경로에서는 공백이 없다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `--no-auto-install` 주입 | 설치된 모든 hook의 lefthook 호출부에 플래그를 붙여 암묵 재설치를 원천 차단 | 근본 차단. checksum 상태와 무관하게 guard가 살아남음. installer가 checksum을 갱신하므로 기능 손실 없음 | hook 텍스트를 후처리해야 하고, 상류 템플릿이 바뀌면 주입이 no-op가 될 수 있음(→ install 시점 fail-fast로 방어) | ✅ |
| self-check가 guard 부재를 감지하면 self-heal | commit-time에 installer를 호출해 guard를 복구 | 사용자 개입 0 | 실행 중인 hook 파일을 그 hook 안에서 다시 쓰는 구조. 첫 commit이 여전히 실패하거나 sh가 스크립트를 읽는 도중 파일이 바뀔 위험 | ❌ |
| `.envrc`에 `watch_file lefthook.yml` | config 변경 시 direnv가 installer를 재실행 | 변경 1줄 | pull 후 새 셸 없이 commit하는 경로를 못 막음. IDE 터미널·GUI 클라이언트 등 direnv를 거치지 않는 진입점도 그대로 | ❌ |
| checksum을 install 시점에 강제 최신화 | `lefthook install`이 이미 하는 일 | 추가 코드 없음 | 이미 그렇게 하고 있고, 문제는 installer를 거치지 않은 채 commit하는 경로다 | ❌ (현상 유지) |
| lefthook 버전 하향 | auto-install이 없던 버전으로 되돌림 | 즉시 해소 | 상류 기능·수정을 포기. 언젠가 다시 올려야 함 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `scripts/ai/install-lefthook-hooks.sh` | 수정 | `require_canonical_lefthook_config`, `refuse_symlinked_hooks`, `configured_hooks`, `disable_lefthook_auto_install` 추가. 실행 순서는 lock → config 검증 → symlink preflight → install → guard 주입 → 플래그 주입 |
| `lefthook.yml` | 수정 | 두 `lefthook-guard-self-check`가 guard 블록 + 세 hook의 설치 여부 + 정확한 lefthook 호출 라인을 검사. 원인 서술에 auto-sync를 추가 |
| `scripts/ai/check-lefthook-staged-config.sh` | 수정 | pre-commit allowlist를 새 self-check 형태로 동기화. `repo_scripts`에 installer 추가 |
| `scripts/ai/lib/tomlkit-bootstrap.sh` | 수정 | 테스트 self-wrap에 `nixpkgs#lefthook` 추가 (end-to-end 테스트가 실제 lefthook을 요구) |
| `lefthook.yml` / `tests/run-all-tests.sh` | 수정 | pre-push와 통합 러너의 `nix shell` wrap에도 동일하게 `nixpkgs#lefthook` 추가 |
| `tests/suites/lefthook.sh` | 수정 | 테스트 9건 추가. fixture가 세 hook을 정의하고 stub이 설정에서 hook 이름을 읽도록 정합 |
| `README.md` | 수정 | hook 목록·self-check 범위·경로 서술 정정 |

### 핵심 코드

```bash
# lefthook install은 configured hook을 제자리에 쓴다 → symlink면 링크를 따라 외부 target을 덮어쓴다.
# 설치 이후에 거부하면 이미 늦으므로 install 전에 세운다.
acquire_install_lock
require_canonical_lefthook_config   # LEFTHOOK_CONFIG를 저장소의 lefthook.yml로 고정
refuse_symlinked_hooks              # configured hook 중 symlink가 있으면 fail
run_lefthook_install
inject_staged_guard
disable_lefthook_auto_install       # 모든 hook 호출부에 --no-auto-install 주입 + 검증
```

```bash
# BEFORE: 플래그가 "파일 어딘가에" 있으면 통과 → 주석 한 줄만으로 오통과
grep -F -- "--no-auto-install" "$hook_path" | grep -Fq 'call_lefthook run '

# AFTER: 호출부가 정확히 하나이고, 그 한 줄이 기대값과 완전히 같아야 한다.
# `"$@"`가 sh 블록에서 빈 문자열로 확장되지 않도록 작은따옴표로 조립한다.
call_count="$(grep -Fc 'call_lefthook run ' "$hook_file" || true)"
[ "$call_count" = "1" ] || fail "expected exactly one 'call_lefthook run' line, found $call_count"
expected_call='call_lefthook run "'"$hook_name"'" --no-auto-install "$@"'
grep -Fxq -- "$expected_call" "$hook_file" || fail "expected exact call line"
```

```python
# `--git-path hooks/pre-commit`은 마지막 구성요소의 symlink를 해석해 target 경로를 준다(실측).
# 그 경로로는 [ -L ] 검사가 무력하고 python도 target을 직접 연다.
# 디렉토리만 해석시키고 파일명을 붙여 symlink를 보존한다.
hook_path="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks)/pre-commit"
```

## 참고 레퍼런스

- PR #750 — staged-config guard 최초 도입. guard가 지키는 신뢰 경계의 정의
- PR #788 — 메인/워크트리 분기 + `lefthook-guard-self-check` 2-layer 도입. "인접 worktree overwrite" 원인을 실측 확인한 근거
- Issue #789 — Remaining work 4번이 이 PR이 다루는 경로("checksum mismatch로 auto-install이 guard를 지우는 경로")를 미검증 항목으로 기록. 이 PR은 그 항목만 해소하며, inline worktree shellHook 통합(NG-1)은 여전히 열려 있다
- Issue #1070 — 정확 호출 라인 계약이 installer·self-check 2곳·allowlist에 분산된 문제. 이 PR에서 범위 밖으로 분리
- `lefthook run --help` (lefthook 2.1.5) — `--no-auto-install    do not implicitly install hooks`. 이 플래그의 근거는 CLI 도움말이다. [온라인 `run` 문서](https://lefthook.dev/usage/commands/run/)에는 이 플래그가 아직 실려 있지 않으므로, 버전 업그레이드 시 `lefthook run --help`로 재확인한다
- [Lefthook `install` 문서](https://lefthook.dev/usage/commands/install/) — "Installs configured hooks to Git hooks." symlink preflight가 필요한 이유

## Human Test Plan

### 정상 동작 검증

1. 이 브랜치를 체크아웃하고 `bash scripts/ai/install-lefthook-hooks.sh`를 실행한다.
   - **기대**: 무출력으로 성공. `grep -F 'call_lefthook run ' "$(git rev-parse --git-path hooks)"/{pre-commit,commit-msg,pre-push}`가 세 줄 모두 `call_lefthook run "<hook>" --no-auto-install "$@"` 형태로 나온다.
   - **실패 시**: `lefthook run --help | grep -- --no-auto-install`로 플래그가 아직 존재하는지 확인한다. 상류가 호출부 형태를 바꿨다면 installer가 `auto-install suppression failed`로 먼저 세운다.

2. **원래 버그 재현 시도**: checksum을 일부러 stale로 만든 뒤 커밋한다.
   ```bash
   printf 'deadbeefdeadbeefdeadbeefdeadbeef 1\n' > "$(git rev-parse --git-path info/lefthook.checksum)"
   touch lefthook.yml
   git commit --allow-empty -m "test: stale checksum"
   ```
   - **기대**: 커밋이 성공한다. `sync hooks:` 메시지가 나타나지 않고, guard 블록(`# BEGIN nixos-config lefthook staged-config guard`)이 pre-commit hook에 그대로 남아 있다.
   - **실패 시**: hook의 lefthook 호출부에 `--no-auto-install`이 있는지 먼저 본다. 없다면 installer를 다시 돌린다.

### Negative 검증 (old 동작이 사라졌는지)

3. 플래그를 일부러 지운 뒤 같은 시나리오를 반복한다.
   ```bash
   H="$(git rev-parse --git-path hooks)/pre-commit"
   sed 's| --no-auto-install | |' "$H" > /tmp/h && cat /tmp/h > "$H"
   printf 'deadbeefdeadbeefdeadbeefdeadbeef 1\n' > "$(git rev-parse --git-path info/lefthook.checksum)"
   touch lefthook.yml
   git commit --allow-empty -m "test: should fail"
   ```
   - **기대**: `sync hooks: ✔️ (...)`가 출력되고 guard가 사라져 `lefthook-guard-self-check`가 commit을 차단한다. 즉 플래그가 실제로 원인을 막고 있었음이 확인된다.
   - **복구**: `bash scripts/ai/install-lefthook-hooks.sh`

### 엣지 케이스

4. 외부 파일을 가리키는 symlink로 hook을 바꾼 뒤 installer를 실행한다.
   ```bash
   printf '#!/bin/sh\n# SENTINEL\nexit 0\n' > /tmp/external-hook && chmod +x /tmp/external-hook
   H="$(git rev-parse --git-path hooks)"; rm -f "$H/pre-push"; ln -s /tmp/external-hook "$H/pre-push"
   bash scripts/ai/install-lefthook-hooks.sh
   ```
   - **기대**: `refusing to install over a symlinked hook`으로 실패하고, `/tmp/external-hook`의 `# SENTINEL`이 그대로 남아 있으며 `$H/pre-push`는 여전히 symlink다.
   - **실패 시**: `refuse_symlinked_hooks`가 `run_lefthook_install`보다 먼저 호출되는지 확인한다.
   - **복구**: `rm -f "$H/pre-push" && bash scripts/ai/install-lefthook-hooks.sh`

5. 저장소 밖의 설정을 `LEFTHOOK_CONFIG`로 지정하고 installer를 실행한다.
   ```bash
   printf 'post-commit:\n  jobs:\n    - name: noop\n      run: "true"\n' > /tmp/other-lefthook.yml
   LEFTHOOK_CONFIG=/tmp/other-lefthook.yml bash scripts/ai/install-lefthook-hooks.sh
   ```
   - **기대**: `LEFTHOOK_CONFIG must point to .../lefthook.yml`로 실패한다. hook 파일은 건드려지지 않는다.
   - **실패 시**: `require_canonical_lefthook_config`가 `run_lefthook_install` 전에 호출되는지 확인한다.

### 인접 기능 regression

6. `bash tests/run-shell-script-tests.sh`를 실행한다.
   - **기대**: 전부 통과(테스트 191건). 특히 `install-lefthook preserves custom local core.hooksPath`, `install-lefthook pins worktree-local hooks path in worktree mode`, `install-lefthook serializes concurrent invocations`가 통과해 PR #750/#788의 설계가 보존됐음을 확인한다.
   - **실패 시**: 실패한 테스트 이름으로 `tests/suites/lefthook.sh`의 해당 함수를 읽는다.

7. 워크트리에서 커밋한 뒤 메인 저장소에서도 커밋한다.
   - **기대**: 양쪽 모두 guard와 플래그가 유지되고, 한쪽의 install이 다른 쪽 hook을 깨뜨리지 않는다(PR #788의 worktree-local 격리 보존).
   - **실패 시**: `git config --worktree --get core.hooksPath`로 워크트리 hook 경로가 격리돼 있는지 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * Git 훅 설치/주입 시 기대되는 호출 형태와 방지 플래그 적용을 더 엄격히 검증해, 자동 동기화나 다른 워크트리의 덮어쓰기처럼 보호가 약해질 수 있는 상황을 조기에 차단합니다.
  * 심볼릭 링크, 저장소 밖 설정, 잘못된 구성 경로는 거부합니다.
* **테스트**
  * 훅 주입 멱등성, 백업 훅 유지, 호출 모양 드리프트/미패치 재실행, self-check 동기화 및 엔드투엔드 가드 유지 여부를 추가로 검증합니다.
* **문서**
  * 훅 검증/훅 실패 시 복구 흐름(커밋 단계 포함)을 더 구체적으로 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->