### PR TITLE
fix(lefthook): 설정에서 빠진 stale hook에도 --no-auto-install 주입

### DIFF
--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -326,20 +326,22 @@ disable_lefthook_auto_install() {
   # `--git-path hooks`는 core.hooksPath를 반영하므로 lefthook이 실제로 hook을 쓴 위치와
   # 일치한다 ($git_dir/hooks와 다를 수 있다 — 사용자가 core.hooksPath를 재정의한 경우).
   # inject_staged_guard가 hook을 찾는 방식과 같은 해석 경로를 쓴다.
-  # 패치 대상은 lefthook.yml이 정의한 hook뿐이다. 디렉토리를 훑어 `call_lefthook run`이 든 파일을
-  # 전부 편입하면, 설정에 없는 남의 hook까지 우리 관리 대상으로 끌어들이고 basename 기반 검증이
-  # 그 파일에서 실패해 install 전체를 막는다. preflight·패치·검증이 같은 집합을 본다.
+  #
+  # 패치 대상은 "lefthook이 만든 모든 hook"이지 "지금 lefthook.yml에 있는 hook"이 아니다.
+  # `lefthook install`은 설정에서 빠진 hook 파일을 지우지 않으므로, 과거에 설정돼 있던 hook이
+  # 플래그 없이 남는다. git은 그 hook도 실행하고(예: pre-commit 다음의 prepare-commit-msg),
+  # 그 안의 `call_lefthook run`이 auto-install을 발동시켜 guard와 플래그를 통째로 지운다.
+  # 실측: `.git/hooks/prepare-commit-msg`(현 lefthook.yml에 없음) 하나로 재현된다.
+  # 반대로 설치 여부 검증(아래)은 configured_hooks에만 적용한다 — 설정 밖 hook의 부재는 정상이다.
   local hook_file hook_name resolved_hooks_dir
   resolved_hooks_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-path hooks)"
   local -a hook_files=()
