### PR TITLE
fix(lefthook): call_lefthook 정의가 없는 깨진 hook을 installer가 감지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ home-manager activation 충돌 정책: macOS에서 mkOutOfStoreSymlink target이
 - 목록: `wt ls --json` (name/branch/path/pr/dirty/unpushed/current/committedAt/age 구조화 출력, jq 파싱용).
 - 정리: `wt cleanup --auto` (MERGED 자동) 또는 `wt cleanup <name>...` (이름 지정). dirty/unpushed 확인 우회는 `--yes`.
 
+**워크트리에서 git hook 파일을 직접 쓰지 않는다.** direnv/`nrs`가 그 워크트리의 `core.hooksPath`를 고정하기 전에는 `git rev-parse --git-path hooks`가 **메인 repo의 `.git/hooks`** 로 해석된다. 그 경로에 쓰면 메인 repo의 hook을 덮어써 이후 모든 커밋이 막힐 수 있다 (#1073에서 관측된 경로). hook 동작을 확인해야 하면 `tests/suites/lefthook.sh`의 격리 fixture(`create_install_lefthook_fixture`)를 쓴다. 이미 덮어썼다면 그 hook 파일을 지운 뒤 direnv를 다시 진입한다 — `lefthook.yml`이 정의하는 hook은 `lefthook install`이 다시 쓴다. 다만 `<hook>.old`가 이미 있으면 lefthook이 백업 rename에 실패해 install이 죽으므로, 그때는 `<hook>`과 `<hook>.old`를 함께 지운다.
+
 ## Bash tool 환경
 
 Bash tool의 inline 스크립트는 zsh에서 실행된다. 아래 bash 전용 문법은 zsh에서 `bad substitution`으로 실패하므로 사용하지 않는다.

--- a/scripts/ai/install-lefthook-hooks.sh
+++ b/scripts/ai/install-lefthook-hooks.sh
@@ -54,6 +54,24 @@ NO_AUTO_INSTALL_FLAG="--no-auto-install"
 # 한 줄로 유지한다 — tests/suites/lefthook.sh가 sed로 추출해 실제 hook 이름 판별에 재사용한다.
 GIT_HOOK_NAMES="applypatch-msg pre-applypatch post-applypatch pre-commit pre-merge-commit prepare-commit-msg commit-msg post-commit pre-rebase post-checkout post-merge pre-push pre-receive update proc-receive post-receive post-update reference-transaction push-to-checkout pre-auto-gc post-rewrite sendemail-validate fsmonitor-watchman p4-changelist p4-prepare-changelist p4-post-changelist p4-pre-submit post-index-change"
 
+# 위 목록 중 git이 exit status를 무시하는 hook. 이 hook이 깨져 exit 127로 죽어도 그 명령은 그대로
+# 성공하므로, installer는 실패 대신 경고만 낸다 — 아무것도 막지 못하는 파일 하나 때문에 direnv
+# 진입까지 막을 이유가 없다.
+#
+# 편입 기준 (`man githooks`, git 2.54): 그 항목이 "cannot affect the outcome of ..." 또는 "does not
+# affect the outcome" 서술을 갖고, **그 문장에 exit status 예외절이 붙지 않을 것.** 예외절이 붙는
+# 대표가 `post-checkout`이다 — "cannot affect the outcome of git switch or git checkout, *other than
+# that the hook's exit status becomes the exit status of these two commands*". 그래서 제외한다
+# (실측: 깨진 post-checkout에서 `git worktree add`가 exit 127을 낸다 — `wt`가 반쯤 만들어진 워크트리를
+# 남기고 죽는다). 아래 목록은 이 기준을 문서 전문에 기계적으로 적용한 결과다.
+#
+# 문서에 exit status 서술이 아예 없으면 넣지 않는다 (fail-closed). `post-rewrite`와 `post-index-change`가
+# 그렇다 — 실측으로는 무시되지만 문서 근거가 없어 단정하지 않는다.
+#
+# 기준은 "문서 근거가 있는가"이지 "이 저장소가 쓰는가"가 아니다. 이 집합은 git의 계약을 그대로 옮긴
+# 것이어야 하므로, 서버측 hook(post-update, post-receive)과 git-p4 hook(p4-post-changelist)도 포함한다.
+GIT_HOOK_NAMES_IGNORING_EXIT_STATUS="post-applypatch post-commit post-merge post-update post-receive p4-post-changelist"
+
 # 30 minutes — install itself runs in ~150ms; this guards against hung child
 # processes (NFS lock issues, OS bugs) rather than normal contention. Matches the
 # convention from modules/shared/scripts/lib/rebuild/locks.sh:198.
@@ -434,6 +452,40 @@ PY
     expected_call='call_lefthook run "'"$hook_name"'" '"$NO_AUTO_INSTALL_FLAG"' "$@"'
     if ! grep -Fxq -- "$expected_call" "$hook_file"; then
       fail "auto-install suppression failed: expected exact call line [$expected_call] in $hook_file"
+    fi
+    # (3) `call_lefthook()` 정의가 있어야 한다. 위 검사 셋 중 어느 것도 이것을 보지 않는다 —
+    # 정의되지 않은 함수를 부르는 문장은 셸 문법상 합법이라 `bash -n`을 통과하고(실측: exit 0),
+    # 호출부 형태만 맞으면 call_count·expected_call도 통과한다. 그런 hook은 git이 실행하는 순간
+    # `call_lefthook: command not found`로 exit 127을 내며 죽는다. 이 검사가 없으면 installer는
+    # 커밋을 막는 hook을 남겨 둔 채 성공을 보고한다 (#1073).
+    #
+    # 이 검사를 여기(python 패치 이후)에 두는 것이 중요하다. 앞으로 옮기는 두 대안은 서로 다른
+    # 이유로 더 나쁘다.
+    #   - 수집 루프(패치 이전, install 이후): 그 시점엔 run_lefthook_install이 configured hook을
+    #     순정 템플릿으로 다시 써서 `--no-auto-install`이 없는 상태다. 거기서 죽으면 플래그가 없는
+    #     채로 남고, lefthook.yml의 lefthook-guard-self-check가 그것을 커밋 차단으로 판정한다.
+    #   - run_lefthook_install 이전 preflight: `fail`이 즉시 exit하므로 install이 아예 돌지 않는다.
+    #     그러면 깨진 configured hook을 install이 다시 써서 고칠 기회를 빼앗는다 (실측: lefthook은
+    #     그 파일을 <name>.old로 밀고 새로 써서 preamble을 복구한다 — 단 <name>.old가 이미 있으면
+    #     rename에 실패해 그 복구도 죽는다). 그 hook은 깨진 채 남고 커밋이 계속 막힌다.
+    # 여기서는 패치가 끝나 플래그가 살아 있고, configured hook은 install이 이미 고친 뒤다.
+    #
+    # 이 배치를 지키는 것은 이 주석뿐이다. 아래 테스트는 검사를 preflight로 옮겨도 통과한다 —
+    # 1회차 install이 심은 플래그가 그대로 남아 "실패 후에도 플래그가 살아 있다"는 단언이 성립한다.
+    #
+    # expected_call 뒤에 두는 것도 의도다. 주석에서 `call_lefthook run `을 언급할 뿐인 남의 hook은
+    # 그 검사에서 먼저 걸려, "정의가 없다"는 엉뚱한 진단을 받지 않는다.
+    if ! grep -Eq '^[[:space:]]*call_lefthook[[:space:]]*\(\)' "$hook_file"; then
+      case " $GIT_HOOK_NAMES_IGNORING_EXIT_STATUS " in
+        *" $hook_name "*)
+          # git이 이 hook의 exit status를 무시하므로 커밋·push는 막히지 않는다. 알리되 멈추지 않는다.
+          echo "install-lefthook-hooks: warning: $hook_file has no call_lefthook() definition and dies with exit 127 when git runs it." >&2
+          echo "  git ignores this hook's exit status, so commits still work. Delete the file if lefthook.yml no longer defines this hook." >&2
+          ;;
+        *)
+          fail "broken hook: no call_lefthook() definition (git would fail it with exit 127; delete the file if lefthook.yml no longer defines this hook): $hook_file"
+          ;;
+      esac
     fi
   done
 }

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -175,6 +175,10 @@ run_test "install-lefthook pins worktree-local hooks path in worktree mode" test
 run_test "install-lefthook injects --no-auto-install into every hook" test_install_lefthook_injects_no_auto_install_into_every_hook
 run_test "install-lefthook --no-auto-install injection is idempotent" test_install_lefthook_no_auto_install_injection_is_idempotent
 run_test "install-lefthook patches a stale unconfigured hook" test_install_lefthook_patches_stale_unconfigured_hook
