### PR TITLE
feat(darwin): Computer Use 금지 대상을 선언적으로 허용

### DIFF
--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -186,6 +186,14 @@ in
       "com.apple.keyboard.fnState" = true;
     };
 
+    # nix-darwin의 typed NSGlobalDomain schema에 없는 전역 preference는 이 경로로 선언한다.
+    CustomUserPreferences.NSGlobalDomain = {
+      # CIR: Computer Use의 금지 대상 가드를 의도적으로 해제한다. Ghostty 접근을
+      # 키 없음(거부) → true(조회·클릭 성공) → 키 없음(재거부)으로 실측했다.
+      # 보안 trade-off: 터미널 같은 민감 앱의 UI와 내용을 읽고 조작할 수 있게 된다.
+      ComputerUseAllowForbiddenTargets = true;
+    };
+
     # 네트워크 볼륨에 .DS_Store 생성 방지
     CustomUserPreferences."com.apple.desktopservices" = {
       DSDontWriteNetworkStores = true;

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -450,6 +450,13 @@ let
                 != null
             );
         }
+        {
+          name = "Test D13 ${hostName}: Computer Use 금지 대상 허용이 활성화되어야 함";
+          cond =
+            hasHost
+            &&
+              cfg.system.defaults.CustomUserPreferences.NSGlobalDomain.ComputerUseAllowForbiddenTargets == true;
+        }
       ]
     ) expectedDarwinHosts
   );


### PR DESCRIPTION
## Summary

- Computer Use의 금지 대상 가드를 해제하는 macOS 전역 preference를 nix-darwin으로 선언해 수동 설정 드리프트를 없앤다.
- 모든 Darwin 호스트의 intent-level eval로 해당 보안 trade-off가 조용히 사라지지 않도록 잠근다.

Closes #1096

## 기존 문제/배경

<img width="596" height="720" alt="image" src="https://github.com/user-attachments/assets/fadc88a7-2abc-4b86-bc6d-1a5aaf06b236" />

