### PR TITLE
fix(eval-tests): match opnix owner to path user

### DIFF
--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -331,6 +331,9 @@ let
   # opnix 1Password SA token materialization
   opnixCfg = nixosCfg.services.onepassword-secrets;
   opnixGithubPat = opnixCfg.secrets.githubPat;
+  opnixGithubPatPathMatch = builtins.match "/run/opnix/([^/]+)/github-pat" opnixGithubPat.path;
+  opnixGithubPatExpectedOwner =
+    if opnixGithubPatPathMatch == null then null else builtins.elemAt opnixGithubPatPathMatch 0;
   opnixTokenSecret = nixosCfg.age.secrets.opnix-service-account-token;
   opnixTmpfilesRules = nixosCfg.systemd.tmpfiles.rules;
 
@@ -550,11 +553,12 @@ let
       cond = nixosCfg.homeserver.opnix.enable && opnixCfg.enable;
     }
     {
-      name = "Test 5b-5: opnix githubPat이 tmpfs(/run/opnix/<user>/github-pat)에 user-owned 0400으로 materialize되어야 함 (path: ${opnixGithubPat.path}, mode: ${opnixGithubPat.mode})";
+      name = "Test 5b-5: opnix githubPat이 tmpfs(/run/opnix/<user>/github-pat)에 matching-user-owned 0400으로 materialize되어야 함 (path: ${opnixGithubPat.path}, mode: ${opnixGithubPat.mode}, owner: ${opnixGithubPat.owner})";
       cond =
-        builtins.match "/run/opnix/[^/]+/github-pat" opnixGithubPat.path != null
+        opnixGithubPatPathMatch != null
         && opnixGithubPat.mode == "0400"
-        && opnixGithubPat.owner != "root";
+        && opnixGithubPat.owner != "root"
+        && opnixGithubPat.owner == opnixGithubPatExpectedOwner;
     }
     {
       name = "Test 5b-6: opnix githubPat reference가 op://Automation/github-pat/token이어야 함";


### PR DESCRIPTION
## Summary

- Test 5b-5가 opnix materialization path의 user segment와 실제 owner가 정확히 일치하는지 검증하도록 강화합니다.
- malformed path에서도 evaluation error가 나지 않도록 capture를 null-safe하게 추출하면서 기존 `0400` 및 non-root 방어를 유지합니다.

Closes #864

## 기존 문제/배경

기존 Test 5b-5는 path 형식과 mode를 확인한 뒤 owner가 `root`가 아닌지만 검사했습니다. 따라서 `/run/opnix/<user>/github-pat`의 `<user>`와 다른 non-root owner가 설정되어도 eval test가 통과해, 런타임에서 파일 접근 권한과 소비 주체가 어긋날 수 있었습니다.

## CIR (Change Intent Record)

- **v1** (PR #842): opnix GitHub PAT materialization에 path, `0400`, non-root owner 안전핀을 도입했습니다.
- **v2** (이번 변경): non-root 여부만으로는 path user와 owner의 불일치를 잡지 못한다는 점을 보완해, path capture를 expected owner로 사용합니다.
- malformed path가 capture list를 만들지 못하는 경우를 정상적인 테스트 실패로 처리하기 위해 capture 결과를 한 번 바인딩하고 `null` 분기 뒤에만 첫 capture를 읽습니다.

**trade-off**: binding 두 개가 추가되지만 path parsing을 한 번만 수행하고, malformed input의 평가 오류와 owner drift를 동시에 명확히 차단합니다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| non-root 검사 유지 | `owner != "root"`만 확인 | 가장 단순 | 다른 non-root owner 불일치를 놓침 | ❌ |
| 설정 username과 직접 비교 | owner를 별도 username 설정과 비교 | 구현이 간단 | path 자체가 잘못된 user를 가리켜도 계약을 직접 검증하지 못함 | ❌ |
| path capture와 null-safe equality | path의 `<user>`를 capture해 owner와 비교하고 기존 root 방어 유지 | 실제 materialization 계약을 직접 검증, malformed path도 false 처리 | 소규모 binding 추가 | ✅ |
| capture를 즉시 `elemAt` | match 결과를 바로 인덱싱 | 코드가 짧음 | malformed path에서 테스트 실패 대신 eval error 발생 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `tests/eval-tests.nix` | 수정 | path match 결과를 한 번 저장하고 expected owner를 null-safe하게 추출한 뒤 Test 5b-5에 owner equality를 추가 |

### 핵심 코드

```nix
opnixGithubPatPathMatch = builtins.match "/run/opnix/([^/]+)/github-pat" opnixGithubPat.path;
opnixGithubPatExpectedOwner =
  if opnixGithubPatPathMatch == null then null else builtins.elemAt opnixGithubPatPathMatch 0;

opnixGithubPatPathMatch != null
&& opnixGithubPat.mode == "0400"
&& opnixGithubPat.owner != "root"
&& opnixGithubPat.owner == opnixGithubPatExpectedOwner
```

서비스 구현, materialization path, GitHub wrapper는 변경하지 않습니다.

## 참고 레퍼런스

- Issue #864 — path user와 owner equality 검증 강화 요구
- PR #842 — opnix native materialization과 기존 Test 5b-5 안전핀 도입

## Human Test Plan

1. **정상 path/owner**: 기본 설정에서 `bash tests/run-eval-tests.sh`를 실행합니다.
   - 기대: `/run/opnix/<user>/github-pat`, mode `0400`, 동일 owner가 모두 만족되어 통과합니다.
   - 실패 시: Test 5b-5 진단의 path/mode/owner를 서로 비교합니다.

2. **mismatched non-root owner**: 임시 검증에서 module owner를 다른 non-root 값으로 바꾸고 eval test를 실행한 뒤 즉시 되돌립니다.
   - 기대: Test 5b-5가 실패합니다.
   - 실패 시: owner equality 조건과 capture index 0을 확인합니다.

3. **root owner/path**: 임시 검증에서 owner를 `root`로 두거나 path user를 `root`로 두고 predicate를 평가합니다.
   - 기대: 기존 non-root guard 때문에 모두 false입니다.
   - 실패 시: `owner != "root"` 조건이 보존됐는지 확인합니다.

4. **malformed path**: user segment가 비어 있거나 suffix가 다른 path로 predicate를 평가합니다.
   - 기대: match가 `null`이 되어 false이며 `builtins.elemAt` 관련 evaluation error는 발생하지 않습니다.
   - 실패 시: expected owner가 `null` 분기 뒤에서만 capture를 읽는지 확인합니다.

5. **secret 비노출 및 실패 진단**: negative test의 stderr를 확인합니다.
   - 기대: 실패 이름에는 path/mode/owner와 Test 5b-5 계약만 나타나고 secret reference, vault 값, token 값은 나타나지 않습니다.
   - 실패 시: Test 5b-5 이름의 interpolation과 throw 경로를 확인하고 민감 값이 있으면 즉시 중단합니다.

6. **회귀 검증**: `nixfmt --check tests/eval-tests.nix`, `nix flake check --no-build --all-systems`, `bash tests/run-all-tests.sh`, `git diff --check`를 실행합니다.
   - 기대: 모두 통과하고 최종 diff에는 `tests/eval-tests.nix`만 포함됩니다.
   - 실패 시: 해당 gate의 첫 실패와 최종 변경 파일 목록을 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * GitHub PAT 보안 검증을 강화했습니다.
  * 토큰 경로에 지정된 사용자와 실제 소유자가 일치하는지 확인합니다.
  * 올바르지 않은 경로 형식도 테스트에서 감지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->