-  for hook_name in $(configured_hooks); do
-    hook_file="$resolved_hooks_dir/$hook_name"
-    # lefthook.yml이 정의한 hook이 하나라도 설치되지 않았다면, auto-install을 끈 지금은 아무도
-    # 되살려 주지 않는다. commit-time self-check가 같은 목록을 fail-fast로 확인하므로, 그 실패를
-    # install 시점으로 당겨 원인을 분명히 남긴다.
-    if [ ! -f "$hook_file" ]; then
-      fail "expected hook not installed: $hook_file (lefthook.yml defines it; check 'lefthook install' output)"
-    fi
+  for hook_file in "$resolved_hooks_dir"/*; do
+    [ -f "$hook_file" ] || continue
+    # lefthook이 기존 hook을 밀어낼 때 남기는 백업본은 git이 실행하지 않으므로 건드리지 않는다.
+    case "$hook_file" in *.old) continue ;; esac
+    # lefthook이 생성한 hook만 고른다. 남이 만든 hook에는 이 호출부가 없다.
+    grep -Fq 'call_lefthook run ' "$hook_file" || continue
     # 아래 python 블록은 rename으로 교체하므로 symlink였다면 링크 자체가 일반 파일로 바뀐다
     # (다른 레이어가 hook을 symlink로 관리한다면 그 경계가 조용히 끊긴다). install 전 preflight가
     # 이미 걸렀어야 하지만, 그 사이의 TOCTOU를 여기서 한 번 더 막는다.
@@ -348,8 +350,18 @@ disable_lefthook_auto_install() {
     fi
     hook_files+=("$hook_file")
   done
+
+  # lefthook.yml이 정의한 hook이 하나라도 설치되지 않았다면, auto-install을 끈 지금은 아무도
+  # 되살려 주지 않는다. commit-time self-check가 같은 목록을 fail-fast로 확인하므로, 그 실패를
+  # install 시점으로 당겨 원인을 분명히 남긴다.
+  for hook_name in $(configured_hooks); do
+    if [ ! -f "$resolved_hooks_dir/$hook_name" ]; then
+      fail "expected hook not installed: $resolved_hooks_dir/$hook_name (lefthook.yml defines it; check 'lefthook install' output)"
+    fi
+  done
+
   if [ "${#hook_files[@]}" -eq 0 ]; then
-    fail "no hooks configured in $repo_root/lefthook.yml"
+    fail "no lefthook-generated hooks found under $resolved_hooks_dir"
   fi
 
   # 200>&- closes the lock fd in the python child (same reason as run_lefthook_install).

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -174,6 +174,7 @@ run_test "install-lefthook serializes concurrent invocations" test_install_lefth
 run_test "install-lefthook pins worktree-local hooks path in worktree mode" test_install_lefthook_worktree_mode_pins_local_hooks_path
 run_test "install-lefthook injects --no-auto-install into every hook" test_install_lefthook_injects_no_auto_install_into_every_hook
 run_test "install-lefthook --no-auto-install injection is idempotent" test_install_lefthook_no_auto_install_injection_is_idempotent
+run_test "install-lefthook patches a stale unconfigured hook" test_install_lefthook_patches_stale_unconfigured_hook
 run_test "install-lefthook leaves .old backup hooks untouched" test_install_lefthook_leaves_old_backup_hooks_untouched
 run_test "install-lefthook fails when lefthook call shape changes" test_install_lefthook_fails_when_lefthook_call_shape_changes
 run_test "install-lefthook fails on an unpatched second lefthook call" test_install_lefthook_fails_on_unpatched_second_call

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -394,6 +394,32 @@ test_install_lefthook_no_auto_install_injection_is_idempotent() {
   assert_hook_call_line "$repo_root/.git/hooks/pre-commit" "pre-commit"
 }
 
+test_install_lefthook_patches_stale_unconfigured_hook() {
+  # `lefthook install`은 설정에서 빠진 hook 파일을 지우지 않는다. 그렇게 남은 hook의
+  # `call_lefthook run` 호출부에 플래그가 없으면, git이 그 hook을 실행할 때(예: pre-commit
+  # 다음의 prepare-commit-msg) auto-install이 발동해 guard와 플래그를 통째로 지운다.
+  # 설정에 없더라도 lefthook이 만든 hook이면 패치 대상이어야 한다.
+  local sandbox repo_root stub_dir hooks_dir stale
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  # 과거 설정에 있다가 빠진 hook을 흉내낸다 (lefthook이 남긴 그대로, 플래그 없음).
+  hooks_dir="$repo_root/.git/hooks"
+  mkdir -p "$hooks_dir"
+  stale="$hooks_dir/prepare-commit-msg"
+  printf '#!/bin/sh\ncall_lefthook run "prepare-commit-msg" "$@"\n' > "$stale"
+  chmod +x "$stale"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "install must not fail on a stale unconfigured hook; output: $INSTALL_LEFTHOOK_OUTPUT"
+
+  # 설정에 없어도 lefthook이 만든 hook이면 플래그가 주입되어 auto-install 우회로가 닫힌다.
+  assert_hook_call_line "$stale" "prepare-commit-msg"
+  assert_hook_call_line "$hooks_dir/pre-commit" "pre-commit"
+}
+
 test_install_lefthook_leaves_old_backup_hooks_untouched() {
   # lefthook은 밀려난 기존 hook을 `<name>.old`로 남긴다. 실행되지 않는 파일이므로
   # 패치 대상에서 제외한다 (되살렸을 때 원본 그대로여야 한다).


### PR DESCRIPTION
## Summary

- 설정에서 빠졌지만 `.git/hooks`에 남아 있는 lefthook hook에도 `--no-auto-install`을 주입한다. `lefthook install`은 `lefthook.yml`에서 사라진 hook 파일을 지우지 않으므로, 플래그 없는 그 hook이 auto-install 우회로가 된다.
- #1071 머지 직후 main에서 원래 버그가 그대로 재현되어 확인한 회귀다. `.git/hooks/prepare-commit-msg` 하나로 `git commit`이 차단된다.

## 기존 문제/배경

#1071은 설치된 hook의 lefthook 호출부에 `--no-auto-install`을 주입해, `lefthook.checksum`이 stale할 때 hook이 암묵 재설치되며 staged-config guard가 사라지는 문제를 막았다. 그런데 머지 후 main에서 검증하니 동일 증상이 재현됐다.

```bash
bash scripts/ai/install-lefthook-hooks.sh          # 세 hook에 플래그 주입 확인
printf 'deadbeefdeadbeefdeadbeefdeadbeef 1\n' > .git/info/lefthook.checksum
touch lefthook.yml
git commit --allow-empty -m "probe"
# → lefthook-guard-self-check (commit-msg): staged-config guard block missing
# → exit 1, pre-commit 호출부에서 --no-auto-install 소실
```

원인은 `.git/hooks/prepare-commit-msg`였다.

```
$ /usr/bin/stat -f '%Sm %N' .git/hooks/prepare-commit-msg
2026-02-10 20:13:28 .git/hooks/prepare-commit-msg

$ grep -F 'call_lefthook run ' .git/hooks/prepare-commit-msg
call_lefthook run "prepare-commit-msg" "$@"      # ← 플래그 없음
```

과거 `lefthook.yml`에 `prepare-commit-msg`가 있던 시절 lefthook이 만든 파일이다. 이후 설정에서 빠졌지만 `lefthook install`은 그 파일을 지우지 않는다(실측 확인). git은 `pre-commit` 다음에 이 hook을 실행하고, 그 안의 `call_lefthook run`이 auto-install을 발동시켜 세 hook과 guard를 통째로 재생성한다.

`pre-commit`과 `commit-msg`를 각각 단독 실행하면 sync가 발동하지 않는다. 즉 #1071이 주입한 플래그는 의도대로 동작하며, **플래그 없는 hook 파일이 하나라도 남으면 그 경로로 우회된다**는 것이 문제다.

## CIR (Change Intent Record)

- **v1** (PR #1071 초기): `disable_lefthook_auto_install`이 hooks 디렉터리를 훑어 `call_lefthook run`을 포함한 파일을 전부 패치했다. 이 방식에서는 `prepare-commit-msg`에도 플래그가 주입되고 있었다.
- **v2** (PR #1071 후반): 리뷰에서 "패치 대상이 configured hook이 아니라 hooks 디렉터리 전체로 확장된다. 설정 밖 파일까지 basename 기반 정확 검증에 걸어 install 전체를 막을 수 있다"는 설계 지적을 받았다. 이를 수용해 패치 대상을 `configured_hooks` 집합으로 좁혔다.
- **v3** (이번 변경): v2가 우회로를 열었음을 머지 후 검증에서 확인했다. 지적의 요지는 **검증 대상**의 문제였는데 **패치 대상**까지 함께 좁힌 것이 과했다. 두 대상을 분리한다.

**trade-off**: 패치 대상이 다시 넓어지지만, 대상 판별을 "lefthook이 생성한 hook"(= `call_lefthook run` 호출부 보유)으로 한정하고 실행되지 않는 `.old` 백업을 제외한다. 설치 여부 검증은 `configured_hooks`에만 적용하므로, 설정 밖 hook이 없다고 install이 실패하는 일은 없다. v2가 막으려던 "설정 밖 파일 때문에 install 전체가 막히는" 상황도 발생하지 않는다 — 그 파일들은 lefthook이 만든 것이라 호출부 형태가 동일하다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 패치 대상 = lefthook 생성 hook 전체 / 설치 검증 = configured_hooks | 두 대상을 분리 | 우회로 차단. 설정 밖 hook 부재로 install이 실패하지 않음 | 패치 대상이 설정보다 넓음 (의도된 것) | ✅ |
| stale hook 파일을 삭제 | `.git/hooks`에서 설정 밖 hook 제거 | 우회로 즉시 제거 | 다른 clone·머신의 stale hook은 그대로. `lefthook.yml`에서 hook을 뺄 때마다 재발. 남의 hook을 지우는 부작용 | ❌ |
| self-check가 모든 hook의 플래그를 검사 | commit-time에 우회로 감지 | 방어 계층 추가 | 원인을 막지 못하고 증상만 잡는다. `lefthook.yml`·allowlist 복제가 더 늘어남 (#1070) | ❌ (후속 고려) |
| lefthook 버전 하향 | auto-install이 없던 버전 | 즉시 해소 | 상류 기능·수정 포기 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `scripts/ai/install-lefthook-hooks.sh` | 수정 | `disable_lefthook_auto_install`의 패치 대상 선정을 `configured_hooks`에서 "hooks 디렉터리의 lefthook 생성 hook 전체"로 되돌리고, 설치 여부 검증만 `configured_hooks`에 남긴다 |
| `tests/suites/lefthook.sh` | 수정 | stale unconfigured hook 회귀 테스트 추가 |
| `tests/shell-script-tests.sh` | 수정 | 새 테스트 등록 |

### 핵심 코드

```bash
# BEFORE (우회로 있음): 패치 대상 = 설정된 hook만
for hook_name in $(configured_hooks); do
  hook_file="$resolved_hooks_dir/$hook_name"
  [ -f "$hook_file" ] || fail "expected hook not installed: ..."
  hook_files+=("$hook_file")
done

# AFTER: 패치 대상 = lefthook이 만든 모든 hook (.old 제외)
for hook_file in "$resolved_hooks_dir"/*; do
  [ -f "$hook_file" ] || continue
  case "$hook_file" in *.old) continue ;; esac
  grep -Fq 'call_lefthook run ' "$hook_file" || continue
  hook_files+=("$hook_file")
done

# 설치 여부 검증은 configured_hooks에만 (설정 밖 hook의 부재는 정상)
for hook_name in $(configured_hooks); do
  [ -f "$resolved_hooks_dir/$hook_name" ] || fail "expected hook not installed: ..."
done
```

## 참고 레퍼런스

- PR #1071 — `--no-auto-install` 주입 도입. 이 PR이 고치는 회귀를 만든 변경
- PR #750 — staged-config guard 최초 도입
- PR #788 — `lefthook-guard-self-check` 2-layer 도입
- Issue #1070 — 정확 호출 라인 계약의 소유점 단일화 (분리된 후속 작업)
- [Lefthook `install` 문서](https://lefthook.dev/usage/commands/install/) — "Installs configured hooks to Git hooks." 설정에서 빠진 hook을 지운다는 언급이 없으며, 실측으로도 지우지 않음을 확인했다

## Human Test Plan

### 회귀 재현 → 해소 확인

1. 설정에 없는 lefthook hook을 심고 installer를 실행한다.
   ```bash
   H="$(git rev-parse --path-format=absolute --git-path hooks)"
   printf '#!/bin/sh\ncall_lefthook run "prepare-commit-msg" "$@"\n' > "$H/prepare-commit-msg"
   chmod +x "$H/prepare-commit-msg"
   bash scripts/ai/install-lefthook-hooks.sh
   grep -F 'call_lefthook run ' "$H/prepare-commit-msg"
   ```
   - **기대**: `call_lefthook run "prepare-commit-msg" --no-auto-install "$@"` — 설정에 없어도 플래그가 주입된다.
   - **실패 시**: `disable_lefthook_auto_install`의 패치 대상 루프가 디렉터리를 훑는지 확인한다.

2. 그 상태에서 checksum을 stale로 만들고 커밋한다.
   ```bash
   printf 'deadbeefdeadbeefdeadbeefdeadbeef 1\n' > "$(git rev-parse --git-path info/lefthook.checksum)"
   touch lefthook.yml
   git commit --allow-empty -m "test: stale checksum with stale hook"
   ```
   - **기대**: 커밋 성공. `sync hooks:` 메시지가 없고 guard 마커가 pre-commit에 남아 있다.
   - **실패 시**: 어떤 hook 파일의 호출부에 플래그가 없는지 `grep -L -- --no-auto-install "$H"/*` 로 찾는다.

### Negative 검증

3. `prepare-commit-msg`의 플래그를 지우고 2번을 반복한다.
   - **기대**: guard가 사라지고 커밋이 차단된다. 즉 그 hook이 실제 우회로였음이 확인된다.
   - **복구**: `bash scripts/ai/install-lefthook-hooks.sh`

### 인접 기능 regression

4. `.old` 백업 파일이 건드려지지 않는지 확인한다.
   ```bash
   grep -F 'call_lefthook run ' "$H"/*.old 2>/dev/null
   ```
   - **기대**: 플래그가 주입되지 않은 원본 그대로. git이 실행하지 않는 파일이므로 대상이 아니다.

5. `bash tests/run-shell-script-tests.sh`
   - **기대**: 전부 통과(193건). 특히 `install-lefthook patches a stale unconfigured hook`(신규), `install-lefthook leaves .old backup hooks untouched`, `install-lefthook ignores global lefthook.yml config keys`, `install-lefthook fails on an unpatched second lefthook call`이 함께 통과해야 한다.
   - **실패 시**: 실패한 테스트 이름으로 `tests/suites/lefthook.sh`의 해당 함수를 읽는다.

6. 머지 후 main에서 `bash scripts/ai/install-lefthook-hooks.sh`를 실행한다.
   - **기대**: `.git/hooks/prepare-commit-msg`에도 플래그가 주입되어, `lefthook.yml`을 수정한 뒤 첫 커밋이 정상 동작한다.
   - **실패 시**: `grep -L -- --no-auto-install "$(git rev-parse --git-path hooks)"/*` 로 누락된 hook을 찾는다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 설정에 없더라도 Lefthook이 생성한 기존 훅 파일이 자동 설치 비활성화 처리에서 누락되지 않도록 개선했습니다.
  * 설정된 훅이 설치되지 않은 경우에는 기존처럼 설치를 중단하고 오류를 표시합니다.
  * 처리할 Lefthook 생성 훅이 없을 때 더 정확한 오류 메시지를 제공합니다.

* **테스트**
  * 설정 외에 남아 있는 기존 훅도 정상적으로 패치되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->