### PR TITLE
feat(claudex): user-adjustable effort and always-bypass permissions

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -104,7 +104,7 @@ git status --short --branch
   - 빈 CLI fallback 목록으로 settings의 `fallbackModel`을 마스킹하고, wrapper-owned `CLAUDE_CODE_EFFORT_LEVEL`을 다시 설정한다.
   - loopback catalog에서 선언 모델을 확인한 뒤 `$HOME/.local/bin/claude`를 실행한다.
   - model은 `gpt-5.6-sol`로 고정한다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
-  - `--dangerously-skip-permissions`로 실행해 세션이 항상 bypassPermissions로 시작한다 (pinned CLI는 시작 플래그 없이 세션 중 bypass 전환이 불가능).
+  - `--dangerously-skip-permissions`로 실행해 세션이 항상 bypassPermissions로 시작한다 (pinned CLI는 시작 플래그 없이 세션 중 bypass 전환이 불가능). 이 계약이 조용히 뒤집히지 않도록 사용자 인자의 `--permission-mode`도 wrapper-owned 옵션으로 거부한다.
 - `modules/shared/programs/claudex/files/claudex-status.sh`
   - launchd service, auth, proxy, catalog 상태를 네 줄로 출력한다.
   - Stage 1 성공 조건은 auth/proxy/catalog ready이며, launchd service는 정보성 상태다.

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -101,9 +101,10 @@ git status --short --branch
   - provider/model/settings 관련 사용자 override를 거부한다.
   - `CLAUDE_CODE_EXTRA_BODY`, inherited `CLAUDE_CODE_EFFORT_LEVEL`, `ANTHROPIC_UNIX_SOCKET`, Claude host-auth bridge 환경을 포함한 endpoint/request/transport override 환경을 scrub한다.
   - wrapper-owned settings 파일로 `CLAUDE_CODE_EXTRA_BODY`를 `{}`로 고정해 user/project settings의 request-body override를 중화한다.
-  - 빈 CLI fallback 목록으로 settings의 `fallbackModel`을 마스킹하고, wrapper-owned `CLAUDE_CODE_EFFORT_LEVEL=high`를 다시 설정한다.
+  - 빈 CLI fallback 목록으로 settings의 `fallbackModel`을 마스킹하고, wrapper-owned `CLAUDE_CODE_EFFORT_LEVEL`을 다시 설정한다.
   - loopback catalog에서 선언 모델을 확인한 뒤 `$HOME/.local/bin/claude`를 실행한다.
-  - model은 `gpt-5.6-sol`, effort는 `high`로 고정한다.
+  - model은 `gpt-5.6-sol`로 고정한다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
+  - `--dangerously-skip-permissions`로 실행해 세션이 항상 bypassPermissions로 시작한다 (pinned CLI는 시작 플래그 없이 세션 중 bypass 전환이 불가능).
 - `modules/shared/programs/claudex/files/claudex-status.sh`
   - launchd service, auth, proxy, catalog 상태를 네 줄로 출력한다.
   - Stage 1 성공 조건은 auth/proxy/catalog ready이며, launchd service는 정보성 상태다.
@@ -143,14 +144,15 @@ git status --short --branch
 7. catalog에 모델이 보이는 것만으로 entitlement 성공으로 판정하지 않는다. 실제 completion이 필요하다.
 8. inherited request body, effort, Unix-socket transport가 wrapper의 endpoint/model/credential 경계를 우회하지 못해야 한다.
 9. byte-identical config render는 inode를 보존한다. runtime contract가 실제로 바뀌면 foreground proxy를 재시작한다.
