### PR TITLE
docs(skills): using-codex-exec·using-claude-p를 codex 0.144.1 / Claude Code 2.1.206 실측으로 전면 현행화

### DIFF
--- a/modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md
@@ -1,24 +1,24 @@
 ---
 name: using-claude-p
-description: |
-  Use Claude Code non-interactive (-p/--print) mode for scripting, automation, and headless
-  execution. Trigger: '''claude -p''', '''비대화형 claude''', '''headless claude''', '''스크립트에서 claude'''. Covers: CLI flag usage and gotchas (--output-format, --allowed-tools, --resume,
-  --dangerously-skip-permissions), JSON output parsing, session chaining, saving results to files,
-  SSH remote execution of claude, harness self-testing (T1~T8), and known flag interaction bugs. Use
-  when users want to run claude programmatically, pipe output, parse results, automate workflows,
-  troubleshoot CLI flag behavior, or execute claude on remote machines. NOT for Codex CLI (use
-  using-codex-exec). NOT for interactive TUI usage.
+description: >-
+  Run Claude Code non-interactively with claude -p for headless automation, JSON parsing, SSH
+  execution, or CLI flag troubleshooting. Use when requests mention `claude -p` or
+  `비대화형/headless claude`. Use using-codex-exec for Codex subprocesses.
 ---
 
 # Claude Code 비대화형 모드 (`claude -p`) 사용
 
-Claude Code의 `-p`/`--print` 모드(비대화형/headless)를 정확하게 사용하는 절차를 다룬다.
+상세 flag·gotcha의 SSOT는 [flag-matrix.md](references/flag-matrix.md)와
+[gotchas.md](references/gotchas.md)이며, 본문은 선택 기준과 성공 계약만 요약한다.
 
 ## 작성 기준
 
-- 확인 날짜: 2026-07-08
-- 확인 버전: Claude Code v2.1.202
+- 확인 날짜: 2026-07-10
+- 확인 버전: Claude Code v2.1.206
 - 재검증: `claude --version && claude --help && claude -p --help`
+
+print 모드는 workspace trust dialog를 생략하고 invalid settings를 조용히 무시할 수 있다
+(2.1.206 help). 자동화 전에는 settings를 별도 검증한다.
 
 ## 범위
 
@@ -45,8 +45,9 @@ claude -p 실행이 필요한가?
 │  └─ NO → 기본 실행 (권한 플래그 불필요)
 │
 ├─ 출력을 프로그래밍적으로 파싱할 필요가 있나?
-│  ├─ YES → --output-format json (v2.1.202 help: single result, 기존 JSON 배열 실측은 재검증 미수행)
-│  │         또는 --output-format stream-json (JSONL)
+│  ├─ YES → --output-format json (top-level 이벤트 배열, 2.1.206 성공 경로 실측)
+│  │         배열/객체를 정규화한 뒤 type=result 탐색
+│  │         또는 --output-format stream-json (JSONL; wire shape 재검증 미수행)
 │  └─ NO → 기본 text 출력
 │
 ├─ harness 인벤토리를 검증하고 싶다면?
@@ -82,18 +83,39 @@ claude -p 실행이 필요한가?
 
 ## 핵심 Gotchas
 
-1. `--allowed-tools` + 인라인 프롬프트 = 버그: 인라인 프롬프트가 도구 이름으로 먹힘 → stdin 필수
-2. `--max-turns 1`은 도구 실행 불가: 도구 사용에 최소 2턴 필요 (호출 + 결과 수신)
-3. 도구 거부/예산 초과도 exit code 0: 실패를 감지하려면 `--output-format json`의 result subtype 확인 필수
+1. `<values...>` variadic flag 뒤 인라인 프롬프트가 flag 값으로 소비됨: `--allowed-tools`, `--disallowed-tools` 등은 stdin으로 prompt 전달
+2. `--max-turns 1`은 도구 실행 불가 — 최소 2턴 필요 (v2.1.202 실측; 2.1.206 재검증 미수행 — help에는 없지만 parser 수용 확인)
+3. exit code나 `subtype=success` 하나만으로 성공 판정 금지: exit + subtype/is_error + 기대 산출물 + 진척 delta 확인
 4. `--cwd`, `--output-file` 플래그 없음: `cd dir && claude -p`, shell redirect `> file` 사용
 5. SSH alias 미로드: non-login shell에서 `c` alias 사용 불가 → `claude` full path 필수
-6. `--append-system-prompt`는 append: 기존 시스템 프롬프트를 override하지 못함
-7. `--tools ""`로 빌트인 비활성화해도 MCP 남아있음: MCP도 비활성화하려면 별도 조치 필요
-8. 플러그인 스킬 인식은 설치 시점 고정: 캐시 수정/symlink/브랜치 변경 무효 → stdin 주입 또는 재설치
-9. 커스텀 환경변수 명시적 전달 필요: `.env` 자동 로드 안 됨 → `VAR=val claude -p`
-10. stdin 대용량 입력 정상 동작: 극단적 상한은 미확인, 프로덕션에서 청킹 병행 권장
+6. `--append-system-prompt`는 append — 기존 시스템 프롬프트를 override하지 못함 (v2.1.202 실측; 2.1.206 재검증 미수행)
+7. `--tools ""`로 빌트인을 비활성화해도 MCP는 남음 — MCP 비활성화는 별도 조치 필요 (v2.1.202 실측; 2.1.206 재검증 미수행)
+8. 플러그인 스킬 인식은 설치 시점에 고정 — 캐시 수정·symlink·브랜치 변경 대신 stdin 주입 또는 재설치 (v2.1.202 실측; 2.1.206 재검증 미수행)
+9. 커스텀 환경변수는 명시적으로 전달 — `.env`는 자동 로드되지 않으므로 `VAR=val claude -p` 사용 (v2.1.202 실측; 2.1.206 재검증 미수행)
+10. 대용량 stdin은 정상 동작 — 극단적 상한은 미확인하므로 프로덕션에서는 청킹 병행 (v2.1.202 실측; 2.1.206 재검증 미수행)
 
 전체 목록: [references/gotchas.md](references/gotchas.md)
+
+## 셸 transport 계약
+
+- stdout, stderr, 업무 산출물을 분리 보관한다. JSON parser 앞 `2>&1`은 stderr를 섞어 파싱을 깨뜨린다.
+- pipeline은 `set -o pipefail`을 사용한다. zsh에서 Claude 자체 exit가 필요하면 pipeline 직후
+  `claude_rc=$pipestatus[2]`로 보존한다.
+- `| head`, `| tail`, 뒤이은 `; echo $?`는 원래 exit를 가릴 수 있으므로 판정 경로에서 제외한다.
+
+## 성공 계약
+
+`claude -p --output-format json` 완료는 다음 조건을 모두 만족해야 한다.
+
+1. process exit가 0이다.
+2. `type=result` 이벤트가 있고 `subtype=success`, `is_error=false`다.
+3. 파일 생성을 요구한 작업은 `test -s "$RESULT"`를 통과하고 기대 완료 표식이 있다.
+4. 반복 pass는 직전 결과 대비 새 finding·수정·판정 같은 진척 delta가 있다.
+
+2.1.206 성공 경로는 4-event 배열과 `result/success`, `is_error:false`, exit 0을 냈다. 반대로
+auth 실패 경로는 `subtype:success`, `is_error:true`, exit 1도 가능했다. 산출물 0개인데 success인
+실전 사례가 있으므로 진척 없는 pass가 연속되면 circuit breaker로 중단한다. child에게 같은
+collector/fan-out을 다시 생성시키지 않는다.
 
 ## SSH 크로스머신 요약
 
@@ -107,7 +129,8 @@ ssh minipc 'zsh -li -c "c -p \"...\""'  # → unmatched quote
 
 - SSH non-login shell에서 alias 미로드 → `claude` full path 필수
 - 3중 중첩 quote 지옥 → 파일 기반 stdin pipe가 유일한 안정 패턴
-- MiniPC sshd 180초 무응답 시 연결 해제 → 장시간 실행 시 `ServerAliveInterval` 추가
+- 무출력 약 10분 뒤 완료된 실측이 있다. 무출력만으로 중단, 프로세스 생존만으로 정상이라 판정하지 않는다.
+- outer timeout과 `ServerAliveInterval`을 적용하고 종료 뒤 `test -s`로 산출물을 확인한다.
 
 상세: [references/patterns.md](references/patterns.md) 패턴 5
 
@@ -127,18 +150,23 @@ ssh minipc 'zsh -li -c "c -p \"...\""'  # → unmatched quote
 | T8 | 동시 실행 안정성 | ~$0.14 |
 
 상세 코드 및 판정 로직: [references/harness-testing.md](references/harness-testing.md)
+비용 수치는 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 ## 하지 말아야 할 패턴
 
 | 금지 패턴 | 발생 에러 | 올바른 대안 |
 |-----------|----------|------------|
 | `--allowed-tools "Bash" "prompt"` | 프롬프트가 도구 이름으로 파싱 | stdin pipe 사용 |
-| `--max-turns 1` + 도구 실행 기대 | Reached max turns | `--max-turns 2` 이상 |
-| exit code로 실패 판정 | 대부분 에러도 exit 0 | `--output-format json` subtype 확인 |
+| `--dangerously-skip-permissions` + `--allowed-tools` | allowlist 구조적 무효 | 제한 필요: allowed-tools + stdin / 제한 불필요: skip 단독 |
+| `--max-turns 1` + 도구 실행 기대 | Reached max turns | `--max-turns 2` 이상 (v2.1.202 실측) |
+| exit 또는 `subtype=success` 하나로 성공 판정 | 무산출물·auth 실패 오판 | 성공 계약 네 조건 확인 |
+| JSON parser 앞 `2>&1` | stderr 혼입으로 파싱 실패 | stdout/stderr/산출물 분리 |
+| 판정 pipeline 끝의 `head`/`tail`/`; echo $?` | 원 exit 은폐 | `pipefail`과 즉시 exit 보존 |
 | SSH에서 `c -p` alias | command not found | `claude -p` full path |
 | 3중 중첩 quote (SSH) | unmatched quote | stdin pipe 패턴 |
 | `--verbose`/`--debug`로 디버그 | stderr 출력 없음 | `--debug-file` 사용 |
 | 플러그인 캐시 디렉토리 수동 수정 | 인식 안 됨 (설치 시점 인덱싱) | SKILL.md stdin 주입 (패턴 9) |
+| child가 같은 collector를 다시 생성 | 무한 자기증식 | 오케스트레이션은 부모 1계층에서만 수행 |
 
 ## 참조
 
@@ -148,4 +176,4 @@ ssh minipc 'zsh -li -c "c -p \"...\""'  # → unmatched quote
 - 플래그 호환성 매트릭스: [references/flag-matrix.md](references/flag-matrix.md)
 
 문서와 CLI 동작이 다를 때는 CLAUDE.md의 "스킬 문서 불일치 시 행동 원칙"을 따른다.
-`claude -p --help` 출력이 이 문서보다 항상 우선하는 진실 원천이다.
+help는 공개 surface의 SSOT다. help에 없는 hidden flag의 제거 여부는 실행 smoke로만 판정한다.

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/flag-matrix.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/flag-matrix.md
@@ -1,46 +1,49 @@
 # `claude -p` 플래그 호환성 매트릭스
 
-- 확인 날짜: 2026-07-08
-- 확인 버전: Claude Code v2.1.202
+- 확인 날짜: 2026-07-10
+- 확인 버전: Claude Code v2.1.206
 - 재검증: `claude --version && claude --help && claude -p --help` 출력과 비교
+
+`--help`는 공개 surface의 SSOT다. help에 없는 hidden flag의 제거 판정은 실행 smoke로만 한다.
+print 모드는 workspace trust dialog를 생략하고 invalid settings를 조용히 무시할 수 있다.
 
 ## `-p` 전용/연동 플래그
 
 `-p`/`--print` 모드에서만 사용 가능하거나, `stream-json`/SDK print 경로와 강하게 묶인 플래그. `--help`의 `only works with --print` 및 관련 표기를 우선한다.
 
-| 플래그 | v2.1.202 `--help` 표기 | 비고 |
+| 플래그 | v2.1.206 `--help` 표기 | 비고 |
 |--------|------------------------|------|
