### PR TITLE
feat(claudex): add CLIProxyAPI resilience knobs to curb 520/429 churn

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -113,6 +113,7 @@ git status --short --branch
 - `modules/shared/programs/claudex/files/config-template.json`
   - runtime-owned host/port/pprof slot은 비워 두고, remote management·plugin·파일 로그·통계 비활성화를 선언한다.
   - `default.nix`의 단일 runtime contract가 최종 `127.0.0.1:8317`, 모델, label, pprof 주소를 runtime과 config에 함께 주입한다.
+  - 세션 불안정(520→429 cooldown 연쇄) 완화용 resilience knob 4종을 선언한다: `max-retry-interval: 30`(cooldown 흡수 활성화 — code default 0이면 완전 비활성), `passthrough-headers: true`(Retry-After 전달), `transient-error-cooldown-seconds: -1`(5xx 부수 벤치 제거), `streaming.{keepalive-seconds: 15, bootstrap-retries: 1}`(520 first-byte 재시도 + idle timeout 방지). 근거는 `default.nix`의 CIR 주석과 §4 참조. 이 값들도 runtime.sh의 config key 화이트리스트가 정확히 검증하므로 값 변경 시 두 곳을 함께 갱신한다.
 
 ### 검증 연결
 

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -216,6 +216,15 @@ git status --short --branch
 - 모든 발동 케이스는 headless `-p` 단발 실행이라 `compact_error:"too_few_groups"`로 요약 자체는 실패한다(압축할 누적 대화 그룹 부족 — 트리거 사슬 동작 증거로는 충분). 실제 요약 성공은 누적 메시지가 많은 대화형 세션에서만 관찰되며 이는 headless 특성이지 wrapper 계약과 무관하다.
 - provider 불안정 재관측: 일부 실행에서 `api_retry` 다수 발생 후 성공 (§4의 520/429 진단과 정합); 안정 구간에서는 위 A/B가 재현적으로 동일했다.
 
