### PR TITLE
feat(claudex): add --fast Codex fast-tier session flag

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -100,10 +100,11 @@ git status --short --branch
 - `modules/shared/programs/claudex/files/claudex.sh`
   - provider/model/settings 관련 사용자 override를 거부한다.
   - `CLAUDE_CODE_EXTRA_BODY`, inherited `CLAUDE_CODE_EFFORT_LEVEL`, `ANTHROPIC_UNIX_SOCKET`, Claude host-auth bridge 환경을 포함한 endpoint/request/transport override 환경을 scrub한다.
-  - wrapper-owned settings 파일로 `CLAUDE_CODE_EXTRA_BODY`를 `{}`로 고정해 user/project settings의 request-body override를 중화한다.
+  - wrapper-owned settings 파일로 `CLAUDE_CODE_EXTRA_BODY`를 고정해 user/project settings의 request-body override를 중화한다. variant는 두 개이며 모두 pinned Nix store 파일이다 — 기본 variant는 `{}`, fast variant는 `{"service_tier":"priority"}`.
   - 빈 CLI fallback 목록으로 settings의 `fallbackModel`을 마스킹하고, wrapper-owned `CLAUDE_CODE_EFFORT_LEVEL`을 다시 설정한다.
   - loopback catalog에서 선언 모델을 확인한 뒤 `$HOME/.local/bin/claude`를 실행한다.
   - model은 `gpt-5.6-sol`로 고정한다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
+  - Codex fast 티어는 불리언 `claudex --fast` 인자만 켠다(`--fast=<값>`은 거부). wrapper가 fast settings variant를 선택해 request body에 `service_tier`를 주입하며, 값은 온-와이어 canonical id인 `"priority"`(카탈로그 id `priority`, 표시명 "Fast")를 사용해 proxy 변환기의 `"fast"` 별칭 매핑에 의존하지 않는다. Claude CLI에는 대응 argv가 없으므로(자체 fastMode는 Anthropic 직접 API 전용 별개 기능) argv 재발행은 없다.
   - `--dangerously-skip-permissions`로 실행해 세션이 항상 bypassPermissions로 시작한다 (pinned CLI는 시작 플래그 없이 세션 중 bypass 전환이 불가능). 이 계약이 조용히 뒤집히지 않도록 사용자 인자의 `--permission-mode`도 wrapper-owned 옵션으로 거부한다.
 - `modules/shared/programs/claudex/files/claudex-status.sh`
   - launchd service, auth, proxy, catalog 상태를 네 줄로 출력한다.
@@ -146,12 +147,14 @@ git status --short --branch
 9. byte-identical config render는 inode를 보존한다. runtime contract가 실제로 바뀌면 foreground proxy를 재시작한다.
 10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 값을 따른다 — 기본 `high`, 명시적 `claudex --effort` 인자(whitelist: low/medium/high/xhigh/max/ultra)만 이를 바꾸며 상속 환경값은 계속 scrub된다.
 11. inherited Claude host-auth bridge와 settings `env.CLAUDE_CODE_EXTRA_BODY`는 wrapper-owned loopback/model/request 계약을 우회하지 못해야 한다.
+12. request body의 `service_tier`는 wrapper-owned 값만 존재한다 — 기본은 필드 미전송(계정 기본 티어), 명시적 `claudex --fast` 인자만 pinned fast settings variant로 `"priority"`를 주입하며 상속 환경값은 계속 scrub된다.
 
 ### 알려진 한계·리스크와 롤백
 
 - **벤더 정책 의존 (전략 리스크)**: 이 브릿지는 Claude Code에 non-Anthropic 모델을 loopback proxy로 연결한다. Codex OAuth entitlement 쪽은 upstream 튜토리얼에서 공개적으로 안내된 경로지만, Anthropic 또는 OpenAI가 언제든 이 조합을 차단할 수 있다. 즉 이 경계의 수명은 두 벤더의 정책에 종속되며, 기술적 완성도와 무관하게 외부 요인으로 무력화될 수 있다.
   - **롤백 경로**: 차단이 관측되면 `default.nix`의 `targetHosts` allowlist에서 해당 호스트를 빼고 `nrs`를 실행한다. 그러면 활성 Home Manager generation에서 네 실행 surface와 CLIProxyAPI enabled-only closure 노출이 즉시 제거되고 descriptor와 runtime library metadata만 남는다(`lib.optionalAttrs enabled` 경계). 단, 이전 generation과 CLIProxyAPI Nix store 경로 자체는 garbage collection 전까지 store에 남으므로, 로컬 잔여물까지 정리하려면 generation 정리와 `nix-collect-garbage` 실행이 별도로 필요하다. credential/state는 repo 밖 `$HOME/Library/Application Support/claudex`에만 있으므로 그 디렉터리를 지우면 로컬 흔적도 제거된다. 일반 `claude` 설정과 인증은 애초에 건드리지 않으므로 별도 복구가 필요 없다.
 - **subagent effort 세밀 제어 불가 (기능 한계)**: wrapper는 `CLAUDE_CODE_SUBAGENT_MODEL`로 subagent 모델만 고정 모델에 맞추고, effort는 세션 단위 값 하나(기본 `high`, `claudex --effort`로 조정 가능)를 세션 전체가 공유한다. subagent effort만 별도로 낮추는 수단은 여전히 없다(pinned Claude Code CLI 자체의 제약). 대량 fan-out 워크플로우에서 토큰 소모가 부담이면 세션 effort 자체를 낮춰서 실행한다.
