### PR TITLE
fix(zsh): guard fzf initialization without ZLE

### DIFF
--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -15,6 +15,7 @@ let
   # mise shims 경로 변수 선언 — envExtra/initContent 공통 SoT.
   # 경로는 constants.mise.shimsDirExpr 우선순위(MISE_DATA_DIR → XDG_DATA_HOME/mise → $HOME/.local/share/mise).
   miseShimsDecl = ''_mise_shims="${constants.mise.shimsDirExpr}"'';
+  fzfZleGuard = ''[[ -n "$TTY" && $options[zle] = on ]]'';
 in
 {
   home.file.".local/bin/atuin-clean-kr" = {
@@ -241,7 +242,7 @@ in
       # enabled even without a shell TTY. Keep HM's order while guarding the
       # generated fzf code at zsh's actual TTY-backed ZLE boundary (#862).
       (lib.mkOrder 910 ''
-        if [[ -n "$TTY" && $options[zle] = on ]]; then
+        if ${fzfZleGuard}; then
           source <(${lib.getExe config.programs.fzf.package} --zsh)
         fi
       '')
@@ -250,7 +251,7 @@ in
       # fzf 키바인딩 재설정 (fzf zsh integration 로드 후 실행)
       #─────────────────────────────────────────────────────────────────────────
       (lib.mkAfter ''
-        if [[ -n "$TTY" && $options[zle] = on ]]; then
+        if ${fzfZleGuard}; then
           # fzf Alt+C → Ctrl+G (한글 IME 호환: Alt 조합은 한글 입력소스에서 IME가 가로챔)
           bindkey -rM emacs '\ec'
           bindkey -rM vicmd '\ec'
@@ -268,7 +269,7 @@ in
       # → _ftb_orig_widget에 fzf-completion이 저장 (**<Tab> 폴백 보존)
       #─────────────────────────────────────────────────────────────────────────
       (lib.mkAfter ''
-        if [[ -n "$TTY" && $options[zle] = on ]]; then
+        if ${fzfZleGuard}; then
           source ${pkgs.zsh-fzf-tab}/share/fzf-tab/fzf-tab.plugin.zsh
         fi
 

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -237,17 +237,28 @@ in
         precmd_functions+=(_repair_claude_symlinks)
       '')
 
+      # CIR: Home Manager only checks the zle option, but `zsh -i -c` keeps it
+      # enabled even without a shell TTY. Keep HM's order while guarding the
+      # generated fzf code at zsh's actual TTY-backed ZLE boundary (#862).
+      (lib.mkOrder 910 ''
+        if [[ -n "$TTY" && $options[zle] = on ]]; then
+          source <(${lib.getExe config.programs.fzf.package} --zsh)
+        fi
+      '')
+
       #─────────────────────────────────────────────────────────────────────────
       # fzf 키바인딩 재설정 (fzf zsh integration 로드 후 실행)
       #─────────────────────────────────────────────────────────────────────────
       (lib.mkAfter ''
-        # fzf Alt+C → Ctrl+G (한글 IME 호환: Alt 조합은 한글 입력소스에서 IME가 가로챔)
-        bindkey -rM emacs '\ec'
-        bindkey -rM vicmd '\ec'
-        bindkey -rM viins '\ec'
-        bindkey -M emacs '\C-g' fzf-cd-widget
-        bindkey -M vicmd '\C-g' fzf-cd-widget
-        bindkey -M viins '\C-g' fzf-cd-widget
+        if [[ -n "$TTY" && $options[zle] = on ]]; then
+          # fzf Alt+C → Ctrl+G (한글 IME 호환: Alt 조합은 한글 입력소스에서 IME가 가로챔)
+          bindkey -rM emacs '\ec'
+          bindkey -rM vicmd '\ec'
+          bindkey -rM viins '\ec'
+          bindkey -M emacs '\C-g' fzf-cd-widget
+          bindkey -M vicmd '\C-g' fzf-cd-widget
+          bindkey -M viins '\C-g' fzf-cd-widget
+        fi
       '')
 
       #─────────────────────────────────────────────────────────────────────────
@@ -257,7 +268,9 @@ in
       # → _ftb_orig_widget에 fzf-completion이 저장 (**<Tab> 폴백 보존)
       #─────────────────────────────────────────────────────────────────────────
       (lib.mkAfter ''
-        source ${pkgs.zsh-fzf-tab}/share/fzf-tab/fzf-tab.plugin.zsh
+        if [[ -n "$TTY" && $options[zle] = on ]]; then
+          source ${pkgs.zsh-fzf-tab}/share/fzf-tab/fzf-tab.plugin.zsh
+        fi
 
         # === Change Intent Record ===
         # v1 (PR #188): LLM 추천으로 tab:accept 설정 — Tab 2-tap 빠른 확정 흐름
@@ -454,7 +467,7 @@ in
   # FZF
   programs.fzf = {
     enable = true;
-    enableZshIntegration = true;
+    enableZshIntegration = false;
     defaultCommand = "${lib.getExe pkgs.fd} --strip-cwd-prefix --exclude .git";
     fileWidgetCommand = "${lib.getExe pkgs.fd} --strip-cwd-prefix --exclude .git";
     changeDirWidgetCommand = "${lib.getExe pkgs.fd} --type d --strip-cwd-prefix --exclude .git";


### PR DESCRIPTION
## Summary

- 실제 shell TTY가 있는 ZLE 경계에서만 fzf의 zsh integration과 관련 widget을 초기화해 headless startup stderr를 깨끗하게 유지합니다.
- Home Manager가 사용하던 `mkOrder 910`과 configured fzf package를 그대로 따라 Atuin, Ctrl+G, fzf-tab의 기존 초기화 순서를 보존합니다.
- 일반 PTY에서는 Ctrl+G 디렉터리 탐색, Tab completion, preview/zstyle을 그대로 유지합니다.

Closes #862

## 기존 문제/배경

pin된 Home Manager fzf integration은 `$options[zle] = on`만 확인한 뒤 `fzf --zsh`를 source합니다. 하지만 강제로 interactive mode를 켠 `zsh -i -c`에서는 실제 shell TTY가 없어도 `interactive=on`, `zle=on`이 남습니다.

fzf 0.73.1이 생성하는 key-bindings와 completion 섹션은 각각 전체 zsh option을 저장했다가 복원합니다. TTY가 없는 상태에서 저장된 `zle=on`을 복원하려는 두 지점이 각각 경고를 내므로 기존 재현은 다음과 같았습니다.

```text
(eval):1: can't change option: zle
(eval):1: can't change option: zle
hello
```

호출자마다 stderr를 숨기면 실제 실패도 함께 가려집니다. 따라서 shell initialization에서 ZLE 사용 가능 경계를 정확히 판정해야 합니다.

## CIR (Change Intent Record)

- 기존 `programs.fzf.enableZshIntegration = true`는 fzf를 Atuin보다 앞에서 초기화하도록 Home Manager의 `mkOrder 910`을 의도적으로 사용했습니다.
- `interactive`와 `zle` option은 live headless 재현에서 모두 `on`이어서 구분 신호가 되지 못했습니다. `-t 0`은 stdin이 redirect됐지만 controlling TTY가 유효한 셸까지 제외하므로 실제 zsh 경계보다 좁았습니다.
- zsh가 내부 `SHTTY`를 찾지 못하면 특수 파라미터 `$TTY`를 빈 문자열로 노출한다는 점을 확인해, `$TTY` 존재와 zle option을 함께 guard로 채택했습니다.
- Home Manager가 생성하는 zle-only guard는 호출자가 확장할 수 없으므로 자동 zsh integration만 끄고, 동일한 order에서 configured fzf package의 `--zsh` 출력을 수동 source합니다. fzf 패키지, 환경변수, 검색/preview 옵션 자체는 제거하지 않습니다.

**trade-off**: upstream Home Manager가 더 정확한 guard를 제공하게 되면 이 수동 source를 재평가해야 합니다. 대신 현재 pin에서도 root cause를 직접 제거하고 기존 초기화 순서를 유지합니다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 호출자 stderr suppression | 각 명령에서 경고를 숨김 | 변경이 작아 보임 | 실제 오류도 숨기고 호출자마다 반복 필요 | ❌ |
| `interactive` 또는 `zle` option 단독 guard | option만 보고 초기화 | 단순함 | headless `zsh -i -c`에서도 둘 다 `on` | ❌ |
| `-t 0` guard | stdin이 TTY인지 확인 | 일반 PTY와 headless를 구분 | stdin redirect + 유효한 controlling TTY를 오판 | ❌ |
| fzf 생성 스크립트 patch | option restore 로직을 로컬 수정 | 직접 경고 지점 제거 | fzf 버전 내부 구현에 강결합 | ❌ |
| HM integration off + order 910 manual composite guard | `$TTY`와 zle option을 함께 확인해 동일 order에서 source | root cause 해결, package override와 Atuin/fzf-tab 순서 보존 | upstream 개선 시 수동 경로 재평가 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|---|---|---|
| `modules/shared/programs/shell/default.nix` | 수정 | fzf zsh integration을 TTY-backed ZLE guard 아래 수동 초기화하고 custom bindkey/fzf-tab source에 같은 guard 적용 |

### 핵심 코드

```nix
fzfZleGuard = ''[[ -n "$TTY" && $options[zle] = on ]]'';

(lib.mkOrder 910 ''
  if ${fzfZleGuard}; then
    source <(${lib.getExe config.programs.fzf.package} --zsh)
  fi
'')

programs.fzf.enableZshIntegration = false;
```

- custom Ctrl+G bind와 fzf-tab source도 동일한 composite guard 안에서만 실행합니다.
- fzf-tab의 `continuous-trigger`, group switch, file/directory 및 git preview zstyle은 내용과 순서를 유지합니다.
- Atuin, zoxide, tmux popup의 fzf 사용과 다른 파일은 변경하지 않습니다.

## 참고 레퍼런스

- Issue #862 — headless zsh startup stderr 오염 보고와 범위 정의
- PR #185 — fzf 내부 Tab/Shift+Tab 이동 바인딩의 도입 근거
- PR #188 — fzf-tab 도입과 fzf completion fallback 순서의 근거
- [Home Manager commit `3abeedcf409ecd8fca201646074bfb31797e8cc2`](https://github.com/nix-community/home-manager/commit/3abeedcf409ecd8fca201646074bfb31797e8cc2) — 현재 pin의 fzf module 구현
- [zsh 5.9.1 `dosetopt()` ZLE 조건](https://github.com/zsh-users/zsh/blob/zsh-5.9.1/Src/options.c#L781-L784) — interactive shell, `SHTTY`, output stream 요구사항
- [fzf v0.73.1 key bindings](https://github.com/junegunn/fzf/blob/v0.73.1/shell/key-bindings.zsh), [completion](https://github.com/junegunn/fzf/blob/v0.73.1/shell/completion.zsh) — 두 option 저장/복원 지점

## Human Test Plan

### Negative: headless startup

1. `zsh -i -c 'echo hello' 2>&1`를 실행합니다.
   - **기대**: 출력이 정확히 `hello` 한 줄이며 ZLE 경고가 없습니다.
2. headless 셸에서 `$TTY`와 widget을 확인합니다.
   - **기대**: `$TTY`는 비어 있고 `fzf-cd-widget`, `fzf-completion`, `fzf-tab-complete`는 등록되지 않습니다.

### Positive: 일반 PTY UX

3. `nrs` 후 새 PTY에서 zsh를 시작합니다.
   - **기대**: startup stderr가 없고 `$TTY`가 non-empty입니다.
4. `bindkey -M emacs '^G'`, `bindkey -M emacs '^I'`, `typeset -p fzf_default_completion _ftb_orig_widget`을 확인합니다.
   - **기대**: Ctrl+G=`fzf-cd-widget`, Tab=`fzf-tab-complete`, fallback=`expand-or-complete`/`fzf-completion`입니다.
5. Ctrl+G를 직접 누르고 취소합니다.
   - **기대**: fzf 디렉터리 선택 UI가 열리고 정상적으로 셸로 복귀합니다.
6. `git checkout ` 뒤 Tab을 누릅니다.
   - **기대**: fzf-tab UI와 git log preview가 표시됩니다.

### Regression

7. `bindkey -M emacs '^R'`을 확인합니다.
   - **기대**: `atuin-search`가 유지됩니다.
8. `zstyle -L ':fzf-tab:*'`와 `zstyle -L ':fzf-tab:complete:*' fzf-preview`를 확인합니다.
   - **기대**: continuous trigger, group switch, file/directory 및 git preview가 유지됩니다.
9. 자동 검증을 실행합니다.
   - `bash tests/run-eval-tests.sh`
   - `nix flake check --no-build --all-systems`
   - `nix develop --command bash tests/run-all-tests.sh`
   - **기대**: 모든 suite가 통과합니다.

### 실패 시 진단

- 경고가 2개면 Home Manager 자동 integration이 남았거나 manual source가 이중 실행되는지 확인합니다.
- 경고가 1개면 fzf key-bindings/completion 중 한 섹션만 guard 밖에서 source되는지 확인합니다.
- Ctrl+R 또는 Tab fallback이 바뀌면 생성된 `.zshrc`에서 fzf(order 910) → Atuin → custom Ctrl+G → fzf-tab 순서를 확인합니다.
- widget 또는 preview가 없으면 `realpath ~/.zshrc`와 `rg -n 'fzf --zsh|fzf-tab|bindkey.*C-g' ~/.zshrc`로 실제 배포 설정을 확인합니다.
- 재적용이 필요하면 먼저 `nrs-lock status`를 확인하고 다른 session의 lock은 해제하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 비대화형 셸 및 ZLE가 비활성화된 환경에서는 fzf 및 zsh-fzf-tab이 불필요하게 로딩되지 않도록 했습니다.
  * 대화형 터미널에서만 fzf Zsh 코드 로딩과 fzf 관련 키 바인딩(예: fzf-cd, 탭 동작)이 적용되도록 개선했습니다.
  * 기본 fzf의 Zsh 통합 활성화를 끄고, 조건이 충족될 때만 동작하도록 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