-10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 환경값 `high`를 따른다.
+10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 값을 따른다 — 기본 `high`, 명시적 `claudex --effort` 인자(whitelist: low/medium/high/xhigh/max/ultra)만 이를 바꾸며 상속 환경값은 계속 scrub된다.
 11. inherited Claude host-auth bridge와 settings `env.CLAUDE_CODE_EXTRA_BODY`는 wrapper-owned loopback/model/request 계약을 우회하지 못해야 한다.
 
 ### 알려진 한계·리스크와 롤백
 
 - **벤더 정책 의존 (전략 리스크)**: 이 브릿지는 Claude Code에 non-Anthropic 모델을 loopback proxy로 연결한다. Codex OAuth entitlement 쪽은 upstream 튜토리얼에서 공개적으로 안내된 경로지만, Anthropic 또는 OpenAI가 언제든 이 조합을 차단할 수 있다. 즉 이 경계의 수명은 두 벤더의 정책에 종속되며, 기술적 완성도와 무관하게 외부 요인으로 무력화될 수 있다.
   - **롤백 경로**: 차단이 관측되면 `default.nix`의 `targetHosts` allowlist에서 해당 호스트를 빼고 `nrs`를 실행한다. 그러면 활성 Home Manager generation에서 네 실행 surface와 CLIProxyAPI enabled-only closure 노출이 즉시 제거되고 descriptor와 runtime library metadata만 남는다(`lib.optionalAttrs enabled` 경계). 단, 이전 generation과 CLIProxyAPI Nix store 경로 자체는 garbage collection 전까지 store에 남으므로, 로컬 잔여물까지 정리하려면 generation 정리와 `nix-collect-garbage` 실행이 별도로 필요하다. credential/state는 repo 밖 `$HOME/Library/Application Support/claudex`에만 있으므로 그 디렉터리를 지우면 로컬 흔적도 제거된다. 일반 `claude` 설정과 인증은 애초에 건드리지 않으므로 별도 복구가 필요 없다.
-- **subagent effort 세밀 제어 불가 (기능 한계)**: wrapper는 `CLAUDE_CODE_SUBAGENT_MODEL`로 subagent 모델만 고정 모델에 맞추고 effort는 세션 전체를 `high`로 고정한다. subagent effort만 별도로 낮추는 수단은 없다(pinned Claude Code CLI 자체의 제약). 대량 fan-out 워크플로우에서는 subagent가 모두 `high`로 돌아 토큰 소모가 커질 수 있다. `ultra`가 아니라 `high`로 고정해 폭증은 완화했지만, 세밀 제어가 필요하면 CLI가 subagent effort 하드셋을 지원할 때까지 기다려야 한다.
+- **subagent effort 세밀 제어 불가 (기능 한계)**: wrapper는 `CLAUDE_CODE_SUBAGENT_MODEL`로 subagent 모델만 고정 모델에 맞추고, effort는 세션 단위 값 하나(기본 `high`, `claudex --effort`로 조정 가능)를 세션 전체가 공유한다. subagent effort만 별도로 낮추는 수단은 여전히 없다(pinned Claude Code CLI 자체의 제약). 대량 fan-out 워크플로우에서 토큰 소모가 부담이면 세션 effort 자체를 낮춰서 실행한다.
+- **bypassPermissions 기본 시작 (의도된 트레이드오프)**: wrapper는 `--dangerously-skip-permissions`로 Claude Code를 실행해 모든 세션이 bypass 모드로 시작한다. pinned CLI가 시작 플래그 없이는 세션 중 bypass 전환을 허용하지 않아 사용자가 기본 bypass를 선택했다. 이를 실제로 동작시키기 위해 `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`도 `0`으로 opt-out했다 — `1`이면 pinned CLI의 allowed_non_write_users hardening이 permission mode를 default로 강제해 bypass 플래그를 조용히 무력화한다(2.1.210 실측). 잔여 노출은 세션 내 서브프로세스가 wrapper-owned loopback API key 환경값을 볼 수 있다는 것인데, 이 key는 `127.0.0.1:8317` 전용이라 영향이 국소적이다. 권한 프롬프트가 필요한 환경에서는 wrapper의 bypass 플래그를 제거해야 하며, 그 경우 세션 중 bypass 전환 옵션도 함께 사라진다.
 - **`commercial-mode: true` 근거**: config template의 `commercial-mode`는 상용/라이선스 플래그가 아니라, upstream 정의상 "high-overhead request logging과 HTTP middleware 기능을 비활성화해 per-request 메모리를 줄이는" 플래그다(upstream 기본값은 `false`). 이 PoC는 credential·request 본문이 로그에 남지 않도록 request logging을 억제할 목적으로 의도적으로 `true`로 뒤집었으며, `logging-to-file`·`usage-statistics-enabled`를 모두 끄는 config-template의 보안 기본값과 같은 맥락이다. upstream 정의의 version-pinned 출처는 CLIProxyAPI `v7.2.73`의 [`config.example.yaml`](https://github.com/router-for-me/CLIProxyAPI/blob/v7.2.73/config.example.yaml)("When true, disable high-overhead request logging and HTTP middleware features to reduce per-request memory usage under high concurrency")과 [`internal/config/config.go`](https://github.com/router-for-me/CLIProxyAPI/blob/v7.2.73/internal/config/config.go)의 `CommercialMode` 필드 주석이다. 이 값이 렌더된 config에 실제로 들어가는 계약은 `tests/suites/claudex.sh`의 config-template 렌더 검증이 커버하며, 실제 로그 억제 동작의 런타임 실측은 upstream 바이너리 동작 범위라 §12의 Stage 2 전 조사(#1108)와 함께 다룬다.
 
 ## 5. 이미 완료된 검증

--- a/modules/shared/programs/claudex/files/claudex.sh
+++ b/modules/shared/programs/claudex/files/claudex.sh
@@ -9,22 +9,64 @@ source "@runtimeLibrary@"
 CLAUDEX_CONFIG_TEMPLATE="@configTemplate@"
 CLAUDEX_WRAPPER_SETTINGS="@wrapperSettings@"
 
+# Effort stays wrapper-owned: the inherited CLAUDE_CODE_EFFORT_LEVEL is scrubbed below and
+# only an explicit, whitelist-validated `claudex --effort <level>` argument may change the
+# session level. The wrapper consumes the argument and re-issues it as its own CLI value so
+# a single deterministic `--effort` reaches Claude.
+effort_level=high
+expect_effort_value=false
+forward_args=()
 scan_options=true
 for arg in "$@"; do
   if [ "$scan_options" = false ]; then
+    forward_args+=("$arg")
+    continue
+  fi
+  if [ "$expect_effort_value" = true ]; then
+    effort_level="$arg"
+    expect_effort_value=false
     continue
   fi
   if [ "$arg" = "--" ]; then
     scan_options=false
+    forward_args+=("$arg")
     continue
   fi
   case "$arg" in
-    --model | --model=* | --fallback-model | --fallback-model=* | --effort | --effort=* | --settings | --settings=* | --setting-sources | --setting-sources=*)
+    --model | --model=* | --fallback-model | --fallback-model=* | --settings | --settings=* | --setting-sources | --setting-sources=*)
       _claudex_error "option is managed by the claudex host wrapper: $arg"
       exit 2
       ;;