+- **fast 티어의 조용한 폴백과 관찰 한계 (기능 한계)**: `claudex --fast`는 request body에 `service_tier:"priority"`를 주입하지만, Codex OAuth 계정에 fast 자격이 없으면 백엔드가 에러 없이 default 티어로 처리한다(upstream 실측 사례: openai/codex#14204). wrapper는 `exec` 구조라 응답을 검사할 수 없으므로 세션 내 자동 감지는 없다. 응답 쪽 관찰도 제한적이다 — pinned proxy는 Anthropic 형식으로 역변환한 응답 `usage.service_tier`에 `--fast` 유무와 무관하게 고정 `"standard"`를 넣으므로(2026-07-15 실측, fast/plain 대조 동일), **응답 usage로는 백엔드 티어 반영을 판별할 수 없다**. 검증 가능한 계약은 요청 주입까지다: loopback 캡처 서버에 fast settings variant로 headless 요청을 보내면 body에 top-level `"service_tier":"priority"`가 실리고, 기본 variant에서는 필드 자체가 없다(동일 실측). 백엔드 전달은 pinned proxy 소스의 claude→codex 변환기가 `service_tier`(fast/priority → `priority` 정규화, 그 외 drop)를 Codex 요청에 주입하고 executor가 이 필드를 삭제하지 않는 것으로 보증한다. 실제 1.5x 처리 여부는 계정 자격과 백엔드 정책에 종속되며 이 경계 밖이다.
 - **bypassPermissions 기본 시작 (의도된 트레이드오프)**: wrapper는 `--dangerously-skip-permissions`로 Claude Code를 실행해 모든 세션이 bypass 모드로 시작한다. pinned CLI가 시작 플래그 없이는 세션 중 bypass 전환을 허용하지 않아 사용자가 기본 bypass를 선택했다. 이를 실제로 동작시키기 위해 `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`도 `0`으로 opt-out했다 — `1`이면 pinned CLI의 allowed_non_write_users hardening이 permission mode를 default로 강제해 bypass 플래그를 조용히 무력화한다(2.1.210 실측). 잔여 노출은 세션 내 서브프로세스가 wrapper-owned loopback API key 환경값을 볼 수 있다는 것인데, 이 key는 `127.0.0.1:8317` 전용이라 영향이 국소적이다. 권한 프롬프트가 필요한 환경에서는 wrapper의 bypass 플래그를 제거해야 하며, 그 경우 세션 중 bypass 전환 옵션도 함께 사라진다.
 - **`commercial-mode: true` 근거**: config template의 `commercial-mode`는 상용/라이선스 플래그가 아니라, upstream 정의상 "high-overhead request logging과 HTTP middleware 기능을 비활성화해 per-request 메모리를 줄이는" 플래그다(upstream 기본값은 `false`). 이 PoC는 credential·request 본문이 로그에 남지 않도록 request logging을 억제할 목적으로 의도적으로 `true`로 뒤집었으며, `logging-to-file`·`usage-statistics-enabled`를 모두 끄는 config-template의 보안 기본값과 같은 맥락이다. upstream 정의의 version-pinned 출처는 CLIProxyAPI `v7.2.73`의 [`config.example.yaml`](https://github.com/router-for-me/CLIProxyAPI/blob/v7.2.73/config.example.yaml)("When true, disable high-overhead request logging and HTTP middleware features to reduce per-request memory usage under high concurrency")과 [`internal/config/config.go`](https://github.com/router-for-me/CLIProxyAPI/blob/v7.2.73/internal/config/config.go)의 `CommercialMode` 필드 주석이다. 이 값이 렌더된 config에 실제로 들어가는 계약은 `tests/suites/claudex.sh`의 config-template 렌더 검증이 커버하며, 실제 로그 억제 동작의 런타임 실측은 upstream 바이너리 동작 범위라 §12의 Stage 2 전 조사(#1108)와 함께 다룬다.
 
@@ -187,6 +190,15 @@ git status --short --branch
 - foreground listener는 descriptor의 pinned executable과 일치하고 status는 `service=missing`, 나머지 ready, exit `0`
 - hostile request-body/effort/Unix-socket/host-auth bridge 환경과 project settings `CLAUDE_CODE_EXTRA_BODY` override를 넣은 실제 completion stdout: 정확히 `CLAUDEX_E2E_OK`; 빈 fallback 목록, wrapper-owned settings, wrapper-owned effort도 함께 실측
 - foreground 종료 후 listener 없음, status exit `1`
+
+2026-07-15 `--fast`(Codex fast 티어) 배치에서는 다음을 확인했다.
+
+- targeted Claudex shell tests 10개(fast 케이스 포함): 통과; full shell suite `217 pass / 0 fail`; Darwin eval(IFD·no-IFD): 통과; `nix flake check --no-build --all-systems`: 통과
+- `nrs` 후 `./scripts/ai/verify-ai-compat.sh` 완전 통과, 배포된 wrapper가 pinned fast settings variant(`{"env":{"CLAUDE_CODE_EXTRA_BODY":"{\"service_tier\":\"priority\"}"}}`)를 참조
+- `claudex --fast=true`/`--fast=priority`: exit 2 거부, `--effort hostile` 거부 계약 유지
+- `claudex --fast -p` headless completion stdout: 정확히 `CLAUDEX_E2E_OK` (exit 0)
+- loopback 캡처 실측: fast settings variant로 실행한 Claude의 `/v1/messages` request body에 top-level `"service_tier":"priority"` 존재, 기본 variant에서는 필드 부재
+- 응답 관찰 한계 실측: proxy 역변환 응답의 `usage.service_tier`는 `--fast` 유무와 무관하게 `"standard"` 고정 — 응답 usage는 티어 판별에 사용 불가 (§4 한계 참조)
 
 새 머신에서는 현재 checkout을 진실 원천으로 삼아 최소한 다음을 다시 실행한다.
 

--- a/modules/shared/programs/claudex/default.nix
+++ b/modules/shared/programs/claudex/default.nix
@@ -64,6 +64,18 @@ let
       env.CLAUDE_CODE_EXTRA_BODY = "{}";
     }
   );