> Computer Use에서 기본적으로 차단되어 있는 앱 리스트 ([🔗 출처](https://x.com/zats/status/2074836519559242230?s=20))


macOS Computer Use는 Ghostty 같은 특정 앱을 안전상의 이유로 기본 차단한다. 기존에는 `ComputerUseAllowForbiddenTargets`가 선언되어 있지 않아 Ghostty 상태 조회가 `Computer Use is not allowed ... for safety reasons` 오류로 거부됐다.

`defaults write -g ComputerUseAllowForbiddenTargets -bool YES`를 수동 실행하면 접근이 허용되지만, 새 장비나 설정 재적용 시 누락될 수 있고 “왜 안전 가드를 풀었는지”가 구성에 남지 않는다. 또한 이 preference는 터미널 UI와 내용을 읽고 조작할 수 있게 하므로, 일반 편의 설정보다 강한 의도 기록과 회귀 검증이 필요하다.

## CIR (Change Intent Record)

- **v1** (이번 변경): 공개된 `defaults write -g` 명령이 실제 효과가 있는지 먼저 검증했다. 동일 Computer Use 세션에서 키 없음(접근 거부) → `true`(Ghostty 조회·메뉴 클릭 성공) → 키 삭제(재거부)로 재현해 no-op 가능성을 제거했다.
- **v2** (이번 변경): typed `system.defaults.NSGlobalDomain`에 직접 키를 선언했으나, 현재 nix-darwin schema가 비공개 키를 노출하지 않아 eval 단계에서 거부됐다.
- **v3** (이번 변경): nix-darwin이 임의 plist 값에 제공하는 `CustomUserPreferences.NSGlobalDomain` 경로로 교정했다. 생성된 activation 명령, `NSGlobalDomain`/`-g` 동등성, 실제 `nrs` 적용과 Computer Use 접근까지 확인했다.

**trade-off**: Computer Use DX와 자동화 범위는 커지지만, 터미널처럼 민감한 앱의 화면과 내용을 에이전트가 읽고 조작할 수 있다. 이 완화는 의도적이며 설정 바로 옆 CIR 주석으로 보존한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 수동 `defaults write -g` | 필요할 때 사용자가 직접 실행 | 가장 단순 | 재현성·의도 추적·새 장비 복원 부족 | ❌ |
| typed `system.defaults.NSGlobalDomain` | 표준 전역 defaults 옵션에 직접 선언 | 의미가 가장 직접적 | 현재 nix-darwin schema에 키가 없어 평가 실패 | ❌ |
| `CustomUserPreferences.NSGlobalDomain` | freeform 전역 preference로 선언 | nix-darwin 표준 activation 사용, 임의 키 지원 | typed option 수준의 문서화는 없음 | ✅ |
| `postActivation`에서 raw command 실행 | 셸에서 명령을 직접 실행 | 원문 명령과 동일 | 선언형 defaults 경로를 우회하고 별도 셸 로직 증가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/configuration.nix` | 설정 추가 | freeform 전역 preference와 안전 경계 완화 CIR 주석 추가 |
| `tests/eval-tests.nix` | 회귀 테스트 추가 | 두 Darwin 호스트 모두에서 설정값이 `true`인지 D13으로 검증 |

### 핵심 코드

```nix
# BEFORE: 선언 없음 — Computer Use가 Ghostty 접근을 safety reasons로 거부

# AFTER
CustomUserPreferences.NSGlobalDomain = {
  ComputerUseAllowForbiddenTargets = true;
};
```

생성되는 activation은 `defaults write NSGlobalDomain ComputerUseAllowForbiddenTargets <true/>`이며, macOS에서 `NSGlobalDomain`은 원문 명령의 `-g`와 같은 전역 preference 도메인으로 동작함을 임시 키 왕복으로 확인했다.

## 참고 레퍼런스

- Issue #1096 — 문제 정의, A→B→A PoC, 구현 범위
- [Peter Steinberger의 원문](https://x.com/steipete/status/2074795172295291224) — preference 명령의 공개 출처

## Human Test Plan

### 선언 및 평가

1. `nix develop -c nix eval --impure --file tests/eval-tests.nix`를 실행한다.
   - **기대**: `true`를 반환하고, 두 Darwin 호스트의 D13이 통과한다.
   - **실패 시**: 설정 경로가 `system.defaults.CustomUserPreferences.NSGlobalDomain`인지 확인한다. typed `system.defaults.NSGlobalDomain` 직접 키는 현재 schema에서 거부된다.

2. `nix develop -c nix flake check --no-build --all-systems`를 실행한다.
   - **기대**: Darwin/NixOS 구성과 양쪽 devShell·package 평가가 모두 통과한다.
   - **실패 시**: 실패한 flake output과 `tests/eval-tests.nix`의 D13 조건을 확인한다.

### 실제 macOS 적용

3. macOS 호스트에서 `nrs`를 실행한 뒤 `defaults read -g ComputerUseAllowForbiddenTargets`를 실행한다.
   - **기대**: 재빌드가 성공하고 defaults 값이 `1`이다.
   - **실패 시**: 생성된 `system.activationScripts.userDefaults.text`에 `defaults write NSGlobalDomain ComputerUseAllowForbiddenTargets`가 포함되는지 확인한다.

4. Computer Use로 `com.mitchellh.ghostty`의 상태를 조회하고 Ghostty 메뉴처럼 무해한 UI를 조작한다.
   - **기대**: safety-reasons 차단 없이 접근성 트리가 반환되고 UI 조작이 성공한다.
   - **실패 시**: defaults 값과 Computer Use 서비스의 macOS 접근성 권한을 구분해 확인한다.

### Negative 및 인접 회귀

5. 필요 시 `defaults delete -g ComputerUseAllowForbiddenTargets` 후 같은 Ghostty 조회를 반복한다.
   - **기대**: safety-reasons 오류로 다시 거부된다. 이후 `nrs`를 재실행하면 값이 `1`로 복구되고 접근이 다시 허용된다.
   - **실패 시**: Computer Use 런타임이 preference를 다시 읽는지와 대상 bundle id를 확인한다.

6. 기존 Dock·Finder·키보드 관련 Darwin eval 테스트도 함께 확인한다.
   - **기대**: D3~D8을 포함한 기존 intent 테스트가 그대로 통과한다.
   - **실패 시**: `CustomUserPreferences.NSGlobalDomain`과 기존 typed `NSGlobalDomain` 설정이 서로 다른 키만 쓰는지 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * macOS 전역 설정에 컴퓨터 사용 제한 대상 허용 옵션을 추가했습니다.

* **버그 수정**
  * 해당 설정이 대상 호스트에서 활성화되도록 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->