+    --effort)
+      expect_effort_value=true
+      ;;
+    --effort=*)
+      effort_level="${arg#--effort=}"
+      ;;
+    *)
+      forward_args+=("$arg")
+      ;;
   esac
 done
+if [ "$expect_effort_value" = true ]; then
+  _claudex_error "--effort requires a value: low, medium, high, xhigh, max, ultra"
+  exit 2
+fi
+case "$effort_level" in
+  low | medium | high | xhigh | max | ultra) ;;
+  *)
+    _claudex_error "invalid --effort level: $effort_level (allowed: low, medium, high, xhigh, max, ultra)"
+    exit 2
+    ;;
+esac
+# The pinned CLI validates --effort argv values (low..max) and warns-then-ignores unknown
+# ones, while CLAUDE_CODE_EFFORT_LEVEL is forwarded unvalidated for the backend to
+# interpret. ultra is a backend-recognized level for the pinned model, so it travels via
+# the wrapper-owned environment value only — passing it as argv would be warn-then-ignored.
+effort_argv=(--effort "$effort_level")
+if [ "$effort_level" = ultra ]; then
+  effort_argv=()
+fi
 
 prepare_state
 assert_single_codex_credential
@@ -98,10 +140,16 @@ export ANTHROPIC_BASE_URL="$CLAUDEX_BASE_URL"
 export ANTHROPIC_AUTH_TOKEN="$api_key"
 export HOME="$CLAUDEX_HOME"
 export CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1
-export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1
+# CIR: SUBPROCESS_ENV_SCRUB is explicitly opted out (0). When set to 1, the pinned CLI's
+# allowed_non_write_users hardening forces the permission mode back to default, which
+# silently defeats --dangerously-skip-permissions (measured on 2.1.210). The user chose
+# always-bypass sessions over subprocess env scrubbing; the residual exposure is the
+# wrapper-owned loopback API key becoming visible to in-session subprocesses, which is a
+# loopback-only credential confined to 127.0.0.1:8317.
+export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0
 export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDEX_MODEL"
 export CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1