+  # CIR: the fast variant carries the Codex fast tier in the wrapper-owned request body.
+  # The injected value is the final on-wire id "priority" (upstream catalog id="priority",
+  # name="Fast", 1.5x speed) rather than the "fast" alias: the pinned proxy's claude->codex
+  # translator maps fast->priority today, but its openai-responses translator already drops
+  # anything that is not exactly "priority", so pinning the canonical id keeps the contract
+  # independent of upstream alias leniency. Both variants stay pinned Nix store files;
+  # `claudex --fast` merely selects which one is passed to --settings.
+  wrapperSettingsFast = pkgs.writeText "claudex-wrapper-settings-fast.json" (
+    builtins.toJSON {
+      env.CLAUDE_CODE_EXTRA_BODY = builtins.toJSON { service_tier = "priority"; };
+    }
+  );
 
   runtimeLibrary = pkgs.replaceVars ./files/claudex-runtime.sh {
     allowTestOverrides = "false";
@@ -113,7 +125,7 @@ let
     );
 
   claudexScript = mkRuntimeScript ./files/claudex.sh {
-    inherit configTemplate wrapperSettings;
+    inherit configTemplate wrapperSettings wrapperSettingsFast;
   };
   statusScript = mkRuntimeScript ./files/claudex-status.sh { };
   loginScript = mkRuntimeScript ./files/claudex-login.sh {

--- a/modules/shared/programs/claudex/files/claudex.sh
+++ b/modules/shared/programs/claudex/files/claudex.sh
@@ -8,12 +8,14 @@ umask 077
 source "@runtimeLibrary@"
 CLAUDEX_CONFIG_TEMPLATE="@configTemplate@"
 CLAUDEX_WRAPPER_SETTINGS="@wrapperSettings@"
+CLAUDEX_WRAPPER_SETTINGS_FAST="@wrapperSettingsFast@"
 
 # Effort stays wrapper-owned: the inherited CLAUDE_CODE_EFFORT_LEVEL is scrubbed below and
 # only an explicit, whitelist-validated `claudex --effort <level>` argument may change the
 # session level. The wrapper consumes the argument and re-issues it as its own CLI value so
 # a single deterministic `--effort` reaches Claude.
 effort_level=high
+fast_tier=false
 expect_effort_value=false
 forward_args=()
 scan_options=true
@@ -43,6 +45,13 @@ for arg in "$@"; do
     --effort=*)
       effort_level="${arg#--effort=}"
       ;;
+    --fast)
+      fast_tier=true
+      ;;
+    --fast=*)
+      _claudex_error "--fast does not accept a value (the Codex fast tier is a boolean session flag)"
+      exit 2
+      ;;
     *)
       forward_args+=("$arg")
       ;;
@@ -66,6 +75,18 @@ esac
 effort_argv=(--effort "$effort_level")
 if [ "$effort_level" = ultra ]; then
   effort_argv=()