+2026-07-15 CLIProxyAPI resilience knob 배치에서는 다음을 확인했다.
+
+- targeted Claudex shell tests 10개(config 화이트리스트 검증 포함): 통과; full shell suite `217 pass / 0 fail`; Darwin eval(IFD·no-IFD): 통과; `nix flake check --no-build --all-systems`: 통과
+- 배포 전 config 실측: 기존 `config.yaml`에 `max-retry-interval`/`passthrough-headers`/`transient-error-cooldown-seconds`/`streaming`이 전부 `null`(부재=upstream 기본 비활성) — 진단 정합
+- `nrs` 후 재렌더 config에 4 knob 정확 반영: `max-retry-interval:30, passthrough-headers:true, transient-error-cooldown-seconds:-1, streaming:{keepalive-seconds:15, bootstrap-retries:1}`
+- **proxy 스키마 검증**: 새 config로 foreground proxy가 정상 파싱·기동(`auth/proxy/catalog=ready`) — 잘못된 키/구조였다면 proxy가 config 파싱 실패로 뜨지 않으므로, 기동 성공이 스키마 정합의 실측 증거다
+- completion 회귀 없음: `claudex -p` stdout 정확히 `RESILIENCE_OK`
+- 429 cooldown 흡수 효과 자체는 실제 upstream rate-limit 상황에서만 관측 가능하므로 여기서는 강제하지 않았다(실사용 관측 대상)
+
 새 머신에서는 현재 checkout을 진실 원천으로 삼아 최소한 다음을 다시 실행한다.
 
 ```bash

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -221,7 +221,7 @@ git status --short --branch
 - targeted Claudex shell tests 10개(config 화이트리스트 검증 포함): 통과; full shell suite `217 pass / 0 fail`; Darwin eval(IFD·no-IFD): 통과; `nix flake check --no-build --all-systems`: 통과
 - 배포 전 config 실측: 기존 `config.yaml`에 `max-retry-interval`/`passthrough-headers`/`transient-error-cooldown-seconds`/`streaming`이 전부 `null`(부재=upstream 기본 비활성) — 진단 정합
 - `nrs` 후 재렌더 config에 4 knob 정확 반영: `max-retry-interval:30, passthrough-headers:true, transient-error-cooldown-seconds:-1, streaming:{keepalive-seconds:15, bootstrap-retries:1}`
-- **proxy 스키마 검증**: 새 config로 foreground proxy가 정상 파싱·기동(`auth/proxy/catalog=ready`) — 잘못된 키/구조였다면 proxy가 config 파싱 실패로 뜨지 않으므로, 기동 성공이 스키마 정합의 실측 증거다
+- **proxy 파싱 검증**: 새 config로 foreground proxy가 정상 기동(`auth/proxy/catalog=ready`) — 값 타입·중첩 구조가 치명적 파싱 오류를 내지 않았다는 증거다(예: `streaming`을 nested object로 두지 않았다면 unmarshal 실패). 단 CLIProxyAPI v7.2.73의 config 로더는 `yaml.Unmarshal`을 `KnownFields` 없이 사용해 unknown top-level key를 조용히 무시하므로, **key 이름 정합은 기동 성공이 아니라 v7.2.73 `config.example.yaml` 소스 대조로 확인**했다
 - completion 회귀 없음: `claudex -p` stdout 정확히 `RESILIENCE_OK`
 - 429 cooldown 흡수 효과 자체는 실제 upstream rate-limit 상황에서만 관측 가능하므로 여기서는 강제하지 않았다(실사용 관측 대상)
 

--- a/modules/shared/programs/claudex/default.nix
+++ b/modules/shared/programs/claudex/default.nix
@@ -46,6 +46,15 @@ let
   #   "high-overhead request logging과 HTTP middleware를 비활성화해 per-request 메모리를 줄이는" 옵션이다.
   #   credential·request 본문이 로그에 남지 않도록 request logging을 억제할 목적으로 의도적으로 true로
   #   두었으며, logging-to-file·usage-statistics-enabled를 끄는 config-template의 보안 기본값과 같은 맥락이다.
+  # CIR: 아래 resilience knob 4종은 upstream 기본값이 전부 "비활성"이라 단일 credential 세션이
+  #   Cloudflare 520 → 429 credential cooldown 연쇄로 불안정했던 것을 완화한다 (deep-research + v7.2.73
+  #   소스 대조). max-retry-interval=30: code default 0이면 cooldown 흡수가 완전히 꺼져 429가 그대로
+  #   클라이언트로 샌다 — 30초 이하 cooldown을 proxy가 내부 대기·재시도로 흡수한다. passthrough-headers=true:
+  #   30초 초과 긴 cooldown의 Retry-After(proxy 자체 합성분 포함)를 Claude Code에 전달해 blind backoff를
+  #   정확한 대기로 바꾼다. transient-error-cooldown-seconds=-1: 5xx(408/500/502/503/504) 후 legacy 60초
+  #   벤치를 끈다(단일 credential이라 이 벤치가 전면 차단이 된다). streaming.bootstrap-retries=1: first-byte
+  #   이전 520(>=500)을 안전 재시도하고, keepalive-seconds=15: SSE heartbeat로 client idle timeout을 막는다.
+  #   mid-stream drop(응답 도중 서버측 종료)은 어떤 knob으로도 완화 불가이며 upstream 버그 수정이 필요하다.
   configTemplateBase = builtins.fromJSON (builtins.readFile ./files/config-template.json);
   configTemplate = pkgs.writeText "claudex-config-template.json" (
     builtins.toJSON (

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -271,8 +271,9 @@ _claudex_render_runtime_config_unlocked() {
       keys == [
         "api-keys", "auth-dir", "commercial-mode", "debug", "error-logs-max-files",
         "host", "logging-to-file", "logs-max-total-size-mb", "max-retry-credentials",
-        "plugins", "port", "pprof", "proxy-url", "remote-management", "tls",
-        "usage-statistics-enabled", "ws-auth"
+        "max-retry-interval", "passthrough-headers", "plugins", "port", "pprof",
+        "proxy-url", "remote-management", "streaming", "tls",
+        "transient-error-cooldown-seconds", "usage-statistics-enabled", "ws-auth"
       ]
       and .host == $bindHost
       and .port == $port
@@ -304,6 +305,12 @@ _claudex_render_runtime_config_unlocked() {
       and .["usage-statistics-enabled"] == false
       and .["proxy-url"] == ""
       and .["max-retry-credentials"] == 1
+      and .["max-retry-interval"] == 30
+      and .["passthrough-headers"] == true
+      and .["transient-error-cooldown-seconds"] == -1
+      and (.streaming | keys == ["bootstrap-retries", "keepalive-seconds"])
+      and .streaming["keepalive-seconds"] == 15
+      and .streaming["bootstrap-retries"] == 1
       and .["ws-auth"] == true
     ' "$tmp" >/dev/null; then
     "$CLAUDEX_RM" -f -- "$tmp"

--- a/modules/shared/programs/claudex/files/config-template.json
+++ b/modules/shared/programs/claudex/files/config-template.json
@@ -31,5 +31,12 @@
   "usage-statistics-enabled": false,
   "proxy-url": "",
   "max-retry-credentials": 1,
+  "max-retry-interval": 30,
+  "passthrough-headers": true,
+  "transient-error-cooldown-seconds": -1,
+  "streaming": {
+    "keepalive-seconds": 15,
+    "bootstrap-retries": 1
+  },
   "ws-auth": true
 }


### PR DESCRIPTION
## Summary

- claudex 세션이 Cloudflare 520 → 429 credential cooldown 연쇄로 자주 불안정하던 것을 완화한다 — CLIProxyAPI resilience config knob 4종을 `config-template.json`에 선언한다.
- **핵심**: 관련 knob이 config에 전부 부재(=upstream 기본 비활성)였다. 특히 `max-retry-interval` 키 부재로 proxy의 cooldown 흡수가 **완전히 꺼져** 429가 그대로 클라이언트로 샜다.

## 기존 문제/배경

claudex(Claude Code → loopback CLIProxyAPI → Codex OAuth 브릿지, Stage 1) 세션에서 단문 응답 1건에 127초가 걸리는 등 불안정이 잦았다. 관측 증상: 30초 stall → Cloudflare 520 → 재시도 2~5회 모두 429 "cooling down" → 성공까지 수 회.

105-agent deep-research + v7.2.73 소스 대조로 진단한 결과, `config-template.json`에 관련 knob이 전부 **부재**였다:
- `max-retry-interval`: code default 0이면 `shouldRetryAfterError`가 `maxWait<=0`에서 short-circuit → **cooldown 흡수가 완전히 비활성** → 429가 클라이언트로 노출.
- `passthrough-headers`: 기본 false → 429의 Retry-After(proxy 자체 합성 cooldown 초 포함)를 버림 → Claude Code가 blind backoff.
- `transient-error-cooldown-seconds`: 기본 0 = legacy 60초 벤치 → 단일 credential에선 5xx 하나가 전면 차단.
- `streaming.bootstrap-retries`: 기본 0 → first-byte 이전 520(status>=500) 안전 재시도 없음.

## CIR (Change Intent Record)

- **진단** (이번 변경 직전): pinned 바이너리/소스 실측으로 "cooling down" 429가 quota cooldown 전용임을 확인하고, deep-research(3표 검증)로 각 knob의 기본값·효과·코드 경로를 교차 검증했다. finding 7·8은 우리 백오프 진단을 maintainer-confirmed로 독립 검증했다.
- **값 선택** (이번 변경): `max-retry-interval=30`(문서 기본값 — 30초 이하 cooldown은 proxy가 내부 흡수, 초과분은 passthrough로 정확한 Retry-After 전달하는 균형점). `transient=-1`(5xx 부수 벤치 제거). `streaming={15,1}`(config.example.yaml 예시값). `disable-cooling`은 upstream 폭주 리스크로 채택하지 않았다.
- **Stage 1 계약 유지** (이번 변경): `max-retry-credentials=1`(canonical credential 1개) 불변. credential pool 확장은 별도 설계 트랙(#1116).
- **화이트리스트 동시 갱신** (이번 변경): runtime.sh가 렌더 config의 key 목록+값을 화이트리스트로 엄격 검증하므로, config-template과 화이트리스트(top-level 21 keys 정렬 + streaming nested)를 함께 갱신했다.
- **검증 서술 정정** (이번 변경, 리뷰 반영): "proxy 기동 성공 = 스키마 정합 실측 증거"가 과장(yaml.Unmarshal이 unknown key 무시)이라는 지적을 반영해, 기동은 값 타입·구조 정합만 증명하고 key 이름은 소스 대조로 확인했음을 명시했다.

**trade-off**: max-retry-interval을 크게 잡으면 proxy가 오래 대기(단일 요청 지연↑), 작으면 429 노출↑. 30은 문서 기본값이자 passthrough와 결합해 균형을 이룬다. mid-stream drop(증상2)은 어떤 knob으로도 완화 불가 — upstream 버그로 #1117 추적.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| resilience knob 4종 config 추가 | max-retry-interval/passthrough/transient/streaming | Stage 1 계약 유지, config만, 즉시 효과 | 429 흡수 효과는 실사용 관측 | ✅ |
| `disable-cooling: true` | cooldown 전역 비활성 | 전면 차단 구조적 제거 | rate-limit 중 upstream 폭주·계정 리스크 | ❌ |
| credential pool 확장 | session-affinity + 다중 credential | quota 전면 차단 해소 | Stage 1 보안 계약 변경 + Codex stateful rebind 400 | ❌ (#1116 별도 트랙) |
| pin 업그레이드(v7.2.74~78) | 최신 버전 | — | 관련 수정 전무(전수 조사) → 무익 | ❌ |
| `max-retry-interval` 미설정 유지 | 현 상태 | 변경 없음 | cooldown 흡수 완전 비활성 → 429 노출 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `config-template.json` | 수정 | resilience knob 4종 추가 (`max-retry-interval:30`, `passthrough-headers:true`, `transient-error-cooldown-seconds:-1`, `streaming:{keepalive-seconds:15, bootstrap-retries:1}`) |
| `claudex-runtime.sh` | 수정 | config key 화이트리스트(top-level 21 keys 정렬 + streaming nested keys) + 값 검증 확장 |
| `default.nix` | 수정 | knob별 근거 CIR 주석 |
| `docs/claudex-poc-handoff.md` | 수정 | §3 config 계약, §5 배포 실측(파싱 검증 서술 정확히) |

### 핵심 코드

```json
"max-retry-interval": 30,
"passthrough-headers": true,
"transient-error-cooldown-seconds": -1,
"streaming": { "keepalive-seconds": 15, "bootstrap-retries": 1 }
```

## 참고 레퍼런스

- Issue #1116 — 세션 불안정 개선 리서치 원본 (이 PR의 근거, credential pool 확장 트랙)
- Issue #1117 — mid-stream resets_at upstream 기여 계획 (증상2 유일 근본책)
- [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) v7.2.73 (pinned), [설정 문서](https://help.router-for.me/configuration/options)

## Human Test Plan

### 자동 회귀 검증

1. 전체 검증.
   ```bash
   nix develop -c bash tests/run-shell-script-tests.sh
   nix develop -c bash tests/run-eval-tests.sh
   nix develop -c nix flake check --no-build --all-systems
   ```
   - **기대**: `통과 217 · 실패 0`, eval(IFD·no-IFD)·flake 통과. claudex 테스트에 config 화이트리스트(21 keys + streaming nested) 검증 포함.
   - **실패 시**: config-template.json의 key 집합과 runtime.sh 화이트리스트 목록/값의 일치를 확인한다.

### 선언 적용과 실측

2. 배포 후 config 반영 확인.
   ```bash
   nrs
   "$HOME/.local/libexec/claudex/claudex-proxy-launcher" --prepare-only
   jq '{max_retry_interval:.["max-retry-interval"], passthrough:.["passthrough-headers"], transient:.["transient-error-cooldown-seconds"], streaming}' "$HOME/Library/Application Support/claudex/config.yaml"
   ```
   - **기대**: `{30, true, -1, {keepalive-seconds:15, bootstrap-retries:1}}`. 변경 전에는 전부 `null`.

3. proxy 파싱 + completion (회귀 없음).
   ```bash
   "$HOME/.local/libexec/claudex/claudex-proxy-launcher"   # 별도 터미널
   claudex-status                                          # auth/proxy/catalog ready
   printf 'Reply with exactly OK\n' | claudex -p --output-format text   # OK
   ```
   - **기대**: proxy가 새 config를 파싱·기동, completion 정상. (값 타입/구조 정합 증거 — key 이름은 소스 대조로 별도 확인)

4. 실사용 관측 (효과 검증). 긴 세션에서 429 "cooling down"이 발생할 때, 이전보다 클라이언트 노출이 줄고(30초 이하 흡수) 노출되는 경우 정확한 대기 시간(Retry-After)이 전달되는지 관찰한다. 429 흡수 효과 자체는 실제 upstream rate-limit 상황에서만 관측된다.

https://claude.ai/code/session_01GirEqfNnTS5SrQVSZdThDF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 런타임 설정에 재시도 간격, 헤더 전달, 일시적 오류 대기 시간 옵션을 추가했습니다.
  * 스트리밍 연결의 keepalive 간격과 초기화 재시도 횟수를 설정할 수 있습니다.
  * 새 설정이 적용된 환경에서 프록시가 정상적으로 준비 상태에 도달합니다.

* **버그 수정**
  * 설정 검증을 강화해 누락되거나 잘못된 값으로 인한 실행 오류를 사전에 확인합니다.
  * 명령줄 자동 완성 동작의 회귀 문제 없이 정상 작동함을 확인했습니다.

* **문서**
  * 새 resilience 설정과 검증 결과를 관련 안내 문서에 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->