-export CLAUDE_CODE_EFFORT_LEVEL=high
+export CLAUDE_CODE_EFFORT_LEVEL="$effort_level"
 export CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3
 export ENABLE_TOOL_SEARCH=false
 export NO_PROXY="$CLAUDEX_NO_PROXY"
@@ -109,9 +157,14 @@ export no_proxy="$CLAUDEX_NO_PROXY"
 
 # An explicitly empty CLI fallback list has higher precedence than fallbackModel loaded from
 # ordinary settings and resolves to no fallback in the pinned Claude Code CLI.
+# CIR: --dangerously-skip-permissions is deliberate. The pinned CLI can only enter
+# bypassPermissions when it is enabled at startup (no mid-session switch without the flag),
+# and the user decided claudex sessions always start in bypass mode. Removing the flag
+# restores normal permission prompts but also removes the mid-session bypass option.
 exec "$claude_bin" \
   --settings "$CLAUDEX_WRAPPER_SETTINGS" \
   --model "$CLAUDEX_MODEL" \
   --fallback-model "" \
-  --effort high \
-  "$@"
+  "${effort_argv[@]}" \
+  --dangerously-skip-permissions \
+  "${forward_args[@]}"

--- a/modules/shared/programs/claudex/files/claudex.sh
+++ b/modules/shared/programs/claudex/files/claudex.sh
@@ -33,7 +33,7 @@ for arg in "$@"; do
     continue
   fi
   case "$arg" in
-    --model | --model=* | --fallback-model | --fallback-model=* | --settings | --settings=* | --setting-sources | --setting-sources=*)
+    --model | --model=* | --fallback-model | --fallback-model=* | --settings | --settings=* | --setting-sources | --setting-sources=* | --permission-mode | --permission-mode=*)
       _claudex_error "option is managed by the claudex host wrapper: $arg"
       exit 2
       ;;

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -514,7 +514,7 @@ EOF
   assert_file_contains "$sandbox/claude.log" "provider_bedrock=unset"
   assert_file_contains "$sandbox/claude.log" "http_proxy=unset"
   assert_file_contains "$sandbox/claude.log" "managed=1"
-  assert_file_contains "$sandbox/claude.log" "scrub=1"
+  assert_file_contains "$sandbox/claude.log" "scrub=0"
   assert_file_contains "$sandbox/claude.log" "subagent=gpt-5.6-sol"
   assert_file_contains "$sandbox/claude.log" "effort_enabled=1"
   assert_file_contains "$sandbox/claude.log" "concurrency=3"
@@ -545,10 +545,11 @@ EOF
     || fail "claudex did not mask settings fallbackModel with an empty CLI fallback list"
   assert_file_contains "$sandbox/claude.log" "arg=--effort"
   assert_file_contains "$sandbox/claude.log" "arg=high"
+  assert_file_contains "$sandbox/claude.log" "arg=--dangerously-skip-permissions"
   assert_file_contains "$sandbox/claude.log" "arg=--"
   assert_file_contains "$sandbox/claude.log" "arg=literal-prompt"
 
-  for flag in --model --fallback-model --effort --settings --setting-sources; do
+  for flag in --model --fallback-model --settings --setting-sources; do
     rm -f "$sandbox/claude.log"
     if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" "$flag" hostile \
       >/dev/null 2>&1; then
@@ -560,6 +561,66 @@ EOF
       fail "claudex accepted managed attached option: $flag"
     fi
   done