+fi
+
+# CIR: the Codex fast tier is wrapper-owned request-body state. The pinned Claude CLI has
+# no argv for it (Claude's own fastMode is a separate Anthropic-direct-only feature that
+# never activates on this loopback provider), so the only channel is the wrapper-owned
+# settings file feeding CLAUDE_CODE_EXTRA_BODY. `--fast` selects between two pinned Nix
+# store settings variants; the inherited CLAUDE_CODE_EXTRA_BODY environment stays scrubbed
+# either way, so hostile request-body overrides remain neutralized. The backend applies the
+# tier only when the OAuth account is entitled and silently falls back to the default tier
+# otherwise (documented limitation; no in-wrapper detection because the wrapper exec()s).
+if [ "$fast_tier" = true ]; then
+  CLAUDEX_WRAPPER_SETTINGS="$CLAUDEX_WRAPPER_SETTINGS_FAST"
 fi
 
 prepare_state

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -80,6 +80,7 @@ _claudex_materialize_runtime() {
 _claudex_materialize_command() {
   local source="$1" destination="$2" runtime="$3" proxy="$4" template="$5"
   local wrapper_settings="${6:-$template}"
+  local wrapper_settings_fast="${7:-$wrapper_settings}"
 
   sed \
     -e "s|@bashBin@|$(command -v bash)|g" \
@@ -87,6 +88,7 @@ _claudex_materialize_command() {
     -e "s|@proxyBin@|$proxy|g" \
     -e "s|@configTemplate@|$template|g" \
     -e "s|@wrapperSettings@|$wrapper_settings|g" \
+    -e "s|@wrapperSettingsFast@|$wrapper_settings_fast|g" \
     "$source" > "$destination"
   _claudex_assert_no_placeholders "$destination"
 }
@@ -94,6 +96,12 @@ _claudex_materialize_command() {
 _claudex_write_wrapper_settings() {
   local destination="$1"
   jq -n '{env: {CLAUDE_CODE_EXTRA_BODY: "{}"}}' > "$destination"
+}
+
+_claudex_write_wrapper_settings_fast() {
+  local destination="$1"
+  jq -n '{env: {CLAUDE_CODE_EXTRA_BODY: ({service_tier: "priority"} | tostring)}}' \
+    > "$destination"
 }
 
 _claudex_file_inode() {
@@ -106,11 +114,13 @@ _claudex_fixture() {
   local generated="$sandbox/generated"
   local fake_proxy="$sandbox/fake-cli-proxy-api"
   local wrapper_settings="$generated/wrapper-settings.json"
+  local wrapper_settings_fast="$generated/wrapper-settings-fast.json"
 
   mkdir -p "$sandbox/home/.local/bin" "$generated"
   _claudex_render_config_template \
     "$root/files/config-template.json" "$generated/config-template.json"
   _claudex_write_wrapper_settings "$wrapper_settings"
+  _claudex_write_wrapper_settings_fast "$wrapper_settings_fast"
   cat > "$sandbox/fake-lockf" <<'EOF'
 #!/usr/bin/env bash
 [ -z "${CLAUDEX_FAKE_LOCK_LOG:-}" ] || printf '%s\n' "$@" >> "$CLAUDEX_FAKE_LOCK_LOG"
@@ -130,7 +140,7 @@ EOF
     _claudex_materialize_command \
       "$root/files/$script.sh" "$generated/$script" \
       "$generated/claudex-runtime.sh" "$fake_proxy" "$generated/config-template.json" \
-      "$wrapper_settings"
+      "$wrapper_settings" "$wrapper_settings_fast"
     chmod +x "$generated/$script"
   done
 }
@@ -144,10 +154,12 @@ _claudex_production_fixture() {
   local curl_bin="$sandbox/production-curl"
   local launchctl_bin="$sandbox/production-launchctl"
   local wrapper_settings="$generated/wrapper-settings.json"
+  local wrapper_settings_fast="$generated/wrapper-settings-fast.json"
   local jq_bin
   jq_bin="$(command -v jq)"
   mkdir -p "$generated" "$declared_home/.local/bin"
   _claudex_write_wrapper_settings "$wrapper_settings"
+  _claudex_write_wrapper_settings_fast "$wrapper_settings_fast"
 
   cat > "$curl_bin" <<'EOF'
 #!/usr/bin/env bash
@@ -200,7 +212,7 @@ EOF
   for script in claudex claudex-login claudex-status claudex-proxy-launcher; do
     _claudex_materialize_command \
       "$root/files/$script.sh" "$generated/$script" "$runtime" "$proxy" \
-      "$sandbox/generated/config-template.json" "$wrapper_settings"
+      "$sandbox/generated/config-template.json" "$wrapper_settings" "$wrapper_settings_fast"
     chmod +x "$generated/$script"
   done
 }
@@ -441,11 +453,12 @@ EOF
 }
 
 test_claudex_wrapper_pins_provider_model_and_argv() {
-  local sandbox state wrapper wrapper_settings settings_arg rc flag
+  local sandbox state wrapper wrapper_settings wrapper_settings_fast settings_arg rc flag
   sandbox="$(new_sandbox)"
   state="$sandbox/state"
   wrapper="$sandbox/generated/claudex"
   wrapper_settings="$sandbox/generated/wrapper-settings.json"
+  wrapper_settings_fast="$sandbox/generated/wrapper-settings-fast.json"
   _claudex_fixture "$sandbox"
   _claudex_prepare_fixture_state "$sandbox"
   _claudex_add_valid_credential "$state"
@@ -621,6 +634,55 @@ EOF
     fail "claudex accepted an invalid split effort level"
   fi
   [[ ! -e "$sandbox/claude.log" ]] || fail "invalid split effort still invoked Claude"
+
+  # --fast selects the pinned fast wrapper-settings variant (service_tier=priority in the
+  # wrapper-owned request body) while the inherited CLAUDE_CODE_EXTRA_BODY stays scrubbed.
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" \
+    CLAUDEX_STATE_DIR="$state" \
+    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" \
+    CLAUDE_CODE_EXTRA_BODY='{"service_tier":"hostile"}' \
+    "$wrapper" --fast -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "claudex --fast did not reach Claude"
+  assert_file_contains "$sandbox/claude.log" "extra_body=unset"
+  assert_file_contains "$sandbox/claude.log" "effort_level=high"
+  settings_arg="$(awk '/^arg=--settings$/ { getline; sub(/^arg=/, ""); print; exit }' "$sandbox/claude.log")"
+  [[ "$settings_arg" == "$wrapper_settings_fast" ]] \
+    || fail "claudex --fast did not pass the fast wrapper-owned settings file"
+  jq -e '(.env.CLAUDE_CODE_EXTRA_BODY | fromjson) == {service_tier: "priority"}
+    and (.env | keys == ["CLAUDE_CODE_EXTRA_BODY"])' \
+    "$settings_arg" >/dev/null \
+    || fail "fast wrapper-owned settings did not pin service_tier=priority"
+
+  # --fast composes with --effort; both wrapper-owned values are re-issued together.
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" \
+    CLAUDEX_STATE_DIR="$state" \
+    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" \
+    "$wrapper" --fast --effort low -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "claudex --fast --effort low did not reach Claude"
+  assert_file_contains "$sandbox/claude.log" "effort_level=low"
+  settings_arg="$(awk '/^arg=--settings$/ { getline; sub(/^arg=/, ""); print; exit }' "$sandbox/claude.log")"
+  [[ "$settings_arg" == "$wrapper_settings_fast" ]] \
+    || fail "claudex --fast --effort low did not keep the fast settings variant"
+
+  # --fast is a boolean session flag; attached values are rejected before Claude runs.
+  for flag in "--fast=true" "--fast=priority"; do
+    rm -f "$sandbox/claude.log"
+    if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" "$flag" \
+      >/dev/null 2>&1; then
+      fail "claudex accepted a value-carrying fast flag: $flag"
+    fi
+    [[ ! -e "$sandbox/claude.log" ]] || fail "rejected fast flag still invoked Claude"
+  done
 }
 
 test_claudex_launcher_and_login_use_fake_boundaries() {
@@ -853,7 +915,7 @@ EOF
 }
 
 test_claudex_nix_generated_command_outputs_are_pinned() {
-  local runtime_drv runtime_out path settings_path
+  local runtime_drv runtime_out path settings_path fast_settings_path
   runtime_drv="$(
     cd "$REPO_ROOT"
     nix eval --impure --raw --expr '
@@ -889,6 +951,12 @@ test_claudex_nix_generated_command_outputs_are_pinned() {
   settings_path="$(sed -n 's/^CLAUDEX_WRAPPER_SETTINGS="\(.*\)"$/\1/p' "$runtime_out/bin/claudex")"
   jq -e '.env.CLAUDE_CODE_EXTRA_BODY == "{}" and (.env | keys == ["CLAUDE_CODE_EXTRA_BODY"])' \
     "$settings_path" >/dev/null || fail "Nix-generated wrapper settings drifted"
+  grep -Fq 'CLAUDEX_WRAPPER_SETTINGS_FAST="/nix/store/' "$runtime_out/bin/claudex" \
+    || fail "Nix-generated claudex does not reference store fast wrapper settings"
+  fast_settings_path="$(sed -n 's/^CLAUDEX_WRAPPER_SETTINGS_FAST="\(.*\)"$/\1/p' "$runtime_out/bin/claudex")"
+  jq -e '(.env.CLAUDE_CODE_EXTRA_BODY | fromjson) == {service_tier: "priority"}
+    and (.env | keys == ["CLAUDE_CODE_EXTRA_BODY"])' \
+    "$fast_settings_path" >/dev/null || fail "Nix-generated fast wrapper settings drifted"
   grep -Fq -- '--local-model' "$runtime_out/libexec/claudex/claudex-proxy-launcher" \
     || fail "Nix-generated proxy launcher does not pass --local-model"
   grep -Fq -- '--codex-device-login' "$runtime_out/bin/claudex-login" \

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -674,13 +674,17 @@ EOF
   [[ "$settings_arg" == "$wrapper_settings_fast" ]] \
     || fail "claudex --fast --effort low did not keep the fast settings variant"
 
-  # --fast is a boolean session flag; attached values are rejected before Claude runs.
+  # --fast is a boolean session flag; attached values are rejected with the wrapper's
+  # managed-option contract exit code 2 before Claude runs.
   for flag in "--fast=true" "--fast=priority"; do
     rm -f "$sandbox/claude.log"
-    if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" "$flag" \
-      >/dev/null 2>&1; then
-      fail "claudex accepted a value-carrying fast flag: $flag"
-    fi
+    set +e
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" "$flag" \
+      >/dev/null 2>&1
+    rc=$?
+    set -e
+    [[ "$rc" == "2" ]] \
+      || fail "claudex returned $rc instead of exit 2 for: $flag"
     [[ ! -e "$sandbox/claude.log" ]] || fail "rejected fast flag still invoked Claude"
   done
 }


### PR DESCRIPTION
## Summary

- `claudex --fast`를 추가한다 — Codex fast 서비스 티어(`service_tier:"priority"`)를 세션 단위로 켜는 불리언 플래그. `--effort`(PR #1110)와 같은 wrapper-owned 명시 인자 패턴을 따른다.
- wrapper가 두 pinned Nix store settings variant 중 하나를 선택해 전달한다 — 기본은 기존과 동일한 `{}`(티어 필드 미전송 = 계정 기본), fast는 `{"service_tier":"priority"}`. 상속 `CLAUDE_CODE_EXTRA_BODY` 환경 scrub은 그대로 유지되어 hostile request-body override 방어는 변하지 않는다.

## 기존 문제/배경

claudex(PR #1107)는 Claude Code 요청을 loopback CLIProxyAPI를 통해 Codex OAuth 모델로 보내는 Stage 1 브릿지다. Codex 백엔드는 fast 티어(카탈로그 id `priority`, 표시명 "Fast", 1.5x speed)를 지원하고 pinned proxy의 claude→codex 변환기도 request body의 `service_tier`를 정규화해 전달할 수 있지만, 기존 wrapper는 이 채널을 쓸 수 없었다.

**문제**: wrapper는 hostile request-body override 방어를 위해 `CLAUDE_CODE_EXTRA_BODY`를 env scrub + wrapper-owned settings `{}` 고정으로 이중 봉쇄한다(PR #1107의 의도된 방어). 그 결과 사용자가 세션 단위로 Codex fast 티어를 켤 수 있는 지원 경로가 전혀 없었다 — 방어 계약을 깨지 않고 이 값을 주입할 wrapper-owned 채널이 필요했다.

## CIR (Change Intent Record)

- **request-body 중화 도입** (PR #1107): `wrapperSettings`의 `env.CLAUDE_CODE_EXTRA_BODY = "{}"` 고정은 user/project settings의 request-body override를 중화하는 방어로 도입됐다.
- **명시 인자 완화 패턴 확립** (PR #1110): effort에 대해 "무조건 거부"를 "whitelist 검증된 명시 CLI 인자만 wrapper가 소비·재소유"로 완화하되, 상속 env scrub은 유지해 암묵적 상속 차단이라는 원래 목적을 보존하는 패턴이 확립됐다.
- **fast 티어 채널 개방** (이번 변경): EXTRA_BODY 고정값을 "두 pinned store variant 중 명시 인자로 선택"으로 확장했다. PR #1107의 방어 의도(상속 env scrub 지속 + `--settings` 최우선 고정 + store 경로 고정)는 구조 변화 없이 유지되고, 사용자 의도는 `--fast` 명시 인자로만 주입된다.
- **와이어 값 결정** (이번 변경): 주입 값은 `"fast"` 별칭이 아니라 최종 온-와이어 canonical id `"priority"`다. pinned proxy(v7.2.73)의 claude→codex 변환기는 fast→priority 별칭 매핑을 해주지만, 같은 프로젝트의 openai-responses 변환기는 정확히 `"priority"`만 통과시키고 별칭을 drop한다 — canonical id를 쓰면 upstream 별칭 관용에 의존하지 않는다.
- **argv 재발행 없음** (이번 변경): pinned Claude CLI에는 대응 argv가 없다. Claude 자체의 fastMode(`speed:"fast"` + beta 헤더)는 Anthropic 직접 API 전용 별개 기능으로, 이 loopback provider에서는 원천 비활성이다. 따라서 wrapper는 인자를 소비하고 settings 경로 선택만 바꾼다.
- **조용한 폴백 수용** (이번 변경, 사용자 결정): 계정 자격 미달 시 백엔드가 에러 없이 default 티어로 처리한다(openai/codex#14204). wrapper는 `exec` 구조라 응답 검사가 불가능하므로 세션 내 감지를 추가하지 않고 handoff 한계 섹션에 문서화했다. 사전 프로브(세션 시작마다 검증 completion) 대안은 매 세션 토큰 비용·시작 지연 때문에 기각됐다.
- **응답 관찰 한계 실측** (이번 변경): E2E에서 proxy 역변환 응답의 `usage.service_tier`가 `--fast` 유무와 무관하게 고정 `"standard"`임을 확인했다 — 응답 usage로는 백엔드 티어 반영을 판별할 수 없다. 검증 가능한 계약은 요청 주입까지이며, loopback 캡처로 request body의 `"service_tier":"priority"` 존재(fast variant)와 필드 부재(기본 variant)를 실측했다.

**trade-off**: request-body 봉쇄가 "완전 고정"에서 "wrapper-owned 이지선다"로 완화되지만, 두 variant 모두 pinned Nix store 파일이고 선택은 whitelist된 불리언 인자뿐이라 임의 값 주입 표면은 열리지 않는다. 실제 1.5x 처리 여부는 계정 자격과 백엔드 정책에 종속되며 이 경계 밖이다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `--fast` 불리언 | 켜기/끄기 단일 플래그 | 유효 상태(미지정/fast)와 표면이 정확히 일치, Codex UI의 Fast 토글과 동일 개념 | 티어 종류가 늘면 확장 필요 | ✅ |
| `--tier <값>` enum | `--effort <값>`과 표면 일관 | 확장성 | 현재 유효 값이 사실상 하나라 과설계 | ❌ |
| 정적 settings variant 2개 | tier별 pinned store 파일을 wrapper가 선택 | store 고정 계약 유지, 동적 생성·env 재발행 불필요 | variant 수만큼 파일 증가 | ✅ |
| 런타임 settings 동적 생성 | wrapper가 mktemp로 settings 생성 | 파일 1개 | "wrapper-owned settings는 store 고정" 계약 훼손 | ❌ |
| env 재발행 (`export CLAUDE_CODE_EXTRA_BODY=...`) | settings 대신 env로 주입 | 구현 최소 | settings env 블록이 process env보다 우선하므로 user/project settings 방어가 깨질 수 있음 | ❌ |
| 와이어 값 `"priority"` | 최종 canonical id 직접 사용 | proxy 별칭 매핑에 비의존, upstream 엄격화에 내성 | 의미가 "fast"보다 덜 직관적 (주석으로 보완) | ✅ |
| 와이어 값 `"fast"` | 별칭을 proxy가 매핑 | 의도 표현이 직관적 | claude 경로 변환기의 관용에 의존 — openai-responses 경로는 이미 별칭 drop | ❌ |
| 폴백 감지 없음 + 문서화 | E2E 실측 1회 + handoff 한계 기재 | exec 구조 유지, 세션 비용 없음 | 자격 상실을 세션 내 감지 못 함 | ✅ |
| 시작 시 사전 프로브 | exec 전 검증 completion으로 티어 확인 | 자격 미달 즉시 경고 | 매 세션 토큰 과금 + 시작 지연, Stage 1 범위 대비 과설계 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claudex/default.nix` | 수정 | `wrapperSettingsFast` pinned settings variant 추가(`service_tier=priority`), 와이어 값 근거 CIR 주석, `claudexScript` 치환 연결 |
| `modules/shared/programs/claudex/files/claudex.sh` | 수정 | 인자 스캔에 `--fast` 소비/`--fast=*` 거부(exit 2) 추가, fast 시 settings 경로 전환, 채널·폴백 근거 CIR 주석 |
| `tests/suites/claudex.sh` | 수정 | fixture materializer에 fast variant 치환 추가, `--fast` settings 선택·내용 검증, `--effort` 조합, 값 부착 거부, Nix-generated output의 fast settings 계약 검증 |
| `docs/claudex-poc-handoff.md` | 수정 | §3 구현 지도, §4 고정 계약 불변식·"알려진 한계"(조용한 폴백 + 응답 관찰 한계), §5 실측 기록 동기화 |

### 핵심 코드

wrapper는 `--fast`를 소비해 pinned settings variant를 선택한다. 상속 env scrub과 `--settings` 재소유 구조는 변하지 않는다.

```bash
    --fast)
      fast_tier=true
      ;;
    --fast=*)
      _claudex_error "--fast does not accept a value (the Codex fast tier is a boolean session flag)"
      exit 2
      ;;
```

```bash
if [ "$fast_tier" = true ]; then
  CLAUDEX_WRAPPER_SETTINGS="$CLAUDEX_WRAPPER_SETTINGS_FAST"
fi
```

```nix
wrapperSettingsFast = pkgs.writeText "claudex-wrapper-settings-fast.json" (
  builtins.toJSON {
    env.CLAUDE_CODE_EXTRA_BODY = builtins.toJSON { service_tier = "priority"; };
  }
);
```

## 참고 레퍼런스

- PR #1107 — claudex Stage 1 도입 (EXTRA_BODY `{}` 중화 방어의 출처)
- PR #1110 — `--effort` wrapper-owned 명시 인자 패턴 (이번 변경이 따르는 완화 선례)
- [openai/codex#14204](https://github.com/openai/codex/issues/14204) — 리터럴 `service_tier:"fast"` 400 거부 및 자격 미달 시 default 폴백 관측
- [CLIProxyAPI v7.2.73](https://github.com/router-for-me/CLIProxyAPI/releases/tag/v7.2.73) — pinned proxy; claude→codex 변환기의 service_tier 정규화(fast/priority → priority, 그 외 drop) 근거
- `docs/claudex-poc-handoff.md` §4 — 조용한 폴백·응답 관찰 한계의 문서화 위치

## Human Test Plan

아래 절차는 이 변경에서 실제로 수행해 통과한 검증을 재현한다.

### 자동 회귀 검증

1. 전체 shell suite와 eval을 실행한다.

   ```bash
   nix develop -c bash tests/run-shell-script-tests.sh
   nix develop -c bash tests/run-eval-tests.sh
   nix develop -c nix flake check --no-build --all-systems
   ```

   - **기대**: `통과 217 · 실패 0`, eval(IFD·no-IFD) 통과, flake check 통과. claudex 테스트에 `--fast` settings 선택·내용·거부 케이스가 포함된다.
   - **실패 시**: fake claude 로그의 `arg=--settings` 다음 줄 경로와 fixture의 `wrapper-settings-fast.json` 내용을 대조한다.

### 선언 적용과 인자 검증

2. 선언을 적용하고 배포된 wrapper를 확인한다.

   ```bash
   nrs
   claudex --fast=true ; echo $?      # 기대: 값 거부 에러 + exit 2
   claudex --effort hostile ; echo $? # 기대: 기존 effort 거부 계약 유지 + exit 2
   sed -n 's/^CLAUDEX_WRAPPER_SETTINGS_FAST="\(.*\)"$/\1/p' ~/.local/bin/claudex | xargs cat
   ```

   - **기대**: 마지막 명령 출력이 정확히 `{"env":{"CLAUDE_CODE_EXTRA_BODY":"{\"service_tier\":\"priority\"}"}}`.
   - **실패 시**: `~/.local/bin/claudex`가 새 store 경로를 가리키는지 확인한다.

### 실측 E2E (proxy ready 상태)

3. fast 경로 headless completion을 실행한다.

   ```bash
   printf '%s\n' 'Reply with exactly CLAUDEX_E2E_OK and nothing else.' \
     | claudex --fast -p --output-format text
   ```

   - **기대**: stdout이 정확히 `CLAUDEX_E2E_OK` 한 줄 (전 경로 completion 성공).
   - **실패 시**: `claudex-status`로 auth/proxy/catalog ready를 확인한다.

4. request 주입 계약을 캡처로 검증한다 (응답 `usage.service_tier`는 proxy가 고정 `"standard"`를 넣으므로 판별에 쓰지 않는다 — handoff §4).

   - loopback 캡처 서버(예: `/v1/messages` POST body를 덤프하고 500을 돌려주는 로컬 HTTP 서버)를 임의 포트에 띄운다.
   - fast settings 파일과 동일 조건으로 Claude CLI를 캡처 서버에 실행한 뒤 body를 확인한다: `jq .service_tier` → **기대**: `"priority"`.
   - 기본 settings로 같은 실행 → **기대**: 필드 부재 (Negative 검증 — 미지정 시 무변경 원칙).
   - **실패 시**: `--settings`로 전달된 파일 경로와 그 안의 `env.CLAUDE_CODE_EXTRA_BODY` 값을 확인한다.

### 인접 regression

5. `--fast` 없는 기존 흐름이 변하지 않았는지 확인한다.

   ```bash
   printf '%s\n' 'Reply with exactly CLAUDEX_E2E_OK and nothing else.' \
     | claudex -p --output-format text
   ```

   - **기대**: `CLAUDEX_E2E_OK`. hostile `CLAUDE_CODE_EXTRA_BODY` env를 주입해도 결과가 동일하다 (scrub 유지).
   - **실패 시**: wrapper의 unset 목록과 기본 settings variant(`{}`)를 확인한다.

https://claude.ai/code/session_01GirEqfNnTS5SrQVSZdThDF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - `claudex --fast` 옵션을 추가했습니다(불리언 플래그로만 동작).
  - `--fast` 사용 시 요청 본문에 `service_tier:"priority"`가 자동으로 주입됩니다.
  - `--fast=<값>`(예: `true`, `priority`) 형식은 거부됩니다.

- **문서**
  - fast 모드 설정 계약 및 알려진 한계·롤백 항목을 갱신했습니다(응답 `usage.service_tier`는 티어 판별에 사용할 수 없음).

- **테스트**
  - fast 모드 설정 변형 생성/전달, 인자 조합 제약, 요청 주입 및 실행 성공을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->