+run_test "install-lefthook rejects a broken hook and keeps configured-hook flags" test_install_lefthook_rejects_hook_without_call_lefthook_definition
+run_test "install-lefthook warns but survives a broken post-* hook" test_install_lefthook_warns_but_survives_a_broken_post_hook
+run_test "install-lefthook exit-status-ignoring hooks are real git hooks" test_install_lefthook_exit_status_ignoring_hooks_are_known_git_hooks
+run_test "install-lefthook premise: bash -n accepts an undefined function call" test_install_lefthook_premise_bash_n_accepts_undefined_function_call
 run_test "install-lefthook leaves .old backup hooks untouched" test_install_lefthook_leaves_old_backup_hooks_untouched
 run_test "install-lefthook fails when lefthook call shape changes" test_install_lefthook_fails_when_lefthook_call_shape_changes
 run_test "install-lefthook fails on an unpatched second lefthook call" test_install_lefthook_fails_on_unpatched_second_call

--- a/tests/suites/lefthook.sh
+++ b/tests/suites/lefthook.sh
@@ -9,7 +9,8 @@
 # run_lefthook_install / inject_staged_guard / disable_lefthook_auto_install 동작이고,
 # lefthook 자체의 install 로직은 별도 신뢰 영역이다.
 # stub은 install 명령 호출 시 설정된 hook(pre-commit/commit-msg/pre-push)을 모두 생성하며,
-# 각 파일은 `call_lefthook run "<hook>" "$@"` 라인을 포함한다.
+# 각 파일은 `call_lefthook()` preamble과 `call_lefthook run "<hook>" "$@"` 호출부를 함께 포함한다
+# (installer가 그 둘을 함께 요구한다 — #1073).
 # 예외: test_lefthook_auto_sync_cannot_drop_guard_end_to_end는 auto-sync 동작 자체를 확인해야
 # 하므로 stub 없이 실제 lefthook 바이너리를 사용한다.
 
@@ -20,10 +21,36 @@ LEFTHOOK_GUARD_BEGIN_MARKER=$(sed -n 's/^BEGIN_MARKER="\(.*\)"$/\1/p' "$REPO_ROO
 LEFTHOOK_GUARD_END_MARKER=$(sed -n 's/^END_MARKER="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 LEFTHOOK_NO_AUTO_INSTALL_FLAG=$(sed -n 's/^NO_AUTO_INSTALL_FLAG="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 LEFTHOOK_GIT_HOOK_NAMES=$(sed -n 's/^GIT_HOOK_NAMES="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
+LEFTHOOK_GIT_HOOK_NAMES_IGNORING_EXIT_STATUS=$(sed -n 's/^GIT_HOOK_NAMES_IGNORING_EXIT_STATUS="\(.*\)"$/\1/p' "$REPO_ROOT/scripts/ai/install-lefthook-hooks.sh")
 [[ -n "$LEFTHOOK_GUARD_BEGIN_MARKER" ]] || fail "could not extract BEGIN_MARKER from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_GUARD_END_MARKER" ]] || fail "could not extract END_MARKER from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_NO_AUTO_INSTALL_FLAG" ]] || fail "could not extract NO_AUTO_INSTALL_FLAG from install-lefthook-hooks.sh"
 [[ -n "$LEFTHOOK_GIT_HOOK_NAMES" ]] || fail "could not extract GIT_HOOK_NAMES from install-lefthook-hooks.sh"