+
+  # --effort is user-adjustable within the validated whitelist; the wrapper consumes the
+  # argument and re-owns both the environment value and the single CLI occurrence.
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" \
+    CLAUDEX_STATE_DIR="$state" \
+    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" \
+    CLAUDE_CODE_EFFORT_LEVEL=low \
+    "$wrapper" --effort xhigh -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "claudex --effort xhigh did not reach Claude"
+  assert_file_contains "$sandbox/claude.log" "effort_level=xhigh"
+  assert_file_contains "$sandbox/claude.log" "arg=xhigh"
+
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" \
+    CLAUDEX_STATE_DIR="$state" \
+    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" \
+    "$wrapper" --effort=medium -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "claudex --effort=medium did not reach Claude"
+  assert_file_contains "$sandbox/claude.log" "effort_level=medium"
+
+  # ultra is argv-invalid on the pinned CLI (warn-then-ignore), so the wrapper must ship it
+  # via the environment value only and omit the --effort argv pair entirely.
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" \
+    CLAUDEX_STATE_DIR="$state" \
+    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" \
+    "$wrapper" --effort ultra -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "claudex --effort ultra did not reach Claude"
+  assert_file_contains "$sandbox/claude.log" "effort_level=ultra"
+  if grep -q '^arg=--effort$' "$sandbox/claude.log"; then
+    fail "claudex passed argv --effort for ultra despite the pinned CLI rejecting it"
+  fi
+
+  for bad_effort in "--effort" "--effort=hostile"; do
+    rm -f "$sandbox/claude.log"
+    if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" $bad_effort \
+      >/dev/null 2>&1; then
+      fail "claudex accepted invalid effort usage: $bad_effort"
+    fi
+    [[ ! -e "$sandbox/claude.log" ]] || fail "invalid effort still invoked Claude"
+  done
+  rm -f "$sandbox/claude.log"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" --effort hostile \
+    >/dev/null 2>&1; then
+    fail "claudex accepted an invalid split effort level"
+  fi
+  [[ ! -e "$sandbox/claude.log" ]] || fail "invalid split effort still invoked Claude"
 }
 
 test_claudex_launcher_and_login_use_fake_boundaries() {

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -549,7 +549,7 @@ EOF
   assert_file_contains "$sandbox/claude.log" "arg=--"
   assert_file_contains "$sandbox/claude.log" "arg=literal-prompt"
 
-  for flag in --model --fallback-model --settings --setting-sources; do
+  for flag in --model --fallback-model --settings --setting-sources --permission-mode; do
     rm -f "$sandbox/claude.log"
     if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" "$flag" hostile \
       >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- `claudex --effort <low|medium|high|xhigh|max|ultra>`를 허용한다. wrapper가 인자를 소비해 whitelist 검증 후 `CLAUDE_CODE_EFFORT_LEVEL`과 단일 `--effort` argv로 재소유하며, 미지정 시 기본은 기존과 같은 `high`다.
- Claude Code를 `--dangerously-skip-permissions`로 실행해 claudex 세션이 항상 bypassPermissions로 시작한다.
- `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`를 `0`으로 opt-out한다 — `1`이면 pinned CLI의 allowed_non_write_users hardening이 permission mode를 default로 강제해 bypass 플래그를 조용히 무력화한다(E2E 실측).

## 기존 문제/배경

Stage 1 wrapper(PR #1107)는 effort를 `high`로 완전 고정했다. `--effort`는 관리 옵션 거부 목록에 있어 exit 2로 차단되고, 상속된 `CLAUDE_CODE_EFFORT_LEVEL`은 scrub 후 `high`로 재설정됐다. 실사용에서 세션별 비용/품질 조절(가벼운 작업은 low, 무거운 작업은 ultra)이 불가능했다.

권한 모드도 문제였다. pinned Claude Code CLI는 시작 플래그 없이는 세션 중 bypassPermissions 전환을 허용하지 않는데, wrapper는 권한 플래그를 넘기지 않아 claudex 세션에서 bypass를 쓸 수 없었다. 실측 과정에서 더 깊은 원인도 발견됐다: 플래그를 직접 넘겨도 wrapper가 export하던 `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1`이 permission mode를 default로 강제해 bypass가 조용히 무력화된다 (headless 실행에서 "Permission mode forced to default" 경고로 확인).

## CIR (Change Intent Record)

- **effort 소유권 재설계** (이번 변경): "무조건 거부"에서 "검증된 명시 인자만 수용"으로 바꿨다. 상속 환경값 scrub은 유지해 계약의 원래 목적(암묵적 상속 차단)을 보존하고, 사용자 의도는 명시적 CLI 인자로만 주입된다. wrapper가 인자를 소비해 자기 값으로 재발행하므로 Claude에는 항상 단일 결정적 `--effort`만 도달한다.
- **ultra의 env 전용 전달** (이번 변경): pinned CLI 2.1.210이 argv `--effort ultra`를 "Unknown --effort value — ignoring it and using the default effort"로 경고 후 무시함을 실측했다. 반면 `CLAUDE_CODE_EFFORT_LEVEL` 환경값은 argv 파싱 검증을 타지 않고 백엔드가 해석한다. 따라서 ultra 선택 시 `--effort` argv 쌍을 통째로 생략하고 env로만 전달해 비결정성을 제거했다.
- **bypass 상시 시작** (이번 변경, 사용자 결정): 시작은 기본 모드로 하되 세션 중 전환만 열어주는 `--allow-dangerously-skip-permissions` 대안을 추천으로 제시했으나, 사용자가 상시 bypass 시작을 선택했다.
- **SUBPROCESS_ENV_SCRUB opt-out** (이번 변경, PR #1107 도입값의 의도적 완화): `=1`은 PR #1107이 hostile-env 방어의 일부로 도입했으나, 이 hardening이 bypass 플래그와 상호 배타적임이 E2E에서 드러났다. bypass를 실현하려면 opt-out이 필수다. 잔여 노출은 세션 내 서브프로세스가 wrapper-owned loopback API key 환경값을 볼 수 있다는 것인데, 이 key는 `127.0.0.1:8317` 전용 로컬 credential이라 영향이 국소적이다. 근거는 코드 인라인 CIR 주석으로도 박제했다.

**trade-off**: 권한 프롬프트라는 방어층과 서브프로세스 env scrub을 포기하는 대신, 단일 사용자 개발 머신에서의 마찰 없는 세션을 얻는다. 프롬프트가 필요한 환경은 wrapper의 bypass 플래그를 제거하면 되지만 그 경우 세션 중 bypass 전환 옵션도 함께 사라진다 — 이 조건은 handoff 한계 섹션에 문서화했다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| effort 완전 고정 유지 | 기존 동작 (`high` 고정) | 계약 단순 | 세션별 비용/품질 조절 불가 | ❌ |
| `--effort` 명시 인자 허용 + whitelist + wrapper 재소유 | 인자를 소비·검증 후 env/argv 재발행 | 명시적 의도만 통과, 결정적 단일 값 | 파싱 로직 추가 | ✅ |
| 상속 env로 effort 조절 허용 | `CLAUDE_CODE_EFFORT_LEVEL` scrub 해제 | 구현 최소 | 암묵적 상속 우회 부활 — 계약 훼손 | ❌ |
| ultra를 argv로 전달 | 다른 레벨과 동일 경로 | 경로 일관성 | pinned CLI가 warn-then-ignore — 적용 레벨 비결정 | ❌ |
| ultra를 env 전용으로 전달 | `--effort` argv 쌍 생략 | 결정적, 경고 없음 | 레벨별 분기 하나 추가 | ✅ |
| `--allow-dangerously-skip-permissions` | 시작은 기본 모드, 세션 중 bypass 전환 가능 | 안전·유연 균형 | 매 세션 수동 전환 필요 | ❌ (사용자 결정) |
| `--dangerously-skip-permissions` 상시 | 모든 세션이 bypass로 시작 | 마찰 없음 | 권한 프롬프트 방어층 제거 | ✅ (사용자 결정) |
| SCRUB=1 유지 + allowedTools 선언 | hardening 유지하며 도구 allowlist | env scrub 보존 | bypass 모드가 아님 — default 모드 내 allowlist라 요구 미충족 | ❌ |
| SCRUB=0 opt-out | 공식 opt-out 경로로 hardening 해제 | bypass 실제 동작 | 서브프로세스가 loopback key env를 볼 수 있음 (loopback 전용이라 국소적) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claudex/files/claudex.sh` | 수정 | 인자 스캔을 재구성 루프로 전환 (effort 파싱·검증·소비), ultra의 env 전용 분기, bypass 플래그 추가, `SUBPROCESS_ENV_SCRUB=0` opt-out + CIR 주석 |
| `tests/suites/claudex.sh` | 수정 | bypass argv 검증, `scrub=0` 검증, `--effort`를 거부 목록에서 분리, xhigh/medium(attached)/ultra(env 전용)/invalid/값 누락 케이스 추가 |
| `docs/claudex-poc-handoff.md` | 수정 | §3 구현 지도와 §4 고정 계약·한계 섹션을 새 effort/권한 계약으로 동기화 |

### 핵심 코드

wrapper는 `--effort`를 소비해 whitelist 검증 후 재소유한다. ultra는 argv 파싱이 거부하므로 env로만 전달한다.

```bash
case "$effort_level" in
  low | medium | high | xhigh | max | ultra) ;;
  *)
    _claudex_error "invalid --effort level: $effort_level (allowed: low, medium, high, xhigh, max, ultra)"
    exit 2
    ;;
esac
effort_argv=(--effort "$effort_level")
if [ "$effort_level" = ultra ]; then
  effort_argv=()
fi

export CLAUDE_CODE_EFFORT_LEVEL="$effort_level"
export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0

exec "$claude_bin" \
  --settings "$CLAUDEX_WRAPPER_SETTINGS" \
  --model "$CLAUDEX_MODEL" \
  --fallback-model "" \
  "${effort_argv[@]}" \
  --dangerously-skip-permissions \
  "${forward_args[@]}"
```

## 참고 레퍼런스

- PR #1107 — Stage 1 wrapper 도입 (effort 고정과 `SUBPROCESS_ENV_SCRUB=1`의 출처)
- `docs/claudex-poc-handoff.md` §4 "알려진 한계·리스크와 롤백" — 이번 트레이드오프의 문서화 위치
- pinned CLI 실측 근거: `claude --effort ultra --version` (2.1.210)이 "Unknown --effort value 'ultra' — ignoring it and using the default effort. Valid values: low, medium, high, xhigh, max." 경고를 출력하고, `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` 상태의 headless 실행이 "Permission mode forced to default" 경고를 출력함

## Human Test Plan

아래 절차는 이 변경에서 실제로 수행해 통과한 검증을 재현한다.

### 자동 회귀 검증

1. 전체 shell suite를 실행한다.

   ```bash
   nix develop -c bash tests/run-shell-script-tests.sh
   ```

   - **기대**: `통과 217 · 실패 0`. claudex wrapper 계약 테스트에 effort override와 bypass argv 검증이 포함된다.
   - **실패 시**: fake claude 로그의 `effort_level=`/`arg=` 라인과 wrapper의 인자 재구성 루프를 대조한다.

### 선언 적용과 인자 검증

2. 선언을 적용하고 wrapper의 인자 검증을 확인한다.

   ```bash
   nrs
   claudex --effort hostile ; echo $?   # 기대: 에러 메시지 + exit 2
   claudex --effort ; echo $?           # 기대: 값 누락 에러 + exit 2
   claudex --model x ; echo $?          # 기대: 관리 옵션 거부 + exit 2 (기존 계약 유지)
   ```

   - **실패 시**: `~/.local/bin/claudex`가 새 store 경로를 가리키는지 확인한다.

### 실측 E2E (proxy ready 상태)

3. foreground proxy가 켜진 머신에서 effort 조정 + bypass 경로로 headless completion을 실행한다.

   ```bash
   printf '%s\n' 'Reply with exactly CLAUDEX_E2E_OK and nothing else.' \
     | claudex --effort ultra -p --output-format text
   ```

   - **기대**: stdout이 정확히 `CLAUDEX_E2E_OK` 한 줄이고, "Permission mode forced to default" 경고가 **출력되지 않는다** (SCRUB opt-out 이전에는 출력됐다).
   - **실패 시**: wrapper의 `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` 값과 `--dangerously-skip-permissions` argv 유무를 확인한다.

4. interactive 세션이 bypassPermissions로 시작하는지 확인한다.

   ```bash
   claudex
   ```

   - **기대**: 세션이 bypass 모드로 시작하고 도구 호출에 권한 프롬프트가 나타나지 않는다.
   - **실패 시**: pinned CLI 버전이 2.1.210인지, wrapper argv에 bypass 플래그가 있는지 확인한다.


https://claude.ai/code/session_01W6zMLY84NDGGPSyXTWfHmr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 세션 `effort`를 `low`, `medium`, `high`, `xhigh`, `max`, `ultra` 중에서 선택할 수 있으며, 허용된 값만 적용됩니다.
  - `--model`, `--fallback-model`, `--settings`, `--setting-sources`, `--permission-mode` 등 호스트 관리 옵션은 세션 실행 전에 차단됩니다.
  - 하위 실행의 스크럽 동작과 전달되는 `effort` 방식이 정리되어 실행 결과의 일관성이 향상됩니다.
- **문서**
  - 권한 우회 및 위험/한계(롤백 포함) 관련 실행 계약이 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->