### PR TITLE
chore(skills): remove stale gpt-5.5 examples

### DIFF
--- a/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md
@@ -109,7 +109,6 @@ echo "FO_DIR=$FO_DIR"
    # marker must apply to `codex`, not `cat` (issue #585 / epic #584).
    # CODEX_PROGRAMMATIC=1은 Codex 0.124+ user-level hooks의 early-exit guard 신호.
    cat "$FO_DIR/agent-1.md" | env CODEX_PROGRAMMATIC=1 codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-     -c model="gpt-5.5" \
      -c model_reasoning_effort="high" \
      -o "$FO_DIR/agent-1-result.md" \
      - \

--- a/modules/shared/scripts/codex-exec-supervised.sh
+++ b/modules/shared/scripts/codex-exec-supervised.sh
@@ -19,7 +19,7 @@
 #
 # 사용 (Layer 1 supervised contract — programmatic 호출의 canonical pattern):
 #   cat prompt.md | codex-exec-supervised --sandbox read-only --ignore-user-config --ignore-rules --ephemeral \
-#     -c model="gpt-5.5" -c model_reasoning_effort="medium" -o result.md -
+#     -c model_reasoning_effort="medium" -o result.md -
 #
 # wrapper 자체 capability probe (사전점검용 — codex exec를 호출하지 않고 의존성만 검증):
 #   codex-exec-supervised --check  # 모든 dependency(setsid/timeout/codex) 가용 시 exit 0, 부재 시 127


### PR DESCRIPTION
## Summary

- canonical wrapper 주석과 fan-out 실행 예제의 낡은 `gpt-5.5` model pin을 제거해 모델 라인업 변경 시 예제가 다시 stale해지지 않게 한다.
- model override 없이 기본 모델 선택에 맡기되 기존 `model_reasoning_effort` 예제는 그대로 보존한다.

Closes #1077

## 기존 문제/배경

`codex-exec-supervised`의 canonical pattern과 `codex-fan-out` 실행 예제가 `-c model="gpt-5.5"`를 명시하고 있었다. 이 값은 현재 모델 사용 원칙과 어긋날 뿐 아니라 기본 모델이 바뀔 때마다 문서 예제가 낡아지는 유지보수 지점을 만든다.

이번 변경은 두 예제의 explicit model override만 제거한다. default model 설정, config 동기화, fixture, historical test data 및 주변 실행 정책은 변경하지 않는다.

## CIR (Change Intent Record)

해당 없음 — 단순 변경. Issue #1077에서 확인된 두 stale example literal만 제거하며, 인접 설정이나 실행 정책으로 범위를 확장하지 않는다.

## ADR (Architecture Decision Record)

해당 없음 — 단순 변경. 구체 모델명으로 치환하지 않고 model override 자체를 생략한다.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/codex-exec-supervised.sh` | 수정 | canonical pattern 주석에서 `gpt-5.5` override 제거, `medium` reasoning effort 보존 |
| `modules/shared/programs/claude/files/skills/codex-fan-out/SKILL.md` | 수정 | fan-out 실행 예제에서 `gpt-5.5` override 제거, `high` reasoning effort 보존 |

### 핵심 변경

```bash
# BEFORE
-c model="gpt-5.5" -c model_reasoning_effort="medium"

# AFTER
-c model_reasoning_effort="medium"
```

fan-out 예제도 동일하게 model override 한 줄만 제거하고 command continuation과 출력·stdin 인자를 유지한다.

## 참고 레퍼런스

- Issue #1077 — stale `gpt-5.5` 예제 정리 요구사항
- PR #1074 — 모델명 고정 없이 기본 선택에 맡기는 원칙을 재확인한 출처

## Human Test Plan

1. **기존 literal 부재 확인**
   - `rg -n 'gpt-5\.5' modules/shared/scripts/ modules/shared/programs/claude/files/skills/`를 실행한다.
   - **기대**: 출력 0건이며 `rg`는 no-match exit 1을 반환한다.
   - **실패 시**: 출력된 경로가 두 변경 파일의 잔존 예제인지, 의도적 fixture/historical data인지 범위를 먼저 구분한다.

2. **다른 model literal로 치환되지 않았는지 확인**
   - `git diff main...HEAD`에서 추가된 `-c model=`, `--model`, `-m` 또는 다른 `gpt-*` literal을 검색한다.
   - **기대**: 새 model pin 0건이며 특히 다른 구체 모델명으로 바뀐 흔적이 없다.
   - **실패 시**: 추가된 override를 제거하고 default model resolution에 맡긴다. default config 자체는 수정하지 않는다.

3. **reasoning effort 보존 확인**
   - 두 예제에서 `model_reasoning_effort="medium"`과 `model_reasoning_effort="high"`를 확인한다.
   - **기대**: wrapper 주석의 `medium`, fan-out 예제의 `high` 및 줄 연속 문자가 그대로 남아 있다.
   - **실패 시**: model pin 제거와 무관한 옵션·continuation 변경이 섞이지 않았는지 diff를 확인한다.

4. **wrapper regression 확인**
   - `shellcheck modules/shared/scripts/codex-exec-supervised.sh`와 `bash tests/test-codex-exec-supervised.sh`를 실행한다.
   - **기대**: shellcheck 경고가 없고 wrapper validation fixture가 통과한다.
   - **실패 시**: shellcheck 위치와 wrapper dependency 경고를 구분한다. `setsid` 부재로 명시된 valid-env skip은 테스트 정책상 환경 경고이며 invalid-env 경계 실패와 구분한다.

5. **저장소 gate 확인**
   - `bash scripts/ai/check-skill-noise.sh`, `bash tests/run-shell-script-tests.sh`, `./scripts/ai/verify-ai-compat.sh`, devShell에서 `bash tests/run-all-tests.sh`, `git diff --check`를 실행한다.
   - **기대**: 모든 gate가 통과하고 전체 suite는 실패 0이다.
   - **실패 시**: inactive mise shim이 `lefthook`을 가로채는 오류라면 devShell의 실제 도구 경로를 확인한 뒤 재실행한다. 그 외에는 최초 실패 driver와 이번 두 파일 diff의 연관성을 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 팬아웃 워커 실행 예시에 높은 모델 추론 노력 설정을 명시했습니다.
  * 감독 실행 명령 예시를 업데이트해 추론 노력과 결과 파일 출력 옵션을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->