### PR TITLE
docs(codex): align skill routing and projection checks

### DIFF
--- a/.claude/skills/configuring-codex/SKILL.md
+++ b/.claude/skills/configuring-codex/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Trigger: 'Codex 설정', 'codex 스킬 인식', 'AGENTS.md 심링크', '.agents/skills 심링크', 'verify-ai-compat',
   'codex 권한', 'codex 업데이트', 'AI 도구 호환', 'codex 바이너리', 'approval_policy', 'sandbox_mode',
   'Codex 권한 프롬프트'.
-  NOT for codex exec 실행 (use using-codex-exec).
+  NOT for codex exec 실행. Direct Codex는 native subagent를 우선하며, Claude/headless subprocess 계약은 아래 런타임 SoT를 참조.
 ---
 
 # Codex CLI 설정
@@ -14,8 +14,8 @@ Codex CLI 호환 레이어와 프로젝트 스킬 발견 문제를 다룹니다.
 
 ## 작성 기준
 
-- 확인 날짜: 2026-07-08
-- 확인 버전: codex-cli 0.142.5 (codex-pin.json/runtime 일치; nix overlay — OpenAI 공식 릴리스 직핀; #890에서 mise npm backend → nix 이관)
+- 확인 날짜: 2026-07-11
+- 확인 버전: codex-cli 0.144.1 (codex-pin.json/runtime 일치; nix overlay — OpenAI 공식 릴리스 직핀; #890에서 mise npm backend → nix 이관)
 - 재검증: `jq -r .version modules/shared/programs/codex/codex-pin.json && codex --version && codex --help`
 
 ## 목적과 범위
@@ -31,8 +31,26 @@ Codex CLI 호환 레이어와 프로젝트 스킬 발견 문제를 다룹니다.
 1. `.agents/skills/*`이 디렉토리 심링크인지 확인 (`ls -la .agents/skills/`)
 2. 프로젝트 루트 `AGENTS.md -> CLAUDE.md` 심링크 확인 (git-tracked)
 3. `./scripts/ai/verify-ai-compat.sh` 실행
-4. `codex exec`로 런타임에서 스킬 이름이 보이는지 확인
+4. 문서화된 runtime recognition 검사로 `codex exec`에서 스킬 이름이 보이는지 확인
 5. 권한 프롬프트 이슈는 `approval_policy`, `sandbox_mode` 설정으로 분리 진단
+
+## 런타임 라우팅과 노출 경계
+
+| 세션 | 기본 실행 경로 |
+|------|----------------|
+| Direct Codex | native subagent. `using-codex-exec`와 `codex-fan-out`은 자기 참조 방지를 위해 의도적으로 노출하지 않으며 직접 호출 대상이 아니다. |
+| Claude Code | `codex exec` subprocess. `using-codex-exec`와 `codex-fan-out`은 이 경로를 위한 adapter 문서다. |
+| headless | `codex exec` subprocess를 foreground serial로 실행한다. |
+
+세션별 binding은 [runtime mapping](../../../modules/shared/programs/claude/files/skills/run-da/references/runtime-mapping.md)이 정본이다.
+Direct Codex에서 native delegation이 거부되었을 때의 별도 승인 fallback은
+[hardening contract](../../../modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md)를 참조하며,
+이 문서에서 fallback 설계를 복제하지 않는다.
+
+Shared skill 노출 정책의 SoT는
+[`default.nix`](../../../modules/shared/programs/codex/default.nix)의 `exposedCodexSkills`와
+`intentionallyNotExposed`다. [`verify-ai-compat.sh`](../../../scripts/ai/verify-ai-compat.sh)는
+그 목록과 project directory projection을 독립적으로 감사하는 oracle이다.
 
 ## `request_user_input` Default Mode 활성화
 
@@ -50,10 +68,10 @@ codex 0.106+에서 default (code) collaboration mode에서도 `request_user_inpu
 
 ## 핵심 파일
 
-- `modules/shared/programs/codex/default.nix` — 설정 및 스킬 투영
+- `modules/shared/programs/codex/default.nix` — 설정, shared skill 노출 정책 SoT, project 스킬 투영
 - `modules/shared/programs/codex/files/config.toml` — 실행 정책/모델 설정 (NixOS)
 - `modules/shared/programs/codex/files/config.darwin.toml` — macOS 전용 설정 (user-scope MCP 포함)
-- `scripts/ai/verify-ai-compat.sh` — 구조 검증
+- `scripts/ai/verify-ai-compat.sh` — 노출 정책 및 directory projection 독립 감사 oracle
 - `modules/shared/programs/claude/files/CLAUDE.md` — 글로벌 라우팅/지침
 - `.claude/skills/*` (원본)
 - `.agents/skills/*` (Codex 발견용 투영)
@@ -125,7 +143,7 @@ Codex CLI는 디렉토리 심링크를 따라가지만 파일 심링크는 무�
 
 ## 실행 정책 / Trust 메모
 
-`codex-cli 0.142.5` 기준으로 `codex --help`에 `codex trust` 독립 서브커맨드는 확인되지 않았다.
+`codex-cli 0.144.1` 기준으로 `codex --help`에 `codex trust` 독립 서브커맨드는 확인되지 않았다.
 권한 프롬프트 동작은 전역 실행 정책으로 제어한다.
 
 ```toml
@@ -133,7 +151,8 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 ```
 
-`trust_level` 프로젝트 엔트리는 경로별 세부 제어가 필요할 때만 추가한다.
+프로젝트 trust의 SoT는 사용자 승인에 의한 디렉토리별 runtime mutation이다. Nix template은
+trust를 하드코딩하지 않고 runtime-owned `config.toml`의 `[projects.*]` 엔트리를 보존한다.
 
 ## 트러블슈팅 / FAQ
 
@@ -174,9 +193,10 @@ done
 codex -a never exec "Answer YES or NO only: Is a skill named 'configuring-codex' available in this workspace?"
 ```
 
-## 관련 스킬
+## 관련 계약
 
-- `using-codex-exec`: Codex exec 실행 래퍼와 headless 실행 경로를 다룰 때 사용
+- 세션별 실행 binding: [runtime mapping](../../../modules/shared/programs/claude/files/skills/run-da/references/runtime-mapping.md)
+- Direct Codex 권한 및 fallback 경계: [hardening contract](../../../modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md)
 
 ## 레퍼런스
 

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -6,6 +6,25 @@
 - 대상 프로젝트: `/Users/green/Workspace/nixos-config`
 - 문제 유형: Codex CLI가 global(user) 스코프 스킬은 인식하지만 project 스코프(`.agents/skills`) 스킬을 안정적으로 인식하지 못함
 
+> 이 문서의 2026-02-08 해결 내용과 확인 결과는 당시 장애의 historical record다.
+> 현재 운영 계약은 아래 재검증 섹션과 2026-02-19 이후 업데이트를 따른다.
+
+## 2026-07-11 재검증: 현재 운영 계약
+
+- Direct Codex의 기본 fan-out은 native subagent다. `using-codex-exec`와 `codex-fan-out`은
+  자기 참조 방지를 위해 Direct Codex에 의도적으로 노출하지 않으며 직접 호출 대상이 아니다.
+- Claude Code는 `codex exec` subprocess, headless는 foreground serial subprocess 경로를 사용한다.
+  세션별 binding의 정본은 [runtime mapping](../../../../modules/shared/programs/claude/files/skills/run-da/references/runtime-mapping.md),
+  Direct Codex delegation fallback의 권한 계약은 [hardening contract](../../../../modules/shared/programs/claude/files/skills/run-da/references/hardening-contract.md)다.
+- Shared skill 노출 정책의 SoT는 [`default.nix`](../../../../modules/shared/programs/codex/default.nix)의
+  `exposedCodexSkills`와 `intentionallyNotExposed`다.
+  [`verify-ai-compat.sh`](../../../../scripts/ai/verify-ai-compat.sh)는 이 정책과 project directory projection을
+  독립적으로 감사하는 oracle이다.
+- Project projection은 `.agents/skills/<name>` directory symlink 단위다. repo-local target은
+  `../../.claude/skills/<name>`이어야 하고 투영된 `SKILL.md`에 접근 가능해야 한다. 레거시 실디렉토리,
+  누락·대상 불일치·고아 entry는 실패하며, 접근 가능한 `SKILL.md`를 가진 절대 target plugin symlink는 허용한다.
+- 실측 `codex-cli 0.144.1`과 `codex-pin.json`의 `0.144.1`이 일치한다.
+
 ## 증상
 
 1. Codex에서 `.agents/skills/<name>/SKILL.md` 기반 스킬이 일부/전부 누락됨
@@ -71,12 +90,17 @@ sandbox_mode = "danger-full-access"
 # 2) SKILL.md 도구-중립성 lint fixture 검증
 ./scripts/ai/verify-ai-compat.sh --run-fixture-tests
 
-# 3) SKILL.md 타입 검증
-find .agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -type l | wc -l
-find .agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -type f | wc -l
+# 3) directory symlink 검증
+for d in .agents/skills/*; do
+  [ -L "$d" ] && echo "OK: $(basename "$d") -> $(readlink "$d")" || echo "FAIL: $(basename "$d")"
+done
 
-# 4) 런타임 인식 검증
-codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' available in this workspace?"
+# 4) pin/runtime 버전 일치 검증
+codex --version
+jq -r .version modules/shared/programs/codex/codex-pin.json
+
+# 5) 런타임 인식 검증
+codex -a never exec "Answer YES or NO only: Is a skill named 'configuring-codex' available in this workspace?"
 ```
 
 ## 2026-02-08 확인 결과
@@ -91,8 +115,9 @@ codex -a never exec "Answer YES or NO only: Is a skill named 'managing-secrets' 
 
 ## codex trust 관련 메모
 
-- `codex-cli 0.142.5` 기준 `codex --help`에 `codex trust` 독립 서브커맨드는 확인되지 않았다.
-- trust 관리는 CLI 서브커맨드가 아니라 `config.toml` 프로젝트 엔트리로만 가능하다.
+- `codex-cli 0.144.1` 기준 `codex --help`에 `codex trust` 독립 서브커맨드는 확인되지 않았다.
+- 프로젝트 trust의 SoT는 사용자 승인에 의한 디렉토리별 runtime mutation이다. Nix template은 trust를
+  하드코딩하지 않고 runtime-owned `config.toml`의 `[projects.*]` 엔트리를 보존한다.
 - 본 케이스에서 Skills 누락의 근본 원인으로는 확인되지 않았다(심링크 이슈가 근본 원인).
 
 ## 회귀 방지 체크리스트

--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -92,12 +92,32 @@ sandbox_mode = "danger-full-access"
 
 # 3) directory symlink 검증
 for d in .agents/skills/*; do
-  [ -L "$d" ] && echo "OK: $(basename "$d") -> $(readlink "$d")" || echo "FAIL: $(basename "$d")"
+  name="$(basename "$d")"
+  target="$(readlink "$d" 2>/dev/null || true)"
+  expected="../../.claude/skills/$name"
+  if [ -d ".claude/skills/$name" ]; then
+    target_ok=false
+    [ "$target" = "$expected" ] && target_ok=true
+  else
+    target_ok=false
+    [[ "$target" = /* ]] && target_ok=true
+  fi
+  if [ -L "$d" ] && [ -d "$d" ] && [ -f "$d/SKILL.md" ] && $target_ok; then
+    echo "OK: $name -> $target"
+  else
+    echo "FAIL: $name"
+  fi
 done
 
 # 4) pin/runtime 버전 일치 검증
-codex --version
-jq -r .version modules/shared/programs/codex/codex-pin.json
+runtime_version="$(codex --version | awk 'NF { print $NF; exit }')"
+pin_version="$(jq -r .version modules/shared/programs/codex/codex-pin.json)"
+if [ -z "$runtime_version" ] || [ -z "$pin_version" ] || [ "$pin_version" = null ] ||
+   [ "$runtime_version" != "$pin_version" ]; then
+  echo "FAIL: runtime=$runtime_version pin=$pin_version" >&2
+  exit 1
+fi
+echo "OK: runtime=$runtime_version pin=$pin_version"
 
 # 5) 런타임 인식 검증
 codex -a never exec "Answer YES or NO only: Is a skill named 'configuring-codex' available in this workspace?"


### PR DESCRIPTION
## Summary

- Direct Codex의 skill routing을 native subagent 기본 경로와 intentionally-not-exposed adapter 경계에 맞춘다.
- projection 검증을 legacy `SKILL.md` file count에서 `.agents/skills/<name>` directory symlink 계약으로 갱신한다.
- exposure policy SoT, 독립 verifier, runtime/pin 버전과 trust ownership을 현재 구현에 맞춰 연결한다.

Closes #836

## 기존 문제/배경

`configuring-codex` 문서는 Direct Codex가 `using-codex-exec`를 직접 호출해야 하는 것처럼 안내했지만, 실제 노출 정책은 `using-codex-exec`와 `codex-fan-out`을 자기 참조 방지를 위해 의도적으로 제외한다. 또한 historical runbook의 활성 검증 절차가 개별 `SKILL.md` file type/count를 검사해, 현재 verifier의 directory-level projection 모델과 충돌했다.

이 drift는 존재하지 않는 skill로 routing하거나 정상적인 directory symlink projection을 잘못 진단하게 만든다. 문서, Nix exposure policy, verifier가 같은 운영 모델을 설명하도록 맞출 필요가 있다.

## CIR (Change Intent Record)

- Historical runbook은 2026-02-08 당시 file symlink 문제와 실파일 복사 대응을 기록하고, 2026-02-19 업데이트에서 directory symlink로 전환된 배경을 보존한다.
- 현재 Direct Codex 정책은 native subagent를 기본으로 사용하고 `using-codex-exec`/`codex-fan-out`을 의도적으로 비노출한다. 두 adapter를 Direct Codex 호출 대상으로 되살리는 대신, Claude Code/headless subprocess 경로라는 역할을 명시하고 상세 fallback 계약은 기존 runtime mapping과 hardening contract에 연결했다.
- 활성 검증 절차에서 legacy file-count 명령만 제거하고 historical 원인·결과는 유지했다. 현재 검증은 directory entry symlink, verifier oracle, runtime recognition을 함께 확인한다.
- runtime과 pin을 직접 측정해 둘 다 `0.144.1`일 때만 두 문서의 stale version stamp를 갱신했다.

Trade-off: 문서에서 fallback 구현 세부를 반복하지 않으므로 관련 계약을 따라가야 하지만, 정책 변경 시 중복 문서가 다시 drift할 위험을 줄인다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Direct Codex에 adapter skill 노출 | `using-codex-exec`/`codex-fan-out`을 직접 호출 대상으로 변경 | 기존 문구를 유지할 수 있음 | 자기 참조를 만들고 #836 범위 밖의 exposure policy 변경 필요 | ❌ |
| fallback contract를 문서에 복제 | 세션별 subprocess 규칙을 `configuring-codex`에 다시 기술 | 한 파일에서 상세 확인 가능 | runtime mapping/hardening contract와 중복되어 재차 drift 가능 | ❌ |
| 현재 routing을 요약하고 SoT 연결 | Direct Codex native, Claude/headless subprocess 경계만 기록하고 상세는 기존 계약 링크 | 실제 노출 정책과 일치하고 중복 최소화 | 상세 확인 시 링크 이동 필요 | ✅ |
| `SKILL.md` file type/count 유지 | projection 내부 파일 형태를 직접 집계 | 과거 상태 재현에 유용 | directory symlink 계약과 verifier 판정을 표현하지 못함 | ❌ |
| directory entry + verifier 검사 | `.agents/skills/*` entry와 독립 oracle로 구조 검증 | repo-local 및 plugin projection 모델과 일치 | verifier 실행 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `.claude/skills/configuring-codex/SKILL.md` | 수정 | 세션별 routing/비노출 경계, exposure SoT와 verifier 링크, `0.144.1` 및 runtime-owned trust 문구 갱신 |
| `.claude/skills/configuring-codex/references/runbook-codex-compat.md` | 수정 | historical record를 보존하면서 현재 운영 계약을 추가하고 legacy file-count를 directory symlink 검증으로 교체 |

핵심 검증 모델:

```bash
for d in .agents/skills/*; do
  name="$(basename "$d")"
  target="$(readlink "$d" 2>/dev/null || true)"
  expected="../../.claude/skills/$name"
  if [ -d ".claude/skills/$name" ]; then
    target_ok=false
    [ "$target" = "$expected" ] && target_ok=true
  else
    target_ok=false
    [[ "$target" = /* ]] && target_ok=true
  fi
  if [ -L "$d" ] && [ -d "$d" ] && [ -f "$d/SKILL.md" ] && $target_ok; then
    echo "OK: $name -> $target"
  else
    echo "FAIL: $name"
  fi
done

runtime_version="$(codex --version | awk 'NF { print $NF; exit }')"
pin_version="$(jq -r .version modules/shared/programs/codex/codex-pin.json)"
if [ -z "$runtime_version" ] || [ -z "$pin_version" ] || [ "$pin_version" = null ] ||
   [ "$runtime_version" != "$pin_version" ]; then
  echo "FAIL: runtime=$runtime_version pin=$pin_version" >&2
  exit 1
fi
echo "OK: runtime=$runtime_version pin=$pin_version"

./scripts/ai/verify-ai-compat.sh
```

## 참고 레퍼런스

- Issue #836 — stale skill routing/projection 문서 drift
- Issue #212 — `using-codex-exec` 자기 참조 방지 배경
- Issue #486 — Direct Codex shared skill exposure policy 배경
- Issue #890 — Codex CLI nix overlay 이관 및 pin/runtime ownership
- [openai/codex PR #8801](https://github.com/openai/codex/pull/8801) — directory symlink traversal 지원
- `modules/shared/programs/codex/default.nix` — `exposedCodexSkills` / `intentionallyNotExposed` SoT
- `scripts/ai/verify-ai-compat.sh` — exposure와 directory projection의 독립 감사 oracle

## Human Test Plan

1. `configuring-codex`의 routing 표를 읽는다.
   - 기대: Direct Codex는 native subagent, Claude Code/headless는 `codex exec` subprocess로 구분되고 두 adapter는 Direct Codex 직접 호출 대상이 아니다.
   - 실패 시: `default.nix`의 `intentionallyNotExposed` 및 runtime mapping과 문구를 대조한다.

2. `.agents/skills/*` directory symlink loop를 실행한다.
   - 기대: 모든 entry가 symlink인 동시에 directory와 `SKILL.md`로 해석되고, repo-local skill은 `../../.claude/skills/<name>`, plugin skill은 접근 가능한 absolute target을 가리켜 `OK`가 된다.
   - 실패 시: `-L`/`-d`/`SKILL.md` 중 실패 조건, `readlink` target class, 누락/고아 entry를 확인한 뒤 `nrs`로 projection을 재적용한다.

3. `./scripts/ai/verify-ai-compat.sh --run-fixture-tests`와 `./scripts/ai/verify-ai-compat.sh`를 실행한다.
   - 기대: fixture와 독립 oracle이 모두 통과하고 exposed 9개/비노출 4개 정책이 일치한다.
   - 실패 시: project directory projection 실패와 shared global exposure 실패를 분리해 진단한다.

4. `codex --version`과 `jq -r .version modules/shared/programs/codex/codex-pin.json`을 빈 값/null 방어가 포함된 비교 블록으로 검사한다.
   - 기대: 둘 다 `0.144.1`이며 비교 블록이 `OK`와 exit 0을 반환한다.
   - 실패 시: mismatch를 exit 1로 판정하고 어느 쪽이 맞다고 추정하지 않은 채 문서 version 갱신을 중단한다.

5. `nrs` 후 fresh runtime recognition을 실행한다.
   - 명령: `codex -a never exec "Answer YES or NO only: Is a skill named 'configuring-codex' available in this workspace?"`
   - 기대: `YES`.
   - 실패 시: activation 직후 verifier, `.agents/skills/configuring-codex` target, runtime PATH resolve 순서로 확인한다.

6. `git diff --check`와 `bash tests/run-all-tests.sh`를 실행한다.
   - 기대: whitespace 오류가 없고 전체 test entrypoint가 green이다.
   - 실패 시: 환경 도구 누락과 실제 fixture 실패를 분리하고, timing-sensitive shell fixture는 `TEST_JOBS=1`로 재현한다.