+[[ -n "$LEFTHOOK_GIT_HOOK_NAMES_IGNORING_EXIT_STATUS" ]] \
+  || fail "could not extract GIT_HOOK_NAMES_IGNORING_EXIT_STATUS from install-lefthook-hooks.sh"
+
+# fixture가 만드는 hook 형태의 유일한 소유점 (printf 포맷).
+#
+# installer는 `call_lefthook()` 정의와 `call_lefthook run` 호출부를 함께 요구하므로
+# (hook_defines_call_lefthook, #1073), preamble이 빠진 fixture는 "깨진 hook"으로 거부된다.
+# 정상 hook을 만드는 곳이 stub 둘 + 파일 밖 fixture 하나로 셋인데, 각자 형태를 들고 있으면
+# 한쪽만 고쳤을 때 조용히 갈라진다. 아래 조각에서만 정의하고 나머지는 전부 파생시킨다.
+#
+# 실제 lefthook 산출물의 골격(shebang → 빈 줄 → ... → `call_lefthook()` 정의 → 호출부)을 따르되,
+# 검사에 무관한 LEFTHOOK_VERBOSE/LEFTHOOK=0 블록은 재현하지 않는다.
+#
+# **불변식: 이 포맷들에는 `%s`(hook 이름) 외의 `%`를 넣지 마라.** 같은 문자열이 두 가지 방식으로
+# 소비되기 때문이다 — `lefthook_hook_preamble`은 `printf '%b'`의 피연산자로(포맷 해석 없음),
+# `write_lefthook_*`와 두 stub은 `printf "$FORMAT"`의 포맷으로(해석 있음) 쓴다. `%`를 하나라도
+# 넣으면 `%b` 경로만 원문을 보존하고 나머지는 조용히 문자를 먹으며, 뒤따르는 `%s`가 인자를 잃어
+# hook 이름까지 빈 문자열이 된다 (실측). 종료코드는 0이라 아무도 알아채지 못한다.
+LEFTHOOK_STUB_HOOK_SHEBANG_FORMAT='#!/bin/sh\n'
+LEFTHOOK_STUB_HOOK_PREAMBLE_FORMAT="$LEFTHOOK_STUB_HOOK_SHEBANG_FORMAT"'\ncall_lefthook()\n{\n  lefthook "$@"\n}\n\n'
+# `%s`는 hook 이름.
+LEFTHOOK_STUB_HOOK_CALL_FORMAT='call_lefthook run "%s" "$@"\n'
+# 정상 hook = preamble + 호출부. 깨진 hook = shebang + 호출부 (preamble의 부재가 핵심).
+LEFTHOOK_STUB_HOOK_FORMAT="$LEFTHOOK_STUB_HOOK_PREAMBLE_FORMAT$LEFTHOOK_STUB_HOOK_CALL_FORMAT"
+LEFTHOOK_STUB_HOOK_BROKEN_FORMAT="$LEFTHOOK_STUB_HOOK_SHEBANG_FORMAT$LEFTHOOK_STUB_HOOK_CALL_FORMAT"
 
 lefthook_config_hook_names() {
   # installer의 configured_hooks와 같은 방식으로 lefthook.yml에서 hook 이름만 뽑는다
@@ -58,6 +85,38 @@ assert_hook_call_line() {
   expected="call_lefthook run \"${hook_name}\" ${LEFTHOOK_NO_AUTO_INSTALL_FLAG} \"\$@\""
   actual=$(grep -F 'call_lefthook run ' "$hook_path" || true)
   [[ "$actual" == "$expected" ]] || fail "hook $hook_path: expected call line [$expected], got [$actual]"
+}
+
+lefthook_hook_preamble() {
+  # LEFTHOOK_STUB_HOOK_PREAMBLE_FORMAT을 그대로 풀어 stdout으로 낸다. 호출부의 *형태*를 시험하는
+  # fixture는 그 뒤에 자기 body를 이어 붙인다 — preamble이 없으면 "깨진 hook" 판정이 먼저 발동해
+  # 엉뚱한 이유로 실패하기 때문이다 (#1073).
+  # preamble 단독은 치환할 인자가 없으므로 `%b`로 백슬래시 이스케이프만 푼다 (SC2059 회피).
+  # 전체 포맷 쪽은 hook 이름 `%s` 치환이 필요해 `%b`를 쓸 수 없다 — 두 경로가 갈리는 지점이며,
+  # 그래서 상수에 `%`를 넣으면 안 된다 (상수 정의부의 불변식 참조).
+  printf '%b' "$LEFTHOOK_STUB_HOOK_PREAMBLE_FORMAT"
+}
+
+write_lefthook_generated_hook() {
+  # lefthook이 남긴 그대로의 hook: preamble + 호출부, 플래그 없음.
+  # 플래그를 일부러 넣지 않는다 — 주입 대상이 되는 것이 이 헬퍼를 쓰는 테스트의 관심사다.
+  # 호출처가 하나뿐이지만 write_lefthook_hook_missing_preamble과 대칭을 이뤄 "정상/깨짐" 두 형태를
+  # 나란히 소유한다. 둘 중 하나만 헬퍼로 두면 다음 사람이 짝을 놓친다.
+  local hook_path="$1" hook_name="$2"
+  # shellcheck disable=SC2059  # 포맷은 신뢰된 상수, hook 이름이 유일한 인자다.
+  printf "$LEFTHOOK_STUB_HOOK_FORMAT" "$hook_name" > "$hook_path"
+  chmod +x "$hook_path"
+}
+
+write_lefthook_hook_missing_preamble() {
+  # 호출부만 있고 `call_lefthook()` 정의가 없는 hook. preamble의 부재가 이 fixture의 존재 이유다
+  # — installer의 사후 검증이 거부해야 하는 대상이자, `bash -n`이 문법 오류로 보지 않는다는 전제의
+  # 표본이다. 호출부 형태는 위 정상 형태와 같은 상수에서 파생된다.
+  # 실제 lefthook의 `.old` 백업은 rename 산물이라 실행 권한을 유지하므로 여기서도 chmod +x 한다.
+  local hook_path="$1" hook_name="$2"
+  # shellcheck disable=SC2059  # 포맷은 신뢰된 상수, hook 이름이 유일한 인자다.
+  printf "$LEFTHOOK_STUB_HOOK_BROKEN_FORMAT" "$hook_name" > "$hook_path"
+  chmod +x "$hook_path"
 }
 
 install_lefthook_git_isolation() {
@@ -113,13 +172,15 @@ write_install_lefthook_stub() {
   # 두 fixture 생성기가 공유하는 lefthook stub. install 동작을 한 곳에서만 정의해
   # 호출 형태나 hook 집합을 바꿀 때 한쪽만 고치는 사고를 막는다.
   # 실제 CLI처럼 lefthook.yml에서 hook 이름을 읽되, 전역 옵션 키(`colors` 등)는 건너뛴다.
+  # 생성하는 hook의 형태는 LEFTHOOK_STUB_HOOK_FORMAT이 단독으로 정한다 (preamble + 호출부).
   cat > "$1/lefthook" <<STUB
 #!/usr/bin/env bash
 # stub for install-lefthook-hooks shell tests: emulate \`lefthook install\` by writing every
-# hook configured in lefthook.yml, each containing the \`call_lefthook run "<hook>" "\$@"\`
-# marker expected by inject_staged_guard and disable_lefthook_auto_install. Hook names come
-# from the config (like the real CLI) and global option keys are skipped, so fixtures and
-# assertions cannot drift apart. The stub also tolerates --force (worktree mode passes it).
+# hook configured in lefthook.yml, each containing the \`call_lefthook()\` preamble and the
+# \`call_lefthook run "<hook>" "\$@"\` marker expected by inject_staged_guard and
+# disable_lefthook_auto_install. Hook names come from the config (like the real CLI) and global
+# option keys are skipped, so fixtures and assertions cannot drift apart. The stub also
+# tolerates --force (worktree mode passes it).
 # Silent on success to mirror the real CLI output we strip.
 set -euo pipefail
 known=" $LEFTHOOK_GIT_HOOK_NAMES "
@@ -129,7 +190,7 @@ case "\${1:-}" in
     hooks_dir="\$(git rev-parse --path-format=absolute --git-path hooks)"
     mkdir -p "\$hooks_dir"
     for hook in \$(awk -v known="\$known" '/^[A-Za-z0-9_.-]+:/ { name = \$1; sub(/:\$/, "", name); if (index(known, " " name " ") > 0) print name }' lefthook.yml); do
-      printf '#!/bin/sh\ncall_lefthook run "%s" "\$@"\n' "\$hook" > "\$hooks_dir/\$hook"
+      printf '$LEFTHOOK_STUB_HOOK_FORMAT' "\$hook" > "\$hooks_dir/\$hook"
       chmod +x "\$hooks_dir/\$hook"
     done
     ;;
@@ -409,8 +470,7 @@ test_install_lefthook_patches_stale_unconfigured_hook() {
   hooks_dir="$repo_root/.git/hooks"
   mkdir -p "$hooks_dir"
   stale="$hooks_dir/prepare-commit-msg"
-  printf '#!/bin/sh\ncall_lefthook run "prepare-commit-msg" "$@"\n' > "$stale"
-  chmod +x "$stale"
+  write_lefthook_generated_hook "$stale" "prepare-commit-msg"
 
   run_install_lefthook_capture "$repo_root" "$stub_dir"
   [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "install must not fail on a stale unconfigured hook; output: $INSTALL_LEFTHOOK_OUTPUT"
@@ -420,9 +480,115 @@ test_install_lefthook_patches_stale_unconfigured_hook() {
   assert_hook_call_line "$hooks_dir/pre-commit" "pre-commit"
 }
 
+test_install_lefthook_rejects_hook_without_call_lefthook_definition() {
+  # 호출부만 있고 preamble(`call_lefthook()` 정의)이 없는 hook은 실행 즉시 exit 127로 죽어
+  # 그 이벤트의 모든 커밋을 막는다. 그런데 `bash -n`은 문법만 보므로 이런 파일도 통과시킨다.
+  # installer가 정의의 부재를 직접 확인하지 않으면, 깨진 hook에 플래그를 주입한 뒤 성공을
+  # 보고하고 커밋 전면 차단 상태를 그대로 남긴다 (#1073에서 실제로 발생).
+  #
+  # 이 테스트는 동시에, installer가 실패하더라도 이미 설치된 hook의 `--no-auto-install`이
+  # 살아 있음을 확인한다. 정의 검사는 python 패치 **이후**에 돈다 — 앞으로 옮기면
+  # run_lefthook_install이 세 hook을 순정 템플릿으로 다시 써서 플래그를 지운 직후에 죽고,
+  # commit-time self-check가 그 상태를 커밋 차단으로 판정한다.
+  local sandbox repo_root stub_dir hooks_dir broken
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  # 1회차: 정상 설치로 세 hook에 플래그를 심는다.
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "first install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  # `prepare-commit-msg`는 git이 exit status를 존중하는 hook이라 깨지면 커밋을 막는다.
+  # 그래서 installer는 경고가 아니라 실패로 알려야 한다.
+  hooks_dir="$repo_root/.git/hooks"
+  broken="$hooks_dir/prepare-commit-msg"
+  write_lefthook_hook_missing_preamble "$broken" "prepare-commit-msg"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" != "0" ]] \
+    || fail "install must fail on a hook that calls call_lefthook without defining it; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "no call_lefthook() definition"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "$broken"
+
+  # 실패했어도 configured hook의 플래그는 손상되지 않아야 한다.
+  local hook_name checked=0
+  for hook_name in $(lefthook_config_hook_names "$repo_root/lefthook.yml"); do
+    assert_hook_call_line "$hooks_dir/$hook_name" "$hook_name"
+    checked=$((checked + 1))
+  done
+  # 3 = write_install_lefthook_fixture_config가 정의하는 hook 수 (pre-commit/commit-msg/pre-push).
+  # 개수를 단언해 위 루프가 조용히 0회 도는 것을 막는다.
+  [[ "$checked" -eq 3 ]] || fail "expected to check 3 configured hooks, checked $checked"
+}
+
+test_install_lefthook_warns_but_survives_a_broken_post_hook() {
+  # git은 `post-*` 계열 hook의 exit status를 무시한다. 그런 hook이 깨져 exit 127로 죽어도 커밋과
+  # push는 그대로 진행되므로, installer는 실패가 아니라 경고를 낸다 — 커밋을 한 건도 막지 못하는
+  # 파일 하나 때문에 direnv 진입까지 막을 이유가 없다 (main도 이 경우 rc=0이었다).
+  local sandbox repo_root stub_dir broken
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stubs"
+  create_install_lefthook_fixture "$repo_root" "$stub_dir"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] || fail "first install failed: $INSTALL_LEFTHOOK_OUTPUT"
+
+  broken="$repo_root/.git/hooks/post-commit"
+  write_lefthook_hook_missing_preamble "$broken" "post-commit"
+
+  run_install_lefthook_capture "$repo_root" "$stub_dir"
+  [[ "$INSTALL_LEFTHOOK_RC" == "0" ]] \
+    || fail "install must not fail on a broken hook whose exit status git ignores; output: $INSTALL_LEFTHOOK_OUTPUT"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "warning:"
+  assert_contains "$INSTALL_LEFTHOOK_OUTPUT" "$broken"
+}
+
+test_install_lefthook_exit_status_ignoring_hooks_are_known_git_hooks() {
+  # 경고 경로는 hook 이름을 GIT_HOOK_NAMES_IGNORING_EXIT_STATUS와 대조해 고른다. 그 목록에 git이
+  # 모르는 이름이 들어가면 그 항목은 영원히 매치되지 않아 조용히 죽은 원소가 되고, 반대로 오타가
+  # 나면 fail이 걸려야 할 hook이 경고로 새어 나간다. 부분집합 관계를 단언해 둘 다 막는다.
+  local ignored known
+  for ignored in $LEFTHOOK_GIT_HOOK_NAMES_IGNORING_EXIT_STATUS; do
+    local found=0
+    for known in $LEFTHOOK_GIT_HOOK_NAMES; do
+      [[ "$ignored" == "$known" ]] && { found=1; break; }
+    done
+    [[ "$found" -eq 1 ]] \
+      || fail "GIT_HOOK_NAMES_IGNORING_EXIT_STATUS contains '$ignored', which is not a git hook name in GIT_HOOK_NAMES"
+  done
+
+  # `post-checkout`은 이름만 보면 이 집합에 속할 것 같지만, git 문서는 그 hook의 exit status가
+  # `git checkout`/`git switch`의 exit status가 된다고 명시한다. 실수로 다시 들어가는 것을 막는다.
+  for ignored in $LEFTHOOK_GIT_HOOK_NAMES_IGNORING_EXIT_STATUS; do
+    [[ "$ignored" != "post-checkout" ]] \
+      || fail "post-checkout must not be treated as exit-status-ignoring: its exit status becomes git checkout's"
+  done
+}
+
+test_install_lefthook_premise_bash_n_accepts_undefined_function_call() {
+  # 위 테스트들이 방어하는 전제를 못박는다: `bash -n`은 정의되지 않은 함수 호출을 문법 오류로
+  # 보지 않는다. 이 전제가 성립하기 때문에 installer가 정의 존재를 따로 확인해야 한다.
+  # bash가 언젠가 이것을 잡기 시작하면 이 테스트가 실패하고, 그때 별도 검사의 필요성을 재검토한다.
+  # hook 이름 인자는 `bash -n` 결과에 영향이 없으므로 임의 값이어도 무방하다.
+  local sandbox probe
+  sandbox=$(new_sandbox)
+  probe="$sandbox/probe.sh"
+  write_lefthook_hook_missing_preamble "$probe" "prepare-commit-msg"
+
+  bash -n "$probe" \
+    || fail "bash -n now rejects an undefined function call; revisit hook_defines_call_lefthook"
+}
+
 test_install_lefthook_leaves_old_backup_hooks_untouched() {
   # lefthook은 밀려난 기존 hook을 `<name>.old`로 남긴다. 실행되지 않는 파일이므로
   # 패치 대상에서 제외한다 (되살렸을 때 원본 그대로여야 한다).
+  # 이 fixture는 preamble이 없어도 된다 — `.old`는 패치 대상 선정에서 확장자로 걸러지므로 정의 검사에
+  # 닿지 않는다. 여기서는 "손대지 않는다"만이 관심사다.
+  # 헬퍼가 실행 권한을 붙이는 것도 의도다. 실제 lefthook의 `.old`는 rename 산물이라 원본 hook의
+  # mode를 그대로 물려받는다.
   local sandbox repo_root stub_dir backup before after
   sandbox=$(new_sandbox)
   repo_root="$sandbox/repo"
@@ -431,7 +597,7 @@ test_install_lefthook_leaves_old_backup_hooks_untouched() {
 
   mkdir -p "$repo_root/.git/hooks"
   backup="$repo_root/.git/hooks/pre-commit.old"
-  printf '#!/bin/sh\ncall_lefthook run "pre-commit" "$@"\n' > "$backup"
+  write_lefthook_hook_missing_preamble "$backup" "pre-commit"
   before=$(cat "$backup")
 
   run_install_lefthook_capture "$repo_root" "$stub_dir"
@@ -443,7 +609,9 @@ test_install_lefthook_leaves_old_backup_hooks_untouched() {
 
 write_drifting_lefthook_stub() {
   # 정상 stub과 같은 hook 집합을 만들되, pre-commit만 body_file 내용으로 덮어써 호출부를
-  # 흐트러뜨린다. 나머지 hook은 정상이라 검증이 pre-commit에서만 걸린다.
+  # 흐트러뜨린다. 나머지 hook은 정상이라 검증이 pre-commit에서만 걸린다 — 그러려면 나머지 hook도
+  # LEFTHOOK_STUB_HOOK_FORMAT의 preamble을 갖춰야 한다. 갖추지 않으면 "깨진 hook" 판정이
+  # 다른 hook에서 먼저 발동해 이 fixture가 겨냥한 검증 지점에 닿지 못한다 (#1073).
   # body를 stub 소스에 리터럴로 심으면 stub 실행 시 `"$@"`/`${VAR}`가 확장돼 버리므로,
   # 파일 경로만 넘기고 그대로 복사한다.
   local stub_dir="$1" body_file="$2"
@@ -456,7 +624,7 @@ case "\${1:-}" in
     hooks_dir="\$(git rev-parse --path-format=absolute --git-path hooks)"
     mkdir -p "\$hooks_dir"
     for hook in \$(awk '/^[A-Za-z0-9_.-]+:/ { sub(/:\$/, "", \$1); print \$1 }' lefthook.yml); do
-      printf '#!/bin/sh\ncall_lefthook run "%s" "\$@"\n' "\$hook" > "\$hooks_dir/\$hook"
+      printf '$LEFTHOOK_STUB_HOOK_FORMAT' "\$hook" > "\$hooks_dir/\$hook"
       chmod +x "\$hooks_dir/\$hook"
     done
     cp "$body_file" "\$hooks_dir/pre-commit"
@@ -486,11 +654,14 @@ test_install_lefthook_fails_when_lefthook_call_shape_changes() {
 
   # 호출부는 하나지만 `"$@"`로 끝나지 않아 주입이 no-op가 된다. decoy 주석에는 플래그만 있어
   # "파일 어딘가에 플래그가 있는가" 식의 느슨한 검사라면 통과해버린다.
-  cat > "$sandbox/drift-body" <<'BODY'
-#!/bin/sh
+  # preamble을 갖춰야 "깨진 hook" 판정이 아니라 호출부 형태 검증까지 도달한다 (#1073).
+  {
+    lefthook_hook_preamble
+    cat <<'BODY'
 # decoy: --no-auto-install appears here, but not on the call line
 call_lefthook run "pre-commit" "$@" # upstream template drift
 BODY
+  } > "$sandbox/drift-body"
   write_drifting_lefthook_stub "$stub_dir" "$sandbox/drift-body"
 
   run_install_lefthook_capture "$repo_root" "$stub_dir"
@@ -508,13 +679,16 @@ test_install_lefthook_fails_on_unpatched_second_call() {
   create_install_lefthook_fixture "$repo_root" "$stub_dir"
 
   # 첫 호출은 column 0이라 패치되지만, 들여쓴 둘째 호출은 주입 대상이 아니라 그대로 남는다.
-  cat > "$sandbox/second-call-body" <<'BODY'
-#!/bin/sh
+  # preamble을 갖춰야 "깨진 hook" 판정이 아니라 호출부 개수 검증까지 도달한다 (#1073).
+  {
+    lefthook_hook_preamble
+    cat <<'BODY'
 call_lefthook run "pre-commit" "$@"
 if [ -n "${EXTRA:-}" ]; then
   call_lefthook run "pre-commit" "$@"
 fi
 BODY
+  } > "$sandbox/second-call-body"
   write_drifting_lefthook_stub "$stub_dir" "$sandbox/second-call-body"
 
   run_install_lefthook_capture "$repo_root" "$stub_dir"


### PR DESCRIPTION
## Summary

- `install-lefthook-hooks.sh`가 `call_lefthook()` 정의를 잃은 hook을 감지하지 못하고 "성공"을 보고하던 검증 공백을 메운다. 사후 검증 루프에 정의 존재 확인을 더한 것이 전부다.
- git이 exit status를 무시하는 hook(`post-*` 등)은 실패가 아니라 경고로 알린다 — 아무것도 막지 못하는 파일 하나 때문에 direnv 진입까지 막지 않는다.
- 실제 lefthook 2.1.5로 main과 4개 시나리오를 대조했고, 네 개의 회귀 테스트를 mutation으로 검증했다.

Closes #1073

## 기존 문제/배경

`disable_lefthook_auto_install`은 hook의 lefthook 호출부에 `--no-auto-install`을 주입한 뒤 세 가지를 검증한다.

1. `bash -n` — 문법 검사
2. `call_lefthook run ` 라인이 정확히 하나
3. 그 한 줄이 기대 호출 라인과 완전 일치

문제는 **정의되지 않은 함수를 부르는 문장이 셸 문법상 합법**이라는 점이다.

```console
$ printf '#!/bin/sh\ncall_lefthook run "prepare-commit-msg" --no-auto-install "$@"\n' > broken
$ bash -n broken; echo "bash -n exit: $?"
bash -n exit: 0
$ sh broken; echo "실행 exit: $?"
broken: line 2: call_lefthook: command not found
실행 exit: 127
```

`call_lefthook()` preamble이 사라진 hook은 세 검사를 전부 통과한다. installer는 그것을 정상 hook으로 취급해 플래그를 주입하고 **커밋 전면 차단 상태를 만든 채 성공을 보고**했다. 실제로 이 저장소의 모든 `git commit`이 차단됐다.

정상 상황에서는 lefthook이 생성한 hook에 preamble이 항상 있으므로 이 공백이 드러나지 않는다. 그러나 hook 파일이 외부에서 잘못 쓰이면 installer가 마지막 관문 역할을 하지 못한다.

## CIR (Change Intent Record)

**발견 경위.** #1073의 사고 파일은 `.git/hooks/prepare-commit-msg`였다. 워크트리에서 `git rev-parse --git-path hooks`가 메인 repo의 `.git/hooks`로 해석되는 상태(direnv가 `core.hooksPath`를 고정하기 전)에서 2줄짜리 stub을 심는 바람에, 메인 repo의 정상 hook(preamble 포함 70여 줄)을 덮어썼다. 그 뒤 installer가 그 2줄 파일에 플래그를 주입하고 사후 검증을 통과시켰다.

조사 초기에는 "lefthook 2.1.5의 `lefthook install`이 `lefthook.yml`에 없는 stale hook을 minimal stub으로 재작성한다"를 의심했다. 격리된 임시 저장소에서 preamble 있는 stale hook(71줄)을 두고 `lefthook install`을 실행한 결과 파일은 그대로 보존됐다(`sync hooks: ✔️ (pre-commit)`만 출력). **lefthook은 이 회귀와 무관하다.** 이 반증이 없었다면 상류 도구를 잘못 지목했을 것이다.

**설계 의도 — 왜 사후 검증인가.** 검사를 앞으로 옮기는 두 대안이 모두 더 나쁘다는 것을 실측으로 확인했다.

- **수집 루프(python 패치 이전, install 이후)로 옮기면**: 그 시점엔 `run_lefthook_install`이 configured hook 세 개를 순정 템플릿으로 다시 써서 `--no-auto-install`이 없는 상태다. 거기서 죽으면 플래그가 없는 채로 남고, `lefthook.yml`의 `lefthook-guard-self-check`가 그것을 커밋 차단으로 판정한다. 게다가 깨진 파일이 남아 있는 한 installer 재실행도 같은 지점에서 죽어 자동 복구가 불가능하다. 고치려던 것과 같은 형태의 피해를 새로 만든다.
- **`run_lefthook_install` 이전 preflight로 옮기면**: `fail`이 즉시 exit하므로 install이 아예 돌지 않는다. 그러면 깨진 configured hook을 `lefthook install`이 다시 써서 고칠 기회(self-heal)를 빼앗는다 — 실측상 lefthook은 그 파일을 `<name>.old`로 밀고 새로 써서 preamble을 복구한다. preflight를 두면 그 복구 이전에 죽어 hook이 깨진 채 남고 커밋이 계속 막힌다.

사후 검증 지점에서는 python 패치가 이미 끝나 플래그가 살아 있고, configured hook은 install이 이미 고친 뒤다. **installer가 실패해도 커밋은 계속 가능하다.**

**설계 의도 — 왜 `expected_call` 뒤인가.** 주석에서 `call_lefthook run `을 언급할 뿐인 남의 hook(예: `# 예전엔 call_lefthook run "pre-commit" "$@" 였다`)은 `expected_call` 검사에서 먼저 걸린다. 정의 검사를 그 앞에 두면 정상 동작하는 사용자 hook에 "정의가 없다"는 엉뚱한 진단과 삭제 안내를 내게 된다.

**설계 의도 — 왜 일부 hook은 경고인가.** git이 exit status를 무시하는 hook은 깨져도 아무것도 막지 못한다. 그런 파일 하나 때문에 direnv 진입 전체를 막는 것은 과하다. 편입 기준은 `man githooks`(git 2.54)가 "cannot affect the outcome of ..." 또는 "does not affect the outcome" 서술을 갖고, **그 문장에 exit status 예외절이 붙지 않는 것**이다.

`post-checkout`은 이름만 보면 이 집합에 속할 것 같지만 문서가 반대로 말한다 — "cannot affect the outcome of git switch or git checkout, *other than that the hook's exit status becomes the exit status of these two commands*". 실측하면 깨진 `post-checkout`에서 `git worktree add`가 exit 127을 내고, `wt`가 반쯤 만들어진 워크트리를 남기고 죽는다. 기준을 "예외절 없음"까지 좁히지 않았다면 이 저장소의 워크트리 도구가 깨졌을 것이다.

`post-rewrite`와 `post-index-change`는 실측으로는 exit status가 무시되지만 문서에 그 서술이 없어 제외했다(fail-closed).

**되돌린 것.** 이 PR은 기존 코드를 제거하지 않는다. `disable_lefthook_auto_install`의 패치 대상 선정과 세 검사는 #1072(`611d27d3`)가 정한 그대로 두고, 네 번째 검사만 더한다. #1072가 "설정 밖 hook도 사후 검증 대상"으로 되돌린 결정과 그 trade-off는 유지된다. 오히려 `post-*`를 경고로 빼내며 `fail` 집합을 좁힌다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 사후 검증 루프에 정의 검사 추가 | `expected_call` 검사 뒤에 `call_lefthook()` 정의 존재 확인 | python 패치 이후라 플래그가 살아 있어 커밋이 막히지 않음. configured hook은 install이 이미 self-heal. 파일을 건드리지 않으므로 부작용 없음 | 깨진 파일에 플래그가 주입된 뒤 실패한다(main도 동일하게 주입했으므로 새 부작용 아님) | ✅ |
| 수집 루프에서 fail-fast | 패치 대상 선정 시 정의가 없으면 즉시 중단 | 파일을 패치하기 전에 멈춤 | `run_lefthook_install`이 이미 플래그를 지운 뒤라 세 hook이 플래그 없이 남고 commit-time self-check가 커밋을 전면 차단. installer 재실행도 같은 지점에서 죽어 자동 복구 불가 | ❌ |
| `run_lefthook_install` 이전 preflight | install 전에 hooks 디렉토리를 훑어 깨진 hook을 거부 | 파일을 전혀 건드리지 않고 이전 install의 플래그가 보존됨 | `lefthook install`의 self-heal 기회를 빼앗아 깨진 configured hook이 영구히 남고 커밋이 계속 막힘 | ❌ |
| preflight + 깨진 파일 자동 격리 | preflight에서 깨진 configured hook을 `.old`로 옮기거나 삭제 | `<name>.old` 선점으로 install이 죽는 경로까지 자동 복구 | 조사와 상태 변경이 섞여, 앞쪽 hook을 치운 뒤 뒤쪽에서 거부하면 `run_lefthook_install`이 실행되지 않아 pre-commit이 통째로 사라진다(gitleaks·staged-config guard 없이 커밋 성립 = fail-open). 판별을 좁히지 않으면 `call_lefthook run `을 주석에서 언급할 뿐인 정상 custom hook까지 삭제 | ❌ |
| commit-time `lefthook-guard-self-check`에 정의 검사 추가 | `lefthook.yml`의 self-check가 preamble도 확인 | 방어 계층 추가 | 도달 불가능한 코드다 — hook이 preamble을 잃으면 그 안의 `run:` 블록이 애초에 실행되지 않는다. 이 검사가 놓일 수 있는 유일한 지점이 installer다 | ❌ |
| 모든 hook에 균일하게 `fail` | exit status 무시 여부를 구분하지 않음 | 규칙이 단순 | 커밋을 한 건도 막지 못하는 `post-commit` 하나가 devShell 진입 전체를 막는다. main은 그 경우 rc=0이었으므로 실사용 회귀 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `scripts/ai/install-lefthook-hooks.sh` | 수정 | `GIT_HOOK_NAMES_IGNORING_EXIT_STATUS` 상수 추가. 사후 검증 루프에 정의 존재 확인(경고/실패 분기) 추가 |
| `tests/suites/lefthook.sh` | 수정 | fixture의 hook 형태를 실제 lefthook 산출물과 동형(preamble 포함)으로 통일. 상수 파생 사슬 정리. 회귀 테스트 4건 |
| `tests/shell-script-tests.sh` | 수정 | 새 테스트 등록 |
| `CLAUDE.md` | 수정 | 워크트리에서 `--git-path hooks`가 메인 repo를 가리키는 함정과 복구 절차 |

### 핵심 코드

```bash
# 편입 기준: `man githooks`(git 2.54)가 "cannot/does not affect the outcome" 서술을 갖고,
# 그 문장에 exit status 예외절이 붙지 않을 것. post-checkout은 예외절이 있어 제외한다.
GIT_HOOK_NAMES_IGNORING_EXIT_STATUS="post-applypatch post-commit post-merge post-update post-receive p4-post-changelist"
```

```bash
    # 사후 검증 루프, expected_call 검사 뒤
    if ! grep -Eq '^[[:space:]]*call_lefthook[[:space:]]*\(\)' "$hook_file"; then
      case " $GIT_HOOK_NAMES_IGNORING_EXIT_STATUS " in
        *" $hook_name "*)
          # git이 이 hook의 exit status를 무시하므로 커밋·push는 막히지 않는다. 알리되 멈추지 않는다.
          echo "install-lefthook-hooks: warning: $hook_file has no call_lefthook() definition and dies with exit 127 when git runs it." >&2
          echo "  git ignores this hook's exit status, so commits still work. Delete the file if lefthook.yml no longer defines this hook." >&2
          ;;
        *)
          fail "broken hook: no call_lefthook() definition (git would fail it with exit 127; delete the file if lefthook.yml no longer defines this hook): $hook_file"
          ;;
      esac
    fi
```

### main 대비 동작 대조 (격리 환경, 실제 lefthook 2.1.5)

| 시나리오 | main | 이 PR |
|---|---|---|
| 깨진 `prepare-commit-msg` (설정 밖, exit status 존중) | rc=0 — 조용히 통과 | **rc=1** |
| 깨진 `post-commit` (설정 밖, exit status 무시) | rc=0 | rc=0 + **경고** |
| 주석에서만 `call_lefthook run`을 언급하는 custom hook | rc=1 (`expected exact call line`) | 동일 |
| 깨진 configured `pre-commit` | rc=0, `lefthook install`이 self-heal | 동일 |

installer가 main과 다르게 동작하는 것은 위 두 줄뿐이다. 나머지는 그대로다.

### 테스트 (전부 mutation 검증)

- 깨진 `prepare-commit-msg`에 installer가 실패하고, **그때도 configured hook의 플래그가 살아남는지.** 정의 검사를 빼면 installer가 빈 출력으로 조용히 성공한다.
- 깨진 `post-commit`에는 경고만 내고 rc=0으로 살아남는지.
- `GIT_HOOK_NAMES_IGNORING_EXIT_STATUS`가 `GIT_HOOK_NAMES`의 부분집합인지, 그리고 `post-checkout`이 재유입되지 않는지.
- `bash -n`이 정의 없는 함수 호출을 통과시킨다는 전제 고정. bash가 언젠가 이것을 잡기 시작하면 이 테스트가 실패하고, 그때 별도 검사의 필요성을 재검토한다.

## 알려진 한계 (이 PR 무관, main 동일)

`<hook>.old`가 이미 존재하면 `lefthook install`이 백업 rename에 실패해(`could not replace the hook: can't rename ... file already exists`) 깨진 configured hook의 자가 치유가 동작하지 않는다. 그 경우 `<hook>`과 `<hook>.old`를 함께 지운 뒤 재실행해야 한다.

이 저장소의 `.git/hooks/pre-push.old`(2026-02-22 생성, 내용은 정상 lefthook hook)가 그 조건을 이미 만족한다. `pre-push`가 손상되면 자동 복구 경로가 없다. 로컬 `.git` 상태이므로 이 PR의 범위 밖이며, 별도 정리를 검토한다.

## 참고 레퍼런스

- Issue #1073 — 이 PR이 닫는 이슈. 재현 절차, 발생 경위, 반증된 가설 기록
- PR #1072 — 설정 밖 stale hook에도 `--no-auto-install`을 주입하도록 패치 대상을 되돌린 변경. 그 trade-off의 안전성 근거("그 파일들은 lefthook이 만든 것이라 호출부 형태가 동일하다")가 거짓인 사례를 이 PR이 다룬다
- PR #1071 — `lefthook run`의 암묵 auto-install이 staged-config guard를 지우는 경로를 차단. `--no-auto-install` 주입과 사후 검증 루프의 출처
- PR #788, PR #750 — staged-config guard와 worktree-local hooks 설계의 출처
- Issue #1070 — 정확 호출 라인 계약이 installer·`lefthook.yml`·allowlist에 복제되어 있는 문제. 이 PR은 그 복제 수를 늘리지 않는다
- [`man githooks`](https://git-scm.com/docs/githooks) — `GIT_HOOK_NAMES_IGNORING_EXIT_STATUS` 편입 기준의 근거. 각 hook 항목의 "cannot/does not affect the outcome" 서술과 `post-checkout`의 예외절
- [POSIX `sh -n`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html) — 문법 검사만 수행하며 명령을 실행하지 않는다. 정의되지 않은 함수 호출이 통과하는 근거

## Human Test Plan

메인 저장소에서 수행한다. 각 단계의 기대 동작이 어긋나면 아래 진단을 참고한다.

### 1. 깨진 설정 밖 hook을 만들고 installer 실행

```bash
printf '#!/bin/sh\ncall_lefthook run "prepare-commit-msg" "$@"\n' > .git/hooks/prepare-commit-msg
chmod +x .git/hooks/prepare-commit-msg
bash scripts/ai/install-lefthook-hooks.sh; echo "rc=$?"
```

기대: `rc=1`. stderr에 `broken hook: no call_lefthook() definition ... : <경로>`.

진단: `rc=0`이면 정의 검사가 동작하지 않는 것이다. `grep -n 'no call_lefthook() definition' scripts/ai/install-lefthook-hooks.sh`로 검사 존재를 확인한다.

### 2. 실패했어도 커밋이 가능한지 (플래그 생존)

```bash
grep -c -- '--no-auto-install' .git/hooks/pre-commit
```

기대: `1`. installer가 실패해도 configured hook의 플래그는 손상되지 않는다.

진단: `0`이면 검사가 python 패치보다 앞에서 돈다는 뜻이다. 그 상태에서는 `lefthook-guard-self-check`가 커밋을 차단한다.

### 3. 안내대로 복구

```bash
rm .git/hooks/prepare-commit-msg
bash scripts/ai/install-lefthook-hooks.sh; echo "rc=$?"
```

기대: `rc=0`.

### 4. exit status를 무시하는 hook은 경고만 (실패 아님)

```bash
printf '#!/bin/sh\ncall_lefthook run "post-commit" "$@"\n' > .git/hooks/post-commit
chmod +x .git/hooks/post-commit
bash scripts/ai/install-lefthook-hooks.sh; echo "rc=$?"
rm .git/hooks/post-commit
```

기대: `rc=0`, stderr에 `warning: ... has no call_lefthook() definition`.

진단: `rc=1`이면 `post-commit`이 `GIT_HOOK_NAMES_IGNORING_EXIT_STATUS`에서 빠진 것이다. git 문서상 `post-commit`은 "cannot affect the outcome of git commit"이다.

### 5. 정상 custom hook은 삭제 안내를 받지 않는지

```bash
cat > .git/hooks/post-commit <<'HOOK'
#!/bin/sh
# 예전엔 call_lefthook run "post-commit" "$@" 였다
echo hi
HOOK
chmod +x .git/hooks/post-commit
bash scripts/ai/install-lefthook-hooks.sh 2>&1 | grep -c 'delete the file'
rm .git/hooks/post-commit
bash scripts/ai/install-lefthook-hooks.sh
```

기대: `0`. 이 hook은 `expected exact call line` 검사에서 먼저 걸려야 하며, "정의가 없으니 지우라"는 안내를 받으면 안 된다.

### 6. 전체 테스트

```bash
bash tests/shell-script-tests.sh
```

기대: 실패 0건.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Git hook 설치 과정에서 필수 구성 누락이나 손상된 hook을 더 정확히 감지합니다.
  - 손상된 hook은 설치를 중단해 커밋 실패를 예방하며, 일부 후처리 hook은 경고 후 설치를 계속합니다.
  - 기존 hook의 설정과 실행 옵션이 잘못 변경되지 않도록 검증이 강화되었습니다.

- **문서**
  - 워크트리에서 Git hook을 안전하게 확인하고 복구하는 방법을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->