-| `--output-format <format>` | 출력 형식: `text`(기본), `json`(single result), `stream-json`(realtime streaming) | 기존 JSON 배열 실측은 [gotcha #6](gotchas.md)에 남김. 실제 `claude -p` 재검증 미수행 |
-| `--no-session-persistence` | 세션 파일 미저장, resume 불가 (`only works with --print`) | 동시 실행 시 충돌 방지에 유용 |
+| `--output-format <format>` | 출력 형식: `text`(기본), `json`(single result), `stream-json`(realtime streaming) | runtime `json`은 top-level 이벤트 배열. 성공 경로 4 events 재확인: 2026-07-10, v2.1.206 |
+| `--no-session-persistence` | 세션 파일 미저장, resume 불가 (`only works with --print`) | 동시 충돌 방지 효과는 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | `--max-budget-usd <amount>` | 최대 비용 제한 (`only works with --print`) | 초과 시 exit code/subtype 동작은 [gotcha #4](gotchas.md) 참조 |
-| `--fallback-model <model>` | 기본 모델 과부하/불가 시 지정 모델로 fallback (`only works with --print`) | 쉼표 구분 목록 가능 |
+| `--fallback-model <model>` | primary 과부하/불가 시 fallback (`only works with --print`) | 쉼표 목록을 순서대로 시도하고 각 user turn 시작에 primary 재시도 |
 | `--input-format <format>` | 입력 형식: `text`(기본), `stream-json` (`only works with --print`) | |
 | `--include-partial-messages` | 부분 메시지 chunk 포함 (`only works with --print` + `--output-format=stream-json`) | |
-| `--include-hook-events` | 모든 hook lifecycle event 포함 (`only works with --output-format=stream-json`) | v2.1.202 help에서 확인된 추가 플래그 |
-| `--replay-user-messages` | stdin user message를 stdout에 재방출 (`--input-format=stream-json` + `--output-format=stream-json`) | v2.1.202 help에서 확인된 추가 플래그 |
+| `--include-hook-events` | 모든 hook lifecycle event 포함 (`only works with --output-format=stream-json`) | v2.1.206 help 재확인 |
+| `--replay-user-messages` | stdin user message를 stdout에 재방출 (`--input-format=stream-json` + `--output-format=stream-json`) | v2.1.206 help 재확인 |
 | `--prompt-suggestions [value]` | print/SDK 모드에서 다음 프롬프트 예측 메시지 emit | `true/false/1/0/yes/no/on/off`, preset `true` |
-| `--json-schema <schema>` | JSON Schema 기반 structured output validation | v2.1.202 help에서 확인된 추가 플래그 |
-| `--max-turns <N>` | `--help` 미표시 | 숨겨진 플래그로 문서 유지. 실제 `claude -p` 재검증 미수행 |
+| `--json-schema <schema>` | JSON Schema 기반 structured output validation | 무효 schema는 모델 호출 전 즉시 오류 (v2.1.205 실측) |
+| `--max-turns <N>` | `--help` 미표시 | hidden parser 수용 재확인: 2026-07-10, v2.1.206. turn semantics는 재검증 미수행 (v2.1.202 기준 서술 유지) |
 
 ## 범용 플래그 (대화형/비대화형 공통)
 
-| 플래그 | v2.1.202 `--help` 표기 | `-p` 모드에서의 동작/주의 |
+| 플래그 | v2.1.206 `--help` 표기 | `-p` 모드에서의 동작/주의 |
 |--------|------------------------|---------------------------|
-| `--model <model>` | 모델 선택. alias(`fable`, `opus`, `sonnet`) 또는 full name 허용 | 정상 동작 |
-| `--system-prompt <prompt>` | 시스템 프롬프트 설정 | 기본 시스템 프롬프트 대신 사용 |
-| `--append-system-prompt <prompt>` | 기본 시스템 프롬프트에 추가 | 기존 지시를 덮어쓰지 못함 |
-| `--resume [value]`, `-r` | session ID 또는 검색어로 resume | `-p`에서 세션 체이닝 가능 |
+| `--model <model>` | 모델 선택. alias(`fable`, `opus`, `sonnet`) 또는 full name 허용 | help surface 확인 |
+| `--system-prompt <prompt>` | session system prompt 설정 | replacement semantics 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| `--append-system-prompt <prompt>` | 기본 시스템 프롬프트에 추가 | 기존 지시와의 override 관계 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| `--resume [value]`, `-r` | session ID 또는 검색어로 resume | chaining runtime 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | `--continue`, `-c` | 현재 디렉토리의 최근 conversation 계속 | 비대화형 자동화에서는 session 명시가 더 안정적 |
 | `--fork-session` | resume/continue 시 새 session ID 생성 | `--resume`/`--continue`와 함께 사용 |
 | `--session-id <uuid>` | 특정 session ID 사용 | UUID 필요 |
 | `--from-pr [value]` | PR 번호/URL 또는 검색어로 PR 연계 세션 resume | 대화형 picker 가능 |
 | `--dangerously-skip-permissions` | 모든 permission check 우회 | `-p`에서 도구 사용 시 흔히 필요 |
 | `--allow-dangerously-skip-permissions` | bypass 옵션을 활성화하되 기본값으로 켜지는 것은 아님 | sandbox용 옵션 |
-| `--permission-mode <mode>` | `acceptEdits`, `auto`, `bypassPermissions`, `manual`, `dontAsk`, `plan` | `bypassPermissions` = `--dangerously-skip-permissions` |
-| `--allowedTools`, `--allowed-tools <tools...>` | 허용할 도구 목록 (쉼표 또는 공백 구분) | 인라인 프롬프트가 도구 이름으로 파싱될 수 있어 stdin 권장 |
-| `--disallowedTools`, `--disallowed-tools <tools...>` | 거부할 도구 목록 | v2.1.202 help에서 확인 |
+| `--permission-mode <mode>` | `acceptEdits`, `auto`, `bypassPermissions`, `manual`, `dontAsk`, `plan` | 구 `default`가 아니라 `manual`; bypass equivalence는 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| `--allowedTools`, `--allowed-tools <tools...>` | 허용할 도구 목록 (쉼표 또는 공백 구분) | variadic이므로 prompt는 stdin. skip-permissions와 병용하면 allowlist 무효 |
+| `--disallowedTools`, `--disallowed-tools <tools...>` | 거부할 도구 목록 | v2.1.206 help 재확인; variadic prompt 흡수 주의 |
 | `--tools <tools...>` | 사용 가능한 built-in tool 목록 지정 | `""` 지정 시 built-in 비활성화, MCP는 별도 |
-| `--disable-slash-commands` | 모든 skills 비활성화 | "Unknown skill" 계열 결과 |
+| `--disable-slash-commands` | 모든 skills 비활성화 | exact response는 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | `--debug [filter]`, `-d` | debug mode + optional filter | `-p` stderr 동작은 [gotcha #22](gotchas.md) 참조 |
 | `--debug-file <path>` | debug log 파일 기록 | `-p` 디버그에는 이 경로가 가장 안정적 |
 | `--verbose` | config의 verbose mode override | `-p` stderr 동작은 [gotcha #22](gotchas.md) 참조 |
@@ -52,28 +55,28 @@
 | `--plugin-dir <path>` | plugin directory 또는 zip 로드 | repeatable |
 | `--plugin-url <url>` | plugin zip URL 로드 | repeatable |
 | `--agent <agent>` | 현재 세션 agent override | |
-| `--agents <json>` | custom agents JSON 정의 | v2.1.202 help에서 확인 |
-| `--bare` | hooks/LSP/plugin sync/CLAUDE.md auto-discovery 등 최소화 | `CLAUDE_CODE_SIMPLE=1`, 명시 context 필요 |
-| `--safe-mode` | customizations 비활성화 | 문제 진단용, auth/model/built-in tools/permissions는 유지 |
+| `--agents <json>` | custom agents JSON 정의 | v2.1.206 help 재확인 |
+| `--bare` | hooks, LSP, plugin sync, attribution, auto-memory, background prefetch, keychain read, CLAUDE.md auto-discovery skip | `CLAUDE_CODE_SIMPLE=1`; auth는 `ANTHROPIC_API_KEY`/`apiKeyHelper`, skills는 계속 resolve |
+| `--safe-mode` | admin policy 외 customizations 비활성화 | `CLAUDE_CODE_SAFE_MODE=1`; auth/model/built-in tools/permissions 유지 |
 | `--effort <level>` | effort level: `low`, `medium`, `high`, `xhigh`, `max` | |
 | `--name <name>`, `-n` | session display name | |
-| `--file <specs...>` | startup file resource download (`file_id:relative_path`) | v2.1.202 help에서 확인 |
+| `--file <specs...>` | startup file resource download (`file_id:relative_path`) | v2.1.206 help 재확인 |
 | `--betas <betas...>` | API key 사용자용 beta header | |
-| `--exclude-dynamic-system-prompt-sections` | machine-specific prompt section을 첫 user message로 이동 | prompt-cache reuse 목적 |
-| `--ide` | IDE 자동 연결 | |
+| `--exclude-dynamic-system-prompt-sections` | machine-specific prompt section을 첫 user message로 이동 | default system prompt에서만 적용; `--system-prompt`면 무시 |
+| `--ide` | IDE 자동 연결 | valid IDE가 정확히 하나일 때만 |
 | `--chrome` / `--no-chrome` | Claude in Chrome integration on/off | |
 | `--remote-control [name]` | Remote Control enabled interactive session 시작 | 대화형 성격이 강함 |
-| `--remote-control-session-name-prefix <prefix>` | Remote Control session name prefix | |
+| `--remote-control-session-name-prefix <prefix>` | Remote Control session name prefix | 기본 prefix는 hostname |
 | `--background`, `--bg` | background agent로 시작 | `claude agents`로 관리 |
-| `--worktree [name]`, `-w` | 새 git worktree 생성 | `--tmux`와 연동 가능 |
-| `--tmux` | worktree용 tmux/iTerm2 pane 생성 | `--worktree` 필요 |
+| `--worktree [name]`, `-w` | git worktree 생성 | 기존 이름은 조용히 reuse하고 RC 0 (v2.1.150 실측; v2.1.206 재검증 미수행) |
+| `--tmux` | worktree용 tmux/iTerm2 pane 생성 | `--worktree` 필요; `--tmux=classic` 지원 |
 | `--ax-screen-reader` | screen-reader friendly output | |
 | `--brief` | SendUserMessage tool 활성화 | agent-to-user communication |
 | `--help`, `-h` / `--version`, `-v` | help/version 출력 | |
 
 ## 존재하지 않거나 `--help`에 없는 플래그
 
-CLI에 없거나 v2.1.202 help에 표시되지 않는 플래그. 사용 전 실제 실행으로 재확인한다.
+CLI에 없거나 v2.1.206 help에 표시되지 않는 플래그. hidden 여부는 실제 실행으로 재확인한다.
 
 | 의도 | 플래그 | 상태/대안 |
 |------|--------|-----------|
@@ -87,13 +90,15 @@ CLI에 없거나 v2.1.202 help에 표시되지 않는 플래그. 사용 전 실�
 
 | 환경변수 | 설명 | 비고 |
 |----------|------|------|
-| `CLAUDE_CODE_MAX_RETRIES` | API 재시도 횟수 | 기본값 오버라이드 (바이너리에서 확인) |
-| `ANTHROPIC_API_KEY` | API 키 | 인증 필수 |
-| *(커스텀 환경변수)* | `VAR=val claude -p` 형태로 명시적 전달 필요. `.env` 자동 로드 안 됨 | [gotcha #39](gotchas.md) |
+| `CLAUDE_CODE_MAX_RETRIES` | API 재시도 횟수 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| `ANTHROPIC_API_KEY` | API-key 인증 경로 | API key 경로 선택 시 필요. 일반 headless는 구독 로그인으로도 성공 실측 |
+| *(커스텀 환경변수)* | `VAR=val claude -p` 형태로 전달 | `.env` 비자동 로드는 재검증 미수행 (v2.1.202 기준 서술 유지); [gotcha #39](gotchas.md) |
 
 ## `--permission-mode` 선택지 비교
 
-v2.1.202 help의 공식 선택지는 `acceptEdits`, `auto`, `bypassPermissions`, `manual`, `dontAsk`, `plan`이다. 기존 문서의 `default`는 help 선택지가 아니며, 아래에서는 "플래그 생략" 상태로만 다룬다.
+v2.1.206 help의 공식 선택지는 `acceptEdits`, `auto`, `bypassPermissions`, `manual`, `dontAsk`, `plan`이다. 기존 `default`는 `manual`로 개명되었고, 아래에서는 생략 상태를 별도로 다룬다.
+
+아래 mode별 hook/permission semantics는 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 | 모드 | 권한 프롬프트 | hooks 호출 | hooks 결정 반영 | 용도 |
 |------|:----------:|:--------:|:-----------:|------|
@@ -108,6 +113,8 @@ v2.1.202 help의 공식 선택지는 `acceptEdits`, `auto`, `bypassPermissions`,
 핵심 차이: `bypassPermissions`는 hooks 결정을 무시하지만, `dontAsk`는 hooks 결정을 반영한다.
 
 ## `-p` 모드에서 동작하지 않는 대화형 기능
+
+아래 runtime 동작은 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 | 기능 | 설명 |
 |------|------|

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/gotchas.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/gotchas.md
@@ -1,40 +1,43 @@
 # 숨겨진 동작
 
-공식 문서에 없는 `claude -p` (비대화형 모드) 동작을 카테고리별로 정리합니다.
+`claude -p`의 help/runtime 차이와 재발 failure mode를 카테고리별로 정리한다.
 
 > 항목 번호(#1, #23 등)는 최초 발견 순서를 유지하며, 카테고리별로 그룹화되어 있다.
 > 번호 순서대로가 아닌 카테고리순으로 정렬되어 있으므로, 특정 번호를 찾으려면 페이지 검색을 사용한다.
 
-## 2026-07-08 재검증 상태 (Claude Code v2.1.202)
+## 2026-07-10 재검증 상태 (Claude Code v2.1.206)
 
 - 재검증 명령: `claude --version && claude --help && claude -p --help`
-- 네트워크 차단 sandbox에서는 실제 `claude -p` 호출이 필요한 항목을 재실행하지 않았다. 해당 항목은 "재검증 미수행 (v2.1.202 기준 서술 유지)"로 표시한다.
+- 실제 실행이 확인된 항목은 `재확인: 2026-07-10, v2.1.206`, 나머지는
+  `재검증 미수행 (v2.1.202 기준 서술 유지)`로 구분한다.
+- `실전 재발 사례`는 실제 업무 사고, `통제 smoke`는 최소 probe에서만 본 현상이다. 별도 라벨이
+  없는 과거 runtime 서술은 v2.1.202 이전의 역사 관측으로 읽는다.
 
 | 항목 | 판정 |
 |------|------|
-| #1 | `--allowed-tools` variadic help 표기 확인. 인라인 프롬프트 파싱 버그는 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #1 | 재확인: 2026-07-10, v2.1.206 — variadic prompt 흡수와 입력 없음 오류 재현; stdin 부재 시 3초 watchdog 경고 후 진행 |
 | #23 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #24 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #39 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #40 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #36/#35 | `--allowed-tools` help 표기 확인. 패턴 매칭 의미는 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #6 | `--output-format` choices 확인. help의 `json` 설명은 `single result`로 변경됨. 실제 JSON shape는 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #17 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #6 | 재확인: 2026-07-10, v2.1.206 — 성공 경로 top-level 4-event JSON 배열. stream-json wire shape는 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #17 | 재확인: 2026-07-10, v2.1.206 — init에 skills/tools/MCP/plugins key 존재; count는 환경 snapshot |
 | #22 | `--debug`, `--verbose`, `--debug-file` help 표기 확인. stderr 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #2/#18/#19 | `--max-turns`가 v2.1.202 help에도 미표시임을 확인. 실제 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #2/#18/#19 | #18 hidden parser 수용 재확인: 2026-07-10, v2.1.206. #2/#19 semantics는 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #4 | `--max-budget-usd` help 표기 확인. exit/subtype 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #20 | `--cwd`가 v2.1.202 help에 없음을 확인 |
-| #21 | `--output-file`/`-o`가 v2.1.202 help에 없음을 확인 |
-| #3 | permission 관련 help 표기 확인. 도구 거부/exit 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #20 | 재확인: 2026-07-10, v2.1.206 help에 `--cwd` 없음 |
+| #21 | 재확인: 2026-07-10, v2.1.206 help에 `--output-file`/`-o` 없음 |
+| #3 | skip-permissions + allowed-tools 제한 무효 재확인: 2026-07-10. 도구 거부/exit 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #7 | `--permission-mode bypassPermissions` help 선택지 확인 |
-| #12/#25/#26/#27 | `--disable-hooks`가 v2.1.202 help에 없음을 확인. hooks 결정 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #33 | `--permission-prompt-tool`이 v2.1.202 help에 없음을 확인. 숨은 플래그 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #5 | `--tools`, `--mcp-config`, `--strict-mcp-config` help 표기와 `--mcp-servers`/`--no-mcp` 부재 확인. MCP 잔존 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #12/#25/#26/#27 | `--disable-hooks`가 v2.1.206 help에 없음을 확인. hooks 결정 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #33 | `--permission-prompt-tool`이 v2.1.206 help에 없음. hidden 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #5 | `--tools`, `--mcp-config`, `--strict-mcp-config` help 표기와 `--mcp-servers`/`--no-mcp` 부재 재확인. MCP 잔존은 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #13 | `--disable-slash-commands` help 표기 확인. 실제 응답 문구는 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #38 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #28/#29/#37/#30 | 재검증 미수행 (v2.1.202 기준 서술 유지) |
+| #28/#29/#37/#30 | #29 success 정상/인증실패 조합 재확인: 2026-07-10, v2.1.206. exhaustive subtype과 #28/#37/#30은 재검증 미수행 (v2.1.202 기준 서술 유지) |
 | #8/#9/#14 | `--resume`, `--append-system-prompt` help 표기 확인. 실제 context/override 동작은 재검증 미수행 (v2.1.202 기준 서술 유지) |
-| #15/#16/#32 | 문서 내 SSH/shell 논리만 유지. CLI 실행 재검증 대상 아님 |
+| #15/#16/#32 | SSH/shell 규칙 유지; 약 10분 무출력 후 완료 사례 반영 |
 | #10/#11/#31/#34 | 재검증 미수행 또는 문서 서술 유지 (v2.1.202 기준) |
 
 ## 목차
@@ -53,17 +56,22 @@
 
 ## 입력 (Input)
 
-### #1. `--allowed-tools` 뒤에 인라인 프롬프트가 도구 이름으로 파싱됨
+### #1. variadic flag 뒤 인라인 프롬프트가 flag 값으로 파싱됨
 
 ```bash
 # ❌ 잘못된 사용
-claude -p --dangerously-skip-permissions --allowedTools "Bash,Read" "ls /tmp 실행해"
+claude -p --allowedTools "Bash,Read" "ls /tmp 실행해"
 # → Error: Input must be provided either through stdin or as a prompt argument
 # "ls /tmp 실행해"가 도구 이름으로 먹힘
 
 # ✅ 올바른 사용 — stdin 필수
-echo "ls /tmp | head -2를 실행해" | claude -p --dangerously-skip-permissions --allowed-tools "Bash,Read"
+echo "ls /tmp | head -2를 실행해" | claude -p --allowed-tools "Bash,Read"
 ```
+
+`--allowed-tools`, `--disallowed-tools`처럼 help가 `<values...>`로 표시하는 variadic flag는 뒤의
+인라인 prompt를 계속 flag 값으로 소비할 수 있다. prompt는 stdin으로 전달한다. stdin이 없으면
+v2.1.206은 약 3초 watchdog 경고 뒤 진행할 수 있으므로, 짧은 정지를 정상 prompt 파싱으로 오인하지
+않는다. 재확인: 2026-07-10, v2.1.206.
 
 ### #23. 빈 줄 vs 빈 문자열 입력 차이
 
@@ -137,9 +145,10 @@ cat skill.md agent.md references.md | claude -p --output-format text > result.md
 # --output-format json → JSON 배열 (전체가 하나의 배열)
 echo "2+3" | claude -p --output-format json | python3 -c "
 import sys, json
-data = json.loads(sys.stdin.read())  # list
-print(f'Type: {type(data).__name__}, Length: {len(data)}')
-for item in data:
+data = json.loads(sys.stdin.read())
+items = data if isinstance(data, list) else [data]
+print(f'Type: {type(data).__name__}, Length: {len(items)}')
+for item in items:
     print(f'  {item.get(\"type\")}/{item.get(\"subtype\", \"-\")}')"
 # Type: list, Length: 4
 #   system/init
@@ -147,12 +156,15 @@ for item in data:
 #   rate_limit_event/-
 #   result/success
 
-# --output-format stream-json → JSONL (라인별 독립 JSON)
+# --output-format stream-json → JSONL (재검증 미수행)
 echo "hello" | claude -p --output-format stream-json | wc -l
-# 4 (system, assistant, rate_limit_event, result 각 1줄)
+# event 수는 고정 계약이 아님
 ```
 
-파싱 방식이 다르므로 주의: `json`은 `json.loads(전체)`, `stream-json`은 라인별 `json.loads(line)`.
+재확인: 2026-07-10, v2.1.206 성공 경로에서 `json`은 system/init, assistant,
+rate_limit_event, result/success의 4-event 배열이었다. event 수와 중간 event 존재는 고정하지 않는다.
+parser는 배열/객체를 정규화한 뒤 `type=result`를 탐색한다. `stream-json` wire shape는 재검증 미수행
+(v2.1.202 기준 서술 유지).
 
 ### #17. init 이벤트에 전체 harness 인벤토리 포함
 
@@ -160,15 +172,17 @@ echo "hello" | claude -p --output-format stream-json | wc -l
 echo "ok" | claude -p --output-format json | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 print(f'Skills: {len(init.get(\"skills\", []))}')
 print(f'Tools: {len(init.get(\"tools\", []))}')
 print(f'MCP: {len(init.get(\"mcp_servers\", []))}')
 print(f'Plugins: {len(init.get(\"plugins\", []))}')"
-# Skills: 43, Tools: 40, MCP: 4, Plugins: 3
+# 2026-07-10 auth-failure snapshot: Skills 76, Tools 28, MCP 2, Plugins 2
 ```
 
-이 패턴으로 harness 전수 검사가 가능하다. [harness-testing.md](harness-testing.md) T1 참조.
+네 key 존재는 재확인했지만 count는 설치·설정에 따른 환경 snapshot이다. 고정 기대값으로 쓰지 않는다.
+[harness-testing.md](harness-testing.md) T1 참조.
 
 ### #22. `-p`에서 `--verbose`/`--debug`는 stderr에 아무것도 출력 안 함
 
@@ -198,16 +212,20 @@ echo "ls /tmp | head -3" | claude -p --dangerously-skip-permissions --max-turns 
 
 ### #4. `--max-budget-usd` 초과도 exit code 0
 
-```bash
-echo "아주 긴 에세이를 5000단어로 써줘" | claude -p --max-budget-usd 0.001; echo "EXIT: $?"
-# Error: Exceeded USD budget (0.001)EXIT: 0
+```zsh
+set -o pipefail
+echo "아주 긴 에세이를 5000단어로 써줘" | claude -p --max-budget-usd 0.001 \
+  > /tmp/budget.stdout 2> /tmp/budget.stderr
+claude_rc=$pipestatus[2]
 ```
 
 예산 초과를 감지하려면 exit code가 아닌 `--output-format json`의 result subtype을 확인해야 한다.
 
 ### #18. `--max-turns`는 `--help`에 표시되지 않는 숨겨진 플래그
 
-`claude --help`/`claude -p --help` v2.1.202 출력에도 `--max-turns`가 없지만, 기존 실측에서는 실제로 동작했다. ⚠️ `CLAUDE_CODE_MAX_TURNS` 환경변수는 v2.1.76 바이너리에 존재하지 않음 (실측 + 소스 분석으로 확인). CLI flag `--max-turns`가 유일한 제어 수단이라는 서술은 실제 `claude -p` 재검증 미수행 (v2.1.202 기준 서술 유지).
+`claude --help`/`claude -p --help` v2.1.206 출력에도 `--max-turns`가 없지만 실행 smoke에서
+parser 수용과 exit 0을 확인했다 (재확인: 2026-07-10). turn 제한 semantics와
+`CLAUDE_CODE_MAX_TURNS` 부재/유일 제어 수단 서술은 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 ### #19. `--max-turns` 도달 시 `is_error: false`
 
@@ -215,7 +233,7 @@ result subtype은 `error_max_turns`이지만 `is_error: false` — 에러가 아
 
 ### #20. `--cwd` 플래그 존재하지 않음
 
-작업 디렉토리를 변경하려면 `cd dir && claude -p` 패턴이 유일한 방법. `--cwd`는 v2.1.202 `claude --help`/`claude -p --help`에도 없다.
+작업 디렉토리를 변경하려면 `cd dir && claude -p`를 사용한다. `--cwd`는 v2.1.206 help에도 없다.
 
 ```bash
 # ❌ 존재하지 않음
@@ -227,7 +245,7 @@ cd /path/to/project && echo "prompt" | claude -p
 
 ### #21. `--output-file` / `-o` 플래그 존재하지 않음
 
-shell redirect를 사용해야 한다. `--output-file`/`-o`는 v2.1.202 `claude --help`/`claude -p --help`에도 없다.
+shell redirect를 사용해야 한다. `--output-file`/`-o`는 v2.1.206 help에도 없다.
 
 ```bash
 # ❌ 존재하지 않음
@@ -243,14 +261,19 @@ echo "prompt" | claude -p > result.txt
 
 ### #3. 권한 없이 도구 사용 시 조용히 거부, exit code 0
 
-```bash
-echo "ls /tmp 실행해줘" | claude -p; echo "EXIT: $?"
-# "허용된 작업 디렉토리 범위 밖..." EXIT: 0
+```zsh
+set -o pipefail
+echo "ls /tmp 실행해줘" | claude -p > /tmp/permission.stdout 2> /tmp/permission.stderr
+claude_rc=$pipestatus[2]
 ```
 
 도구를 못 썼는데도 에러가 아닌 정상 종료. 실패를 감지하려면 출력 내용을 파싱해야 한다.
 
-⚠️ `--dangerously-skip-permissions` + `--allowed-tools` 상호작용: `--dangerously-skip-permissions`는 `--allowed-tools` 제한을 완전히 무시한다. `--allowed-tools "Read"`로 Bash를 제한하더라도 `--dangerously-skip-permissions`가 있으면 Bash가 제한 없이 사용 가능하다. 도구를 실제로 제한하려면 `--dangerously-skip-permissions` 없이 `--allowed-tools`를 단독 사용하라. v2.1.81 실측 (v2.1.202 실제 `claude -p` 재검증 미수행, 서술 유지).
+권한 거부/exit 조합은 재검증 미수행 (v2.1.202 기준 서술 유지).
+
+⚠️ `--dangerously-skip-permissions` + `--allowed-tools` 상호작용: skip-permissions는 allowlist를
+구조적으로 무효화한다. 도구를 제한하려면 skip-permissions 없이 allowed-tools와 stdin을 사용하고,
+제한이 불필요하면 skip-permissions를 단독 사용한다. 재확인: 2026-07-10, v2.1.206 실사용 6회.
 
 ### #7. `--permission-mode bypassPermissions` = `--dangerously-skip-permissions`
 
@@ -259,9 +282,11 @@ echo "ls /tmp | head -2" | claude -p --permission-mode bypassPermissions
 # ✅ --dangerously-skip-permissions와 동일하게 동작
 ```
 
-### #12/25. `--dangerously-skip-permissions`는 hooks의 block을 무시하지 않음
+### #12/25. `--dangerously-skip-permissions`는 hooks를 호출하지만 결정을 반영하지 않음
 
-Permission prompt만 건너뛰고, hooks 자체는 호출된다. 단, `bypassPermissions` 모드에서는 hooks의 결정이 passthrough로 무시된다 (#26 참조). ⚠️ `--disable-hooks` 플래그는 v2.1.202 `claude --help`/`claude -p --help`에도 존재하지 않음.
+hooks 자체는 호출되지만 `bypassPermissions`에서는 allow/deny/block 결정이 passthrough로 무시된다
+(#26 참조). `--disable-hooks` 플래그는 v2.1.206 help에도 없다. hook runtime은 재검증 미수행
+(v2.1.202 기준 서술 유지).
 
 ### #26. `bypassPermissions` 모드에서 hooks는 호출되지만 결정이 passthrough로 무시됨
 
@@ -269,11 +294,13 @@ hooks 자체는 실행되지만, hooks의 allow/deny/block 결정이 결과에 �
 
 ### #27. 권한 모드 생략 시 hooks의 allow/deny/block 결정은 정상 반영됨
 
-비대화형 모드에서도 `--permission-mode`를 생략한 기본 동작에서는 hooks의 결정이 존중된다. v2.1.202 help의 `--permission-mode` 선택지에는 `default`가 없으므로, 기존 "default 모드" 표현은 플래그 생략 상태로 해석한다.
+비대화형 모드에서도 `--permission-mode`를 생략한 기본 동작에서는 hooks의 결정이 존중된다.
+v2.1.206 help의 선택지에는 구 `default` 대신 `manual`이 있으며, 생략 상태는 별도로 해석한다.
+hook runtime은 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 ### #33. `--permission-prompt-tool`로 MCP 도구에 퍼미션 처리 위임 가능
 
-비대화형 모드에서 인터랙티브 권한 프롬프트를 MCP 도구에 위임할 수 있다. 자체 퍼미션 UI가 있는 CI/CD 시스템에 유용. `--permission-prompt-tool`은 v2.1.202 `claude --help`/`claude -p --help`에 표시되지 않으며, 실제 `claude -p` 재검증 미수행 (v2.1.202 기준 서술 유지).
+비대화형 모드에서 인터랙티브 권한 프롬프트를 MCP 도구에 위임할 수 있다. 자체 퍼미션 UI가 있는 CI/CD 시스템에 유용. `--permission-prompt-tool`은 v2.1.206 help에 표시되지 않으며, hidden 동작은 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 ---
 
@@ -286,9 +313,9 @@ echo "현재 디렉토리의 파일 목록을 보여줘" | claude -p --tools ""
 # "Figma 관련 MCP 도구만 사용할 수 있는 상태입니다."
 ```
 
-⚠️ `--mcp-servers ""` / `--no-mcp` 플래그는 v2.1.202 `claude --help`/`claude -p --help`에도 존재하지 않음. `--mcp-config`와 `--strict-mcp-config`는 help에 있으나, 빈 MCP 구성으로 전체 비활성화하는 패턴은 별도 재검증 필요.
+⚠️ `--mcp-servers ""` / `--no-mcp` 플래그는 v2.1.206 help에도 존재하지 않음. `--mcp-config`와 `--strict-mcp-config`는 help에 있으나, 빈 MCP 구성으로 전체 비활성화하는 패턴은 별도 재검증 필요.
 
-⚠️ 역방향도 성립: `--allowed-tools "mcp__server__tool"`에 MCP 도구명을 명시해도 해당 MCP 서버가 세션에서 초기화되지 않으면 사용 불가. `--allowed-tools`는 허용 목록이지, 서버 활성화 지시가 아니다. MCP 서버 초기화는 `.mcp.json` 또는 `settings.json`의 MCP 설정에 의존한다 (`.mcp.json`에 미등록이거나 서버 프로세스가 init 단계에서 연결 실패한 경우 "미활성"). `--strict-mcp-config`로 특정 MCP 설정만 로드하는 것도 가능하다 (v2.1.202 help 확인). MCP 초기화 동작은 v2.1.81 실측 (v2.1.202 실제 `claude -p` 재검증 미수행, 서술 유지).
+⚠️ 역방향도 성립: `--allowed-tools "mcp__server__tool"`에 MCP 도구명을 명시해도 해당 MCP 서버가 세션에서 초기화되지 않으면 사용 불가. `--allowed-tools`는 허용 목록이지, 서버 활성화 지시가 아니다. MCP 서버 초기화는 `.mcp.json` 또는 `settings.json`의 MCP 설정에 의존한다 (`.mcp.json`에 미등록이거나 서버 프로세스가 init 단계에서 연결 실패한 경우 "미활성"). `--strict-mcp-config`로 특정 MCP 설정만 로드하는 surface는 v2.1.206 help에서 확인했다. MCP 초기화 동작은 재검증 미수행 (v2.1.202 기준 서술 유지).
 
 ### #13. `--disable-slash-commands`로 스킬 비활성화 시 "Unknown skill"
 
@@ -332,18 +359,37 @@ cat skill-content.md agent-instructions.md | claude -p --output-format text > re
 
 비대화형 모드에서는 Notification 이벤트 자체가 발생하지 않으므로 hook이 실행되지 않는다.
 
-### #29. result subtype 종류 — 6종
+### #29. result subtype/exit 조합은 고정 계약이 아님
 
-| subtype | 의미 | exit code |
-|---------|------|-----------|
-| `success` | 정상 완료 | 0 |
-| `error_max_turns` | `--max-turns` 도달 | 0 |
-| `error_max_budget_usd` | `--max-budget-usd` 초과 | 0 |
-| `error_max_structured_output_retries` | 구조화 출력 재시도 초과 | 0 |
-| `error_during_execution` | 실행 중 오류 | 1 |
-| `error_utilization_penalty` | 사용량 패널티 | 0 |
+제목의 6종은 v2.1.202까지 관측한 역사 목록이며 exhaustive enum으로 사용하지 않는다.
 
-`success`와 `error_during_execution`만 exit code가 다르다. 나머지 에러는 모두 exit code 0.
+| 관측 경로 | subtype | is_error | process exit | 재확인 |
+|----------|---------|:--------:|:------------:|--------|
+| 인증된 정상 완료 | `success` | false | 0 | 2026-07-10, v2.1.206 |
+| pre-auth 실패 (`Not logged in`) | `success` | true | 1 | 2026-07-10, v2.1.206 |
+
+기존 `error_max_turns`, `error_max_budget_usd`, `error_max_structured_output_retries`,
+`error_during_execution`, `error_utilization_penalty` mapping은 재검증 미수행
+(v2.1.202 기준 서술 유지). 성공 판정에는 exit, subtype, is_error, 기대 산출물을 함께 사용한다.
+
+### #41. exit 0 / `subtype=success`여도 업무 성공이 아닐 수 있음
+
+collector가 exit 0과 success를 반환했지만 기대 산출물이 0개인 채 자기증식한 실전 사고가 있었다.
+무진척 pass도 5회 관측됐다. 다음을 모두 확인한다.
+
+1. exit 0
+2. result가 `subtype=success`, `is_error=false`
+3. 기대 파일 `test -s "$RESULT"`와 완료 표식
+4. 직전 pass 대비 진척 delta
+
+진척 없는 pass가 연속되면 circuit breaker로 중단한다. child가 같은 collector/fan-out을 다시
+생성하는 self-replicating orchestration은 금지한다. 관측 출처: 실전 재발 사례.
+
+### #42. shell pipeline이 원 exit와 JSON 채널을 가릴 수 있음
+
+JSON parser 앞 `2>&1`는 stderr를 stdout에 섞어 파싱을 깨뜨린다. `| head`, `| tail`, 뒤이은
+`; echo $?`는 Claude 원 exit를 가릴 수 있다. stdout, stderr, 업무 산출물을 분리하고
+`set -o pipefail`과 zsh `pipestatus`로 Claude exit를 즉시 보존한다. 관측 출처: 통제 smoke 2회.
 
 ### #37. Stop hooks → MCP 종료 → SessionEnd hooks 순서
 
@@ -370,8 +416,8 @@ echo "이 프로젝트는 어떤 프로젝트야?" | claude -p
 
 ```bash
 SESSION_ID=$(echo "나의 비밀 코드는 XRAY42야" | claude -p --output-format json | python3 -c "
-import sys, json; data=json.loads(sys.stdin.read())
-for item in data:
+import sys, json; data=json.loads(sys.stdin.read()); items=data if isinstance(data,list) else [data]
+for item in items:
     if isinstance(item, dict) and item.get('type')=='system':
         print(item['session_id']); break")
 echo "내 비밀 코드가 뭐였어?" | claude -p --resume "$SESSION_ID"
@@ -420,6 +466,9 @@ echo "hostname 실행하고 결과만 보고해" | ssh minipc 'claude -p --dange
 
 MiniPC sshd 설정: `ClientAliveInterval=60`, `ClientAliveCountMax=3` → 180초 무응답 시 연결 해제. Mac client에 `ServerAliveInterval`이 미설정되어 있으므로, 장시간 `-p` 실행 시 SSH 연결이 끊길 수 있다.
 
+무출력 약 10분 뒤 정상 완료된 실측이 있다. 무출력만으로 중단, 프로세스 생존만으로 정상이라
+판정하지 않는다. outer timeout과 keepalive를 적용하고 완료 후 `test -s`로 기대 산출물을 검증한다.
+
 ```bash
 # 장시간 실행 시 ServerAliveInterval 설정
 ssh -o ServerAliveInterval=30 minipc 'echo "long prompt" | claude -p --dangerously-skip-permissions'
@@ -459,7 +508,7 @@ wait
 
 ## 참고
 
-- 확인 날짜: 2026-07-08
-- 확인 버전: Claude Code v2.1.202
+- 확인 날짜: 2026-07-10
+- 확인 버전: Claude Code v2.1.206
 - 확인 범위: 문서 메타데이터/핵심 항목 기준이며, 각 항목의 재검증 상태는 본문 주석(예: "재검증 미수행")을 따른다.
 - 재검증: `claude --version && claude --help && claude -p --help` 출력과 비교 후, 변경된 항목이 있으면 갱신한다

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/harness-testing.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/harness-testing.md
@@ -2,11 +2,15 @@
 
 `claude -p --output-format json`의 init 이벤트를 활용하여 harness 구성요소를 자동 검증한다.
 
-- 확인 날짜: 2026-07-08
-- 확인 버전: Claude Code v2.1.202
+- 확인 날짜: 2026-07-10
+- 확인 버전: Claude Code v2.1.206
 - 재검증: `claude --version && claude --help && claude -p --help`
-- 확인 범위: CLI help와 스탬프만 재검증. T1~T8 실제 `claude -p` 실행은 네트워크 차단 sandbox에서 미수행
-- 비용: 각 테스트 ~$0.07 (1-turn, 최소 프롬프트)
+- 확인 범위: 인증된 JSON 성공 probe에서 4-event 배열과 init key를 재확인. T1~T8 전체는 재검증 미수행 (v2.1.202 기준 서술 유지)
+- 비용: 각 테스트 ~$0.07 (v2.1.202 기준 서술 유지; 현재 비용 재검증 미수행)
+
+공통 성공 계약: Claude exit 0, `result/success` + `is_error=false`, 기대 산출물 `test -s`, 기대
+marker를 모두 확인한다. JSON stdout, stderr, 업무 산출물을 분리하고 parser 앞에 `2>&1`을 두지 않는다.
+반복 테스트는 직전 결과 대비 진척 delta가 없으면 circuit breaker로 중단한다.
 
 ## T1: Harness 인벤토리 검증
 
@@ -17,36 +21,53 @@
 ```bash
 #!/usr/bin/env bash
 # T1: Harness Inventory Check
-RESULT=$(echo "ok" | claude -p --output-format json 2>/dev/null)
+set -o pipefail
+echo "ok" | claude -p --output-format json > /tmp/harness-init.json 2> /tmp/harness-init.stderr
+CLAUDE_RC=${PIPESTATUS[1]}
+test "$CLAUDE_RC" -eq 0 && test -s /tmp/harness-init.json || exit 1
+RESULT=$(< /tmp/harness-init.json)
 
 SKILLS=$(echo "$RESULT" | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 print(len(init.get('skills', [])))")
 
 TOOLS=$(echo "$RESULT" | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 print(len(init.get('tools', [])))")
 
 MCP=$(echo "$RESULT" | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 print(len(init.get('mcp_servers', [])))")
 
 PLUGINS=$(echo "$RESULT" | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 print(len(init.get('plugins', [])))")
+
+RESULT_OK=$(echo "$RESULT" | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+items = data if isinstance(data, list) else [data]
+results = [d for d in items if isinstance(d, dict) and d.get('type')=='result']
+ok = bool(results) and results[-1].get('subtype') == 'success' and not results[-1].get('is_error', False)
+print('yes' if ok else 'no')")
 
 echo "Skills: $SKILLS, Tools: $TOOLS, MCP: $MCP, Plugins: $PLUGINS"
 
 # 판정 기준 (기대값은 환경에 따라 조정)
 PASS=true
+[ "$RESULT_OK" != "yes" ] && echo "FAIL: result event is not successful" && PASS=false
 [ "$SKILLS" -lt 10 ] && echo "FAIL: Skills too few ($SKILLS < 10)" && PASS=false
 [ "$TOOLS" -lt 10 ] && echo "FAIL: Tools too few ($TOOLS < 10)" && PASS=false
 # MCP 서버 0개는 정상이다 (이 저장소는 관리 MCP 서버를 두지 않는다) — MCP 개수 단언 없음
@@ -65,12 +86,14 @@ $PASS && echo "T1: PASS" || echo "T1: FAIL"
 ```bash
 #!/usr/bin/env bash
 # T2: Skill Trigger Spot Check
-RESULT=$(echo "ok" | claude -p --output-format json 2>/dev/null)
+test -s /tmp/harness-init.json || { echo "T2: FAIL (run T1 first)"; exit 1; }
+RESULT=$(< /tmp/harness-init.json)
 
 SKILL_LIST=$(echo "$RESULT" | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 for s in init.get('skills', []):
     print(s)")
 
@@ -169,12 +192,14 @@ if [ ! -f "$MCP_CONFIG" ]; then
   exit 0
 fi
 
-RESULT=$(echo "ok" | claude -p --output-format json 2>/dev/null)
+test -s /tmp/harness-init.json || { echo "T4: FAIL (run T1 first)"; exit 1; }
+RESULT=$(< /tmp/harness-init.json)
 
 MCP_SERVERS=$(echo "$RESULT" | python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 for s in init.get('mcp_servers', []):
     print(s)")
 
@@ -211,20 +236,24 @@ $PASS && echo "T4: PASS" || echo "T4: FAIL"
 #!/usr/bin/env bash
 # T5: Permission Model Check
 PASS=true
+set -o pipefail
 
 # 5a: 권한 없이 도구 사용 → 도구 미실행 (exit 0이지만 도구 못 씀)
-RESULT_NO_PERM=$(echo "ls /tmp | head -1을 실행하고 결과만 출력해" | claude -p --output-format json 2>/dev/null)
-HAS_TOOL_USE=$(echo "$RESULT_NO_PERM" | python3 -c "
+echo "ls /tmp | head -1을 실행하고 결과만 출력해" | claude -p --output-format json \
+  > /tmp/t5-no-perm.json 2> /tmp/t5-no-perm.stderr
+T5A_RC=${PIPESTATUS[1]}
+HAS_TOOL_USE=$(python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-for d in data:
+items = data if isinstance(data, list) else [data]
+for d in items:
     if isinstance(d, dict) and d.get('type')=='assistant':
         for block in d.get('message', {}).get('content', []):
             if isinstance(block, dict) and block.get('type')=='tool_use':
                 print('yes'); exit()
-print('no')" 2>/dev/null)
+print('no')" < /tmp/t5-no-perm.json)
 
-if [ "$HAS_TOOL_USE" = "no" ]; then
+if [ "$T5A_RC" -eq 0 ] && [ "$HAS_TOOL_USE" = "no" ]; then
   echo "  ✓ 5a: Tool blocked without permissions"
 else
   echo "  ✗ 5a: Tool should be blocked without permissions"
@@ -232,14 +261,18 @@ else
 fi
 
 # 5b: 권한 우회 → 도구 실행 성공
-RESULT_WITH_PERM=$(echo "echo T5_CHECK를 Bash로 실행하고 결과만 출력해" | claude -p --dangerously-skip-permissions --output-format json 2>/dev/null)
-HAS_RESULT=$(echo "$RESULT_WITH_PERM" | python3 -c "
+echo "echo T5_CHECK를 Bash로 실행하고 결과만 출력해" | claude -p --dangerously-skip-permissions --output-format json \
+  > /tmp/t5-with-perm.json 2> /tmp/t5-with-perm.stderr
+T5B_RC=${PIPESTATUS[1]}
+HAS_RESULT=$(python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-result = [d for d in data if d.get('type')=='result'][0]
-print('yes' if 'T5_CHECK' in result.get('result', '') else 'no')" 2>/dev/null)
+items = data if isinstance(data, list) else [data]
+result = [d for d in items if isinstance(d, dict) and d.get('type')=='result'][0]
+ok = result.get('subtype') == 'success' and not result.get('is_error', False)
+print('yes' if ok and 'T5_CHECK' in result.get('result', '') else 'no')" < /tmp/t5-with-perm.json)
 
-if [ "$HAS_RESULT" = "yes" ]; then
+if [ "$T5B_RC" -eq 0 ] && [ "$HAS_RESULT" = "yes" ]; then
   echo "  ✓ 5b: Tool allowed with --dangerously-skip-permissions"
 else
   echo "  ✗ 5b: Tool should work with --dangerously-skip-permissions"
@@ -269,9 +302,13 @@ else
   EXPECTED_HOST="greenhead-MacBookPro"
 fi
 
-RESULT=$(echo "hostname을 실행하고 결과만 출력해" | ssh "$REMOTE" 'claude -p --dangerously-skip-permissions' 2>/dev/null)
+set -o pipefail
+echo "hostname을 실행하고 결과만 출력해" | ssh "$REMOTE" 'claude -p --dangerously-skip-permissions' \
+  > /tmp/t6-remote.txt 2> /tmp/t6-remote.stderr
+SSH_RC=${PIPESTATUS[1]}
+RESULT=$(< /tmp/t6-remote.txt)
 
-if echo "$RESULT" | grep -qi "$EXPECTED_HOST"; then
+if [ "$SSH_RC" -eq 0 ] && test -s /tmp/t6-remote.txt && grep -qi "$EXPECTED_HOST" /tmp/t6-remote.txt; then
   echo "  ✓ Remote hostname: $RESULT"
   echo "T6: PASS"
 else
@@ -283,6 +320,8 @@ fi
 판정 로직: 원격 hostname이 기대값과 일치하면 PASS.
 
 > 이 테스트는 SSH 연결이 가능한 환경에서만 실행한다. SSH 연결 실패 시 별도 진단.
+> 무출력 약 10분 뒤 완료된 사례가 있으므로 outer timeout을 두되 무출력만으로 중단하지 않는다.
+> 종료 뒤 기대 결과 파일/marker를 검증한다.
 
 ## T7: 세션 체이닝
 
@@ -294,15 +333,19 @@ fi
 #!/usr/bin/env bash
 # T7: Session Chaining
 SECRET="T7_$(date +%s)"
+set -o pipefail
 
 # 1단계: 비밀 코드 설정 + session_id 추출
-SESSION_ID=$(echo "나의 비밀 코드는 ${SECRET}이야. 확인했으면 '확인'이라고만 답해." | claude -p --output-format json 2>/dev/null | python3 -c "
-import sys, json; data=json.loads(sys.stdin.read())
-for item in data:
+echo "나의 비밀 코드는 ${SECRET}이야. 확인했으면 '확인'이라고만 답해." | claude -p --output-format json \
+  > /tmp/t7-first.json 2> /tmp/t7-first.stderr
+T7_FIRST_RC=${PIPESTATUS[1]}
+SESSION_ID=$(python3 -c "
+import sys, json; data=json.loads(sys.stdin.read()); items=data if isinstance(data,list) else [data]
+for item in items:
     if isinstance(item, dict) and item.get('type')=='system':
-        print(item['session_id']); break")
+        print(item['session_id']); break" < /tmp/t7-first.json)
 
-if [ -z "$SESSION_ID" ]; then
+if [ "$T7_FIRST_RC" -ne 0 ] || [ -z "$SESSION_ID" ]; then
   echo "  ✗ Failed to extract session_id"
   echo "T7: FAIL"
   exit 1
@@ -310,9 +353,12 @@ fi
 echo "  Session: $SESSION_ID"
 
 # 2단계: resume으로 이전 컨텍스트 조회
-RECALL=$(echo "내 비밀 코드가 뭐였어? 코드만 답해." | claude -p --resume "$SESSION_ID" 2>/dev/null)
+echo "내 비밀 코드가 뭐였어? 코드만 답해." | claude -p --resume "$SESSION_ID" \
+  > /tmp/t7-recall.txt 2> /tmp/t7-recall.stderr
+T7_RECALL_RC=${PIPESTATUS[1]}
+RECALL=$(< /tmp/t7-recall.txt)
 
-if echo "$RECALL" | grep -q "$SECRET"; then
+if [ "$T7_RECALL_RC" -eq 0 ] && test -s /tmp/t7-recall.txt && grep -q "$SECRET" /tmp/t7-recall.txt; then
   echo "  ✓ Session recalled: $SECRET"
   echo "T7: PASS"
 else
@@ -334,10 +380,12 @@ fi
 # T8: Concurrent Execution
 TMPDIR=$(mktemp -d)
 
-echo "echo T8_PROC1" | claude -p --dangerously-skip-permissions --no-session-persistence > "$TMPDIR/proc1.txt" 2>&1 &
+echo "echo T8_PROC1" | claude -p --dangerously-skip-permissions --no-session-persistence \
+  > "$TMPDIR/proc1.txt" 2> "$TMPDIR/proc1.stderr" &
 PID1=$!
 
-echo "echo T8_PROC2" | claude -p --dangerously-skip-permissions --no-session-persistence > "$TMPDIR/proc2.txt" 2>&1 &
+echo "echo T8_PROC2" | claude -p --dangerously-skip-permissions --no-session-persistence \
+  > "$TMPDIR/proc2.txt" 2> "$TMPDIR/proc2.stderr" &
 PID2=$!
 
 wait $PID1
@@ -366,6 +414,9 @@ $PASS && echo "T8: PASS" || echo "T8: FAIL"
 
 판정 로직: 두 프로세스 모두 exit 0이고 각각의 출력에 기대 문자열이 포함되면 PASS.
 
+동시 실행 안정성과 `--no-session-persistence`의 충돌 방지 효과는 재검증 미수행
+(v2.1.202 기준 서술 유지).
+
 ---
 
 ## 실행 전략
@@ -384,6 +435,7 @@ $PASS && echo "T8: PASS" || echo "T8: FAIL"
 최적화: T1, T2(그리고 관리 MCP가 있는 경우 T4)는 동일한 init 이벤트를 재사용하므로, 한 번의 `claude -p --output-format json` 호출 결과를 파일에 저장하고 공유한다:
 
 ```bash
-echo "ok" | claude -p --output-format json > /tmp/harness-init.json 2>/dev/null
+echo "ok" | claude -p --output-format json \
+  > /tmp/harness-init.json 2> /tmp/harness-init.stderr
 # T1, T2(그리고 mcp.json이 있으면 T4)에서 /tmp/harness-init.json을 읽어서 판정
 ```

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/harness-testing.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/harness-testing.md
@@ -25,43 +25,22 @@ set -o pipefail
 echo "ok" | claude -p --output-format json > /tmp/harness-init.json 2> /tmp/harness-init.stderr
 CLAUDE_RC=${PIPESTATUS[1]}
 test "$CLAUDE_RC" -eq 0 && test -s /tmp/harness-init.json || exit 1
-RESULT=$(< /tmp/harness-init.json)
 
-SKILLS=$(echo "$RESULT" | python3 -c "
+# 파싱은 한 번으로 통합한다. system 이벤트 부재/JSON 오류 시 python이 non-zero로 죽고
+# || 가드가 즉시 FAIL 처리하므로, 빈 변수로 후속 판정이 오염되지 않는다.
+INV=$(python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
 items = data if isinstance(data, list) else [data]
 init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
-print(len(init.get('skills', [])))")
-
-TOOLS=$(echo "$RESULT" | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-items = data if isinstance(data, list) else [data]
-init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
-print(len(init.get('tools', [])))")
-
-MCP=$(echo "$RESULT" | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-items = data if isinstance(data, list) else [data]
-init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
-print(len(init.get('mcp_servers', [])))")
-
-PLUGINS=$(echo "$RESULT" | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-items = data if isinstance(data, list) else [data]
-init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
-print(len(init.get('plugins', [])))")
-
-RESULT_OK=$(echo "$RESULT" | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-items = data if isinstance(data, list) else [data]
 results = [d for d in items if isinstance(d, dict) and d.get('type')=='result']
 ok = bool(results) and results[-1].get('subtype') == 'success' and not results[-1].get('is_error', False)
-print('yes' if ok else 'no')")
+print(len(init.get('skills', [])))
+print(len(init.get('tools', [])))
+print(len(init.get('mcp_servers', [])))
+print(len(init.get('plugins', [])))
+print('yes' if ok else 'no')" < /tmp/harness-init.json) || { echo "T1: FAIL (JSON parse or missing system event)"; exit 1; }
+{ read -r SKILLS; read -r TOOLS; read -r MCP; read -r PLUGINS; read -r RESULT_OK; } <<< "$INV"
 
 echo "Skills: $SKILLS, Tools: $TOOLS, MCP: $MCP, Plugins: $PLUGINS"
 
@@ -303,7 +282,8 @@ else
 fi
 
 set -o pipefail
-echo "hostname을 실행하고 결과만 출력해" | ssh "$REMOTE" 'claude -p --dangerously-skip-permissions' \
+# outer timeout: 원격 hang 시 무기한 대기 방지 (SSH_RC 124 = timeout 발동; macOS는 coreutils timeout 필요)
+echo "hostname을 실행하고 결과만 출력해" | timeout "${SSH_TIMEOUT:-900}" ssh "$REMOTE" 'claude -p --dangerously-skip-permissions' \
   > /tmp/t6-remote.txt 2> /tmp/t6-remote.stderr
 SSH_RC=${PIPESTATUS[1]}
 RESULT=$(< /tmp/t6-remote.txt)
@@ -339,14 +319,18 @@ set -o pipefail
 echo "나의 비밀 코드는 ${SECRET}이야. 확인했으면 '확인'이라고만 답해." | claude -p --output-format json \
   > /tmp/t7-first.json 2> /tmp/t7-first.stderr
 T7_FIRST_RC=${PIPESTATUS[1]}
+# 성공 계약: exit 0 + session_id만으로 부족하다. result/success까지 검증해야
+# 실패한 첫 세션을 resume 대상으로 쓰는 오판을 막는다 (assert 실패 → non-zero → SESSION_ID 빈 값).
 SESSION_ID=$(python3 -c "
 import sys, json; data=json.loads(sys.stdin.read()); items=data if isinstance(data,list) else [data]
+results=[d for d in items if isinstance(d,dict) and d.get('type')=='result']
+assert results and results[-1].get('subtype')=='success' and not results[-1].get('is_error', False), 'first call result is not successful'
 for item in items:
     if isinstance(item, dict) and item.get('type')=='system':
         print(item['session_id']); break" < /tmp/t7-first.json)
 
 if [ "$T7_FIRST_RC" -ne 0 ] || [ -z "$SESSION_ID" ]; then
-  echo "  ✗ Failed to extract session_id"
+  echo "  ✗ First call did not succeed (result/success or session_id missing)"
   echo "T7: FAIL"
   exit 1
 fi

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/patterns.md
@@ -57,8 +57,8 @@ echo "ls /tmp | head -2를 실행해" | claude -p --allowed-tools "Bash,Read"
 set -o pipefail
 echo "ok" | claude -p --output-format json > /tmp/claude-init.json 2> /tmp/claude-init.stderr
 claude_rc=$pipestatus[2]
-test "$claude_rc" -eq 0
-python3 -c "
+# 검증 실패가 후속 파싱을 막도록 && 게이트로 연결한다 (실패해도 다음 줄이 실행되는 단독 test 금지)
+[ "$claude_rc" -eq 0 ] && test -s /tmp/claude-init.json && python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
 items = data if isinstance(data, list) else [data]
@@ -97,10 +97,9 @@ import sys, json; data=json.loads(sys.stdin.read()); items=data if isinstance(da
 for item in items:
     if isinstance(item, dict) and item.get('type')=='system':
         print(item['session_id']); break" < /tmp/claude-session.json)
-test -n "$SESSION_ID"
-
-# 2단계: 후속 호출 — 이전 세션 이어가기
-echo "내 비밀 코드가 뭐였어?" | claude -p --resume "$SESSION_ID"
+# 2단계: 후속 호출 — SESSION_ID 검증을 && 게이트로 연결 (빈 값이면 resume을 실행하지 않는다)
+test -n "$SESSION_ID" && \
+  echo "내 비밀 코드가 뭐였어?" | claude -p --resume "$SESSION_ID"
 # → "XRAY42"라고 말씀하셨습니다
 ```
 
@@ -131,7 +130,10 @@ cat > /tmp/remote-prompt.md <<'PROMPT'
 hostname과 uptime을 실행하고 결과를 보고한다.
 PROMPT
 
-cat /tmp/remote-prompt.md | ssh minipc 'claude -p --dangerously-skip-permissions'
+# outer timeout으로 원격 hang 시 무기한 대기를 방지한다 (exit 124 = timeout; macOS는 coreutils timeout 필요)
+cat /tmp/remote-prompt.md | timeout 900 ssh minipc 'claude -p --dangerously-skip-permissions' \
+  > /tmp/remote-result.txt 2> /tmp/remote-result.stderr
+test -s /tmp/remote-result.txt
 ```
 
 ### 주의사항
@@ -139,7 +141,8 @@ cat /tmp/remote-prompt.md | ssh minipc 'claude -p --dangerously-skip-permissions
 - SSH non-login shell에서 alias(`c`)가 로드되지 않음 → `claude` full path 사용 필수
 - 3중 중첩 quote를 시도하지 말 것 → 반드시 stdin pipe 패턴 사용
 - MiniPC sshd 180초 무응답 시 연결 해제 → `ssh -o ServerAliveInterval=30` 추가
-- 무출력 약 10분 뒤 완료된 실측이 있다. outer timeout을 두되 무출력만으로 중단하지 않는다.
+- outer timeout은 위 "파일 기반 프롬프트" 예제처럼 호출자가 직접 적용한다 — "기본 패턴"의 최소 예제에는 포함되어 있지 않다.
+- 무출력 약 10분 뒤 완료된 실측이 있다. 무출력만으로 중단하지 않는다.
 - 프로세스 생존만으로 정상이라 판정하지 않고 완료 후 `test -s`로 기대 산출물을 확인한다.
 - 자세한 gotchas: [gotchas.md](gotchas.md) #15, #16, #32
 
@@ -155,7 +158,8 @@ echo "3+7의 결과만 숫자로" | claude -p | xargs -I{} sh -c 'echo "{}에 5�
 주의:
 - 중간 출력이 예상과 다를 수 있으므로, 결과 형식을 명확히 지시해야 한다 ("숫자로만", "JSON으로만" 등)
 - 각 호출은 독립 세션이다 (컨텍스트 공유 없음). 컨텍스트 유지가 필요하면 패턴 4 (세션 체이닝) 사용
-- pipe chain runtime은 재검증 미수행 (v2.1.202 기준 서술 유지). 업무 성공 판정에는 중간 결과를 파일로 분리한다.
+- pipe chain runtime은 재검증 미수행 (v2.1.202 기준 서술 유지).
+- 위 직결 예제는 빠른 실험 전용이다. 업무 성공 판정이 필요하면 이 패턴 대신 각 호출의 출력을 파일로 분리하고 exit·기대 marker를 검증한다 (SKILL.md 셸 transport 계약 참조).
 
 ## 패턴 7: 동시 실행
 
@@ -300,10 +304,18 @@ cat untrusted-skill.md | claude -p --allowed-tools "Read,Grep,Glob" --output-for
 
 ```bash
 SCHEMA='{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}'
+set -o pipefail
 echo "현재 변경을 한 문장으로 요약해" | claude -p \
   --output-format json --json-schema "$SCHEMA" \
   > /tmp/structured.json 2> /tmp/structured.stderr
-test -s /tmp/structured.json
+claude_rc=${PIPESTATUS[1]}
+[ "$claude_rc" -eq 0 ] && test -s /tmp/structured.json && python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+items = data if isinstance(data, list) else [data]
+results = [d for d in items if isinstance(d, dict) and d.get('type')=='result']
+assert results and results[-1].get('subtype')=='success' and not results[-1].get('is_error', False), 'result is not successful'
+print('structured output OK')" < /tmp/structured.json
 ```
 
 `--json-schema`는 2.1.206 help에 있고, 무효 schema가 모델 호출 전에 즉시 실패하는 동작은
@@ -312,11 +324,14 @@ v2.1.205에서 실측했다. 성공 payload의 세부 필드는 고정하지 말
 ## 패턴 11: `--bare` 격리 실행
 
 ```bash
-test -n "$ANTHROPIC_API_KEY"
+test -n "$ANTHROPIC_API_KEY" || echo "FAIL: API key required for --bare"
+set -o pipefail
 echo "주입한 prompt만 사용해 한 줄로 답해" | \
   env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude -p --bare --output-format json \
   > /tmp/bare.json 2> /tmp/bare.stderr
-test -s /tmp/bare.json
+claude_rc=${PIPESTATUS[1]}
+# json 출력이므로 test -s만으로는 부족하다 — 패턴 8과 동일하게 result/success까지 파싱해 판정한다.
+[ "$claude_rc" -eq 0 ] && test -s /tmp/bare.json
 ```
 
 `--bare`는 hooks, LSP, plugin sync, attribution, auto-memory, background prefetch, keychain read,
@@ -327,14 +342,15 @@ settings `apiKeyHelper` 경로가 필요하며, skills는 계속 resolve된다 (
 
 ```bash
 SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+set -o pipefail
 echo "첫 단계" | claude -p --session-id "$SESSION_ID" \
   > /tmp/session-first.txt 2> /tmp/session-first.stderr
-test -s /tmp/session-first.txt
-
+# 첫 호출의 exit·산출물 검증을 통과해야만 fork를 실행한다 (text 출력이므로 result 이벤트 검증은 불가)
+[ "${PIPESTATUS[1]}" -eq 0 ] && test -s /tmp/session-first.txt && \
 echo "이전 context에서 새 session으로 분기해" | \
   claude -p --resume "$SESSION_ID" --fork-session \
   > /tmp/session-fork.txt 2> /tmp/session-fork.stderr
-test -s /tmp/session-fork.txt
+[ "${PIPESTATUS[1]}" -eq 0 ] && test -s /tmp/session-fork.txt
 ```
 
 `--session-id`의 UUID 요구와 `--fork-session` surface는 2.1.206 help에서 확인했다. 실제 context

--- a/modules/shared/programs/claude/files/skills/using-claude-p/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-claude-p/references/patterns.md
@@ -2,6 +2,10 @@
 
 각 패턴은 Claude Code 세션 안팎에서 동일하게 재현 가능한 순수 셸 명령으로 작성한다.
 
+JSON/JSONL 호출은 stdout, stderr, 업무 산출물을 분리한다. parser 앞 `2>&1`, 판정 pipeline의
+`head`/`tail`, 원 exit를 가리는 후속 `echo $?`를 금지한다. pipeline은 `set -o pipefail`과 zsh
+`pipestatus`로 Claude exit를 즉시 보존한다.
+
 ## 패턴 1: 기본 사용 — 인라인 프롬프트 / stdin pipe
 
 가장 기본적인 실행. 단순 질의에 사용한다.
@@ -24,22 +28,23 @@ cat /tmp/prompt.md | claude -p
 - 긴 프롬프트는 파일로 작성 후 stdin pipe로 전달
 - ⚠️ `--allowed-tools` 사용 시 인라인 프롬프트가 도구 이름으로 먹힘 → stdin 필수 ([gotchas.md](gotchas.md) #1)
 
-## 패턴 2: 도구 실행 — 권한 우회
+## 패턴 2: 도구 실행 — 제한 여부 선택
 
-도구 사용이 필요한 경우 `--dangerously-skip-permissions` 필수 (비대화형에서는 TTY가 없어 권한 프롬프트 불가).
+도구 제한이 필요 없을 때만 `--dangerously-skip-permissions`를 단독 사용한다.
 
 ```bash
 echo "hostname 명령을 실행하고 결과만 보고해" | claude -p --dangerously-skip-permissions
 # → greenhead-MacBookPro.local
 ```
 
-도구를 제한하려면 `--allowed-tools`를 조합한다:
+도구를 제한하려면 skip-permissions 없이 variadic flag 뒤 prompt를 stdin으로 전달한다.
 
 ```bash
-echo "ls /tmp | head -2를 실행해" | claude -p --dangerously-skip-permissions --allowed-tools "Bash,Read"
+echo "ls /tmp | head -2를 실행해" | claude -p --allowed-tools "Bash,Read"
 ```
 
 주의:
+- `--dangerously-skip-permissions`와 `--allowed-tools` 병용은 allowlist를 구조적으로 무효화하므로 금지
 - `--max-turns 1`이면 도구 실행 불가 (최소 2턴 필요, [gotchas.md](gotchas.md) #2)
 - 도구 거부 시 exit code는 여전히 0 ([gotchas.md](gotchas.md) #3)
 - `--tools ""`로 빌트인 비활성화해도 MCP는 남아있음 ([gotchas.md](gotchas.md) #5)
@@ -48,27 +53,33 @@ echo "ls /tmp | head -2를 실행해" | claude -p --dangerously-skip-permissions
 
 `--output-format json`의 init 이벤트에 전체 harness 정보가 포함된다. 스킬, 도구, MCP, 플러그인 전수 검사에 핵심.
 
-```bash
-echo "ok" | claude -p --output-format json | python3 -c "
+```zsh
+set -o pipefail
+echo "ok" | claude -p --output-format json > /tmp/claude-init.json 2> /tmp/claude-init.stderr
+claude_rc=$pipestatus[2]
+test "$claude_rc" -eq 0
+python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 print(f'Session: {init[\"session_id\"]}')
 print(f'Skills: {len(init.get(\"skills\", []))}')
 print(f'Tools: {len(init.get(\"tools\", []))}')
 print(f'MCP servers: {len(init.get(\"mcp_servers\", []))}')
-print(f'Plugins: {len(init.get(\"plugins\", []))}')"
+print(f'Plugins: {len(init.get(\"plugins\", []))}')" < /tmp/claude-init.json
 ```
 
 스킬 이름만 추출:
 
 ```bash
-echo "ok" | claude -p --output-format json | python3 -c "
+python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-init = [d for d in data if isinstance(d, dict) and d.get('type')=='system'][0]
+items = data if isinstance(data, list) else [data]
+init = [d for d in items if isinstance(d, dict) and d.get('type')=='system'][0]
 for s in sorted(init.get('skills', [])):
-    print(f'  {s}')"
+    print(f'  {s}')" < /tmp/claude-init.json
 ```
 
 이 패턴이 harness 셀프테스트 T1의 기반이다. [harness-testing.md](harness-testing.md) T1 참조.
@@ -79,11 +90,14 @@ for s in sorted(init.get('skills', [])):
 
 ```bash
 # 1단계: 첫 호출 — session_id 추출
-SESSION_ID=$(echo "나의 비밀 코드는 XRAY42야" | claude -p --output-format json | python3 -c "
-import sys, json; data=json.loads(sys.stdin.read())
-for item in data:
+echo "나의 비밀 코드는 XRAY42야" | claude -p --output-format json \
+  > /tmp/claude-session.json 2> /tmp/claude-session.stderr
+SESSION_ID=$(python3 -c "
+import sys, json; data=json.loads(sys.stdin.read()); items=data if isinstance(data,list) else [data]
+for item in items:
     if isinstance(item, dict) and item.get('type')=='system':
-        print(item['session_id']); break")
+        print(item['session_id']); break" < /tmp/claude-session.json)
+test -n "$SESSION_ID"
 
 # 2단계: 후속 호출 — 이전 세션 이어가기
 echo "내 비밀 코드가 뭐였어?" | claude -p --resume "$SESSION_ID"
@@ -94,6 +108,9 @@ echo "내 비밀 코드가 뭐였어?" | claude -p --resume "$SESSION_ID"
 - 다단계 작업을 여러 `-p` 호출로 분할
 - 첫 호출에서 컨텍스트 설정 → 후속 호출에서 실행
 - 스테이트풀한 검증 시나리오
+
+`--resume` help surface는 2.1.206에서 확인했지만 context chaining runtime은 재검증 미수행
+(v2.1.202 기준 서술 유지).
 
 ## 패턴 5: SSH 경유 크로스머신
 
@@ -121,7 +138,9 @@ cat /tmp/remote-prompt.md | ssh minipc 'claude -p --dangerously-skip-permissions
 
 - SSH non-login shell에서 alias(`c`)가 로드되지 않음 → `claude` full path 사용 필수
 - 3중 중첩 quote를 시도하지 말 것 → 반드시 stdin pipe 패턴 사용
-- MiniPC sshd 180초 무응답 시 연결 해제 → 장시간 실행 시 `ssh -o ServerAliveInterval=30` 추가
+- MiniPC sshd 180초 무응답 시 연결 해제 → `ssh -o ServerAliveInterval=30` 추가
+- 무출력 약 10분 뒤 완료된 실측이 있다. outer timeout을 두되 무출력만으로 중단하지 않는다.
+- 프로세스 생존만으로 정상이라 판정하지 않고 완료 후 `test -s`로 기대 산출물을 확인한다.
 - 자세한 gotchas: [gotchas.md](gotchas.md) #15, #16, #32
 
 ## 패턴 6: pipe chain — 출력을 다음 입력으로
@@ -136,6 +155,7 @@ echo "3+7의 결과만 숫자로" | claude -p | xargs -I{} sh -c 'echo "{}에 5�
 주의:
 - 중간 출력이 예상과 다를 수 있으므로, 결과 형식을 명확히 지시해야 한다 ("숫자로만", "JSON으로만" 등)
 - 각 호출은 독립 세션이다 (컨텍스트 공유 없음). 컨텍스트 유지가 필요하면 패턴 4 (세션 체이닝) 사용
+- pipe chain runtime은 재검증 미수행 (v2.1.202 기준 서술 유지). 업무 성공 판정에는 중간 결과를 파일로 분리한다.
 
 ## 패턴 7: 동시 실행
 
@@ -153,34 +173,46 @@ wait
 - 다른 프롬프트를 동시에 평가
 - CI에서 독립적인 검증 작업 병렬화
 
+재검증 미수행 (v2.1.202 기준 서술 유지): 같은 directory 동시 실행 안정성과
+`--no-session-persistence`의 충돌 방지 효과.
+
 ## 패턴 8: JSON 결과 파싱
 
 `--output-format json` 출력에서 필요한 정보를 추출하는 패턴.
 
 ### 텍스트 응답 추출
 
-```bash
-echo "2+3" | claude -p --output-format json | python3 -c "
+```zsh
+set -o pipefail
+echo "2+3" | claude -p --output-format json > /tmp/claude-result.json 2> /tmp/claude-result.stderr
+claude_rc=$pipestatus[2]
+python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-result = [d for d in data if d.get('type')=='result'][0]
-print(result['result'])"
+items = data if isinstance(data, list) else [data]
+result = [d for d in items if isinstance(d, dict) and d.get('type')=='result'][0]
+if result.get('subtype') != 'success' or result.get('is_error', False):
+    raise SystemExit('result event is not a successful task result')
+print(result.get('result', ''))" < /tmp/claude-result.json
+test "$claude_rc" -eq 0
 # → 5
 ```
 
 ### result subtype 확인
 
 ```bash
-echo "prompt" | claude -p --output-format json | python3 -c "
+python3 -c "
 import sys, json
 data = json.loads(sys.stdin.read())
-result = [d for d in data if d.get('type')=='result'][0]
+items = data if isinstance(data, list) else [data]
+result = [d for d in items if isinstance(d, dict) and d.get('type')=='result'][0]
 print(f'subtype: {result.get(\"subtype\")}')
-print(f'is_error: {result.get(\"is_error\", False)}')"
+print(f'is_error: {result.get(\"is_error\", False)}')" < /tmp/claude-result.json
 ```
 
-subtype 종류: `success`, `error_max_turns`, `error_max_budget_usd`, `error_during_execution` 등 6종.
-⚠️ `success`와 `error_during_execution`만 exit code가 다르다 (나머지는 모두 0). [gotchas.md](gotchas.md) #29 참조.
+정상 성공 경로는 2.1.206에서 top-level 4-event 배열, `subtype=success`, `is_error=false`,
+exit 0이었다. auth 실패 경로는 `subtype=success`, `is_error=true`, exit 1도 가능하다. subtype
+목록과 exit mapping을 exhaustive 계약으로 사용하지 않는다. [gotchas.md](gotchas.md) #29 참조.
 
 ### stream-json (JSONL) 파싱
 
@@ -194,6 +226,8 @@ done
 # Event: rate_limit_event
 # Event: result
 ```
+
+stream-json wire shape는 재검증 미수행 (v2.1.202 기준 서술 유지). parser는 stderr를 섞지 않는다.
 
 ## 패턴 9: 미설치 플러그인 스킬을 stdin 주입으로 우회
 
@@ -243,6 +277,7 @@ esac
 cat "${CAT_FILES[@]}" \
   | MY_TOKEN="xxx" claude -p --output-format text --dangerously-skip-permissions \
   > /tmp/result.md 2>/tmp/stderr.txt
+test -s /tmp/result.md
 ```
 
 ### 주의사항
@@ -259,6 +294,52 @@ cat "${CAT_FILES[@]}" \
 cat untrusted-skill.md | claude -p --allowed-tools "Read,Grep,Glob" --output-format text
 ```
 
+대용량 stdin·plugin indexing runtime은 재검증 미수행 (v2.1.202 기준 서술 유지).
+
+## 패턴 10: JSON Schema 구조화 출력
+
+```bash
+SCHEMA='{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}'
+echo "현재 변경을 한 문장으로 요약해" | claude -p \
+  --output-format json --json-schema "$SCHEMA" \
+  > /tmp/structured.json 2> /tmp/structured.stderr
+test -s /tmp/structured.json
+```
+
+`--json-schema`는 2.1.206 help에 있고, 무효 schema가 모델 호출 전에 즉시 실패하는 동작은
+v2.1.205에서 실측했다. 성공 payload의 세부 필드는 고정하지 말고 패턴 8처럼 `type=result`를 찾는다.
+
+## 패턴 11: `--bare` 격리 실행
+
+```bash
+test -n "$ANTHROPIC_API_KEY"
+echo "주입한 prompt만 사용해 한 줄로 답해" | \
+  env ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude -p --bare --output-format json \
+  > /tmp/bare.json 2> /tmp/bare.stderr
+test -s /tmp/bare.json
+```
+
+`--bare`는 hooks, LSP, plugin sync, attribution, auto-memory, background prefetch, keychain read,
+CLAUDE.md auto-discovery를 skip하고 `CLAUDE_CODE_SIMPLE=1`을 설정한다. auth는 API key 또는
+settings `apiKeyHelper` 경로가 필요하며, skills는 계속 resolve된다 (2.1.206 help).
+
+## 패턴 12: session ID 고정·fork
+
+```bash
+SESSION_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+echo "첫 단계" | claude -p --session-id "$SESSION_ID" \
+  > /tmp/session-first.txt 2> /tmp/session-first.stderr
+test -s /tmp/session-first.txt
+
+echo "이전 context에서 새 session으로 분기해" | \
+  claude -p --resume "$SESSION_ID" --fork-session \
+  > /tmp/session-fork.txt 2> /tmp/session-fork.stderr
+test -s /tmp/session-fork.txt
+```
+
+`--session-id`의 UUID 요구와 `--fork-session` surface는 2.1.206 help에서 확인했다. 실제 context
+round-trip은 재검증 미수행 (v2.1.202 기준 서술 유지).
+
 ---
 
 ## 빠른 참조 표
@@ -274,3 +355,6 @@ cat untrusted-skill.md | claude -p --allowed-tools "Read,Grep,Glob" --output-for
 | 병렬 실행 | 7 | `claude -p ... &` + `--no-session-persistence` |
 | 결과 파싱 | 8 | `--output-format json` → python3 파싱 |
 | 미설치 스킬 stdin 주입 | 9 | `cat SKILL.md agent.md \| claude -p` |
+| 구조화 출력 | 10 | `--json-schema` + JSON event parser |
+| 최소화 실행 | 11 | API key/helper + `--bare` |
+| session 고정·분기 | 12 | `--session-id` / `--fork-session` |

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -1,24 +1,33 @@
 ---
 name: using-codex-exec
-description: |
-  Run Codex CLI non-interactive (codex exec, codex review).
-  Trigger: 'codex exec', 'codex 실행', '비대화형 codex', 'codex review', '--yolo'.
-  NOT for Codex settings/skill projection. NOT for claude -p (use using-claude-p).
+description: >-
+  Run Codex CLI subprocesses for explicit codex exec requests, Claude Code or headless automation,
+  and non-interactive code review. Use when requests mention `codex exec` or `비대화형 codex`.
+  Use using-claude-p for Claude headless execution.
 ---
 
 # Codex Exec 사용
 
-이 문서는 `codex exec` / `codex exec review`를 직접 호출하는 절차를 다룬다.
-이 스킬은 다음 경로에서 참조된다:
-- Claude Code 세션: `run-da`(audit 모드 포함) 등의 fan-out 시 기본 경로 (codex exec subprocess)
-- headless 세션: CI, `codex exec` subprocess 등에서의 codex exec 직접 실행 (`claude -p` 자체의 사용법은 using-claude-p 스킬 참조)
-- Codex 세션: fan-out은 native subagent가 기본이므로, 이 스킬은 사용자의 명시적 `codex exec` 요청에만 적용
+이 문서는 `codex exec` / `codex exec review` subprocess의 라우팅과 성공 계약을 다룬다.
+상세 명령·제약의 SSOT는 [patterns.md](references/patterns.md)와
+[known-issues.md](references/known-issues.md)이며, 본문은 선택 기준과 필수 절차만 요약한다.
+
+## 실행 경로 게이트
+
+| 실행 문맥 | 선택 경로 | 적용 조건 |
+|----------|----------|----------|
+| Direct Codex 세션의 review/audit/planning fan-out | native subagent | 기본 경로. nested `codex exec`를 선택하지 않는다. |
+| Claude Code 세션·headless 자동화 | `codex-exec-supervised` (Layer 1) | stdin EOF + process group + timeout 보장이 필요한 programmatic 호출. [known-issues.md §15](references/known-issues.md#15-codex-exec-supervised-wrapper로-14-위에-process-grouptimeout-한계-보강-issue-593) 참조. |
+| 사용자가 literal raw 실행을 요청했거나 1회성 수동 진단 | raw `codex exec` | alias를 피하도록 `command codex` 또는 `env ... codex`로 호출한다. |
+
+`run-da`·`codex-fan-out`은 각 스킬의 라우팅 계약이 우선한다. Direct Codex 세션에서
+subprocess fallback이 필요하면 해당 스킬이 요구하는 별도 사용자 승인을 먼저 받는다.
 
 ## 작성 기준
 
-- 확인 날짜: 2026-07-03
-- 확인 버전: codex-cli 0.142.5
-- 재검증: `codex --version && codex exec --help && codex exec review --help`
+- 확인 날짜: 2026-07-10
+- 확인 버전: codex-cli 0.144.1
+- 재검증: `command codex --version && command codex exec --help && command codex exec review --help && command codex exec resume --help`
 
 CLI 버전이 바뀌면 플래그/동작이 달라질 수 있으므로, 실행 전 도움말로 확인한다.
 
@@ -59,9 +68,10 @@ codex exec 실행이 필요한가?
 │
 ├─ 세션 재개인가?
 │  └─ YES → codex exec resume --last 또는 <session-id>
-│           ⚠️ --ephemeral 세션은 resume 불가
+│           ⚠️ --ephemeral 원본은 0.144.1에서 새 세션으로 silent fallback 가능
+│           → stderr/session id와 응답 context로 실제 재개 여부 검증
 │
-└─ 일반 실행 → codex exec -s workspace-write [-o result.md]
+└─ 일반 실행 → 위 실행 경로 게이트로 raw/supervised 선택
                → references/patterns.md 패턴 1 참조
 ```
 
@@ -73,13 +83,15 @@ codex exec 실행이 필요한가?
 | `codex review` | top-level alias (⚠️ `codex exec review`와 다름 — 아래 gotcha §5 참조) |
 | `--yolo` | `--dangerously-bypass-approvals-and-sandbox`의 숨은 alias |
 
+대화형 zsh의 `codex` alias가 bypass 플래그를 자동 부착할 수 있다. 예제는 alias를 거치지 않는
+`command codex` 또는 `env CODEX_PROGRAMMATIC=1 codex` 형태만 사용한다.
+
 ## 호환성 매트릭스
 
-### exec 전용 플래그 (review 미지원)
+### exec 전용 플래그 (review/resume 미지원)
 
 | 플래그 | 설명 |
 |--------|------|
-| `-i, --image <FILE>...` | 이미지 첨부 (0.142.5 기준 다중 지정 가능) |
 | `-s, --sandbox <SANDBOX_MODE>` | 샌드박스 정책 (read-only, workspace-write, danger-full-access) — review/resume은 미지원 |
 | `-C, --cd <DIR>` | 작업 디렉토리 지정 |
 | `--add-dir <DIR>` | 추가 쓰기 가능 디렉토리 |
@@ -88,6 +100,19 @@ codex exec 실행이 필요한가?
 | `-p, --profile <CONFIG_PROFILE_V2>` | `$CODEX_HOME/<name>.config.toml`을 기본 유저 config 위에 레이어 |
 | `--color <COLOR>` | 색상 설정 (always/never/auto) |
 
+### exec · resume image 플래그
+
+| 명령 | 플래그 | 설명 |
+|------|--------|------|
+| exec | `-i, --image <FILE>...` | 이미지 여러 개 첨부 가능 |
+| resume | `-i, --image <FILE>` | 재개 turn에 이미지 한 개 첨부 가능 (0.144.1 help 재확인) |
+
+review에는 image 플래그가 없다.
+
+별도 `codex sandbox` subcommand의 공개 permission-profile 표기는
+`-P, --permission-profile <NAME>`이다. `codex exec -s`의 대체 표기가 아니며
+`--sandbox-permission-profile`은 0.144.1에서 `unexpected argument`로 거부된다.
+
 ### review 전용 플래그
 
 | 플래그 | 설명 |
@@ -95,7 +120,7 @@ codex exec 실행이 필요한가?
 | `--uncommitted` | 미커밋 변경 리뷰 |
 | `--base <BRANCH>` | 베이스 브랜치 대비 리뷰 |
 | `--commit <SHA>` | 특정 커밋 리뷰 |
-| `--title <TITLE>` | 리뷰 요약 제목 (scope flag와 조합 가능, 상호 배타 규칙에 미참여. 단독 사용 시 `--commit <SHA>` 필요 — 재확인: 2026-07-03, 0.142.5) |
+| `--title <TITLE>` | 리뷰 요약 제목 (scope flag와 조합 가능, 상호 배타 규칙에 미참여. 단독 사용 시 `--commit <SHA>` 필요 — 재확인: 2026-07-10, 0.144.1) |
 
 ### exec · review · resume 공통 플래그
 
@@ -104,7 +129,7 @@ codex exec 실행이 필요한가?
 | `-c, --config <key=value>` | config 오버라이드 |
 | `--enable <FEATURE>` | 피처 활성화 |
 | `--disable <FEATURE>` | 피처 비활성화 |
-| `--strict-config` | config.toml에 인식 불가 필드가 있으면 에러 (신규, 0.142.5) |
+| `--strict-config` | 전달한 `-c`뿐 아니라 로드된 config 전체의 미인식 필드를 오류로 처리. capability probe는 `--ignore-user-config --strict-config`로 user config drift를 격리 |
 | `-m, --model <MODEL>` | 모델 선택 (생략 권장 — config.toml 기본값 사용) |
 | `--output-schema <FILE>` | JSON Schema 출력 형식 — 0.142.5부터 review/resume도 지원 (이전에는 exec 전용) |
 | `--dangerously-bypass-approvals-and-sandbox` | 샌드박스 우회 (`--yolo` 숨은 alias) |
@@ -114,11 +139,11 @@ codex exec 실행이 필요한가?
 | `--ignore-user-config` | `$CODEX_HOME/config.toml` 로드 차단 (auth만 유지) |
 | `--ignore-rules` | user/project execpolicy `.rules` 파일 로드 차단 |
 | `--json` | JSONL 이벤트 출력 |
-| `-o, --output-last-message <FILE>` | 마지막 메시지 파일 저장 (review의 upstream bug #12502는 0.142.5에서 해소됨 — known-issues.md §2 참조) |
+| `-o, --output-last-message <FILE>` | 마지막 메시지 파일 저장. review에서 `-o`·stdout 모두 정상 (0.144.1 실측); upstream #12502의 open 상태와 로컬 동작은 분리 — known-issues.md §2 참조 |
 
-⚠️ 승인(approval) 관련 CLI 플래그는 존재하지 않는다. `exec`/`review`/`resume`은 headless 실행이므로 승인 프롬프트 자체가 불가능하고, approval은 항상 `never`로 고정된다 (`--ignore-user-config`로 확인한 CLI 기본값 기준, 2026-07-03 실측). 과거 버전에 있던 자동 실행 플래그(승인 자동화 + `--sandbox workspace-write`를 한 번에 지정)는 0.142.5에서 완전히 제거되었다. 동일 의도의 실행은 아래로 대체한다:
+⚠️ 승인(approval) 관련 공개 CLI 플래그는 존재하지 않는다. `exec`/`review`/`resume`은 headless 실행이므로 승인 프롬프트 자체가 불가능하고, approval은 항상 `never`로 고정된다 (재검증 미수행: 0.142.5 기준 서술 유지). 과거 단축 플래그 `--full-auto`는 0.144.1 help에는 없지만 hidden parser가 수용하고 `--sandbox workspace-write` 사용을 안내하는 deprecation warning을 낸다. 새 문서·스크립트에서는 아래 공개 surface를 사용한다:
 
-- `exec`: `-s workspace-write` (승인은 이미 자동이므로 샌드박스 tier만 지정하면 된다)
+- `exec`: `-s workspace-write`로 sandbox tier만 지정한다
 - `review`/`resume`: 전용 sandbox 플래그가 없으므로 `config.toml`의 `sandbox_mode`를 따르거나, 필요 시 `--dangerously-bypass-approvals-and-sandbox`를 사용한다
 
 ### ⚠️ review 상호 배타 규칙
@@ -139,30 +164,48 @@ error: the argument '[PROMPT]' cannot be used with '--base <BRANCH>'
 error: the argument '--base <BRANCH>' cannot be used with '--uncommitted'
 ```
 
-재확인: 2026-07-03, 0.142.5에서도 4개 변형 모두 동일하게 상호 배타 유지됨 (완화되지 않음).
+재확인: 2026-07-10, 0.144.1에서 여섯 pairwise 조합 모두 상호 배타 유지. upstream #7825는 closed-as-not-planned이며, 이슈 상태와 runtime 제약을 분리한다.
 
 근본 원인과 상세 분석: [references/known-issues.md](references/known-issues.md) §1
 
 ## 입력 방법
 
-표 안의 모든 `codex exec` 호출에는 `env CODEX_PROGRAMMATIC=1`을 codex 프로세스에 적용한다 (issue #585: Codex 0.124+ user-level hooks의 early-exit 신호).
+programmatic 호출에는 `CODEX_PROGRAMMATIC=1`을 Codex 프로세스에 적용한다. 이 값은 CLI가
+자동 주입하지 않는 caller 계약이다 (재확인: 2026-07-10, 0.144.1 환경변수 부재 실측).
 
 | 방법 | 예시 |
 |------|------|
-| 인라인 문자열 | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "짧은 질의"` |
-| stdin 파이프 | `cat prompt.md \| env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result.md` |
-| stdin 마커 | `env CODEX_PROGRAMMATIC=1 codex exec review -` (stdin에서 읽음) |
-| 파일 리다이렉트 | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write < prompt.md -o result.md` |
-| here-doc | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write <<'EOF' ... EOF` |
+| 인라인 문자열 (raw 수동) | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "짧은 질의"` |
+| stdin 파이프 (programmatic) | `cat prompt.md \| env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o result.md -` |
+| stdin 마커 (raw review) | `cat prompt.md \| env CODEX_PROGRAMMATIC=1 codex exec review -` |
+| 파일 리다이렉트 (raw 수동) | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result.md < prompt.md` |
+| here-doc (raw 수동) | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write <<'EOF' ... EOF` |
 
-⚠️ PROMPT 인자와 stdin을 동시에 사용하는 경우(0.142.5 신규 동작, `codex exec --help` 기준): stdin이 파이프된 상태에서 PROMPT 인자도 함께 주어지면, stdin 내용이 프롬프트에 `<stdin>` 블록으로 append된다. 이전 버전에서는 이 조합의 동작이 문서화되어 있지 않았다. 위 표의 각 방법은 여전히 단독 사용을 기본으로 하되, 혼용 시 이 append 동작을 인지한다.
+PROMPT 인자와 piped stdin을 함께 주면 stdin 내용이 `<stdin>` 블록으로 append된다
+(재확인: 2026-07-10, 0.144.1). `-` 마커는 PROMPT 인자의 대체재이므로 다른 PROMPT 인자와
+동시에 쓰면 `error: unexpected argument '-' found`로 실패한다.
+
+## 셸 transport 계약
+
+- stdout, stderr, `-o` 결과를 서로 다른 파일에 저장한다. JSON/JSONL parser 앞에서 `2>&1`로
+  stderr를 합치면 파싱이 깨진다.
+- pipeline에는 `set -o pipefail`을 적용한다. zsh에서 Codex 자체 exit가 필요하면 pipeline 직후
+  `codex_rc=$pipestatus[2]`로 보존한다.
+- `| head`, `| tail`, 뒤이은 `; echo $?`는 원래 exit를 가릴 수 있으므로 판정 경로에 두지 않는다.
+
+```zsh
+set -o pipefail
+cat prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o result.md - >stdout.log 2>stderr.log
+codex_rc=$pipestatus[2]
+```
 
 ## 표준 실행 절차
 
-NixOS에서 `-s read-only` / `-s workspace-write`를 구조적으로 강제하려면 `bubblewrap`이
-PATH에 있어야 한다. bwrap 의존성, 임시 우회, tier별 실측은 [known-issues.md §16](references/known-issues.md#16-nixos-bwrap-의존)을 참조한다.
+NixOS에서 `-s read-only` / `-s workspace-write`는 bubblewrap 경로를 사용한다. system bwrap 부재 시
+bundled fallback과 nested bwrap 기각 결과는 [known-issues.md §16](references/known-issues.md#16-nixos-bwrap-의존)을 참조한다.
 
-### 일반 exec
+### 일반 exec — Claude Code·headless 자동화
 
 프롬프트를 파일로 작성하고, stdin 파이프로 전달하며, `-o`로 결과를 저장한다:
 
@@ -176,25 +219,32 @@ PROMPT
 
 ```bash
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
-cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/result.md 2>&1
+cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o /tmp/result.md - \
+  > /tmp/stdout.log 2> /tmp/stderr.log
+test -s /tmp/result.md
 ```
 
-인라인 프롬프트도 가능하다 (짧은 질의에 한해):
+사용자가 literal raw 실행을 요청한 1회성 수동 진단에서는 인라인 프롬프트도 가능하다:
 
 ```bash
 env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "git diff 기준으로 회귀 가능성 한 줄 요약"
 ```
 
-### 코드 리뷰 — scope flag만 사용 (커스텀 지시 불필요)
+### 코드 리뷰 — scope flag만 사용 (Claude Code·headless 자동화)
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
-env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted > /tmp/review.md 2>&1
-env CODEX_PROGRAMMATIC=1 codex exec review --commit <sha> > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
+  -o /tmp/review.md > /tmp/review-stdout.log 2> /tmp/review-stderr.log
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --uncommitted \
+  -o /tmp/review.md > /tmp/review-stdout.log 2> /tmp/review-stderr.log
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit <sha> \
+  -o /tmp/review.md > /tmp/review-stdout.log 2> /tmp/review-stderr.log
 ```
 
-review 결과 저장에는 `-o`(`--output-last-message`) 또는 stdout 리다이렉트(`> file 2>&1`) 둘 다 사용 가능하다.
-`-o`가 빈 파일을 생성하던 upstream bug(#12502)는 0.142.5에서 해소됨 (재확인: 2026-07-03, known-issues.md §2 참조). 과거 문서/스크립트가 이 회피책으로 stdout 리다이렉트를 쓰고 있다면 그대로 두어도 무방하다 — 대체 필수는 아니다.
+review 결과 저장에는 `-o`(`--output-last-message`)와 stdout이 모두 동작한다
+(재확인: 2026-07-10, 0.144.1). upstream #12502는 open이지만 로컬에서는 stderr 회귀가
+재현되지 않았다. 이슈 상태와 로컬 동작은 [known-issues.md §2](references/known-issues.md)를 참조한다.
 
 ### 코드 리뷰 — 커스텀 지시 필요
 
@@ -206,6 +256,8 @@ PROMPT과 scope flag이 상호 배타이므로, 두 가지 대안 중 선택한�
 scope flag으로 review를 실행하면 지시가 자동 적용된다.
 (지시 파일 우선순위: [references/patterns.md](references/patterns.md) 패턴 3 참조)
 
+재검증 미수행 (0.142.5 기준 서술 유지): AGENTS instruction의 실제 적용과 우선순위.
+
 방법 B — exec 우회 (1회성 지시, 최대 유연성)
 
 `codex exec` (review 미사용)에 `git diff` 출력과 커스텀 지시를 프롬프트로 직접 전달한다.
@@ -215,28 +267,57 @@ scope flag으로 review를 실행하면 지시가 자동 적용된다.
 
 ### 세션 재개
 
+Claude Code/headless의 programmatic 재개는 supervised 경로를 사용한다:
+
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec resume --last          # 마지막 세션 재개
-env CODEX_PROGRAMMATIC=1 codex exec resume <session-id>    # 특정 세션 재개
-env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제하여 전체 세션 중 최신 재개
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume --last          # 마지막 세션 재개
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume <session-id>    # 특정 세션 재개
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume --last --all    # cwd 필터 해제하여 전체 세션 중 최신 재개
 ```
 
-⚠️ `--ephemeral` 세션은 파일이 저장되지 않으므로 resume 불가. `No saved session found` 에러 발생.
+사용자가 요청한 1회성 수동 진단은 alias를 피하도록 raw `command codex exec resume --last`를 사용할 수 있다.
+
+`--ephemeral` 세션은 저장되지 않는다. 0.144.1에서 저장 세션이 없는 cwd의
+`resume --last`는 오류 대신 새 session id로 조용히 시작해 exit 0을 반환했다. resume 성공 여부를
+exit code만으로 판정하지 말고 stderr banner의 session id와 응답 context가 원 세션과 이어지는지 확인한다.
+
+## 성공 계약
+
+프로세스 exit만으로 업무 성공을 판정하지 않는다. 아래 네 조건을 모두 확인한다.
+
+1. wrapper/CLI exit가 0이다.
+2. stderr에 timeout, usage limit, sandbox denial, unsupported model 오류가 없다.
+3. 기대 산출물이 존재하고 비어 있지 않다: `test -s "$RESULT"`.
+4. 반복 라운드라면 직전 결과 대비 새 finding·수정·판정 같은 진척 delta가 있다.
+
+완료 표식을 요구한 작업은 결과 본문에도 그 표식이 있어야 한다. 진척 없는 pass가 연속되면 circuit
+breaker로 중단하고 같은 호출을 증식시키지 않는다. fan-out은 패턴 8 스모크를 한 번 통과한 뒤 시작한다.
+
+| 분류 | 신호 | 처리 |
+|------|------|------|
+| PATH 미해석 | `command -v codex` 실패 또는 exit 127 | `command -v codex` → `codex-exec-supervised --check` → 확인된 절대경로 순으로 진단. 설치 부재로 단정하지 않는다. |
+| 부모 sandbox denial | session/config 파일 쓰기 거부, nested 실행 | 소유권 변경 없이 [known-issues.md §18](references/known-issues.md#18-중첩-codex-session-파일-쓰기-거부와-sudo-chown-오진)로 분기 |
+| timeout | wrapper exit 124/137 | stderr·프로세스 정리를 확인한 뒤 fresh retry 1회만 허용 |
+| usage limit | usage/rate limit 명시 | 신규 세션 재시도는 무익하므로 fail-fast. 이미 진행 중인 세션은 계속될 수 있음 |
+| unsupported model | metadata warning 또는 unsupported error | `-m`을 제거하고 config 기본 모델로 제한된 fresh retry |
+| exit 0 + 산출물 없음 | `test -s` 실패 | 실패로 처리하고 stderr·라우팅·resume session id를 조사 |
 
 ## Gotchas
 
-1. `--search`는 exec에서 미동작: `error: unexpected argument '--search' found`. 대안: `-c web_search=live` (재확인: 2026-07-03, 0.142.5에서도 동일)
-2. 과거 자동 실행 플래그(승인 자동화 + `--sandbox workspace-write`를 함께 지정하던 단축 플래그)는 0.142.5에서 완전히 제거됨: 그 이름 그대로 호출하면 `error: unexpected argument ... found`. exec에서는 `-s workspace-write`로 명시한다. 재확인 결과 이 조합은 config.toml의 `sandbox_mode`를 조용히 override하지 않는다 — 명시한 `-s` 값이 그대로 적용된다 (2026-07-03 실측: `-s read-only` 지정 시 config.toml이 `danger-full-access`여도 실제로 `read-only`로 실행됨).
-3. CODEX_API_KEY는 exec 전용: interactive TUI와 VS Code extension에서는 무시됨. OPENAI_API_KEY는 auth 체인에 미참여 (TUI prefill 전용). 우선순위: CODEX_API_KEY > ephemeral tokens > auth.json (상세: [known-issues.md §17](references/known-issues.md#17-exec-auth-chain-우선순위와-login-status-한계))
-4. ephemeral 세션 resume 불가: `--ephemeral`으로 실행한 세션은 파일 미저장되어 `No saved session found` 에러 발생
-5. `codex review` (top-level) vs `codex exec review`: 전자는 `-m`, `--json`, `-o`, `--output-schema`, `--ephemeral`, `-s/--sandbox` 등 미지원 (재확인: 2026-07-03, `codex review --help`). 비대화형 자동화에는 반드시 `codex exec review` 사용
-6. Bash tool sandbox에서 `&` + `$!` 미작동: Claude Code의 Bash tool에서 background process PID 캡처(`$!`)가 리터럴 문자열로 반환됨. shell-level 병렬 대신 여러 병렬 Bash tool 호출 (예: codex exec 경로의 `run-da` — audit 모드 포함) + `cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -` stdin pipe를 사용한다. 이 제약은 Codex 세션의 native subagent 경로에는 적용되지 않는다. 상세: [known-issues.md](references/known-issues.md) §11
-7. stdin pipe로 stdin hang 방지: Claude Code Bash tool에서 병렬 호출 시 codex exec가 background로 자동 전환되면, stdin이 닫히지 않아 `Reading additional input from stdin...`에서 hang이 발생한다. `cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -` stdin pipe를 사용하면 pipe EOF가 stdin을 구조적으로 닫아 hang을 방지한다: `cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --ephemeral -o "$DIR/result.md" - 2>"$DIR/stderr.log"`. 인라인 인자 `"$(cat file)"`와 `< /dev/null`은 사용하지 않는다. 상세: [known-issues.md](references/known-issues.md) §14
+1. `--search`는 exec에서 미동작: `error: unexpected argument '--search' found`. 대안 config key `-c web_search=live`는 strict config 검증을 통과했으나 실제 tool 제공은 재검증 미수행 (2026-07-10, 0.144.1).
+2. `--full-auto`는 0.144.1 help에서 숨겨졌지만 parser가 수용하고 deprecation warning을 낸다. 새 호출은 `-s workspace-write`를 사용한다. 명시한 `-s` 값이 `config.toml`의 `sandbox_mode`를 override한다 (2026-07-03, 0.142.5 실측: `-s read-only` 지정 시 config가 `danger-full-access`여도 read-only로 실행됨; 0.144.1 재검증 미수행).
+3. CODEX_API_KEY는 exec 전용: interactive TUI와 VS Code extension에서는 무시됨. OPENAI_API_KEY는 auth 체인에 미참여 (TUI prefill 전용). 우선순위: CODEX_API_KEY > ephemeral tokens > auth.json. 재검증 미수행 (0.142.5 기준 서술 유지; 상세: [known-issues.md §17](references/known-issues.md#17-exec-auth-chain-우선순위와-login-status-한계))
+4. ephemeral resume silent fallback: `--ephemeral` 원본은 저장되지 않으며, 저장 세션이 없는 cwd의 `resume --last`는 0.144.1에서 오류 대신 새 세션을 시작하고 exit 0을 반환했다. session id와 응답 context로 판정한다.
+5. `codex review` (top-level) vs `codex exec review`: 전자는 `-m`, `--json`, `-o`, `--output-schema`, `--ephemeral`, `-s/--sandbox` 등 미지원 (재확인: 2026-07-10, 0.144.1 help). 비대화형 자동화에는 반드시 `codex exec review` 사용
+6. Bash tool sandbox에서 `&` + `$!` 미작동: Claude Code의 Bash tool에서 background process PID 캡처(`$!`)가 리터럴 문자열로 반환됨. shell-level 병렬 대신 여러 병렬 Bash tool 호출 + supervised stdin pipe를 사용한다. 이 제약은 Codex 세션의 native subagent 경로에는 적용되지 않는다. 재검증 미수행 (0.142.5 기준 서술 유지; 상세: [known-issues.md](references/known-issues.md) §11)
+7. stdin pipe로 stdin hang 방지: `cat file | env CODEX_PROGRAMMATIC=1 codex-exec-supervised ... -`로 EOF를 보장한다. `Reading additional input...` banner 하나만으로 hang이라 단정하지 말고, banner + 무진척 + 결과 미생성을 함께 확인한다. 상세: [known-issues.md](references/known-issues.md) §14
+8. `-c hooks.*` inline override는 stdin과 독립적으로 hang을 유발한 실측 축이다. programmatic 호출에서 제거하고 [known-issues.md §15](references/known-issues.md#15-codex-exec-supervised-wrapper로-14-위에-process-grouptimeout-한계-보강-issue-593)의 supervisor·timeout 계약을 적용한다.
 
 ## 모델 사용 원칙
 
 - 기본 모델: `~/.codex/config.toml`의 `model` 값을 따른다.
 - 리뷰 전용 모델: `review_model` 설정으로 분리 가능하다.
+- 모델/review_model runtime과 unsupported-model exact response는 재검증 미수행 (0.142.5 기준 서술 유지).
 - 실무 원칙:
   1. `-m`을 생략하고 기본 모델을 사용한다.
   2. `model is not supported` 오류 시 `-m`을 제거하고 재시도한다.
@@ -245,14 +326,17 @@ env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제�
 ## 운영 체크리스트
 
 실행 전:
-- `codex --version`으로 기대 버전 확인
+- `command -v codex`로 비대화형 PATH를 확인하고, programmatic 경로는 `command -v codex-exec-supervised && codex-exec-supervised --check`까지 통과
+- `command codex --version`으로 기대 버전 확인
 - `pwd`가 대상 저장소 루트인지 확인
 - 프롬프트 파일 경로와 결과 파일 경로를 분리
+- fan-out 전 패턴 8 스모크 1회 통과
 
 실행 후:
-- 결과 파일 생성 여부 확인 (`-o` 또는 리다이렉트)
+- CLI/wrapper exit 보존 및 확인
+- 결과 파일이 비어 있지 않은지 확인 (`test -s "$RESULT"`)
 - 빈 결과 시 stderr 로그부터 확인
-- 다음 라운드 입력에 반영할 액션 항목만 추출
+- 반복 작업이면 직전 결과 대비 진척 delta 확인
 
 ## 하지 말아야 할 패턴
 
@@ -260,10 +344,17 @@ env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제�
 |-----------|----------|------------|
 | review에서 PROMPT + scope flag | `'[PROMPT]' cannot be used with '--base'` | 의사결정 트리의 방법 A 또는 B |
 | exec 전용 플래그를 review에 전달 | `unexpected argument` | exec 전용/공통 매트릭스 확인 |
+| PROMPT 인자와 `-` 마커 동시 사용 | `unexpected argument '-'` | PROMPT 또는 stdin marker 중 하나만 선택 |
+| `--ephemeral` 뒤 `resume --last`의 exit 0을 재개 성공으로 간주 | 새 세션 silent fallback | session id와 응답 context 확인 |
+| programmatic 호출에 raw `codex exec` 사용 | hang/자식 프로세스 잔존 | 실행 경로 게이트의 supervised wrapper 사용 |
+| `-c hooks.*` inline override | stdin과 무관한 silent hang 가능 | override 제거 + §15 supervisor 적용 |
+| JSON parser 앞 `2>&1` | stderr 혼입으로 JSON 파싱 실패 | stdout/stderr/result 분리 |
+| 판정 pipeline 끝에 `head`/`tail`/`; echo $?` | 원 exit 은폐 | `pipefail`과 즉시 exit 보존 |
 | `-m o3` / `-m o4-mini` 등 비Codex 모델 지정 | "Model metadata not found" + "model is not supported" | `-m` 생략, config.toml 기본 모델 사용 |
 | `-m` 플래그로 매번 다른 모델 지정 | 불일치/에러 위험 | config.toml 기본값 사용 원칙 |
 | 실패 원인 미확인 후 반복 재시도 | 동일 에러 반복 | known-issues.md 진단 절차 |
 | 긴 루프에서 결과 파일 저장 생략 | 결과 유실 | `-o` 또는 리다이렉트 필수 사용 |
+| child가 같은 collector/fan-out을 다시 생성 | 무한 자기증식 | 오케스트레이션은 부모 1계층에서만 수행 |
 
 ## 참조
 
@@ -271,4 +362,6 @@ env CODEX_PROGRAMMATIC=1 codex exec resume --last --all    # cwd 필터 해제�
 - 제한사항/트러블슈팅: [references/known-issues.md](references/known-issues.md)
 
 문서와 CLI 동작이 다를 때는 CLAUDE.md의 "스킬 문서 불일치 시 행동 원칙"을 따른다.
-`codex exec --help` / `codex exec review --help` 출력이 이 문서보다 항상 우선하는 진실 원천이다.
+help는 공개 surface의 SSOT다. help에서 사라진 hidden flag의 제거 여부는 실행 smoke로만 판정한다.
+문서에서 명령 문자열을 찾을 때는 command substitution을 피하도록 `rg -F 'codex exec'`처럼
+작은따옴표와 fixed-string 검색을 사용한다.

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -219,10 +219,13 @@ PROMPT
 
 ```bash
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
+rm -f /tmp/result.md   # 이전 실행의 non-empty 잔존 결과로 인한 오판 방지
+set -o pipefail
 cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   -s workspace-write -o /tmp/result.md - \
   > /tmp/stdout.log 2> /tmp/stderr.log
-test -s /tmp/result.md
+codex_rc=${PIPESTATUS[1]}   # zsh는 $pipestatus[2]
+[ "$codex_rc" -eq 0 ] && test -s /tmp/result.md
 ```
 
 사용자가 literal raw 실행을 요청한 1회성 수동 진단에서는 인라인 프롬프트도 가능하다:

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -232,7 +232,8 @@ cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   > /tmp/stdout.log 2> /tmp/stderr.log
 # PIPESTATUS는 다음 명령에서 리셋되므로 배열을 먼저 스냅샷한다. cat 실패(프롬프트 파일 부재)도 판정에 포함.
 pipe_rcs=("${PIPESTATUS[@]}")   # zsh는 ("${pipestatus[@]}") — 인덱스가 1부터
-[ "${pipe_rcs[0]}" -eq 0 ] && [ "${pipe_rcs[1]}" -eq 0 ] && test -s /tmp/result.md
+[ "${pipe_rcs[0]}" -eq 0 ] && [ "${pipe_rcs[1]}" -eq 0 ] && test -s /tmp/result.md \
+  && ! grep -q "ERROR:" /tmp/stderr.log   # 성공 계약 조건 2 (CLI 오류의 ERROR: prefix 검사)
 ```
 
 사용자가 literal raw 실행을 요청한 1회성 수동 진단에서는 인라인 프롬프트도 가능하다:
@@ -256,8 +257,13 @@ env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
 # env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit <sha> ... (동일 형태)
 
 review_rc=$?
-[ "$review_rc" -eq 0 ] && test -s /tmp/review.md
+[ "$review_rc" -eq 0 ] && test -s /tmp/review.md \
+  && ! grep -q "ERROR:" /tmp/review-stderr.log
 ```
+
+stderr 검사는 성공 계약 조건 2의 구현이다 — usage limit·sandbox panic 등 CLI 오류는
+`ERROR:` prefix로 출력된다 (진행 로그·배너에는 이 prefix가 없다). stderr에는 최종 메시지
+사본도 남으므로, 본문에 우연히 `ERROR:`가 포함되면 보수적으로 실패 처리하고 직접 확인한다.
 
 review 결과 저장에는 `-o`(`--output-last-message`)와 stdout이 모두 동작한다
 (재확인: 2026-07-10, 0.144.1). upstream #12502는 open이지만 로컬에서는 stderr 회귀가
@@ -296,6 +302,7 @@ resume_rc=$?
 # silent fallback 검증: 반환된 session id가 요청한 세션과 일치해야 하며, 최종 판정에 연결한다.
 [ "$resume_rc" -eq 0 ] \
   && grep -Fq "session id: $SESSION" /tmp/resume-stderr.log \
+  && ! grep -q "ERROR:" /tmp/resume-stderr.log \
   && test -s /tmp/resume-result.md
 # 위 판정 실패, 또는 응답(/tmp/resume-result.md)이 원 세션의 context를 잇지 않으면 재개 실패로 처리한다.
 ```
@@ -312,7 +319,8 @@ session id·응답 context 확인을 포함하는 이유다. 불일치하거나 
 프로세스 exit만으로 업무 성공을 판정하지 않는다. 아래 네 조건을 모두 확인한다.
 
 1. wrapper/CLI exit가 0이다.
-2. stderr에 timeout, usage limit, sandbox denial, unsupported model 오류가 없다.
+2. stderr에 timeout, usage limit, sandbox denial, unsupported model 오류가 없다
+   (구현: `! grep -q "ERROR:" <stderr>` — CLI 오류는 `ERROR:` prefix로 출력되고 진행 로그·배너에는 없다).
 3. 기대 산출물이 존재하고 비어 있지 않다: `test -s "$RESULT"`.
 4. 반복 라운드라면 직전 결과 대비 새 finding·수정·판정 같은 진척 delta가 있다.
 

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -191,6 +191,9 @@ PROMPT 인자와 piped stdin을 함께 주면 stdin 내용이 `<stdin>` 블록�
   stderr를 합치면 파싱이 깨진다.
 - pipeline에는 `set -o pipefail`을 적용한다. zsh에서 Codex 자체 exit가 필요하면 pipeline 직후
   `codex_rc=$pipestatus[2]`로 보존한다.
+- 좌측 명령(`cat` 등)의 실패까지 판정에 포함하려면 pipeline 직후 배열을 먼저 스냅샷한다
+  (`pipe_rcs=("${PIPESTATUS[@]}")`; zsh는 `("${pipestatus[@]}")`) — `$?`나 개별 원소를 나중에
+  읽으면 그 사이 명령이 PIPESTATUS를 리셋한다.
 - `| head`, `| tail`, 뒤이은 `; echo $?`는 원래 exit를 가릴 수 있으므로 판정 경로에 두지 않는다.
 
 ```zsh
@@ -227,8 +230,9 @@ set -o pipefail
 cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   -s workspace-write -o /tmp/result.md - \
   > /tmp/stdout.log 2> /tmp/stderr.log
-codex_rc=${PIPESTATUS[1]}   # zsh는 $pipestatus[2]
-[ "$codex_rc" -eq 0 ] && test -s /tmp/result.md
+# PIPESTATUS는 다음 명령에서 리셋되므로 배열을 먼저 스냅샷한다. cat 실패(프롬프트 파일 부재)도 판정에 포함.
+pipe_rcs=("${PIPESTATUS[@]}")   # zsh는 ("${pipestatus[@]}") — 인덱스가 1부터
+[ "${pipe_rcs[0]}" -eq 0 ] && [ "${pipe_rcs[1]}" -eq 0 ] && test -s /tmp/result.md
 ```
 
 사용자가 literal raw 실행을 요청한 1회성 수동 진단에서는 인라인 프롬프트도 가능하다:
@@ -283,15 +287,17 @@ scope flag으로 review를 실행하면 지시가 자동 적용된다.
 Claude Code/headless의 programmatic 재개는 supervised 경로를 사용한다:
 
 ```bash
+SESSION="<session-id>"   # 재개할 세션 id
 rm -f /tmp/resume-result.md
-env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume <session-id> \
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume "$SESSION" \
   -o /tmp/resume-result.md > /tmp/resume-stdout.log 2> /tmp/resume-stderr.log
 resume_rc=$?
 
-# silent fallback 검증: exit 0만으로 재개 성공을 판정하지 않는다 (아래 설명 참조).
-grep -m1 "session id:" /tmp/resume-stderr.log   # 의도한 세션 id와 일치하는지 확인
-[ "$resume_rc" -eq 0 ] && test -s /tmp/resume-result.md
-# 응답 내용(/tmp/resume-result.md)이 원 세션의 context를 실제로 잇는지도 확인한다.
+# silent fallback 검증: 반환된 session id가 요청한 세션과 일치해야 하며, 최종 판정에 연결한다.
+[ "$resume_rc" -eq 0 ] \
+  && grep -Fq "session id: $SESSION" /tmp/resume-stderr.log \
+  && test -s /tmp/resume-result.md
+# 위 판정 실패, 또는 응답(/tmp/resume-result.md)이 원 세션의 context를 잇지 않으면 재개 실패로 처리한다.
 ```
 
 변형: `resume --last` (같은 cwd의 마지막 세션), `resume --last --all` (cwd 필터 해제).

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -280,6 +280,8 @@ scope flag으로 review를 실행하면 지시가 자동 적용된다.
 (지시 파일 우선순위: [references/patterns.md](references/patterns.md) 패턴 3 참조)
 
 재검증 미수행 (0.142.5 기준 서술 유지): AGENTS instruction의 실제 적용과 우선순위.
+재검증 방법: 임시 repo의 `AGENTS.md`에 고유 marker 지시(예: "리뷰 결과 첫 줄에 AGENTS_APPLIED를 출력")를 넣고
+`codex exec review --uncommitted`를 실행해 결과에 marker가 반영되는지 확인한다.
 
 방법 B — exec 우회 (1회성 지시, 최대 유연성)
 
@@ -368,6 +370,7 @@ breaker로 중단하고 같은 호출을 증식시키지 않는다. fan-out은 �
 
 실행 후:
 - CLI/wrapper exit 보존 및 확인
+- stderr에 `ERROR:` prefix가 없는지 확인 (성공 계약 조건 2)
 - 결과 파일이 비어 있지 않은지 확인 (`test -s "$RESULT"`)
 - 빈 결과 시 stderr 로그부터 확인
 - 반복 작업이면 직전 결과 대비 진척 delta 확인

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md
@@ -207,7 +207,10 @@ bundled fallback과 nested bwrap 기각 결과는 [known-issues.md §16](referen
 
 ### 일반 exec — Claude Code·headless 자동화
 
-프롬프트를 파일로 작성하고, stdin 파이프로 전달하며, `-o`로 결과를 저장한다:
+프롬프트를 파일로 작성하고, stdin 파이프로 전달하며, `-o`로 결과를 저장한다.
+아래 고정 `/tmp` 경로는 단일 수동 실행 데모다 — 동시/병렬 실행은 결과·로그를 서로 덮어쓰므로
+세션별 네임스페이스 디렉토리로 격리한다 ([known-issues.md §12](references/known-issues.md#12-동시-다중-세션-간-tmpda--경쟁-상태);
+경로 격리 시 임의 suffix의 literal 재사용 규칙은 [#632 절](references/known-issues.md#literal-재사용-시-random-suffix-환각-금지-issue-632)을 따른다):
 
 ```bash
 cat > /tmp/prompt.md <<'PROMPT'
@@ -236,13 +239,20 @@ env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write "git diff 기준으로 �
 
 ### 코드 리뷰 — scope flag만 사용 (Claude Code·headless 자동화)
 
+아래 세 명령은 순차 실행하는 파이프라인이 아니라 scope별 택일 대안이다.
+선택한 하나만 실행하고, 실행 전 결과 파일을 초기화하며, 종료 후 성공 계약을 검증한다:
+
 ```bash
+rm -f /tmp/review.md   # 이전 실행의 잔존 결과로 인한 오판 방지
+
+# 셋 중 하나를 선택:
 env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
   -o /tmp/review.md > /tmp/review-stdout.log 2> /tmp/review-stderr.log
-env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --uncommitted \
-  -o /tmp/review.md > /tmp/review-stdout.log 2> /tmp/review-stderr.log
-env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit <sha> \
-  -o /tmp/review.md > /tmp/review-stdout.log 2> /tmp/review-stderr.log
+# env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --uncommitted ... (동일 형태)
+# env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit <sha> ... (동일 형태)
+
+review_rc=$?
+[ "$review_rc" -eq 0 ] && test -s /tmp/review.md
 ```
 
 review 결과 저장에는 `-o`(`--output-last-message`)와 stdout이 모두 동작한다
@@ -273,16 +283,23 @@ scope flag으로 review를 실행하면 지시가 자동 적용된다.
 Claude Code/headless의 programmatic 재개는 supervised 경로를 사용한다:
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume --last          # 마지막 세션 재개
-env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume <session-id>    # 특정 세션 재개
-env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume --last --all    # cwd 필터 해제하여 전체 세션 중 최신 재개
+rm -f /tmp/resume-result.md
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised resume <session-id> \
+  -o /tmp/resume-result.md > /tmp/resume-stdout.log 2> /tmp/resume-stderr.log
+resume_rc=$?
+
+# silent fallback 검증: exit 0만으로 재개 성공을 판정하지 않는다 (아래 설명 참조).
+grep -m1 "session id:" /tmp/resume-stderr.log   # 의도한 세션 id와 일치하는지 확인
+[ "$resume_rc" -eq 0 ] && test -s /tmp/resume-result.md
+# 응답 내용(/tmp/resume-result.md)이 원 세션의 context를 실제로 잇는지도 확인한다.
 ```
 
+변형: `resume --last` (같은 cwd의 마지막 세션), `resume --last --all` (cwd 필터 해제).
 사용자가 요청한 1회성 수동 진단은 alias를 피하도록 raw `command codex exec resume --last`를 사용할 수 있다.
 
 `--ephemeral` 세션은 저장되지 않는다. 0.144.1에서 저장 세션이 없는 cwd의
-`resume --last`는 오류 대신 새 session id로 조용히 시작해 exit 0을 반환했다. resume 성공 여부를
-exit code만으로 판정하지 말고 stderr banner의 session id와 응답 context가 원 세션과 이어지는지 확인한다.
+`resume --last`는 오류 대신 새 session id로 조용히 시작해 exit 0을 반환했다 — 위 예제가
+session id·응답 context 확인을 포함하는 이유다. 불일치하거나 결과가 비면 재개 실패로 처리한다.
 
 ## 성공 계약
 

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -305,8 +305,10 @@ set -o pipefail
 cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   -s workspace-write -o /tmp/smoke-result.md - \
   > /tmp/smoke.stdout 2> /tmp/smoke.stderr
-smoke_rc=${PIPESTATUS[1]}   # zsh는 $pipestatus[2]
-[ "$smoke_rc" -eq 0 ] && test -s /tmp/smoke-result.md && grep -q "SMOKE_DONE" /tmp/smoke-result.md
+# PIPESTATUS는 다음 명령에서 리셋되므로 배열을 먼저 스냅샷한다 (cat 실패도 판정에 포함).
+pipe_rcs=("${PIPESTATUS[@]}")   # zsh는 ("${pipestatus[@]}") — 인덱스가 1부터
+[ "${pipe_rcs[0]}" -eq 0 ] && [ "${pipe_rcs[1]}" -eq 0 ] \
+  && test -s /tmp/smoke-result.md && grep -q "SMOKE_DONE" /tmp/smoke-result.md
 ```
 
 wrapper exit 0, non-empty 결과, 기대한 완료 표식이 모두 확인되면 통과다. fan-out은 이 스모크를

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -293,17 +293,20 @@ git worktree 환경에서 `codex exec`를 실행할 때:
 
 ```bash
 cat > /tmp/smoke.md <<'PROMPT'
-현재 작업 디렉토리에서 가장 중요한 리스크 1개만 한 줄로 답한다.
+현재 작업 디렉토리에서 가장 중요한 리스크 1개만 한 줄로 답한 뒤, 마지막 줄에 SMOKE_DONE만 출력한다.
 PROMPT
 ```
 
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다 (§11 하위 항목).
 
 ```bash
+rm -f /tmp/smoke-result.md   # 이전 실행의 non-empty 잔존 결과로 인한 오판 방지
+set -o pipefail
 cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   -s workspace-write -o /tmp/smoke-result.md - \
   > /tmp/smoke.stdout 2> /tmp/smoke.stderr
-test -s /tmp/smoke-result.md
+smoke_rc=${PIPESTATUS[1]}   # zsh는 $pipestatus[2]
+[ "$smoke_rc" -eq 0 ] && test -s /tmp/smoke-result.md && grep -q "SMOKE_DONE" /tmp/smoke-result.md
 ```
 
 wrapper exit 0, non-empty 결과, 기대한 완료 표식이 모두 확인되면 통과다. fan-out은 이 스모크를

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/known-issues.md
@@ -10,9 +10,10 @@ Codex 세션에서 `spawn_agent` / `wait_agent` / `close_agent`로 오케스트�
 실패 시 아래 명령으로 환경을 먼저 확인한다:
 
 ```bash
-codex --version
-codex exec --help
-codex exec review --help
+command -v codex
+command codex --version
+command codex exec --help
+command codex exec review --help
 pwd
 git rev-parse --show-toplevel
 ```
@@ -20,6 +21,26 @@ git rev-parse --show-toplevel
 - CLI 버전/옵션 존재 여부 확인
 - 저장소 루트 밖에서 실행 중인지 확인
 - 워크트리(worktree) 환경이면 `git rev-parse --git-dir`로 git 디렉토리 경로 확인
+- 비대화형 PATH에서 `command -v codex`가 실패하면 곧바로 미설치로 단정하지 않는다.
+  programmatic 경로는 `command -v codex-exec-supervised` →
+  `codex-exec-supervised --check` → 확인된 Codex 절대경로 순으로 진단한다.
+
+오류 기록은 stdout, stderr, `-o` 결과, exit code를 분리한다. JSON/JSONL parser 앞에
+`2>&1`를 두지 않고, pipeline은 `set -o pipefail`과 zsh `pipestatus`로 Codex exit를 보존한다.
+`| head`, `| tail`, 뒤이은 `; echo $?`는 원래 exit를 가릴 수 있다.
+
+| 오류 분류 | 재시도 정책 | 관측 출처 |
+|----------|-------------|----------|
+| PATH/의존성 exit 127 | 경로·wrapper `--check` 후에만 재실행 | 실전 재발 사례 7건 + wrapper smoke |
+| 부모 sandbox denial | 소유권 변경 금지, §18 분기 | 실전 재발 사례 6건 |
+| timeout exit 124/137 | 자식 정리 확인 후 fresh retry 최대 1회 | 실전 재발 사례 |
+| usage limit | fail-fast. 신규 세션 재시도 금지 | 실전 재발 사례; 2026-07-10 재확인 |
+| unsupported model | `-m` 제거 후 fresh retry 최대 1회 | 통제 smoke에서 관측 |
+| exit 0 + `-o` 미생성 | 실패 처리, stderr·라우팅·session id 조사 | 실전 재발 사례 5건 |
+
+SSH/원격 장기 실행은 약 10분 무출력 뒤 완료된 실측이 있으므로 무출력만으로 중단이라 단정하지
+않는다. 반대로 프로세스 생존만으로 정상이라 단정하지도 않는다. outer timeout을 두고 종료 후
+`test -s "$RESULT"`로 산출물을 검증한다.
 
 ---
 
@@ -84,7 +105,7 @@ pub commit: Option<String>,
 
 | 이슈/PR | 상태 | 설명 |
 |---------|------|------|
-| [#7825](https://github.com/openai/codex/issues/7825) | OPEN (2025-12-10~) | PROMPT + scope flag 조합 기능 요청. 커뮤니티 확인됨. |
+| [#7825](https://github.com/openai/codex/issues/7825) | CLOSED AS NOT PLANNED (2026-03-29) | 이슈는 종결됐지만 0.144.1 runtime 제약은 유지. |
 | [#11903](https://github.com/openai/codex/pull/11903) | CLOSED (미머지, 2026-02-16) | `additional_instructions: Option<String>`을 `ReviewRequest`에 추가하는 PR. `ReviewTarget` 해석 후 비어있지 않은 추가 지시를 append하는 구현. invitation-only 기여 정책으로 close됨. |
 | [#6432](https://github.com/openai/codex/issues/6432) | OPEN (2025-11-09~) | headless review 전체 제안. `custom [PROMPT\|-]` preset 포함. 부분 구현 상태. |
 
@@ -98,51 +119,38 @@ pub commit: Option<String>,
 
 재검증 방법: 아래 명령이 에러 없이 실행되면 제약이 해소된 것이다:
 
-```bash
-echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - --base main 2>&1 | head -5
+```zsh
+set -o pipefail
+printf 'test\n' | env CODEX_PROGRAMMATIC=1 codex exec review - --base main \
+  > /tmp/review-conflict.stdout 2> /tmp/review-conflict.stderr
+codex_rc=$pipestatus[2]
 ```
 
-재확인: 2026-07-03, codex-cli 0.142.5 — 위 명령은 여전히 `error: the argument '[PROMPT]' cannot be used with '--base <BRANCH>'`로 실패한다. 4개 변형(PROMPT/--base/--uncommitted/--commit) 모두 clap `conflicts_with_all`로 상호 배타가 유지됨. 제약 미해소.
+재확인: 2026-07-10, codex-cli 0.144.1 — 여섯 pairwise 조합이 모두 clap exit 2로
+실패했다. 이슈 상태와 runtime 제약을 분리한다. 관측 출처: 통제 smoke.
 
 ### 2. review `-o` upstream bug — 빈 파일 생성 (0.142.5에서 해소됨)
 
 심각도: 높음 (해소 전 기준 — 버전 하한 판단 근거로 보존)
 
-0.142.5에서 해소됨 (재확인: 2026-07-03). 실제 uncommitted diff가 있는 상태에서 `codex exec review --uncommitted -o <file>`을 실행한 결과, `Warning: no last agent message` 경고 없이 파일에 리뷰 내용이 정상 기록됨을 확인했다. 아래는 해소 전(v0.104.0~v0.115.0-alpha) 증상의 기록이다.
+0.144.1에서 `-o`와 stdout 모두 정상이다 (재확인: 2026-07-10). 실제 버그가 있는 diff에
+`review --uncommitted -o`를 실행해 두 채널에 동일 review가 기록되고 `-o` 파일이 non-empty임을
+확인했다. stderr에는 진행 로그와 사본이 있었으며, upstream [#12502](https://github.com/openai/codex/issues/12502)는
+여전히 open이지만 보고 내용은 “review가 stdout 대신 stderr로 감”이다. 로컬 0.144.1에서는 그 회귀도
+재현되지 않았다. upstream 상태와 로컬 판정을 분리한다. 관측 출처: 통제 smoke.
 
-관찰된 동작 (해소 전): `-o` 사용 시 `Warning: no last agent message; wrote empty content` 출력, 0바이트 파일 생성 (v0.114.0에서 직접 재현)
+해소 전 역사: v0.104.0~v0.115.0-alpha에서는 `Warning: no last agent message; wrote empty content`와
+0바이트 `-o` 파일을 직접 재현했다. 이 기록은 버전 하한 판단용으로만 보존한다.
 
-참고: `-o`(`--output-last-message`)는 `codex exec review --help`에 표시되므로 CLI 파서는 인자를 수용한다. 문제는 `ReviewTask::run()`이 None을 반환하여 빈 파일이 생성되는 것이다.
-
-관련 GitHub Issues:
-
-| 이슈 | 상태 | 설명 |
-|------|------|------|
-| [#12502](https://github.com/openai/codex/issues/12502) | OPEN (2026-02-22~) | review `-o` 빈 파일 생성 보고 |
-| [#14335](https://github.com/openai/codex/issues/14335) | OPEN (2026-03-11~) | 동일 증상 재보고 |
-
-영향 범위: v0.104.0 ~ v0.115.0-alpha (직접 검증 기준). 0.142.5는 영향 범위 밖 (해소 확인).
-
-재현 (해소 전, 역사적 기록):
+재검증 방법: 실제 diff가 있는 저장소에서 stdout/stderr/result를 분리한 뒤 두 결과를 확인한다.
 
 ```bash
-echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review - -o /tmp/test.md 2>&1
-# v0.114.0 기준: 0바이트 파일 + "Warning: no last agent message; wrote empty content"
+env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted \
+  -o /tmp/review-result.md \
+  > /tmp/review.stdout 2> /tmp/review.stderr
+rc=$?
+test "$rc" -eq 0 && test -s /tmp/review-result.md && test -s /tmp/review.stdout
 ```
-
-워크어라운드 (해소 전 필요했던 방법, 0.142.5에서는 불필요하지만 유지해도 무방): stdout 리다이렉트로 대체한다:
-
-```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review-result.md 2>&1
-```
-
-재검증 방법: 아래 명령으로 `-o`가 비어있지 않은 파일을 생성하면 수정된 것이다:
-
-```bash
-echo "modified" >> file.txt && echo "test" | env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted -o /tmp/test.md 2>&1 && [ -s /tmp/test.md ] && echo "FIXED" || echo "STILL BROKEN"
-```
-
-2026-07-03 실측 결과: 실제 uncommitted diff가 있는 저장소에서 위 재검증 명령이 `FIXED`를 반환함 (`codex exec review --uncommitted -o <file>`로 직접 재현, PROMPT 없이 scope flag만 사용). `echo "test" | ... review - -o ...`처럼 PROMPT를 stdin으로 줄 경우 diff가 없으면 "There are no ... changes to review" 메시지가 정상 저장되는 것으로 대체되므로, 리그레션 확인 시 실제 diff가 있는 상태에서 재현해야 한다.
 
 ### 3. review가 working-tree 변경을 잘못 포함
 
@@ -155,6 +163,8 @@ echo "modified" >> file.txt && echo "test" | env CODEX_PROGRAMMATIC=1 codex exec
 대안:
 - 리뷰 전 워킹트리를 깨끗한 상태로 만든다 (`git stash`).
 - 리뷰 결과를 실제 diff와 대조하여 검증한다.
+
+재검증 미수행 (codex-cli 0.142.5 기준 서술 유지): `--base`의 working-tree 포함 여부.
 
 ### 4. exec review가 공식 CLI reference에 미문서화
 
@@ -173,11 +183,14 @@ echo "modified" >> file.txt && echo "test" | env CODEX_PROGRAMMATIC=1 codex exec
 
 ### 5. `unexpected argument '--approval-mode' found`
 
-원인: `codex exec`는 `--approval-mode` 플래그를 받지 않는다. exec/review/resume은 headless 실행이라 승인 프롬프트 자체가 없고, 승인 관련 CLI 플래그는 애초에 존재하지 않는다 (승인은 항상 `never`로 고정 — 재확인: 2026-07-03, 0.142.5, `--ignore-user-config`로 CLI 기본값 직접 확인).
+원인: `codex exec`는 `--approval-mode` 플래그를 받지 않는다. exec/review/resume의 공개
+surface에 승인 관련 CLI 플래그가 없다. approval `never` 고정 동작은 재검증 미수행
+(0.142.5 기준 서술 유지).
 
 해결: 세밀한 샌드박스 조정이 필요하면 exec에서 `-s, --sandbox <MODE>`를 사용한다 (review/resume은 `-s` 미지원 — config.toml의 `sandbox_mode`를 따른다). 그 외 조정은 `-c key=value`로 처리한다.
 
-과거 버전에는 승인 자동화 + `--sandbox workspace-write`를 한 번에 지정하는 단축 플래그가 있었으나, 0.142.5 `codex exec --help` / `codex exec review --help` / `codex exec resume --help` 어디에도 나타나지 않는다 (완전히 제거됨). 문서/스크립트에 그 이름이 남아 있으면 `-s workspace-write`로 치환한다.
+과거 승인 자동화 + workspace-write 단축 플래그 `--full-auto`는 0.144.1 help에 없지만 hidden parser가
+수용하며 deprecation warning을 낸다. 새 문서/스크립트는 `-s workspace-write`를 사용한다.
 
 ### 6. 결과 파일이 비어 있음 (`-o` 사용 시)
 
@@ -186,14 +199,17 @@ echo "modified" >> file.txt && echo "test" | env CODEX_PROGRAMMATIC=1 codex exec
 원인:
 - 실행이 중간 실패하여 마지막 에이전트 메시지가 없을 수 있다.
 - `Warning: no last agent message; wrote empty content` 경고가 stderr에 출력된다.
-- review 서브커맨드에서 `-o` 사용 시: upstream bug #12502로 항상 빈 파일 생성. §2 참조.
+- exit 0이어도 업무 산출물이 생성되지 않은 실전 사례가 있다.
+- review `-o`의 과거 빈 파일 증상은 0.144.1에서 해소됨. §2 참조.
 
 해결:
-1. `2>&1`로 stderr를 함께 캡처한다.
-2. review에서는 `-o` 대신 stdout 리다이렉트(`> file 2>&1`)를 사용한다.
+1. stdout, stderr, `-o` 결과를 별도 파일로 캡처한다.
+2. `test -s "$RESULT"`를 통과하지 못하면 exit 0이어도 실패로 처리한다.
 3. 프롬프트 파일 내용이 비어 있지 않은지 확인한다.
 4. 상위 오류(`model is not supported` 등)를 먼저 해결한다.
 5. 최소 프롬프트(패턴 8 스모크 테스트)로 재현 범위를 줄인다.
+
+관측 출처: exit 0 + 산출물 누락은 실전 재발 사례 5건. review `-o` 해소는 통제 smoke.
 
 ### 7. stdin 입력이 멈춘 것처럼 보임
 
@@ -208,8 +224,12 @@ echo "modified" >> file.txt && echo "test" | env CODEX_PROGRAMMATIC=1 codex exec
    ```
 2. 인라인 프롬프트로 비교 실행한다:
    ```bash
-   codex exec -s workspace-write "짧은 스모크 테스트"
+   command codex exec -s workspace-write "짧은 스모크 테스트"
    ```
+
+`Reading additional input from stdin...` banner 자체는 stdin append 경로 진입 표시다. hang은 banner,
+무진척, 결과 미생성이 함께 나타날 때 판정한다. PROMPT와 piped stdin 병용은 0.144.1에서
+`<stdin>` 블록 append로 정상 완료될 수 있다.
 
 ### 8. Git 저장소 체크 실패
 
@@ -236,6 +256,8 @@ ERROR: {"detail":"The '<model>' model is not supported when using Codex with a C
 1. `-m`을 제거하고 기본 모델(`~/.codex/config.toml`)로 재시도한다.
 2. 동일 오류 반복 시 `codex exec --help`와 계정 모델 접근 정책을 확인한다.
 
+재검증 미수행 (codex-cli 0.142.5 기준 서술 유지): unsupported-model runtime response.
+
 ### 10. `Model metadata ... not found` 경고
 
 증상:
@@ -248,6 +270,8 @@ warning: Model metadata for `<model>` not found. Defaulting to fallback metadata
 
 해결: `-m`을 제거하거나 `config.toml`의 기본 모델로 되돌린다.
 
+재검증 미수행 (codex-cli 0.142.5 기준 서술 유지): model metadata warning runtime response.
+
 ---
 
 ## 워크트리(Worktree) 환경 참고사항
@@ -258,6 +282,8 @@ git worktree 환경에서 `codex exec`를 실행할 때:
 - `--base` 동작은 동일하다: worktree에서도 `origin/main...HEAD` diff가 정상 계산된다.
 - detached HEAD 주의: worktree가 detached HEAD 상태이면 브랜치 기반 비교가 실패할 수 있다. `git branch --show-current`로 브랜치 상태를 확인한다.
 - Codex App의 worktree 버그는 codex exec와 무관하다: Codex App(GUI)에는 다수의 worktree 관련 버그(cross-worktree writes, UI freeze 등)가 보고되어 있으나, 이는 CLI exec 실행에 영향을 주지 않는다.
+
+재검증 미수행 (codex-cli 0.142.5 기준 서술 유지): worktree/`--base`/detached HEAD runtime.
 
 ---
 
@@ -274,11 +300,14 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다 (§11 하위 항목).
 
 ```bash
-cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/smoke-result.md 2>&1
-cat /tmp/smoke-result.md
+cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o /tmp/smoke-result.md - \
+  > /tmp/smoke.stdout 2> /tmp/smoke.stderr
+test -s /tmp/smoke-result.md
 ```
 
-통과하면 기존 복잡한 프롬프트로 단계적으로 복귀한다.
+wrapper exit 0, non-empty 결과, 기대한 완료 표식이 모두 확인되면 통과다. fan-out은 이 스모크를
+한 번 통과한 뒤 시작한다. 통과하면 기존 복잡한 프롬프트로 단계적으로 복귀한다.
 실패하면 §0 공통 진단부터 다시 시작한다.
 
 ---
@@ -286,6 +315,9 @@ cat /tmp/smoke-result.md
 ### 11. Claude Code Bash tool sandbox 제약
 
 심각도: 치명적 — Bash tool에서 codex exec 병렬 실행 시 반드시 적용
+
+현재 재검증 미수행 (codex-cli 0.142.5 기준 서술 유지). 아래 날짜·버전별 관측을 역사적
+실전 사례로 보존한다.
 
 관찰된 동작 (2026-03-29 재현):
 
@@ -336,7 +368,7 @@ Codex 세션의 native subagent 경로와 일반 터미널에는 이 제약을 �
    # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
    cat "$DA_DIR/domain.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
      --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-     -c model="gpt-5.5" -c model_reasoning_effort="medium" \
+     -c model_reasoning_effort="medium" \
      -o "$DA_DIR/domain-result.md" \
      - \
      2>"$DA_DIR/domain-stderr.log"
@@ -355,7 +387,7 @@ Background 대안 — 다수 병렬 실행 시 LLM 블로킹 방지:
     # Bash tool 호출 시 run_in_background: true 파라미터 사용
     cat "$DA_DIR/domain.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
       --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-      -c model="gpt-5.5" -c model_reasoning_effort="medium" \
+      -c model_reasoning_effort="medium" \
       -o "$DA_DIR/domain-result.md" \
       - \
       2>"$DA_DIR/domain-stderr.log"
@@ -389,14 +421,16 @@ echo "PID: $!"
 
 관찰된 동작: 특정 Bash tool sandbox 구성에서 heredoc과 codex exec를 같은 호출에 체이닝하면 hang이 발생한다. 정확한 메커니즘은 미확정이나, heredoc이 stdin 상태에 영향을 주어 후속 codex exec가 추가 입력을 기다리는 것으로 추정된다. `run_in_background` 환경에서만 발생하며, 일반 터미널에서는 재현되지 않는다.
 
-재현 (codex-cli v0.118.0, 2026-04-01 확인. 원 재현에는 당시 존재하던 자동실행 플래그를 사용했으나 0.142.5에서 제거되어 아래는 `-s workspace-write`로 치환한 등가 명령이다 — 버그는 stdin/heredoc 상호작용이 원인이라 이 치환으로 재현 조건이 바뀌지 않는다):
+재현 (codex-cli v0.118.0, 2026-04-01 확인. 원 재현에는 당시 자동실행 단축 플래그를
+사용했으나 현재 공개 surface에서는 숨겨지고 deprecated되었으므로 아래는 `-s workspace-write`로
+치환한 등가 명령이다 — 버그는 stdin/heredoc 상호작용이 원인이라 재현 조건은 바뀌지 않는다):
 
 HANG — heredoc 체이닝 (같은 Bash 호출):
 ```bash
 (umask 077; TDIR=$(mktemp -d /tmp/test-XXXXXX) && cat > "$TDIR/prompt.md" <<'EOF'
 테스트 프롬프트
 EOF
-codex exec -s workspace-write --ephemeral -o "$TDIR/result.md" "$(cat "$TDIR/prompt.md")")
+command codex exec -s workspace-write --ephemeral -o "$TDIR/result.md" "$(cat "$TDIR/prompt.md")")
 # → 무한 대기
 ```
 
@@ -421,7 +455,7 @@ TDIR=/tmp/test-a1b2c3
 [ -f "$TDIR/prompt.md" ] || { echo "missing prompt=$TDIR/prompt.md"; exit 1; }
 cat "$TDIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-  -c model="gpt-5.5" -c model_reasoning_effort="medium" \
+  -c model_reasoning_effort="medium" \
   -o "$TDIR/result.md" \
   - \
   2>"$TDIR/stderr.log"
@@ -455,12 +489,18 @@ cat "$TDIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
 
 근본 원인: Claude Code Bash tool이 병렬 실행 시 background 전환하면서 stdin이 적절히 닫히지 않음. codex exec는 인자로 프롬프트를 받아도 stdin이 열려있으면 추가 입력을 기다림.
 
-해결: 모든 codex exec 호출에 `< /dev/null`을 추가하여 stdin을 즉시 EOF로 만든다. (아래 명령의 샌드박스 플래그는 §13 최초 기록 당시의 자동실행 플래그를 0.142.5 제거 이후 등가 표기인 `-s workspace-write`로 치환한 것 — stdin EOF 해결 패턴 자체와는 무관하다.)
+해결: 모든 codex exec 호출에 `< /dev/null`을 추가하여 stdin을 즉시 EOF로 만든다. (아래 명령의
+샌드박스 플래그는 §13 최초 기록 당시의 자동실행 단축 플래그를 현재 공개 표기인
+`-s workspace-write`로 치환한 것 — stdin EOF 해결 패턴 자체와는 무관하다.)
 ```bash
-codex exec -s workspace-write --ephemeral -o "$DIR/result.md" "$(cat prompt.md)" < /dev/null
+command codex exec -s workspace-write --ephemeral -o "$DIR/result.md" "$(cat prompt.md)" < /dev/null
 ```
 
 참고: Codex 공식 플러그인의 background 작업은 `stdio: "ignore"`로 stdin/stdout/stderr를 모두 /dev/null로 리다이렉트한다 (동일 효과).
+
+관련 upstream: [#20919](https://github.com/openai/codex/issues/20919) (non-TTY stdin hang),
+[#19945](https://github.com/openai/codex/issues/19945) (TTY 분리 + 긴 prompt silent crash, 0.124 회귀).
+관측 출처: 실전 재발 사례. 현재 semantic 재검증 미수행 (v0.142.5 기준 서술 유지).
 
 ### 14. stdin pipe로 §13의 stdin hang을 구조적 해결
 
@@ -475,7 +515,7 @@ codex exec -s workspace-write --ephemeral -o "$DIR/result.md" "$(cat prompt.md)"
 ```bash
 # §13의 < /dev/null 패턴을 대체:
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
-cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --ephemeral \
+cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write --ephemeral \
   -o "$DIR/result.md" \
   - \
   2>"$DIR/stderr.log"
@@ -490,6 +530,10 @@ cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --
 
 발견 세션: #443 PR 작업 중 DA for_pr R4 (2026-04-11). Correctness reviewer가 대규모 diff 포함 프롬프트에서 hang.
 
+관련 upstream: [#20919](https://github.com/openai/codex/issues/20919) (non-TTY stdin hang),
+[#19945](https://github.com/openai/codex/issues/19945) (TTY 분리 + 긴 prompt silent crash, 0.124 회귀).
+관측 출처: 실전 재발 사례. 현재 semantic 재검증 미수행 (v0.142.5 기준 서술 유지).
+
 ### 15. `codex-exec-supervised` wrapper로 §14 위에 process group/timeout 한계 보강 (issue #593)
 
 심각도: 보강 패턴 — §14 stdin pipe + supervised wrapper로 inline TOML override + npm wrapper detach 부재 한계까지 차단
@@ -498,6 +542,10 @@ cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --
 
 1. `-c hooks.<event>='[...]'` inline TOML override — Mac codex 0.128 8 PoC variant 중 vH(host HOME + no override + stdin pipe + read-only)만 OK, override 포함 vA-G + vJ 모두 hang. Agent D source 분석은 `-c` parse/merge 정상이지만 override shape가 hook engine MatcherGroup 등록 실패 가능성을 시사 (정밀 위치 [UNVERIFIED]).
 2. npm wrapper(@openai/codex) detach/process group 부재 — `codex-cli/bin/codex.js`의 `spawn(binaryPath, args, {stdio:"inherit", env})`은 `detached:true`도, process group 생성도 없다. SIGINT/SIGTERM/SIGHUP은 forward되지만 SIGKILL은 forward 불가. `timeout` 단독은 wrapper PID만 죽여 native binary가 잔존할 수 있다.
+
+후속 5-variant 실측에서도 `-c hooks.*` inline override 제거 시 12초 안에 성공하고 override
+포함 시 hang했다. `Reading additional input...` banner만으로 hang을 판정하지 말고 banner + 무진척 +
+`-o` 결과 미생성을 함께 확인한다. 관측 출처: 통제 smoke.
 
 외부 evidence:
 - [gstack#1034](https://github.com/garrytan/gstack/issues/1034) — Claude Code Bash 비대화형 세션에서 argv prompt + 열린 stdin → EOF 대기. macOS, codex v0.121. fix: `</dev/null`.
@@ -512,7 +560,6 @@ cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --
 # §14 stdin pipe + §15 supervised wrapper 결합 (Layer 1 — 모든 programmatic 호출 공통)
 cat "$DIR/prompt.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-  -c model="gpt-5.5" \
   -c model_reasoning_effort="medium" \
   -o "$DIR/result.md" \
   - \
@@ -586,12 +633,16 @@ nix shell nixpkgs#bubblewrap --command env CODEX_PROGRAMMATIC=1 codex exec -s wo
   직접 시도하지 않았다.
 - `read-only` / `workspace-write`에서는 네트워크가 차단되었고, `danger-full-access` 및 config 기본값에서는 허용되었다.
 - `~/.codex/config.toml`의 `sandbox_mode = "danger-full-access"` 기본값은 이 이슈에서 변경하지 않는다.
+- bwrap 안에서 Codex를 다시 실행하는 nested bwrap 우회는 초기화 실패로 기각됨
+  (2026-07-09 실측). fan-out 전에 패턴 8 스모크를 1회 통과시킨다.
 
 ### 17. exec auth chain 우선순위와 login status 한계
 
 심각도: 정보 — scratch `CODEX_HOME`이나 `--ignore-user-config`를 쓰는 자동화에서 auth 경계를 오해하면 `Not logged in` 또는 의도치 않은 계정 사용으로 실패한다.
 
 운영 계약: `codex exec` 경로의 auth 우선순위는 `CODEX_API_KEY > ephemeral tokens > auth.json`이다. `OPENAI_API_KEY`는 exec auth chain에 참여하지 않으며, interactive TUI에서 API key 입력을 보조하는 prefill로만 취급한다.
+
+전체 credential matrix는 재검증 미수행 (codex-cli 0.142.5 기준 서술 유지).
 
 현재 CLI에서 실측 가능한 경계:
 - `codex exec --help` (codex-cli 0.142.5, 2026-07-07)는 `--ignore-user-config`를 "`$CODEX_HOME/config.toml`은 로드하지 않지만 auth는 `CODEX_HOME`을 계속 사용"하는 플래그로 설명한다. 따라서 이 플래그는 MCP/config 표면 차단용이지 auth 차단용이 아니다.
@@ -601,9 +652,28 @@ nix shell nixpkgs#bubblewrap --command env CODEX_PROGRAMMATIC=1 codex exec -s wo
 재검증:
 
 ```bash
-codex exec --help | rg -- '--ignore-user-config|auth still uses'
+command codex exec --help | rg -- '--ignore-user-config|auth still uses'
 tmp=$(mktemp -d /tmp/codex-auth-check-XXXXXX)
-CODEX_HOME="$tmp" codex login status
-CODEX_HOME="$tmp" OPENAI_API_KEY=sk-dummy codex login status
+env CODEX_HOME="$tmp" codex login status
+env CODEX_HOME="$tmp" OPENAI_API_KEY=sk-dummy codex login status
 rm -rf "$tmp"
 ```
+
+### 18. 중첩 Codex session 파일 쓰기 거부와 `sudo chown` 오진
+
+심각도: 높음 — nested `codex exec`가 부모 sandbox 안에서 session 파일을 만들 때 발생
+
+증상: CLI가 session 디렉토리 쓰기 실패 뒤 `sudo chown` 계열 소유권 수정을 제안할 수 있다.
+중첩 실행 6회 실측에서는 실제 소유권 문제가 아니라 부모 Codex sandbox의 write denial이었다.
+관측 출처: 실전 재발 사례.
+
+진단 분기:
+
+1. `id`와 `ls -ld "$CODEX_HOME" "$CODEX_HOME/sessions"`로 실제 owner/mode를 기록한다.
+2. Direct Codex 세션 안의 nested 호출인지, 대상 경로가 부모 sandbox writable root 밖인지 확인한다.
+3. 동일 사용자·동일 경로가 부모 sandbox 밖의 허용된 수동 진단에서 쓰기 가능하면 sandbox denial로
+   판정하고 native subagent 또는 승인된 supervised 경로로 라우팅한다.
+4. 실제 owner 불일치가 독립적으로 확인될 때만 사용자에게 별도 복구 작업을 보고한다.
+
+CLI 제안만 보고 `sudo chown`을 실행하지 않는다. 소유권 변경은 host mutation이며 부모 sandbox
+denial을 해결하지 못하고 정상 파일의 owner를 훼손할 수 있다.

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
@@ -1,8 +1,14 @@
 # using-codex-exec 상황별 실행 패턴
 
-각 패턴은 Claude Code 세션 안팎에서 동일하게 재현 가능한 순수 셸 명령으로 작성한다.
+각 패턴은 Claude Code/headless programmatic 경로를 기본으로 하며 Layer 1
+`codex-exec-supervised`를 사용한다. Direct Codex fan-out은 native subagent가 기본이고, 사용자가
+literal raw 실행을 요청한 경우에만 `env ... codex exec`로 wrapper를 대체한다.
 
 > ⚠️ Bash tool은 zsh에서 실행됨. bash 전용 문법(간접 확장, case modification 등) 사용 금지 — 상세 규칙은 repo 루트 `CLAUDE.md` "Bash tool 환경" 섹션 참조.
+
+모든 예제는 stdout, stderr, `-o` 결과를 분리한다. JSON/JSONL parser 앞 `2>&1`, 판정 pipeline의
+`head`/`tail`, 원 exit를 가리는 후속 `echo $?`를 금지한다. pipeline은 `set -o pipefail`과 zsh
+`pipestatus`로 Codex exit를 보존한다.
 
 ## 패턴 1: 기본 exec — 파일 프롬프트 → 결과 저장
 
@@ -17,17 +23,21 @@ PROMPT
 
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다 ([known-issues.md §11](known-issues.md) 하위 항목).
 
-```bash
+```zsh
 # marker must apply to `codex`, not `cat` (issue #585): Codex 0.124+ user-level hooks의 early-exit 신호.
-cat /tmp/codex-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/codex-result.md 2>&1
-cat /tmp/codex-result.md
+set -o pipefail
+cat /tmp/codex-prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o /tmp/codex-result.md - \
+  > /tmp/codex.stdout 2> /tmp/codex.stderr
+codex_rc=$pipestatus[2]
+test "$codex_rc" -eq 0 && test -s /tmp/codex-result.md
 ```
 
 핵심 요소:
 - `-o`: 마지막 에이전트 메시지를 파일로 저장. 루프 연동 시 필수.
-- `2>&1`: stderr도 함께 캡처하여 실패 원인 추적에 활용.
-- stdin pipe 패턴 (`cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -`): pipe EOF가 stdin을 자동으로 닫아, Claude Code Bash tool의 background 전환 시 stdin hang을 구조적으로 방지한다. `< /dev/null`은 pipe가 대체하므로 불필요. 인라인 인자 `"$(cat file)"`는 사용하지 않는다 ([known-issues.md §14](known-issues.md)). marker는 codex 프로세스에 적용한다 (issue #585).
-- 인라인 프롬프트(`codex exec -s workspace-write "..."`)는 짧은 질의에만 사용.
+- stderr: 별도 파일로 캡처하여 실패 원인을 추적.
+- stdin pipe 패턴: pipe EOF가 stdin을 닫아 background 전환 시 hang을 방지한다. `< /dev/null`은 불필요하고, marker는 Codex 프로세스에 적용한다 (issue #585).
+- 인라인 프롬프트(`env CODEX_PROGRAMMATIC=1 codex exec ...`)는 literal raw 수동 실행의 짧은 질의에만 사용.
 
 ## 패턴 2: 코드 리뷰 — scope flag만 사용 (커스텀 지시 불필요)
 
@@ -36,7 +46,8 @@ cat /tmp/codex-result.md
 ### 브랜치 비교
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
+  -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
 ```
 
 현재 브랜치를 `main`과 비교하여 리뷰한다.
@@ -44,7 +55,8 @@ env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
 ### 미커밋 변경
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --uncommitted > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --uncommitted \
+  -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
 ```
 
 staged/unstaged/untracked 변경을 함께 리뷰한다. 커밋 전 self-review에 적합.
@@ -52,15 +64,18 @@ staged/unstaged/untracked 변경을 함께 리뷰한다. 커밋 전 self-review�
 ### 특정 커밋
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 > /tmp/review.md 2>&1
-env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 --title "Fix sandbox leak" > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit abc1234 \
+  -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit abc1234 --title "Fix sandbox leak" \
+  -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
 ```
 
 `--title`은 `--commit`과 함께 사용하여 리뷰 요약에 커밋 제목을 표시한다.
+각 호출은 exit 0과 `test -s /tmp/review.md`를 모두 통과해야 성공이다.
 
 ### 주의사항
 
-- `-o`도 사용 가능: 0.142.5에서 review의 `-o` 빈 파일 생성 upstream bug(#12502)가 해소되어, `-o`와 stdout 리다이렉트(`> file 2>&1`) 둘 다 사용할 수 있다 (재확인: 2026-07-03, known-issues.md §2).
+- `-o`와 stdout 모두 정상: 0.144.1 로컬 실측에서 두 채널에 review가 기록됐다. upstream #12502는 open이지만 로컬 미재현 (재확인: 2026-07-10, known-issues.md §2).
 - PROMPT 금지: scope flag과 PROMPT은 상호 배타. 자세한 내용은 SKILL.md 호환성 매트릭스 참조.
 
 ## 패턴 2b: stdin PROMPT로 review
@@ -68,7 +83,8 @@ env CODEX_PROGRAMMATIC=1 codex exec review --commit abc1234 --title "Fix sandbox
 scope flag 없이 PROMPT을 stdin으로 전달하여 review를 실행한다.
 
 ```bash
-cat prompt.md | env CODEX_PROGRAMMATIC=1 codex exec review - > /tmp/result.md 2>&1
+cat prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised review \
+  -o /tmp/result.md - > /tmp/result.stdout 2> /tmp/result.stderr
 ```
 
 > ⚠️ scope flag 미사용: PROMPT 사용 시 scope flag(`--uncommitted`/`--base`/`--commit`)와
@@ -101,7 +117,8 @@ EOF
 2. scope flag으로 리뷰를 실행한다:
 
 ```bash
-env CODEX_PROGRAMMATIC=1 codex exec review --base main > /tmp/review.md 2>&1
+env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
+  -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
 ```
 
 ### 전역 정책 (모든 프로젝트에 적용)
@@ -116,6 +133,8 @@ AGENTS.override.md > AGENTS.md > TEAM_GUIDE.md > .agents.md
 ```
 
 디렉토리 트리 깊은 곳의 파일이 상위를 오버라이드한다.
+
+재검증 미수행 (0.142.5 기준 서술 유지): AGENTS instruction의 실제 적용과 깊이별 우선순위.
 
 ## 패턴 4: 커스텀 리뷰 — exec 우회 (1회성 지시)
 
@@ -137,8 +156,10 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. diff가 클 수 있으므로 stdin pipe를 사용한다.
 
 ```bash
-cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/review-result.md - 2>&1
-cat /tmp/review-result.md
+cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o /tmp/review-result.md - \
+  > /tmp/review.stdout 2> /tmp/review.stderr
+test -s /tmp/review-result.md
 ```
 
 ### 미커밋 변경 리뷰
@@ -153,12 +174,14 @@ PROMPT
 ```
 
 ```bash
-cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/review-result.md - 2>&1
+cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o /tmp/review-result.md - \
+  > /tmp/review.stdout 2> /tmp/review.stderr
 ```
 
 ### 장점
 
-- `-o`로 결과 저장 가능 (0.142.5부터는 review 서브커맨드에서도 `-o`가 정상 동작하므로, 이 장점은 상대적으로 작아졌다 — patterns.md §패턴 2 주의사항 참조).
+- `-o`로 결과 저장 가능 (0.144.1에서는 review 서브커맨드도 정상 — 패턴 2 참조).
 - 프롬프트 내용을 완전히 자유롭게 구성 가능.
 - `--output-schema`와 조합하여 구조화된 JSON 출력도 가능.
 
@@ -168,7 +191,7 @@ cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-wri
 리터럴 텍스트만 전달할 때는 `<<'PROMPT'` (따옴표 포함)를 사용한다.
 패턴 1, 5, 8은 명령 치환이 불필요하므로 `<<'PROMPT'`를 사용한다.
 
-코드 블록 분리: `run_in_background` 환경에서 heredoc과 codex exec를 같은 Bash 호출에 넣으면 stdin hang이 발생한다 ([known-issues.md §11](known-issues.md) 하위 항목 참조). 모든 패턴에서 heredoc(프롬프트 생성)과 codex exec(실행)를 별도 코드 블록으로 분리한다. 실행 블록에서는 stdin pipe(`cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -`)를 사용한다.
+코드 블록 분리: `run_in_background` 환경에서 heredoc과 codex exec를 같은 Bash 호출에 넣으면 stdin hang이 발생한다 ([known-issues.md §11](known-issues.md) 하위 항목 참조). 모든 패턴에서 heredoc(프롬프트 생성)과 codex exec(실행)를 별도 코드 블록으로 분리한다. 실행 블록에서는 supervised stdin pipe를 사용한다.
 
 ### 단점
 
@@ -189,11 +212,11 @@ Ignore style-only issues.
 PROMPT
 ```
 
-⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. DA 루프에서는 stdin pipe(`cat file | env CODEX_PROGRAMMATIC=1 codex exec ... -`)를 사용한다.
+⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. DA 루프에서는 supervised stdin pipe를 사용한다.
 
 ```bash
-cat /tmp/da-round1.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/da-round1-result.md \
-  - 2>/tmp/da-round1-stderr.log
+cat /tmp/da-round1.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o /tmp/da-round1-result.md \
+  - > /tmp/da-round1-stdout.log 2>/tmp/da-round1-stderr.log
 cat /tmp/da-round1-result.md
 ```
 
@@ -214,12 +237,14 @@ PROMPT
 ```
 
 ```bash
-cat /tmp/da-round2.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/da-round2-result.md \
-  - 2>/tmp/da-round2-stderr.log
+cat /tmp/da-round2.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o /tmp/da-round2-result.md \
+  - > /tmp/da-round2-stdout.log 2>/tmp/da-round2-stderr.log
 ```
 
 핵심: 매 라운드마다 `-o`로 결과를 파일 저장하여 이력을 보존한다.
 이전 라운드 결과를 후속 프롬프트에 포함하지 않는다 (프롬프트 조향 금지).
+각 라운드는 `test -s`와 직전 라운드 대비 진척 delta를 확인한다. 진척 없는 pass가 연속되면
+circuit breaker로 중단하며 child가 같은 collector를 다시 생성하게 하지 않는다.
 
 ## 패턴 6: 구조화 출력 — --output-schema
 
@@ -262,28 +287,35 @@ PROMPT
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다. diff가 클 수 있으므로 stdin pipe를 사용한다.
 
 ```bash
-cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --output-schema /tmp/review-schema.json \
-  -o /tmp/review-structured.json - 2>&1
+cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write --output-schema /tmp/review-schema.json \
+  -o /tmp/review-structured.json - > /tmp/schema.stdout 2> /tmp/schema.stderr
+test -s /tmp/review-structured.json
 ```
 
-주의: `--output-schema`는 0.142.5부터 exec뿐 아니라 review/resume에서도 지원된다 (재확인: 2026-07-03, `codex exec review --help`). 이전에는 exec 전용이었다.
+주의: `--output-schema`는 exec/review/resume help에 모두 있다 (재확인: 2026-07-10,
+0.144.1). 실제 schema-conforming output은 재검증 미수행 (0.142.5 기준 서술 유지).
 
 ## 패턴 7: JSONL 이벤트 스트림
 
 자동화 파서와 연결하거나 실행 과정을 기록할 때 사용한다.
 
 ```bash
-cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --json > /tmp/events.jsonl
+cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write --json - > /tmp/events.jsonl 2> /tmp/events.stderr
 ```
 
 주요 이벤트 타입:
 - `thread.started` / `turn.started` / `turn.completed` / `turn.failed`
 - `item.completed` (에이전트 메시지)
 
+이 event 종류와 `--json + -o` 병용 결과는 재검증 미수행 (0.142.5 기준 서술 유지).
+
 최종 요약문을 파일로도 보존하려면 `-o`를 별도로 함께 사용한다:
 
 ```bash
-cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --json -o /tmp/result.md > /tmp/events.jsonl
+cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write --json -o /tmp/result.md - \
+  > /tmp/events.jsonl 2> /tmp/events.stderr
 ```
 
 ## 패턴 8: 스모크 테스트
@@ -292,22 +324,31 @@ cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --js
 
 ```bash
 cat > /tmp/smoke.md <<'PROMPT'
-현재 디렉토리 기준으로 가장 중요한 리스크 1개만 한 줄로 답한다.
+현재 디렉토리 기준으로 가장 중요한 리스크 1개만 한 줄로 답하고,
+마지막 줄에 SMOKE_COMPLETE를 출력한다.
 PROMPT
 ```
 
 ⚠️ `run_in_background` 환경: 여기서 Bash tool 호출을 종료하고, 아래를 별도 호출로 실행한다 ([known-issues.md §11](known-issues.md) 하위 항목).
 
-```bash
-cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o /tmp/smoke-result.md 2>&1
-cat /tmp/smoke-result.md
+```zsh
+rm -f /tmp/smoke-result.md /tmp/smoke.stdout /tmp/smoke.stderr
+set -o pipefail
+cat /tmp/smoke.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
+  -s workspace-write -o /tmp/smoke-result.md - \
+  > /tmp/smoke.stdout 2> /tmp/smoke.stderr
+codex_rc=$pipestatus[2]
+test "$codex_rc" -eq 0 && test -s /tmp/smoke-result.md
+rg -q '^SMOKE_COMPLETE$' /tmp/smoke-result.md
 ```
 
 성공 기준:
-- 명령이 비정상 종료되지 않는다.
-- 결과 파일이 생성되고 비어 있지 않다.
+- wrapper/CLI exit가 0이다.
+- stderr에 timeout, usage limit, sandbox denial, unsupported model 오류가 없다.
+- 결과 파일이 생성되고 비어 있지 않다 (`test -s`).
+- 요청한 완료 표식이 결과에 있다.
 
-통과하면, 기존 복잡한 프롬프트로 단계적으로 복귀한다.
+fan-out 전에 이 패턴을 1회 필수 실행한다. 통과하면 기존 복잡한 프롬프트로 단계적으로 복귀한다.
 
 ## exec vs review 비교표
 
@@ -316,20 +357,21 @@ cat /tmp/smoke-result.md
 | 프롬프트 | 완전 자유 제어 | diff 컨텍스트 내장 |
 | 대상 | 범용 작업 | 코드 리뷰 특화 |
 | diff 스코핑 | 수동 (heredoc 등) | 자동 (--uncommitted/--base/--commit) |
-| `-o` 동작 | 정상 | 정상 (0.142.5 — upstream bug #12502 해소, 재확인: 2026-07-03) |
+| `-o` 동작 | 정상 | 정상 (0.144.1 로컬 실측; upstream #12502 open이나 미재현, 2026-07-10) |
 
 ## 빠른 참조 표
 
-모든 `codex exec` 호출에는 `env CODEX_PROGRAMMATIC=1`을 codex 프로세스에 적용한다 (issue #585: Codex 0.124+ user-level hooks의 early-exit 신호).
+모든 programmatic 호출에는 `env CODEX_PROGRAMMATIC=1`을 wrapper 프로세스에 적용한다. wrapper가
+Codex 자식으로 환경을 전달하며 CLI 자체는 이 값을 자동 주입하지 않는다.
 
 | 상황 | 패턴 | 명령 요약 |
 |------|------|-----------|
-| 일반 실행 | 1 | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result` |
-| 리뷰 (기본) | 2 | `env CODEX_PROGRAMMATIC=1 codex exec review --base main > result` |
-| 리뷰 (stdin PROMPT) | 2b | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex exec review - > result` |
-| 리뷰 + 커스텀 지시 (영구) | 3 | AGENTS.md 작성 후 `env CODEX_PROGRAMMATIC=1 codex exec review --base` |
-| 리뷰 + 커스텀 지시 (1회) | 4 | `cat diff+지시 \| env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write -o result -` |
-| 피드백 루프 | 5 | 라운드별 prompt → `env CODEX_PROGRAMMATIC=1 codex exec -o` → 분석 → 반복 |
-| 구조화 출력 | 6 | `env CODEX_PROGRAMMATIC=1 codex exec --output-schema schema.json -o result` |
-| JSONL 스트림 | 7 | `env CODEX_PROGRAMMATIC=1 codex exec -s workspace-write --json > events.jsonl` |
-| 환경 점검 | 8 | 최소 프롬프트로 `env CODEX_PROGRAMMATIC=1 codex exec` 스모크 테스트 |
+| 일반 실행 | 1 | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o result -` |
+| 리뷰 (기본) | 2 | `env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main -o result` |
+| 리뷰 (stdin PROMPT) | 2b | `cat prompt \| env CODEX_PROGRAMMATIC=1 codex-exec-supervised review -o result -` |
+| 리뷰 + 커스텀 지시 (영구) | 3 | AGENTS.md 작성 후 `env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base` |
+| 리뷰 + 커스텀 지시 (1회) | 4 | `cat diff+지시 \| env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o result -` |
+| 피드백 루프 | 5 | 라운드별 prompt → supervised `-o` → 진척 검증 → 반복 |
+| 구조화 출력 | 6 | supervised `--output-schema schema.json -o result` |
+| JSONL 스트림 | 7 | supervised `--json` + stdout/stderr 분리 |
+| 환경 점검 | 8 | fan-out 전 supervised 최소 스모크 |

--- a/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
+++ b/modules/shared/programs/claude/files/skills/using-codex-exec/references/patterns.md
@@ -48,6 +48,7 @@ test "$codex_rc" -eq 0 && test -s /tmp/codex-result.md
 ```bash
 env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
   -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
+test -s /tmp/review.md
 ```
 
 현재 브랜치를 `main`과 비교하여 리뷰한다.
@@ -57,6 +58,7 @@ env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
 ```bash
 env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --uncommitted \
   -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
+test -s /tmp/review.md
 ```
 
 staged/unstaged/untracked 변경을 함께 리뷰한다. 커밋 전 self-review에 적합.
@@ -68,6 +70,7 @@ env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit abc1234 \
   -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
 env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --commit abc1234 --title "Fix sandbox leak" \
   -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
+test -s /tmp/review.md
 ```
 
 `--title`은 `--commit`과 함께 사용하여 리뷰 요약에 커밋 제목을 표시한다.
@@ -85,6 +88,7 @@ scope flag 없이 PROMPT을 stdin으로 전달하여 review를 실행한다.
 ```bash
 cat prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised review \
   -o /tmp/result.md - > /tmp/result.stdout 2> /tmp/result.stderr
+test -s /tmp/result.md
 ```
 
 > ⚠️ scope flag 미사용: PROMPT 사용 시 scope flag(`--uncommitted`/`--base`/`--commit`)와
@@ -119,6 +123,7 @@ EOF
 ```bash
 env CODEX_PROGRAMMATIC=1 codex-exec-supervised review --base main \
   -o /tmp/review.md > /tmp/review.stdout 2> /tmp/review.stderr
+test -s /tmp/review.md
 ```
 
 ### 전역 정책 (모든 프로젝트에 적용)
@@ -177,6 +182,7 @@ PROMPT
 cat /tmp/review-prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   -s workspace-write -o /tmp/review-result.md - \
   > /tmp/review.stdout 2> /tmp/review.stderr
+test -s /tmp/review-result.md
 ```
 
 ### 장점
@@ -217,7 +223,7 @@ PROMPT
 ```bash
 cat /tmp/da-round1.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o /tmp/da-round1-result.md \
   - > /tmp/da-round1-stdout.log 2>/tmp/da-round1-stderr.log
-cat /tmp/da-round1-result.md
+test -s /tmp/da-round1-result.md && cat /tmp/da-round1-result.md
 ```
 
 ### 후속 라운드
@@ -239,6 +245,7 @@ PROMPT
 ```bash
 cat /tmp/da-round2.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised -s workspace-write -o /tmp/da-round2-result.md \
   - > /tmp/da-round2-stdout.log 2>/tmp/da-round2-stderr.log
+test -s /tmp/da-round2-result.md
 ```
 
 핵심: 매 라운드마다 `-o`로 결과를 파일 저장하여 이력을 보존한다.
@@ -316,6 +323,7 @@ cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
 cat /tmp/prompt.md | env CODEX_PROGRAMMATIC=1 codex-exec-supervised \
   -s workspace-write --json -o /tmp/result.md - \
   > /tmp/events.jsonl 2> /tmp/events.stderr
+test -s /tmp/result.md
 ```
 
 ## 패턴 8: 스모크 테스트


### PR DESCRIPTION
## Summary

- using-codex-exec / using-claude-p 두 스킬을 codex-cli 0.144.1 · Claude Code v2.1.206 실측 기준으로 전면 현행화한다. 두 스킬은 이 저장소의 모든 programmatic AI 실행(run-da, codex-fan-out, SSH 크로스머신)이 참조하는 실행 계약 문서라, drift가 모든 fan-out 세션에 전파된다.
- 문서 격차·모순으로 LLM이 실전에서 오판한 사례(세션로그 전수조사에서 수집)를 계약으로 흡수한다: 실행 경로 게이트, 성공 계약, silent fallback 경고, 셸 transport 규칙.
- 이전 갱신이 sandbox 제약으로 보류했던 "재검증 미수행" 항목 중 실행 실측이 가능한 것을 해소하고, 나머지는 구버전 스탬프로 명시 보류한다.

## 기존 문제/배경

**AS-IS**: using-codex-exec는 codex-cli 0.142.5(2026-07-03), using-claude-p는 v2.1.202(2026-07-08) 기준으로 작성됐고, 활성 CLI는 0.144.1 / 2.1.206이다. 버전 격차는 작아 보이지만 실측 결과 문서 주장 131건 중 13건이 이미 틀렸다.

**실전 피해 사례** (세션로그 전수조사, Mac 2대분 + MiniPC):

- `--output-format json`을 "단일 객체"로 해석해 파싱이 깨진 사례 4건 (`AttributeError: 'list' object has no attribute 'keys'`). 실측상 v2.1.150부터 일관되게 이벤트 배열.
- `--ephemeral` 후 `resume --last`가 문서의 "No saved session found 에러"와 달리 **조용히 새 세션을 시작하고 exit 0을 반환** — 경고하던 에러보다 위험한 silent fallback으로 동작이 반전됨.
- patterns.md가 `--dangerously-skip-permissions`+`--allowedTools` 병용을 권장 — 본문·gotchas의 "병용 시 제한 무효"와 정면 모순 (실사용 6회에서 allowlist 구조적 무효 확인).
- description의 `'''claude -p'''` 삼중따옴표가 시스템 프롬프트 스킬 목록에 리터럴로 렌더링 (이전 감사에서 발견됐으나 미수정).
- Direct Codex 세션이 native subagent 대신 nested `codex exec`를 선택해 장시간 무결과 후 kill한 라우팅 오판 2건 — 본문 raw 예제와 references의 supervised 계약이 split-brain 상태였다.
- exit 0 / `subtype=success`인데 산출물 0인 사례 (자기증식 collector 폭주, review `-o` 미생성 5회) — 성공 판정 계약 부재.

drift로 인한 문서 재작성은 이번이 두 번째다 (0.122.0→0.142.5에 이어). 같은 패턴의 재발이므로 이번에는 CLI 사실 갱신에 그치지 않고, 세션로그가 증언하는 "문서가 놓친 실패 모드"까지 계약화했다.

## CIR (Change Intent Record)

- **v1** (PR #49 → #110 → #233): using-codex-exec 최초 작성과 전면 재설계. claude -p 스킬은 PR #248에서 분리 신설.
- **v2** (이슈 #861 → PR #967): 0.122.0→0.142.5 1차 drift 현행화. "help 전문 캡처 → 주장 대조표 → 실행 실측" 방법론과 "해소 항목은 삭제 대신 버전 표기 보존" 규율 확립 (plans/022).
- **v3** (이슈 #1018 → PR #1036): using-claude-p 버전 스탬프 v2.1.202 갱신. 단 실행이 필요한 gotcha 25+건은 당시 실행 환경 제약으로 "재검증 미수행 (v2.1.202 기준 서술 유지)"로 명시 보류.
- **v4** (이번 변경): 2차 drift(0.142.5→0.144.1, 2.1.202→2.1.206) + 세션로그 3건·GitHub 논의·공식문서 조사 + 131개 주장 전수 실측을 종합. 조사·리뷰 설계와 실측·집필을 분리한 이중 검증(교차 실측)으로 진행 — 예: "`--max-turns` 완전 제거" 오판을 실행 smoke로 반박하고, 그 오판 자체를 "hidden flag는 help 부재만으로 제거 판정 금지" 원칙의 근거로 흡수.

**제거·되돌림 명시**:
- patterns.md(using-claude-p)의 skip-permissions+allowlist 병용 예제 제거 — v1 시기(PR #248 계열)에 도입된 예제이나, SKILL 본문·gotchas #3과 모순이며 실사용에서 allowlist가 무효였음이 확인되어 금지 패턴으로 반전.
- known-issues §2의 해소 전 재현 로그(0바이트 `-o` 등) 압축 — 버전 하한 판단 근거는 1-2줄 역사 기록으로 보존 (v2 규율 유지).
- "과거 자동 실행 플래그는 완전히 제거됨"(PR #967에서 도입한 서술) 되돌림 — 0.144.1 실측에서 hidden parser가 수용하며 deprecation warning을 내는 것으로 반증됨.

**trade-off**: 실측 불가 항목을 삭제하지 않고 "재검증 미수행 (구버전 기준 서술 유지)" 스탬프로 보존해 문서가 다소 길어졌다. 대신 각 주장의 신뢰도(재확인 날짜·출처: 실전 재발 vs 통제 smoke)가 명시되어, 다음 drift 갱신 때 재실측 대상을 기계적으로 추출할 수 있다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 버전 스탬프만 갱신 | v3(PR #1036) 방식 반복 | 저비용 | 실전 오판 사례 미해소, 부채 이월 | ❌ |
| 전면 재작성 | 두 스킬을 백지에서 재구성 | 구조 최적화 자유 | run-da·codex-fan-out이 참조하는 앵커·gotcha 번호 계약 파괴 위험 | ❌ |
| 실측 대조표 기반 차분 갱신 | 131개 주장 대조표 판정에 따라 차분 수정, 앵커·번호 보존 | 참조 계약 유지 + 실측 근거 추적 가능 | 대조표 작성 비용 | ✅ |
| 실행 경로: supervised 단일 표준 | 모든 호출을 wrapper로 통일 | 규칙 단순 | Direct Codex native 경로·수동 진단 raw 경로와 충돌 (라우팅 오판 재생산) | ❌ |
| 실행 경로: 3-way 게이트 | native / supervised / raw를 실행 문맥으로 분기 | 라우팅 오판 실사례 2건 직접 해소 | 표 1개 추가 | ✅ |
| 재검증 미수행 처리: 지침 삭제 + 스탬프 | 요약에서 미실측 지침 제거 | 스탬프 정직성 | 각 세션 LLM이 즉시 쓸 행동 지침 소실 | ❌ |
| 재검증 미수행 처리: 지침 유지 + 스탬프 병기 | 행동 지침 본문 유지, 신뢰도만 표기 | 실용성과 정직성 양립 | 줄당 길이 증가 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `...skills/using-codex-exec/SKILL.md` | 수정 | 3-way 실행 경로 게이트, 성공 계약·오류 분류표, 셸 transport 계약, ephemeral resume silent fallback, hidden `--full-auto` 정정, `resume -i/--image`, zsh alias 경고, description 다이어트(한국어 트리거 유지) |
| `...skills/using-codex-exec/references/known-issues.md` | 수정 | §1~§17 앵커 전부 보존. §2/§6 `-o` 모순 통일, #7825·#12502 이슈 상태와 로컬 동작 분리, §16 nested bwrap 기각 추가, 신규 §18(중첩 sandbox session-write 거부 → `sudo chown` 오진 방지), §0에 오류 분류·재시도 정책 표 |
| `...skills/using-codex-exec/references/patterns.md` | 수정 | programmatic 예제를 supervised wrapper로 통일, stdout/stderr/result 분리, fan-out 전 스모크 필수 게이트화 |
| `...skills/using-claude-p/SKILL.md` | 수정 | description 삼중따옴표 제거+다이어트, JSON 이벤트 배열 확정, variadic flag 일반화, 성공 계약(4조건)+circuit breaker, 셸 transport 계약 |
| `...skills/using-claude-p/references/gotchas.md` | 수정 | #1~#40 번호 보존, #1 variadic 일반화, #29 subtype/exit 예외 반영, 신규 #41(성공 오판)·#42(shell exit/채널 은폐), 실측/보류 스탬프 분리 |
| `...skills/using-claude-p/references/flag-matrix.md` | 수정 | 2.1.206 신규 플래그(--json-schema, --bare, --safe-mode, --session-id, --fallback-model 등), `ANTHROPIC_API_KEY`를 API-key 인증 경로로 한정 |
| `...skills/using-claude-p/references/patterns.md` | 수정 | skip-permissions+allowlist 병용 제거, 배열/객체 정규화 parser, json-schema·bare·session-id 패턴 추가 |
| `...skills/using-claude-p/references/harness-testing.md` | 수정 | JSON 정규화·result 검증, stderr 분리·원 exit 보존, T5~T8 판정 기준 강화 |

### 핵심 변경 예시

실행 경로 게이트 (using-codex-exec/SKILL.md 서두):

| 실행 문맥 | 선택 경로 |
|----------|----------|
| Direct Codex 세션의 fan-out | native subagent |
| Claude Code 세션·headless 자동화 | `codex-exec-supervised` (Layer 1) |
| literal raw 요청·1회성 수동 진단 | raw `codex exec` (`command codex`로 alias 우회) |

ephemeral resume 서술 반전 (BEFORE/AFTER):

```markdown
# BEFORE
⚠️ --ephemeral 세션은 파일이 저장되지 않으므로 resume 불가. `No saved session found` 에러 발생.

# AFTER (0.144.1 실측)
--ephemeral 세션은 저장되지 않는다. 0.144.1에서 저장 세션이 없는 cwd의 resume --last는
오류 대신 새 session id로 조용히 시작해 exit 0을 반환했다. resume 성공 여부를 exit code만으로
판정하지 말고 stderr banner의 session id와 응답 context가 원 세션과 이어지는지 확인한다.
```

## 참고 레퍼런스

- 이슈 #861 / PR #967 — 1차 drift 현행화 (0.122.0→0.142.5), 실측 대조표 방법론 선례 (`plans/022-using-codex-exec-doc-refresh.md`)
- 이슈 #1018 / PR #1036 — using-claude-p 스탬프 갱신, "재검증 미수행" 보류 항목의 출처
- 이슈 #836 — configuring-codex의 stale 스탬프 (본 PR 스코프 밖, 해당 이슈에 위임)
- 이슈 #504 / #447 — upstream sync 자동화 재개 조건("drift로 인한 실사용 오류 재발") — 이번이 2회째 재발로 조건 충족, 별도 이슈 등록 후보
- 이슈 #995 / PR #1003 — NixOS bwrap sandbox tier 실측 (§16의 기반, 이번에 nested bwrap 기각 추가)
- openai/codex#7825 — review PROMPT/scope 상호배타 (closed-as-not-planned; runtime 제약은 0.144.1에서도 유지)
- openai/codex#12502 — review 출력 stderr 회귀 보고 (open; 로컬 0.144.1 미재현)
- openai/codex#20919, openai/codex#19945 — stdin non-TTY hang·silent crash upstream 보고 (§13/§14 각주)

## Human Test Plan

### 정상 동작 검증

1. 버전-스탬프 일치를 확인한다: `command codex --version && claude --version`
   - **기대**: `codex-cli 0.144.1`, `2.1.206` — 두 SKILL.md "작성 기준"과 일치.
   - **실패 시**: CLI가 그새 더 올라간 것 — 문서 서두의 재검증 명령으로 help 대조 후 갱신 필요 여부 판단.
2. resume image 매트릭스를 확인한다: `command codex exec resume --help | grep -A1 image`
   - **기대**: `-i, --image <FILE>` 존재 (매트릭스의 "resume image 지원" 서술과 일치).
   - **실패 시**: help 전문과 SKILL.md 호환성 매트릭스를 대조한다.
3. JSON 배열 계약을 확인한다: `echo "1+1?" | claude -p --output-format json | python3 -c "import json,sys; d=json.load(sys.stdin); print(type(d).__name__)"`
   - **기대**: `list` (이벤트 배열).
   - **실패 시**: gotchas #6·SKILL 의사결정 트리의 shape 서술을 재실측한다.

### 엣지 케이스

4. ephemeral resume silent fallback을 재현한다: 저장 세션이 없는 임시 디렉토리에서 `codex exec --ephemeral "hi"` 후 `codex exec resume --last --skip-git-repo-check "이어서"`
   - **기대**: 에러 없이 exit 0, stderr banner에 새 session id — 문서의 silent fallback 서술 그대로.
   - **실패 시**: `No saved session found` 에러가 나면 upstream 동작이 다시 바뀐 것 — gotcha 4를 재갱신한다.

### Negative 검증

5. 삼중따옴표 잔존을 확인한다: `grep -c "'''" modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md`
   - **기대**: 0건.
6. 병용 모순 잔존을 확인한다: using-claude-p patterns.md에서 `--dangerously-skip-permissions`와 `--allowed-tools`가 같은 명령에 함께 등장하는 예제 부재 (금지 패턴 표 제외).
   - **기대**: 병용 예제 0건, 금지 패턴 표에만 등장.

### Regression 검증

7. 참조 계약을 확인한다: run-da·codex-fan-out이 참조하는 known-issues.md 앵커(§11 literal 재사용, §15 supervised wrapper, §16 bwrap)와 gotchas #1~#40 번호 존재.
   - **기대**: 전부 존재 (신규는 §18, #41~#42만).
   - **실패 시**: 앵커 제목 diff를 확인해 참조 측 스킬과 정합 복구.
8. 게이트를 실행한다: `bash tests/run-shell-script-tests.sh && ./scripts/ai/verify-ai-compat.sh`
   - **기대**: 셸 테스트 193/193 통과. verify-ai-compat은 pre-existing template↔live drift(`model_reasoning_effort: ultra vs xhigh`, main에도 동일) 1건 외 오류 없음.
   - **실패 시**: 실패 항목이 skills 관련인지 확인 — skills 무관 실패면 본 PR 스코프 밖.

https://claude.ai/code/session_013fq13QAbEr3gfnyeSbYRqq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Claude Code 비대화형(`claude -p`) 가이드를 v2.1.206 기준으로 업데이트해, JSON/JSONL 처리·성공 판정·권한/MCP/SSH·세션 재개 및 셸 파이프라인(종료코드 보존, stdout/stderr 분리) 안내를 강화했습니다.
  * gotchas, 플래그 매트릭스, 실행 패턴 및 하네스 셀프테스트 문서를 최신 재검증 기준으로 정리했습니다.
  * Codex 실행/리뷰 가이드를 v0.144.1 기준으로 갱신하고, supervised 실행 전환과 결과 파일 검증·실패 대응 절차를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->