### PR TITLE
feat(claudex): 혼합 fleet Stage 1.5 — --mixed 모드와 claude credential 공존

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -150,6 +150,9 @@ git status --short --branch
 7. catalog에 모델이 보이는 것만으로 entitlement 성공으로 판정하지 않는다. 실제 completion이 필요하다.
 8. inherited request body, effort, Unix-socket transport가 wrapper의 endpoint/model/credential 경계를 우회하지 못해야 한다.
 9. byte-identical config render는 inode를 보존한다. runtime contract가 실제로 바뀌면 foreground proxy를 재시작한다.
+10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 값을 따른다 — 기본 `high`, 명시적 `claudex --effort` 인자(whitelist: low/medium/high/xhigh/max/ultra)만 이를 바꾸며 상속 환경값은 계속 scrub된다.
+11. inherited Claude host-auth bridge와 settings `env.CLAUDE_CODE_EXTRA_BODY`는 wrapper-owned loopback/model/request 계약을 우회하지 못해야 한다.
+12. request body의 `service_tier`는 wrapper-owned 값만 존재한다 — 기본은 필드 미전송(계정 기본 티어), 명시적 `claudex --fast` 인자만 pinned fast settings variant로 `"priority"`를 주입하며 상속 환경값은 계속 scrub된다.
 
 ### 모드별 기대값 (default vs mixed)
 
@@ -163,9 +166,6 @@ git status --short --branch
 | `--fast` | 허용 | 거부 (exit 2) |
 | catalog 검증 | main 1종 | main + subagent 2종 |
 | claude.ai 커넥터 | 비활성 (auth token이 로그인을 덮음) | 비활성 (동일) |
-10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 값을 따른다 — 기본 `high`, 명시적 `claudex --effort` 인자(whitelist: low/medium/high/xhigh/max/ultra)만 이를 바꾸며 상속 환경값은 계속 scrub된다.
-11. inherited Claude host-auth bridge와 settings `env.CLAUDE_CODE_EXTRA_BODY`는 wrapper-owned loopback/model/request 계약을 우회하지 못해야 한다.
-12. request body의 `service_tier`는 wrapper-owned 값만 존재한다 — 기본은 필드 미전송(계정 기본 티어), 명시적 `claudex --fast` 인자만 pinned fast settings variant로 `"priority"`를 주입하며 상속 환경값은 계속 scrub된다.
 
 ### 알려진 한계·리스크와 롤백
 

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -102,11 +102,12 @@ git status --short --branch
   - `CLAUDE_CODE_EXTRA_BODY`, inherited `CLAUDE_CODE_EFFORT_LEVEL`, `ANTHROPIC_UNIX_SOCKET`, Claude host-auth bridge 환경을 포함한 endpoint/request/transport override 환경을 scrub한다.
   - wrapper-owned settings 파일로 `CLAUDE_CODE_EXTRA_BODY`를 고정해 user/project settings의 request-body override를 중화한다. variant는 두 개이며 모두 pinned Nix store 파일이다 — 기본 variant는 `{}`, fast variant는 `{"service_tier":"priority"}`.
   - 빈 CLI fallback 목록으로 settings의 `fallbackModel`을 마스킹하고, wrapper-owned `CLAUDE_CODE_EFFORT_LEVEL`을 다시 설정한다.
-  - loopback catalog에서 선언 모델을 확인한 뒤 `$HOME/.local/bin/claude`를 실행한다.
-  - model은 `gpt-5.6-sol`로 고정한다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
+  - loopback catalog에서 세션의 main model(및 mixed에서는 subagent model까지)을 확인한 뒤 `$HOME/.local/bin/claude`를 실행한다.
+  - model 계약은 역할별로 고정한다: default 모드 main = `gpt-5.6-sol`, 모든 모드의 subagent(`CLAUDE_CODE_SUBAGENT_MODEL`) = `gpt-5.6-sol`, `--mixed` 모드 main = `claude-fable-5`. 사용자 `--model` override는 여전히 거부된다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
+  - `--mixed`(불리언; `--mixed=<값>` 거부)는 혼합 fleet 세션을 연다: main은 proxy의 claude credential로 서빙되는 Claude 모델, 서브에이전트는 그대로 gpt. mixed는 canonical auth에 codex+claude credential이 모두 있어야 시작되고(`claudex-login --claude`로 추가), `--mixed --fast` 조합은 fail-closed로 거부된다(fast 티어는 Codex 백엔드 전용 request-body knob).
   - Codex fast 티어는 불리언 `claudex --fast` 인자만 켠다(`--fast=<값>`은 거부). wrapper가 fast settings variant를 선택해 request body에 `service_tier`를 주입하며, 값은 온-와이어 canonical id인 `"priority"`(카탈로그 id `priority`, 표시명 "Fast")를 사용해 proxy 변환기의 `"fast"` 별칭 매핑에 의존하지 않는다. Claude CLI에는 대응 argv가 없으므로(자체 fastMode는 Anthropic 직접 API 전용 별개 기능) argv 재발행은 없다.
   - `--dangerously-skip-permissions`로 실행해 세션이 항상 bypassPermissions로 시작한다 (pinned CLI는 시작 플래그 없이 세션 중 bypass 전환이 불가능). 이 계약이 조용히 뒤집히지 않도록 사용자 인자의 `--permission-mode`도 wrapper-owned 옵션으로 거부한다.
-  - context window를 wrapper-owned `CLAUDE_CODE_MAX_CONTEXT_TOKENS=258000`으로 고정하고, 같은 값을 `CLAUDE_CODE_AUTO_COMPACT_WINDOW`로도 재발행한다 (후자가 없으면 미인식 모델에서 compact window source가 "auto"로 남아 pinned CLI가 auto-compact를 로컬 세션 가드로 비활성화한다 — 2.1.210 실측). 두 상속 환경값 모두 scrub된다. 값은 upstream의 임시 하향분이라 재상향 시 재조정이 필요하다 — 아래 "context 사용률 표시는 근사치" 항목과 후속 이슈 참조.
+  - context window를 wrapper-owned `CLAUDE_CODE_MAX_CONTEXT_TOKENS=258000`으로 고정하고, 같은 값을 `CLAUDE_CODE_AUTO_COMPACT_WINDOW`로도 재발행한다 (후자가 없으면 미인식 모델에서 compact window source가 "auto"로 남아 pinned CLI가 auto-compact를 로컬 세션 가드로 비활성화한다 — 2.1.210 실측). 두 상속 환경값 모두 scrub된다. 값은 upstream의 임시 하향분이라 재상향 시 재조정이 필요하다 — 아래 "context 사용률 표시는 근사치" 항목과 후속 이슈 참조. 예외: `--mixed`에서는 `CLAUDE_CODE_AUTO_COMPACT_WINDOW`를 재발행하지 않는다 — 이 env에는 모델 스코프가 없어 인식 모델인 Claude main의 compact 임계까지 끌어내리기 때문이며, 대가로 mixed의 gpt 서브에이전트는 auto-compact 없이 돈다(서브 작업이 window를 크게 밑돈다는 가정, 이슈 #1127). `CLAUDE_CODE_MAX_CONTEXT_TOKENS`는 비-claude 모델 전용이라 양쪽 모드에서 유지된다.
 - `modules/shared/programs/claudex/files/claudex-status.sh`
   - launchd service, auth, proxy, catalog 상태를 네 줄로 출력한다.
   - Stage 1 성공 조건은 auth/proxy/catalog ready이며, launchd service는 정보성 상태다.
@@ -118,7 +119,7 @@ git status --short --branch
 ### 검증 연결
 
 - `tests/suites/claudex.sh`: fake boundary, state mode, credential shape, wrapper scrub, wrapper-owned settings, 파생 runtime 계약, 실제 Nix-generated command output, layout drift, synthetic disabled Home Manager closure를 검증한다. fixture materialization 뒤 미치환 placeholder가 하나라도 남으면 실패한다.
-- `tests/shell-script-tests.sh`: 위 suite의 10개 테스트를 전체 shell suite에 등록한다.
+- `tests/shell-script-tests.sh`: 위 suite의 11개 테스트를 전체 shell suite에 등록한다.
 - `tests/eval-tests.nix`: descriptor, 실제·synthetic host 노출, pin, config, no-launchd/no-activation 계약과 portable Nix derivation 계약을 평가한다. 실제 command output 내용은 shell test가 build/read한다.
 - `lefthook.yml`과 `scripts/ai/check-lefthook-staged-config.sh`: JSON pin/template 변경이 eval 검증을 타도록 한다.
 
@@ -128,13 +129,14 @@ git status --short --branch
 |---|---|
 | Proxy | CLIProxyAPI `7.2.73`, Darwin arm64 |
 | Bind | `127.0.0.1:8317` |
-| 모델 | `gpt-5.6-sol` |
+| 모델 (default main / subagent) | `gpt-5.6-sol` / `gpt-5.6-sol` |
+| 모델 (mixed main) | `claude-fable-5` (`claudex --mixed`; descriptor `.model`은 default main alias) |
 | Runtime state | `$HOME/Library/Application Support/claudex` |
 | Descriptor | `$HOME/.config/claudex/runtime.json`, schema `2` |
 | Enabled hosts | `greenhead-MacBookPro`, `work-MacBookPro` |
 | Claude 실행 파일 | `$HOME/.local/bin/claude` |
 | Service label | `org.nix-community.home.claudex-proxy` |
-| Context window override | `CLAUDE_CODE_MAX_CONTEXT_TOKENS=258000` + `CLAUDE_CODE_AUTO_COMPACT_WINDOW=258000` (wrapper-owned; upstream 임시 하향 추종, 단일 상수 공유) |
+| Context window override | `CLAUDE_CODE_MAX_CONTEXT_TOKENS=258000` + `CLAUDE_CODE_AUTO_COMPACT_WINDOW=258000` (wrapper-owned; upstream 임시 하향 추종, 단일 상수 공유). mixed에서는 AUTO_COMPACT_WINDOW 미발행 |
 | Stage 1 service | 없음; foreground launcher만 존재 |
 
 보안·정합성 불변식:
@@ -142,12 +144,25 @@ git status --short --branch
 1. listener는 loopback만 사용한다.
 2. client API key는 state 디렉터리의 mode `0600` 파일이며, 정확히 64자의 lowercase hex여야 한다.
 3. state/auth/runtime 디렉터리는 symlink가 아니어야 하고 private mode를 유지해야 한다.
-4. canonical auth에는 정확히 하나의 유효 Codex credential만 허용한다.
+4. canonical auth의 credential set 계약: codex 정확히 1개(필수) + claude 최대 1개(mixed 필수), 그 외 타입·비JSON·중복은 거부한다 (`assert_credential_set`). claude credential이 공존하면 default 세션도 loopback key를 통해 이론상 그 credential에 닿을 수 있다 — 이 잔여 노출은 명시적으로 수용된 결정이다 (이슈 #1127, Stage 2 경계 재검토는 #1108).
 5. proxy 실행 파일과 config template은 Nix store 경로로 고정한다.
 6. 일반 `claude`의 settings와 인증은 변경하지 않는다.
 7. catalog에 모델이 보이는 것만으로 entitlement 성공으로 판정하지 않는다. 실제 completion이 필요하다.
 8. inherited request body, effort, Unix-socket transport가 wrapper의 endpoint/model/credential 경계를 우회하지 못해야 한다.
 9. byte-identical config render는 inode를 보존한다. runtime contract가 실제로 바뀌면 foreground proxy를 재시작한다.
+
+### 모드별 기대값 (default vs mixed)
+
+| 축 | `claudex` (default) | `claudex --mixed` |
+|---|---|---|
+| main model (`--model`) | `gpt-5.6-sol` | `claude-fable-5` |
+| subagent (`CLAUDE_CODE_SUBAGENT_MODEL`) | `gpt-5.6-sol` | `gpt-5.6-sol` |
+| credential set | codex 1 (claude 0..1 허용) | codex 1 + claude 1 필수 |
+| `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | 258000 | 258000 (비-claude 모델 전용이라 main 무영향) |
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | 258000 | 미발행 (main의 자체 auto-compact 보존; gpt 서브는 auto-compact 없음) |
+| `--fast` | 허용 | 거부 (exit 2) |
+| catalog 검증 | main 1종 | main + subagent 2종 |
+| claude.ai 커넥터 | 비활성 (auth token이 로그인을 덮음) | 비활성 (동일) |
 10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 값을 따른다 — 기본 `high`, 명시적 `claudex --effort` 인자(whitelist: low/medium/high/xhigh/max/ultra)만 이를 바꾸며 상속 환경값은 계속 scrub된다.
 11. inherited Claude host-auth bridge와 settings `env.CLAUDE_CODE_EXTRA_BODY`는 wrapper-owned loopback/model/request 계약을 우회하지 못해야 한다.
 12. request body의 `service_tier`는 wrapper-owned 값만 존재한다 — 기본은 필드 미전송(계정 기본 티어), 명시적 `claudex --fast` 인자만 pinned fast settings variant로 `"priority"`를 주입하며 상속 환경값은 계속 scrub된다.
@@ -360,7 +375,10 @@ find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print 2>/dev/null | wc -l
 
 - `0`: `claudex-login`을 실행한다.
 - `1`: `claudex-login`이 자체 schema 검증 후 ready로 종료하는지 확인한다.
-- `2` 이상 또는 invalid: 자동 삭제·선택하지 말고 중단한 뒤 사용자에게 보고한다.
+- `2`: codex+claude 공존(mixed set)이면 정상이다 — `claudex-status`가 auth=ready를 보고하는지 확인한다. 같은 타입 2개거나 invalid면 아래 규칙을 따른다.
+- 타입별 중복 또는 invalid: 자동 삭제·선택하지 말고 중단한 뒤 사용자에게 보고한다.
+
+mixed 세션용 claude credential 추가는 `claudex-login --claude`로 수행한다 (동일 staging → 타입 검증 → 원자 승격 절차; 기존 codex credential은 건드리지 않는다).
 
 실행:
 

--- a/modules/shared/programs/claudex/default.nix
+++ b/modules/shared/programs/claudex/default.nix
@@ -24,16 +24,29 @@ let
   apiKeyFile = "${stateDir}/client-api-key";
   stateLock = "${stateDir}/state.lock";
   workDir = "${stateDir}/work";
+  # CIR: the model contract is role-split for the --mixed session mode (issue #1127).
+  #   defaultMainModel — the default-mode main model (and the descriptor `.model` alias
+  #     below, kept for schema backward compatibility with existing consumers/eval locks).
+  #   subagentModel — every mode's CLAUDE_CODE_SUBAGENT_MODEL.
+  #   mixedMainModel — the --mixed main model (Claude via the proxy's claude credential).
+  #     claude-fable-5 exists in the pinned proxy's embedded catalog; entitlement is
+  #     confirmed at session start by the wrapper's catalog check, not here.
+  # mixedMainModel/subagentModel are deliberately NOT exposed in the descriptor: no
+  # consumer exists today, and schema surface grows only with a consumer + schema bump.
   runtimeContract = {
     bindHost = "127.0.0.1";
     port = 8317;
-    model = "gpt-5.6-sol";
+    defaultMainModel = "gpt-5.6-sol";
+    subagentModel = "gpt-5.6-sol";
+    mixedMainModel = "claude-fable-5";
     label = "org.nix-community.home.claudex-proxy";
   };
   inherit (runtimeContract)
     bindHost
     port
-    model
+    defaultMainModel
+    subagentModel
+    mixedMainModel
     label
     ;
   pprofPort = port - 1;
@@ -127,7 +140,9 @@ let
     launchctlBin = "/bin/launchctl";
     inherit
       bindHost
-      model
+      defaultMainModel
+      subagentModel
+      mixedMainModel
       label
       ;
     port = toString port;
@@ -177,8 +192,10 @@ let
       configFile
       bindHost
       port
-      model
       ;
+    # Descriptor `.model` stays the defaultMainModel alias (schema 2 compatibility);
+    # role-split fields are wrapper-internal until a descriptor consumer exists.
+    model = defaultMainModel;
     hostName = hostname;
     runtimeLibrary = toString runtimeLibrary;
     source = if enabled then toString runtimePackage else null;

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -32,6 +32,13 @@ case "$#" in
 esac
 
 prepare_state
+# The whole canonical directory must be well-formed before this command reports ready or
+# promotes anything — a malformed sibling entry would otherwise be masked here and only
+# surface when the next session start rejects the set.
+_claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR" || {
+  _claudex_error "canonical auth directory holds a malformed entry; remove it explicitly before logging in"
+  exit 1
+}
 existing_rc=0
 existing_path="$(_claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type")" || existing_rc=$?
 case "$existing_rc" in
@@ -102,7 +109,15 @@ _claudex_credential_json_valid "$staged_path" "$cred_type" || {
 
 _claudex_promote_staged_credential() {
   local staged destination existing_rc
-  # Same-type duplicate is refused; the other type's entry may coexist (mixed set).
+  # Validate the final state BEFORE moving anything: the canonical set must be well-formed
+  # (a malformed sibling means the move would only produce another invalid state) and must
+  # not already hold this type. The full default/mixed set contract is deliberately NOT
+  # asserted here — codex-only and claude-only are legitimate mid-login states (either
+  # login order is allowed); the per-mode contract is asserted at session start instead.
+  _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR" || {
+    _claudex_error "canonical auth directory holds a malformed entry; staged credential was not promoted"
+    return 1
+  }
   existing_rc=0
   _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null || existing_rc=$?
   if [ "$existing_rc" -ne 1 ]; then
@@ -121,7 +136,8 @@ _claudex_promote_staged_credential() {
     _claudex_error "atomic credential promotion did not complete"
     return 1
   fi
-  assert_credential_set "$CLAUDEX_AUTH_DIR" default
+  _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null \
+    && _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR"
 }
 
 with_state_lock _claudex_promote_staged_credential

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -9,25 +9,43 @@ source "@runtimeLibrary@"
 CLAUDEX_PROXY_BIN="@proxyBin@"
 CLAUDEX_CONFIG_TEMPLATE="@configTemplate@"
 
-if [ "$#" -ne 0 ]; then
-  echo "usage: claudex-login" >&2
-  exit 2
-fi
-
-prepare_state
-canonical_count="$(credential_count)"
-case "$canonical_count" in
+# Type-routed login: the no-arg path keeps the original Codex device-code flow; --claude
+# adds the Anthropic OAuth credential that the --mixed session mode requires. Each path is
+# idempotent per credential type and never touches the other type's canonical entry.
+cred_type=codex
+login_flag=--codex-device-login
+case "$#" in
   0) ;;
   1)
-    if assert_single_codex_credential; then
-      echo "claudex-login: canonical Codex credential is already ready"
-      exit 0
+    if [ "$1" = "--claude" ]; then
+      cred_type=claude
+      login_flag=--claude-login
+    else
+      echo "usage: claudex-login [--claude]" >&2
+      exit 2
     fi
-    _claudex_error "canonical credential is invalid; remove it explicitly before logging in again"
-    exit 1
     ;;
   *)
-    _claudex_error "canonical auth directory contains $canonical_count entries; refusing to choose or delete one"
+    echo "usage: claudex-login [--claude]" >&2
+    exit 2
+    ;;
+esac
+
+prepare_state
+existing_rc=0
+existing_path="$(_claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type")" || existing_rc=$?
+case "$existing_rc" in
+  0)
+    if _claudex_credential_json_valid "$existing_path" "$cred_type"; then
+      echo "claudex-login: canonical $cred_type credential is already ready"
+      exit 0
+    fi
+    _claudex_error "canonical $cred_type credential is invalid; remove it explicitly before logging in again"
+    exit 1
+    ;;
+  1) ;;
+  *)
+    _claudex_error "canonical auth directory holds duplicate $cred_type entries; refusing to choose or delete one"
     exit 1
     ;;
 esac
@@ -48,7 +66,7 @@ _claudex_ensure_private_dir "$staging_auth"
   _claudex_render_runtime_config_unlocked
 )
 
-echo "claudex-login: follow the device-code instructions printed by CLIProxyAPI"
+echo "claudex-login: follow the $cred_type OAuth instructions printed by CLIProxyAPI"
 set +e
 (
   cd "$staging"
@@ -60,45 +78,51 @@ set +e
     no_proxy="$CLAUDEX_NO_PROXY" \
     "$CLAUDEX_PROXY_BIN" \
       --config "$staging_config" \
-      --codex-device-login \
+      "$login_flag" \
       --no-browser \
       --local-model
 )
 login_rc=$?
 set -e
 if [ "$login_rc" -ne 0 ]; then
-  _claudex_error "device login failed"
+  _claudex_error "$cred_type login failed"
   exit "$login_rc"
 fi
 
 # Upstream has command paths that log an error and return success, so exit 0 is insufficient.
-# Trust only the staged filesystem contract.
-assert_single_codex_credential "$staging_auth" || {
-  _claudex_error "device login did not produce exactly one valid Codex credential"
+# Trust only the staged filesystem contract: exactly one entry, of the requested type.
+staged_path="$(_claudex_single_credential_path "$staging_auth")" || {
+  _claudex_error "$cred_type login did not produce exactly one credential"
+  exit 1
+}
+_claudex_credential_json_valid "$staged_path" "$cred_type" || {
+  _claudex_error "$cred_type login did not produce a valid $cred_type credential"
   exit 1
 }
 
 _claudex_promote_staged_credential() {
-  local staged_path destination count
-  count="$(credential_count "$CLAUDEX_AUTH_DIR")" || return 1
-  if [ "$count" -ne 0 ]; then
-    _claudex_error "another login changed the canonical auth directory; staged credential was not promoted"
+  local staged destination existing_rc
+  # Same-type duplicate is refused; the other type's entry may coexist (mixed set).
+  existing_rc=0
+  _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null || existing_rc=$?
+  if [ "$existing_rc" -ne 1 ]; then
+    _claudex_error "another login changed the canonical $cred_type credential; staged credential was not promoted"
     return 1
   fi
-  staged_path="$(_claudex_single_credential_path "$staging_auth")" || return 1
-  _claudex_credential_json_valid "$staged_path" || return 1
-  destination="$CLAUDEX_AUTH_DIR/${staged_path##*/}"
+  staged="$(_claudex_single_credential_path "$staging_auth")" || return 1
+  _claudex_credential_json_valid "$staged" "$cred_type" || return 1
+  destination="$CLAUDEX_AUTH_DIR/${staged##*/}"
   if [ -e "$destination" ] || [ -L "$destination" ]; then
     _claudex_error "refusing to overwrite an existing canonical credential"
     return 1
   fi
-  "$CLAUDEX_MV" -n -- "$staged_path" "$destination" || return 1
-  if [ -e "$staged_path" ] || [ -L "$staged_path" ]; then
+  "$CLAUDEX_MV" -n -- "$staged" "$destination" || return 1
+  if [ -e "$staged" ] || [ -L "$staged" ]; then
     _claudex_error "atomic credential promotion did not complete"
     return 1
   fi
-  assert_single_codex_credential "$CLAUDEX_AUTH_DIR"
+  assert_credential_set "$CLAUDEX_AUTH_DIR" default
 }
 
 with_state_lock _claudex_promote_staged_credential
-echo "claudex-login: canonical Codex credential is ready"
+echo "claudex-login: canonical $cred_type credential is ready"

--- a/modules/shared/programs/claudex/files/claudex-proxy-launcher.sh
+++ b/modules/shared/programs/claudex/files/claudex-proxy-launcher.sh
@@ -37,7 +37,9 @@ prepare_state
 if [ "$mode" = "prepare" ]; then
   exit 0
 fi
-assert_single_codex_credential
+# The proxy serves whatever valid set is present; the default contract (codex required,
+# claude optional) is the launch bar — mixed entitlement is asserted by `claudex --mixed`.
+assert_credential_set "$CLAUDEX_AUTH_DIR" default
 _claudex_assert_safe_work_dir
 
 cd "$CLAUDEX_WORK_DIR"

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -15,7 +15,8 @@
 #   _claudex_error _claudex_read_api_key _claudex_render_runtime_config_unlocked
 #   _claudex_ensure_private_dir _claudex_single_credential_path
 #   _claudex_credential_json_valid _claudex_credential_type_of
-#   _claudex_credential_path_of_type _claudex_assert_safe_work_dir
+#   _claudex_credential_path_of_type _claudex_assert_entries_wellformed
+#   _claudex_assert_safe_work_dir
 
 if [ "@allowTestOverrides@" = "true" ]; then
   CLAUDEX_JQ="${CLAUDEX_JQ:-@jqBin@}"
@@ -392,12 +393,37 @@ _claudex_credential_json_valid() {
 
 # Prints the declared .type of a credential file, or nothing when the file is not a
 # readable JSON object with a string type. Never fails the caller; type routing decisions
-# stay with the caller.
+# stay with the caller. Symlinks and non-regular entries (FIFO, directory) yield no type
+# without opening them — jq would follow a symlink or block forever on a FIFO.
 _claudex_credential_type_of() {
   local path="$1"
+  if [ -L "$path" ] || [ ! -f "$path" ]; then
+    return 0
+  fi
   "$CLAUDEX_JQ" -r 'if type == "object" and (.type | type == "string") then .type else empty end' \
     "$path" 2>/dev/null || true
 }
+
+# Asserts every entry in the directory is a well-formed codex/claude credential without
+# constraining counts. Partial sets (codex-only or claude-only) are legitimate mid-login
+# states, so login-time checks use this instead of the full assert_credential_set contract.
+_claudex_assert_entries_wellformed() (
+  local dir="$1"
+  local entry cred_entry_type
+  _claudex_assert_private_dir "$dir" || return 1
+  shopt -s dotglob nullglob
+  for entry in "$dir"/*; do
+    cred_entry_type="$(_claudex_credential_type_of "$entry")"
+    case "$cred_entry_type" in
+      codex | claude) ;;
+      *)
+        _claudex_error "unexpected credential entry in $dir: ${entry##*/}"
+        return 1
+        ;;
+    esac
+    _claudex_credential_json_valid "$entry" "$cred_entry_type" || return 1
+  done
+)
 
 # Prints the path of the unique credential of the given type. Return codes: 0 = exactly
 # one entry of that type exists (path printed), 1 = none exist (silent — callers use this

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -9,12 +9,13 @@
 #
 # Package-internal command API:
 #   with_state_lock prepare_state credential_count
-#   assert_single_codex_credential curl_loopback wait_for_proxy_ready
+#   assert_credential_set curl_loopback wait_for_proxy_ready
 #
 # Package-internal cross-file API (not stable for external callers):
 #   _claudex_error _claudex_read_api_key _claudex_render_runtime_config_unlocked
 #   _claudex_ensure_private_dir _claudex_single_credential_path
-#   _claudex_credential_json_valid _claudex_assert_safe_work_dir
+#   _claudex_credential_json_valid _claudex_credential_type_of
+#   _claudex_credential_path_of_type _claudex_assert_safe_work_dir
 
 if [ "@allowTestOverrides@" = "true" ]; then
   CLAUDEX_JQ="${CLAUDEX_JQ:-@jqBin@}"
@@ -76,7 +77,11 @@ CLAUDEX_READY_DELAY_SECONDS="${CLAUDEX_READY_DELAY_SECONDS:-0.25}"
 
 CLAUDEX_BIND_HOST="@bindHost@"
 CLAUDEX_PORT="@port@"
-CLAUDEX_MODEL="@model@"
+# Role-split model contract (single CLAUDEX_MODEL previously carried catalog check,
+# subagent env, and CLI --model at once; the mixed mode forks main vs subagent roles).
+CLAUDEX_DEFAULT_MAIN_MODEL="@defaultMainModel@"
+CLAUDEX_SUBAGENT_MODEL="@subagentModel@"
+CLAUDEX_MIXED_MAIN_MODEL="@mixedMainModel@"
 CLAUDEX_LABEL="@label@"
 CLAUDEX_PPROF_ADDR="${CLAUDEX_BIND_HOST}:@pprofPort@"
 CLAUDEX_BASE_URL="http://${CLAUDEX_BIND_HOST}:${CLAUDEX_PORT}"
@@ -361,7 +366,14 @@ _claudex_single_credential_path() (
 )
 
 _claudex_credential_json_valid() {
-  local path="$1"
+  local path="$1" cred_type="$2"
+  case "$cred_type" in
+    codex | claude) ;;
+    *)
+      _claudex_error "unsupported credential type: $cred_type"
+      return 1
+      ;;
+  esac
   case "${path##*/}" in
     *.json) ;;
     *)
@@ -370,13 +382,44 @@ _claudex_credential_json_valid() {
       ;;
   esac
   _claudex_assert_private_file "$path" || return 1
-  "$CLAUDEX_JQ" -e '
+  "$CLAUDEX_JQ" -e --arg credType "$cred_type" '
     type == "object"
-    and .type == "codex"
+    and .type == $credType
     and (.access_token | type == "string" and length > 0)
     and (.refresh_token | type == "string" and length > 0)
   ' "$path" >/dev/null 2>&1
 }
+
+# Prints the declared .type of a credential file, or nothing when the file is not a
+# readable JSON object with a string type. Never fails the caller; type routing decisions
+# stay with the caller.
+_claudex_credential_type_of() {
+  local path="$1"
+  "$CLAUDEX_JQ" -r 'if type == "object" and (.type | type == "string") then .type else empty end' \
+    "$path" 2>/dev/null || true
+}
+
+# Prints the path of the unique credential of the given type. Return codes: 0 = exactly
+# one entry of that type exists (path printed), 1 = none exist (silent — callers use this
+# as an existence probe), 2 = more than one entry of that type (error printed).
+_claudex_credential_path_of_type() (
+  local dir="$1" cred_type="$2"
+  local entry cred_entry_type found=""
+  _claudex_assert_private_dir "$dir" || return 2
+  shopt -s dotglob nullglob
+  for entry in "$dir"/*; do
+    cred_entry_type="$(_claudex_credential_type_of "$entry")"
+    if [ "$cred_entry_type" = "$cred_type" ]; then
+      if [ -n "$found" ]; then
+        _claudex_error "expected at most one $cred_type credential in $dir"
+        return 2
+      fi
+      found="$entry"
+    fi
+  done
+  [ -n "$found" ] || return 1
+  printf '%s' "$found"
+)
 
 # Run a command or shell function under the canonical state lock. The descriptor and state
 # live on local APFS; /usr/bin/lockf's fd mode gives us kernel-backed exclusion without a
@@ -418,11 +461,60 @@ credential_count() (
   printf '%s\n' "${#entries[@]}"
 )
 
-assert_single_codex_credential() {
-  local path
-  path="$(_claudex_single_credential_path "${1:-$CLAUDEX_AUTH_DIR}")" || return 1
-  _claudex_credential_json_valid "$path"
-}
+# Validates the canonical credential set for a session mode.
+#   default: exactly one codex credential (required) + at most one claude credential.
+#   mixed:   exactly one codex credential + exactly one claude credential.
+# Any entry that is not a valid codex/claude credential JSON is rejected in both modes.
+# CIR: mixed Stage 1.5 keeps a single proxy and a single canonical auth dir. Once a claude
+# credential is present, a default (non-mixed) session can technically reach it through the
+# same loopback API key — the user explicitly accepted this residual exposure (issue #1127
+# decision; same trust domain as the Stage 1 "loopback key visible to in-session
+# subprocesses" acceptance in claudex.sh). Splitting per-provider auth dirs/proxies was
+# rejected because credential auto-refresh rewrites files and copies would drift; the
+# follow-up boundary review is tracked on the Stage 2 gate issue #1108.
+assert_credential_set() (
+  local dir="$1" mode="$2"
+  local entry cred_entry_type codex_count=0 claude_count=0
+  case "$mode" in
+    default | mixed) ;;
+    *)
+      _claudex_error "assert_credential_set mode must be default or mixed"
+      return 1
+      ;;
+  esac
+  _claudex_assert_private_dir "$dir" || return 1
+  shopt -s dotglob nullglob
+  for entry in "$dir"/*; do
+    cred_entry_type="$(_claudex_credential_type_of "$entry")"
+    case "$cred_entry_type" in
+      codex) codex_count=$((codex_count + 1)) ;;
+      claude) claude_count=$((claude_count + 1)) ;;
+      *)
+        _claudex_error "unexpected credential entry in $dir: ${entry##*/}"
+        return 1
+        ;;
+    esac
+    _claudex_credential_json_valid "$entry" "$cred_entry_type" || return 1
+  done
+  if [ "$codex_count" -ne 1 ]; then
+    _claudex_error "expected exactly one codex credential in $dir (found $codex_count)"
+    return 1
+  fi
+  case "$mode" in
+    default)
+      if [ "$claude_count" -gt 1 ]; then
+        _claudex_error "expected at most one claude credential in $dir (found $claude_count)"
+        return 1
+      fi
+      ;;
+    mixed)
+      if [ "$claude_count" -ne 1 ]; then
+        _claudex_error "mixed mode requires exactly one claude credential in $dir (found $claude_count; run claudex-login --claude)"
+        return 1
+      fi
+      ;;
+  esac
+)
 
 curl_loopback() (
   local path="${1:-}"

--- a/modules/shared/programs/claudex/files/claudex-status.sh
+++ b/modules/shared/programs/claudex/files/claudex-status.sh
@@ -22,21 +22,21 @@ fi
 
 if [ -d "$CLAUDEX_AUTH_DIR" ] && [ ! -L "$CLAUDEX_AUTH_DIR" ]; then
   count="$(credential_count 2>/dev/null || printf 'invalid')"
-  if [ "$count" = "1" ]; then
-    if assert_single_codex_credential >/dev/null 2>&1; then
+  if [ "$count" != "0" ]; then
+    # The default set contract (codex exactly 1, claude at most 1) is the readiness bar;
+    # a mixed-capable set is a valid superset, so status stays mode-agnostic.
+    if assert_credential_set "$CLAUDEX_AUTH_DIR" default >/dev/null 2>&1; then
       auth_state="ready"
     else
       auth_state="invalid"
     fi
-  elif [ "$count" != "0" ]; then
-    auth_state="invalid"
   fi
 fi
 
 if [ "$auth_state" = "ready" ] && payload="$(curl_loopback /v1/models 2>/dev/null)"; then
   if "$CLAUDEX_JQ" -e '.data | type == "array"' <<< "$payload" >/dev/null 2>&1; then
     proxy_state="ready"
-    if "$CLAUDEX_JQ" -e --arg model "$CLAUDEX_MODEL" \
+    if "$CLAUDEX_JQ" -e --arg model "$CLAUDEX_DEFAULT_MAIN_MODEL" \
       '.data | any(.id == $model)' <<< "$payload" >/dev/null 2>&1; then
       catalog_state="ready"
     else

--- a/modules/shared/programs/claudex/files/claudex.sh
+++ b/modules/shared/programs/claudex/files/claudex.sh
@@ -17,6 +17,7 @@ CLAUDEX_MAX_CONTEXT_TOKENS="@maxContextTokens@"
 # a single deterministic `--effort` reaches Claude.
 effort_level=high
 fast_tier=false
+mixed_mode=false
 expect_effort_value=false
 forward_args=()
 scan_options=true
@@ -51,6 +52,13 @@ for arg in "$@"; do
       ;;
     --fast=*)
       _claudex_error "--fast does not accept a value (the Codex fast tier is a boolean session flag)"
+      exit 2
+      ;;
+    --mixed)
+      mixed_mode=true
+      ;;
+    --mixed=*)
+      _claudex_error "--mixed does not accept a value (mixed fleet is a boolean session flag)"
       exit 2
       ;;
     *)
@@ -90,13 +98,37 @@ if [ "$fast_tier" = true ]; then
   CLAUDEX_WRAPPER_SETTINGS="$CLAUDEX_WRAPPER_SETTINGS_FAST"
 fi
 
+# CIR: --mixed --fast is rejected fail-closed. service_tier=priority is a Codex-backend
+# request-body knob; how the pinned proxy's claude translator treats an unexpected
+# service_tier on the mixed main model is unverified, so v1 refuses the combination
+# instead of risking silent divergence between main and subagent request bodies.
+if [ "$mixed_mode" = true ] && [ "$fast_tier" = true ]; then
+  _claudex_error "--mixed does not support --fast (Codex fast tier is not defined for the mixed Claude main model)"
+  exit 2
+fi
+
+# Mode-resolved model roles: the main model drives the CLI --model and catalog check;
+# the subagent model always rides CLAUDE_CODE_SUBAGENT_MODEL below.
+credential_mode=default
+main_model="$CLAUDEX_DEFAULT_MAIN_MODEL"
+if [ "$mixed_mode" = true ]; then
+  credential_mode=mixed
+  main_model="$CLAUDEX_MIXED_MAIN_MODEL"
+fi
+
 prepare_state
-assert_single_codex_credential
+assert_credential_set "$CLAUDEX_AUTH_DIR" "$credential_mode"
 wait_for_proxy_ready
 catalog="$(curl_loopback /v1/models)"
-if ! "$CLAUDEX_JQ" -e --arg model "$CLAUDEX_MODEL" \
+if ! "$CLAUDEX_JQ" -e --arg model "$main_model" \
   '.data | type == "array" and any(.id == $model)' <<< "$catalog" >/dev/null; then
-  _claudex_error "declared model is absent from the proxy catalog (catalog is not an entitlement check)"
+  _claudex_error "main model $main_model is absent from the proxy catalog (catalog is not an entitlement check)"
+  exit 1
+fi
+if [ "$main_model" != "$CLAUDEX_SUBAGENT_MODEL" ] \
+  && ! "$CLAUDEX_JQ" -e --arg model "$CLAUDEX_SUBAGENT_MODEL" \
+    '.data | type == "array" and any(.id == $model)' <<< "$catalog" >/dev/null; then
+  _claudex_error "subagent model $CLAUDEX_SUBAGENT_MODEL is absent from the proxy catalog (catalog is not an entitlement check)"
   exit 1
 fi
 
@@ -173,7 +205,7 @@ export CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1
 # wrapper-owned loopback API key becoming visible to in-session subprocesses, which is a
 # loopback-only credential confined to 127.0.0.1:8317.
 export CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0
-export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDEX_MODEL"
+export CLAUDE_CODE_SUBAGENT_MODEL="$CLAUDEX_SUBAGENT_MODEL"
 export CLAUDE_CODE_ALWAYS_ENABLE_EFFORT=1
 export CLAUDE_CODE_EFFORT_LEVEL="$effort_level"
 # CIR: the pinned CLI assumes a 200k context window for unrecognized model names, and the
@@ -193,7 +225,16 @@ export CLAUDE_CODE_MAX_CONTEXT_TOKENS="$CLAUDEX_MAX_CONTEXT_TOKENS"
 # symptom). CLAUDE_CODE_AUTO_COMPACT_WINDOW is the CLI's official env channel that flips the
 # source to "env" and re-enables the compact threshold check. It shares the same
 # wrapper-owned value so the issue #1113 re-tune stays single-sourced.
-export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$CLAUDEX_MAX_CONTEXT_TOKENS"
+# CIR: the export is default-mode only. Unlike MAX_CONTEXT_TOKENS (which the CLI applies to
+# non-claude model names only), AUTO_COMPACT_WINDOW has no model scoping — in --mixed it
+# would drag the *recognized* Claude main model's compact threshold down to the gpt value,
+# while the Claude main needs no env channel at all (recognized models keep their own
+# auto-compact). The accepted cost: gpt subagents in mixed sessions run without
+# auto-compact, bounded by the "subagent tasks stay well under the window" assumption
+# recorded on issue #1127. Do not re-add the export for mixed without rechecking both.
+if [ "$mixed_mode" = false ]; then
+  export CLAUDE_CODE_AUTO_COMPACT_WINDOW="$CLAUDEX_MAX_CONTEXT_TOKENS"
+fi
 export CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY=3
 export ENABLE_TOOL_SEARCH=false
 export NO_PROXY="$CLAUDEX_NO_PROXY"
@@ -207,7 +248,7 @@ export no_proxy="$CLAUDEX_NO_PROXY"
 # restores normal permission prompts but also removes the mid-session bypass option.
 exec "$claude_bin" \
   --settings "$CLAUDEX_WRAPPER_SETTINGS" \
-  --model "$CLAUDEX_MODEL" \
+  --model "$main_model" \
   --fallback-model "" \
   "${effort_argv[@]}" \
   --dangerously-skip-permissions \

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -73,7 +73,11 @@ let
   claudexEnabledRuntimeBuildPhaseMatchesDescriptor =
     nixpkgsLib.hasInfix "--replace-fail @bindHost@ ${claudexEnabledDescriptor.bindHost}" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @port@ ${toString claudexEnabledDescriptor.port}" claudexEnabledRuntimeBuildPhase
-    && nixpkgsLib.hasInfix "--replace-fail @model@ ${claudexEnabledDescriptor.model}" claudexEnabledRuntimeBuildPhase
+    # Descriptor `.model` is the defaultMainModel alias; the role-split subagent/mixed
+    # substitutions exist without a descriptor field (wrapper-internal contract).
+    && nixpkgsLib.hasInfix "--replace-fail @defaultMainModel@ ${claudexEnabledDescriptor.model}" claudexEnabledRuntimeBuildPhase
+    && nixpkgsLib.hasInfix "--replace-fail @subagentModel@ " claudexEnabledRuntimeBuildPhase
+    && nixpkgsLib.hasInfix "--replace-fail @mixedMainModel@ " claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @label@ ${claudexEnabledDescriptor.label}" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @stateDir@ " claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix claudexEnabledDescriptor.stateDir claudexEnabledRuntimeBuildPhase

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -76,8 +76,8 @@ let
     # Descriptor `.model` is the defaultMainModel alias; the role-split subagent/mixed
     # substitutions exist without a descriptor field (wrapper-internal contract).
     && nixpkgsLib.hasInfix "--replace-fail @defaultMainModel@ ${claudexEnabledDescriptor.model}" claudexEnabledRuntimeBuildPhase
-    && nixpkgsLib.hasInfix "--replace-fail @subagentModel@ " claudexEnabledRuntimeBuildPhase
-    && nixpkgsLib.hasInfix "--replace-fail @mixedMainModel@ " claudexEnabledRuntimeBuildPhase
+    && nixpkgsLib.hasInfix "--replace-fail @subagentModel@ gpt-5.6-sol" claudexEnabledRuntimeBuildPhase
+    && nixpkgsLib.hasInfix "--replace-fail @mixedMainModel@ claude-fable-5" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @label@ ${claudexEnabledDescriptor.label}" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @stateDir@ " claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix claudexEnabledDescriptor.stateDir claudexEnabledRuntimeBuildPhase

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -261,6 +261,7 @@ run_test "claudex runtime API and private state" test_claudex_runtime_api_and_pr
 run_test "claudex runtime derives its internal contract" test_claudex_runtime_derived_contract
 run_test "claudex credential and loopback contract" test_claudex_credential_and_loopback_contract
 run_test "claudex wrapper pins provider model and argv" test_claudex_wrapper_pins_provider_model_and_argv
+run_test "claudex mixed mode contract" test_claudex_mixed_mode_contract
 run_test "claudex launcher and login use fake boundaries" test_claudex_launcher_and_login_use_fake_boundaries
 run_test "claudex production execution boundaries are pinned" test_claudex_production_execution_boundaries
 run_test "claudex Stage 1 status is sanitized" test_claudex_status_is_sanitized

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -7,6 +7,14 @@
 # and Nix-generated grep below all read this one constant to keep future re-tunes atomic.
 _CLAUDEX_EXPECTED_MAX_CONTEXT_TOKENS=258000
 
+# Role-split model expectations (production source of truth: runtimeContract in
+# modules/shared/programs/claudex/default.nix). The default main and subagent models are
+# currently the same id; keeping separate constants makes the role of each assertion
+# explicit and future re-tunes atomic.
+_CLAUDEX_EXPECTED_DEFAULT_MAIN_MODEL=gpt-5.6-sol
+_CLAUDEX_EXPECTED_SUBAGENT_MODEL=gpt-5.6-sol
+_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL=claude-fable-5
+
 _claudex_assert_no_placeholders() {
   local path="$1"
   if grep -Eq '@[A-Za-z_][A-Za-z0-9_-]*@' "$path"; then
@@ -38,7 +46,9 @@ _claudex_materialize_runtime() {
   local launchctl_bin="${CLAUDEX_FIXTURE_LAUNCHCTL_BIN:-/bin/launchctl}"
   local bind_host="${CLAUDEX_FIXTURE_BIND_HOST:-127.0.0.1}"
   local port="${CLAUDEX_FIXTURE_PORT:-8317}"
-  local model="${CLAUDEX_FIXTURE_MODEL:-gpt-5.6-sol}"
+  local default_main_model="${CLAUDEX_FIXTURE_DEFAULT_MAIN_MODEL:-$_CLAUDEX_EXPECTED_DEFAULT_MAIN_MODEL}"
+  local subagent_model="${CLAUDEX_FIXTURE_SUBAGENT_MODEL:-$_CLAUDEX_EXPECTED_SUBAGENT_MODEL}"
+  local mixed_main_model="${CLAUDEX_FIXTURE_MIXED_MAIN_MODEL:-$_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL}"
   local label="${CLAUDEX_FIXTURE_LABEL:-org.nix-community.home.claudex-proxy}"
   local pprof_port="${CLAUDEX_FIXTURE_PPROF_PORT:-$((port - 1))}"
   local state_dir="${CLAUDEX_FIXTURE_STATE_DIR:-$declared_home/Library/Application Support/claudex}"
@@ -76,7 +86,9 @@ _claudex_materialize_runtime() {
     -e "s|@launchctlBin@|$launchctl_bin|g" \
     -e "s|@bindHost@|$bind_host|g" \
     -e "s|@port@|$port|g" \
-    -e "s|@model@|$model|g" \
+    -e "s|@defaultMainModel@|$default_main_model|g" \
+    -e "s|@subagentModel@|$subagent_model|g" \
+    -e "s|@mixedMainModel@|$mixed_main_model|g" \
     -e "s|@label@|$label|g" \
     -e "s|@pprofPort@|$pprof_port|g" \
     "$source" > "$destination"
@@ -263,7 +275,7 @@ test_claudex_runtime_api_and_private_state() {
       declare -F | sed "s/^declare -f //" | grep -v "^_" | sort
     ' _ "$runtime"
   })"
-  expected=$'assert_single_codex_credential\ncredential_count\ncurl_loopback\nprepare_state\nwait_for_proxy_ready\nwith_state_lock'
+  expected=$'assert_credential_set\ncredential_count\ncurl_loopback\nprepare_state\nwait_for_proxy_ready\nwith_state_lock'
   [[ "$command_functions" == "$expected" ]] || fail "claudex runtime command API drifted: $command_functions"
   [[ ! -e "$state" ]] || fail "sourcing claudex runtime must be inert"
 
@@ -383,17 +395,20 @@ test_claudex_runtime_derived_contract() {
   CLAUDEX_FIXTURE_BIND_HOST=127.0.0.42 \
     CLAUDEX_FIXTURE_PORT=18317 \
     CLAUDEX_FIXTURE_PPROF_PORT=18316 \
-    CLAUDEX_FIXTURE_MODEL=sentinel-model \
+    CLAUDEX_FIXTURE_DEFAULT_MAIN_MODEL=sentinel-default-main \
+    CLAUDEX_FIXTURE_SUBAGENT_MODEL=sentinel-subagent \
+    CLAUDEX_FIXTURE_MIXED_MAIN_MODEL=sentinel-mixed-main \
     CLAUDEX_FIXTURE_LABEL=org.example.claudex-sentinel \
     _claudex_materialize_runtime "$runtime" "$template"
 
   output="$(HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
     source "$1"
-    printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
-      "$CLAUDEX_BIND_HOST" "$CLAUDEX_PORT" "$CLAUDEX_MODEL" "$CLAUDEX_LABEL" \
-      "$CLAUDEX_PPROF_ADDR" "$CLAUDEX_BASE_URL" "$CLAUDEX_NO_PROXY"
+    printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
+      "$CLAUDEX_BIND_HOST" "$CLAUDEX_PORT" \
+      "$CLAUDEX_DEFAULT_MAIN_MODEL" "$CLAUDEX_SUBAGENT_MODEL" "$CLAUDEX_MIXED_MAIN_MODEL" \
+      "$CLAUDEX_LABEL" "$CLAUDEX_PPROF_ADDR" "$CLAUDEX_BASE_URL" "$CLAUDEX_NO_PROXY"
   ' _ "$runtime")"
-  expected=$'127.0.0.42\n18317\nsentinel-model\norg.example.claudex-sentinel\n127.0.0.42:18316\nhttp://127.0.0.42:18317\n127.0.0.42,localhost'
+  expected=$'127.0.0.42\n18317\nsentinel-default-main\nsentinel-subagent\nsentinel-mixed-main\norg.example.claudex-sentinel\n127.0.0.42:18316\nhttp://127.0.0.42:18317\n127.0.0.42,localhost'
   [[ "$output" == "$expected" ]] || fail "derived runtime contract drifted: $output"
 
   HOME="$sandbox/home" \
@@ -420,17 +435,45 @@ test_claudex_credential_and_loopback_contract() {
 
   _claudex_add_valid_credential "$state"
   HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
-    source "$1"; assert_single_codex_credential
+    source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" default
   ' _ "$runtime" || fail "valid Codex credential was rejected"
 
   printf '%s' '{"type":"claude","access_token":"secret","refresh_token":"secret"}' \
     > "$state/auth/codex-test.json"
+  chmod 600 "$state/auth/codex-test.json"
   if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
-    source "$1"; assert_single_codex_credential
+    source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" default
   ' _ "$runtime" >/dev/null 2>&1; then
-    fail "wrong-provider credential was accepted"
+    fail "claude-only credential set was accepted without a codex credential"
   fi
   _claudex_add_valid_credential "$state"
+
+  # Mixed-set contract: codex + claude coexistence is a valid default set, required for
+  # mixed; a second claude entry or an unknown provider breaks both modes.
+  printf '%s' '{"type":"claude","access_token":"claude-access","refresh_token":"claude-refresh"}' \
+    > "$state/auth/claude-test.json"
+  chmod 600 "$state/auth/claude-test.json"
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
+    source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" default
+  ' _ "$runtime" || fail "codex+claude coexistence was rejected in default mode"
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
+    source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" mixed
+  ' _ "$runtime" || fail "codex+claude coexistence was rejected in mixed mode"
+  rm "$state/auth/claude-test.json"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
+    source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" mixed
+  ' _ "$runtime" >/dev/null 2>&1; then
+    fail "mixed mode accepted a set without a claude credential"
+  fi
+  printf '%s' '{"type":"gemini","access_token":"x","refresh_token":"y"}' \
+    > "$state/auth/gemini-test.json"
+  chmod 600 "$state/auth/gemini-test.json"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
+    source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" default
+  ' _ "$runtime" >/dev/null 2>&1; then
+    fail "unknown-provider credential was accepted"
+  fi
+  rm "$state/auth/gemini-test.json"
 
   _claudex_make_ready_curl "$sandbox"
 
@@ -708,6 +751,93 @@ EOF
   done
 }
 
+test_claudex_mixed_mode_contract() {
+  local sandbox state wrapper rc
+  sandbox="$(new_sandbox)"
+  state="$sandbox/state"
+  wrapper="$sandbox/generated/claudex"
+  _claudex_fixture "$sandbox"
+  _claudex_prepare_fixture_state "$sandbox"
+  _claudex_add_valid_credential "$state"
+
+  # Mixed catalog fake: the mixed main model and the subagent model are both served.
+  cat > "$sandbox/fake-curl" <<EOF
+#!/usr/bin/env bash
+IFS= read -r _header || true
+printf '%s' '{"data":[{"id":"$_CLAUDEX_EXPECTED_SUBAGENT_MODEL"},{"id":"$_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL"}]}'
+EOF
+  chmod +x "$sandbox/fake-curl"
+
+  cat > "$sandbox/home/.local/bin/claude" <<EOF
+#!/usr/bin/env bash
+{
+  printf 'subagent=%s\n' "\${CLAUDE_CODE_SUBAGENT_MODEL-unset}"
+  printf 'max_context=%s\n' "\${CLAUDE_CODE_MAX_CONTEXT_TOKENS-unset}"
+  printf 'auto_compact_window=%s\n' "\${CLAUDE_CODE_AUTO_COMPACT_WINDOW-unset}"
+  printf 'arg=%s\n' "\$@"
+} > "$sandbox/claude.log"
+exit 23
+EOF
+  chmod +x "$sandbox/home/.local/bin/claude"
+
+  # --mixed refuses to start without a claude credential (fail-closed, before exec).
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" --mixed -- literal-prompt >/dev/null 2>&1; then
+    fail "--mixed started without a claude credential"
+  fi
+  [[ ! -e "$sandbox/claude.log" ]] || fail "--mixed invoked Claude without a claude credential"
+
+  printf '%s' '{"type":"claude","access_token":"claude-access","refresh_token":"claude-refresh"}' \
+    > "$state/auth/claude-test.json"
+  chmod 600 "$state/auth/claude-test.json"
+
+  # Mixed happy path: Claude main model on argv, gpt subagent env, no auto-compact window.
+  set +e
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" --mixed -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "claudex --mixed did not reach Claude"
+  assert_file_contains "$sandbox/claude.log" "subagent=$_CLAUDEX_EXPECTED_SUBAGENT_MODEL"
+  assert_file_contains "$sandbox/claude.log" "max_context=$_CLAUDEX_EXPECTED_MAX_CONTEXT_TOKENS"
+  assert_file_contains "$sandbox/claude.log" "auto_compact_window=unset"
+  assert_file_contains "$sandbox/claude.log" "arg=--model"
+  assert_file_contains "$sandbox/claude.log" "arg=$_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL"
+
+  # Default mode keeps working with the coexisting claude credential and keeps its
+  # auto-compact window export.
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" -- literal-prompt
+  rc=$?
+  set -e
+  [[ "$rc" == "23" ]] || fail "default claudex did not run with a coexisting claude credential"
+  assert_file_contains "$sandbox/claude.log" "arg=$_CLAUDEX_EXPECTED_DEFAULT_MAIN_MODEL"
+  assert_file_contains "$sandbox/claude.log" "auto_compact_window=$_CLAUDEX_EXPECTED_MAX_CONTEXT_TOKENS"
+
+  # Managed-flag hygiene: --mixed is a boolean and combines with neither a value nor --fast.
+  rm -f "$sandbox/claude.log"
+  set +e
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" --mixed=1 >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" == "2" ]] || fail "--mixed=1 was not rejected with exit 2"
+  set +e
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$wrapper" --mixed --fast >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" == "2" ]] || fail "--mixed --fast was not rejected with exit 2"
+  [[ ! -e "$sandbox/claude.log" ]] || fail "rejected mixed combination still invoked Claude"
+
+  # Mixed fails when the catalog lacks the mixed main model (subagent-only catalog).
+  _claudex_make_ready_curl "$sandbox"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" --mixed -- literal-prompt >/dev/null 2>&1; then
+    fail "--mixed accepted a catalog without the mixed main model"
+  fi
+}
+
 test_claudex_launcher_and_login_use_fake_boundaries() {
   local sandbox state launcher login proxy_log jq_bin expected_work rc
   sandbox="$(new_sandbox)"
@@ -810,6 +940,55 @@ EOF
   HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" "$login" \
     >/dev/null
   [[ ! -e "$proxy_log" ]] || fail "existing canonical credential triggered another device login"
+
+  # --claude adds the second provider credential next to the codex entry (mixed set).
+  cat > "$sandbox/fake-cli-proxy-api" <<EOF
+#!/usr/bin/env bash
+printf 'arg=%s\n' "\$@" > "$proxy_log"
+claude=false
+config=''
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --claude-login) claude=true; shift ;;
+    --config) config="\$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ "\$claude" = true ] || exit 1
+auth_dir="\$("$jq_bin" -r '.["auth-dir"]' "\$config")"
+mkdir -p "\$auth_dir"
+chmod 700 "\$auth_dir"
+printf '%s' '{"type":"claude","access_token":"claude-access","refresh_token":"claude-refresh"}' > "\$auth_dir/claude-stage.json"
+chmod 600 "\$auth_dir/claude-stage.json"
+exit 0
+EOF
+  chmod +x "$sandbox/fake-cli-proxy-api"
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    "$login" --claude >/dev/null
+  assert_file_contains "$proxy_log" "arg=--claude-login"
+  [[ "$(find "$state/auth" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "2" ]] \
+    || fail "claude login did not add the second credential next to the codex entry"
+  jq -e '.type == "claude" and .access_token == "claude-access"' \
+    "$state/auth/claude-stage.json" >/dev/null || fail "promoted claude credential is invalid"
+  jq -e '.type == "codex"' "$state/auth/codex-stage.json" >/dev/null \
+    || fail "claude login touched the canonical codex credential"
+
+  # Both login paths are idempotent per credential type once their entry exists.
+  rm -f "$proxy_log"
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    "$login" --claude >/dev/null
+  [[ ! -e "$proxy_log" ]] || fail "existing claude credential triggered another claude login"
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    "$login" >/dev/null
+  [[ ! -e "$proxy_log" ]] || fail "coexisting claude credential broke the no-arg login no-op"
+
+  # Usage hygiene: unknown or extra arguments are rejected.
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$login" --claude extra >/dev/null 2>&1; then
+    fail "claudex-login accepted extra arguments"
+  fi
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$login" --hostile >/dev/null 2>&1; then
+    fail "claudex-login accepted an unknown flag"
+  fi
 }
 
 test_claudex_production_execution_boundaries() {
@@ -988,6 +1167,8 @@ test_claudex_nix_generated_command_outputs_are_pinned() {
     || fail "Nix-generated proxy launcher does not pass --local-model"
   grep -Fq -- '--codex-device-login' "$runtime_out/bin/claudex-login" \
     || fail "Nix-generated login does not pass --codex-device-login"
+  grep -Fq -- '--claude-login' "$runtime_out/bin/claudex-login" \
+    || fail "Nix-generated login does not support --claude-login"
 }
 
 test_claudex_release_layout_verifier() {

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -989,6 +989,33 @@ EOF
   if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$login" --hostile >/dev/null 2>&1; then
     fail "claudex-login accepted an unknown flag"
   fi
+
+  # Claude-first login order: --claude into an EMPTY auth dir must promote cleanly
+  # (codex-only and claude-only are legitimate mid-login states; the old full-set assert
+  # made this path fail after the move).
+  rm -rf "$state/auth"
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    "$login" --claude >/dev/null || fail "claude-first login into an empty auth dir failed"
+  [[ "$(find "$state/auth" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "1" ]] \
+    || fail "claude-first login did not leave exactly one credential"
+  jq -e '.type == "claude"' "$state/auth/claude-stage.json" >/dev/null \
+    || fail "claude-first promoted credential is invalid"
+
+  # A malformed sibling blocks both the ready short-circuit and promotion (no partial
+  # promotion next to a poisoned set; no false ready that the session gate would reject).
+  printf '%s' '{"type":"gemini","access_token":"x","refresh_token":"y"}' \
+    > "$state/auth/gemini-bad.json"
+  chmod 600 "$state/auth/gemini-bad.json"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    "$login" --claude >/dev/null 2>&1; then
+    fail "login reported ready despite a malformed sibling entry"
+  fi
+  rm -f "$proxy_log"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    "$login" >/dev/null 2>&1; then
+    fail "codex login proceeded despite a malformed sibling entry"
+  fi
+  rm "$state/auth/gemini-bad.json"
 }
 
 test_claudex_production_execution_boundaries() {


### PR DESCRIPTION
<!-- methodology: finding-unknowns -->

## Summary

- `claudex --mixed`: 메인 루프는 Claude(`claude-fable-5`, 프록시의 claude.ai OAuth credential 경유), 서브에이전트는 `gpt-5.6-sol`(Codex credential)로 도는 **혼합 fleet 세션** 지원
- credential 계약을 `assert_credential_set <dir> <default|mixed>`로 일반화 — canonical auth에 codex 1 + claude 0..1 공존 허용, `claudex-login --claude`로 Anthropic OAuth credential 추가
- 모델 계약을 역할별 상수 3종(defaultMainModel/subagentModel/mixedMainModel)으로 분리, E2E 실측 완료 (MAIN=Fable 5, SUB=gpt-5.6-sol)

Closes #1127

## 기존 문제/배경

claudex(Stage 1)는 세션 전체를 gpt-5.6-sol로 바꾸는 escape hatch라 두 세계가 배타적이었다: claudex 세션은 메인까지 gpt이고, 일반 claude 세션은 gpt를 쓸 수 없다. 서브에이전트/Workflow 작업량만 Codex 구독으로 옮기는 중간 지대가 없어, 대량 에이전트 fan-out(ultracode 등)이 전부 Anthropic 사용량을 소모했다.

사전 프로토타입(#1127 본문)으로 성립 조건을 실측했다: per-agent frontmatter 모델이 프록시까지 전달됨(negative probe로 확정), per-agent base URL 채널은 부재(공식 문서), 따라서 "세션 전체를 프록시 뒤에 두고 모델명 라우팅"이 유일 구조이며 메인=Claude를 위해 프록시에 Anthropic credential 등록이 필요하다.

## CIR (Change Intent Record)

**발견 경위**: 외부 레퍼런스(X 스레드의 claudex 레시피 + 아티팩트) 분석 → 코드베이스·세션 로그·issue/PR 전수조사 → 프로토타입 실측(#1127) → 계획 수립·검증 → 구현·E2E의 흐름. 프로토타입에서 wrapper의 `CLAUDE_CODE_SUBAGENT_MODEL` export가 frontmatter를 덮는 우선순위(공식 문서와 일치)를 실측해, 혼합 fleet의 라우팅 채널로 역이용하는 설계를 채택했다.

**핵심 결정** (검토·확정 순):

1. **credential 등록 방식** — claude.ai 구독 OAuth를 CLIProxyAPI에 등록 (Console API key 종량제 대신). 기존 Codex OAuth와 동일 패턴(loopback 전용, credential이 머신을 떠나지 않음)이며 추가 비용이 없다. ToS 관점 미지는 라벨된 리스크로 수용.
2. **경계 설계 — 단일 프록시·단일 auth-dir 수용**: claude credential이 공존하면 default(non-mixed) 세션도 loopback key를 통해 이론상 그 credential에 닿을 수 있다. 리뷰에서 확인된 이 노출을 **명시적으로 수용**했다 — Stage 1에서 이미 수용한 "loopback key가 세션 내 서브프로세스에 보임"과 동일 신뢰 도메인(본인 머신 loopback)이고, 확대분은 "Claude 구독 quota도 소비 가능"으로 한정되며, 대안(이중 프록시)은 credential 자동 refresh가 파일을 재작성해 복사본이 drift하는 문제와 프록시 2개 수동 운영을 유발한다. 근거는 runtime의 `assert_credential_set` CIR 주석과 handoff 불변식 4에 박제, 후속 경계 검토는 #1108에 위임.
3. **mixed에서 `CLAUDE_CODE_AUTO_COMPACT_WINDOW` 미발행**: 이 env에는 모델 스코프가 없어 인식 모델인 Claude 메인의 compact 임계까지 258k로 끌어내린다 (기존 export의 CIR은 "미인식 모델 전용 세션" 전제 — #1115). 대가로 mixed의 gpt 서브에이전트는 auto-compact 없이 돌며, "서브 작업은 window를 크게 밑돈다"는 가정으로 수용 (#1127 Notes). `CLAUDE_CODE_MAX_CONTEXT_TOKENS`는 비-claude 모델 전용이라 양쪽 모드 유지.
4. **`--mixed --fast` fail-closed 거부**: fast 티어(`service_tier=priority`)는 Codex 백엔드 전용 request-body knob이고, 프록시의 claude 변환기가 이를 어떻게 다루는지 미검증이라 v1은 거부.
5. **raw count 분기 교체**: status/login에 남아 있던 "엔트리 수 1만 정상" 분기를 assert 교체만으로 두면 codex+claude 공존 시 조용히 깨진다는 리뷰 지적을 반영, 타입별 조회(`_claudex_credential_path_of_type`)로 전면 교체.

**구현 중 결정** (implementation-notes 흡수):

- `_claudex_credential_path_of_type` 반환 계약을 rc 0(정확히 1개)/1(부재, 무음)/2(중복, 에러)로 세분화 — login의 idempotent 분기가 부재와 중복을 구분해야 해서. 계획 대비 유일한 이탈이며 그 외 이탈 없음.
- status의 auth ready 판정은 `default` 계약 재사용 (mixed-capable set은 default의 유효 상위집합 — status는 모드 불문 단일 기준). proxy-launcher도 동일.
- login `--claude`의 staging 검증은 기존 `_claudex_single_credential_path`(총 1개) + 타입 검증 재사용 (staging은 항상 단일 credential).
- 별도 count 함수는 만들지 않음 (기존 `credential_count`가 전체 수 담당).

**해소된 미지** (E2E 실측):

- claude credential JSON의 `.type == "claude"` + access/refresh_token 구조 — staging 검증 통과로 가정 확정.
- 프록시의 mixed 카탈로그 노출 시점 — **재시작 불필요**, credential 승격 직후 claude 모델 14종 핫로드.
- `claude-fable-5` entitlement — 카탈로그·실 completion 통과, 값 재조정 불필요.

**리뷰 국면 발견** (리뷰 루프도 영토다):

- 리뷰가 실버그를 발굴했다: 승격 함수의 full default set assert는 **빈 auth에서 `--claude`를 먼저 로그인하는 순서**(claude-first)에서 mv 완료 후 실패했다 — E2E는 codex credential이 선존재해 미검출. 수정: 승격 전 canonical 전체 well-formed 검증(오염 set 옆 부분 승격 차단) + 승격 후 검증을 "요청 타입 정확히 1 + 전체 well-formed"로 교체. **codex-only/claude-only는 합법적 중간 상태**(로그인 순서 자유)라는 계약을 이 수정에서 명문화했고, 모드별 set 계약은 세션 시작이 assert한다.
- already-ready 단락도 malformed sibling이 있으면 ready 대신 에러로 전환 — "login은 ready라는데 세션이 거부"하는 UX 불일치 제거.
- type probe(`_claudex_credential_type_of`)가 symlink/비정규 파일(FIFO 등)을 열지 않도록 가드 — jq hang·symlink 추종 차단 (방어 계층 일관성).

**잔여 미지** (범위 밖, #1127 Notes): 지속 부하에서의 429 quota 임계 정량값, effort/service_tier의 서브에이전트 전달 충실도(#1112 연접).

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 단일 프록시 + 단일 auth-dir + 타입별 계약 | canonical auth에 codex+claude 공존, 모드별 assert | drift 없음, 운영 단순, Stage 1 구조 보존 | default 세션이 이론상 claude credential에 닿음 (수용·문서화) | ✅ |
| 이중 프록시 (mixed 전용 포트·auth-dir·key) | provider별 완전 격리 | trust boundary 명확 | codex credential 이중화 → 자동 refresh drift, 프록시 2개 수동 운영, 구현 복잡도 | ❌ |
| default 경로에서 claude credential 불허 | 공존 자체를 거부 | 경계 단순 | claude 로그인 후 기본 claudex 사용 불가 — 두 모드 공존이 목표인데 상호 배타가 됨 | ❌ |
| `CLAUDE_CODE_SUBAGENT_MODEL` 대신 frontmatter 에이전트 정의 배포 | 에이전트별 선택적 혼합 | 세밀 제어 | wrapper env가 frontmatter를 덮는 우선순위(실측)와 충돌 — env 채널이 이미 전역 라우팅을 제공, 선택 혼합은 후속 범위 | ❌ |
| descriptor에 역할별 모델 필드 노출 | mixedMainModel 등 schema 확장 | 외부 관측 가능 | 현재 소비자 없음 — schema surface 선공개 (YAGNI) | ❌ |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claudex/files/claudex-runtime.sh` | `_claudex_credential_json_valid <path> <type>` 파라미터화, `_claudex_credential_type_of`·`_claudex_credential_path_of_type` 신설, `assert_credential_set <dir> <default\|mixed>` 공개 API (구 `assert_single_codex_credential` 제거), 역할별 모델 치환 3종 |
| `modules/shared/programs/claudex/files/claudex.sh` | `--mixed` 파싱(불리언, 값·`--fast` 조합 거부), 모드별 main model 선택·카탈로그 2종 검증, mixed에서 AUTO_COMPACT_WINDOW 미발행(+CIR) |
| `modules/shared/programs/claudex/files/claudex-login.sh` | `--claude` 경로(`-claude-login` OAuth), 타입별 idempotent 체크·원자 승격 (다른 타입 엔트리 불가침) |
| `modules/shared/programs/claudex/files/claudex-status.sh` | auth ready = `assert_credential_set default`, catalog는 default main model 기준 |
| `modules/shared/programs/claudex/files/claudex-proxy-launcher.sh` | 기동 기준을 default 계약으로 교체 |
| `modules/shared/programs/claudex/default.nix` | 역할별 모델 상수 3종 + CIR, descriptor `.model`은 defaultMainModel alias 유지 |
| `tests/suites/claudex.sh` | 신규 mixed 계약 테스트, login `--claude`·credential set 케이스, fixture placeholder 3분리, API exact-lock 갱신, 기대 모델 상수 3종 |
| `tests/eval-tests.nix` | 치환 검증을 역할별 placeholder로 갱신 |
| `docs/claudex-poc-handoff.md` | 고정 계약·불변식·트러블슈팅 갱신 + 모드별 기대값 표 신설 |

핵심 계약 (runtime):

```bash
# default: codex 정확히 1 (필수) + claude 0..1, mixed: codex 1 + claude 1.
# 그 외 타입/비JSON/중복은 양쪽 모드에서 거부.
assert_credential_set "$CLAUDEX_AUTH_DIR" "$credential_mode"
```

## 참고 레퍼런스

- 이슈 #1127 (프로토타입 실측 정본 + 설계 결정 트래킹)
- 이슈 #1108 (Stage 2 게이트 — 경계 후속 검토 코멘트 예정), #1113 (context window 재상향), #1112 (service_tier passthrough), #1121 (credential pool 설계 — 이번 "타입별 1개 공존"과 구분되는 동일 provider 다계정 트랙)
- PR #1107 (Stage 1 도입), #1114/#1115 (context window·auto-compact env 채널), #1120 (resilience knobs)
- Claude Code 공식 문서: sub-agents(`model` frontmatter full ID), model-config(`CLAUDE_CODE_SUBAGENT_MODEL` 우선순위) — https://code.claude.com/docs/en/sub-agents , https://code.claude.com/docs/en/model-config
- CLIProxyAPI upstream (Claude OAuth 백엔드·모델명 라우팅): https://github.com/router-for-me/CLIProxyAPI

## Human Test Plan

1. `nrs` 후 `claudex-status` → auth/proxy/catalog ready (codex credential만 있어도 ready — default 계약).
2. `claudex -p "Reply with exactly: CLAUDEX_E2E_OK"` → `CLAUDEX_E2E_OK` (default 무회귀). 실패 시: 프록시 가동 여부(`claudex-status`), auth 디렉토리 상태 확인.
3. `claudex-login --claude` → 브라우저에서 claude.ai OAuth 승인 → "canonical claude credential is ready". 재실행 시 "already ready" no-op. 실패 시: staging 디렉토리 잔존 여부(`auth.login.*`), 에러 문구의 타입 검증 단계 확인.
4. `/v1/models` 조회 → claude-* 모델이 카탈로그에 등장 (프록시 재시작 불필요 — 실측). 안 보이면 그때만 foreground 프록시 재시작.
5. `claudex --mixed -p "What model are you?"` → Claude(Fable 5) 응답. 서브에이전트 스폰 시 gpt-5.6-sol로 동작. 실패 시: mixed는 claude credential 필수(에러 문구가 `claudex-login --claude` 안내), 카탈로그 2종 검증 로그 확인.
6. `claudex --mixed --fast` → exit 2 거부. `claudex --mixed=1` → exit 2 거부.
7. (관측) mixed 세션에서 claude.ai 커넥터 비활성 경고가 뜬다 — 예상 동작 (커넥터 필요 작업은 일반 `claude` 세션 사용).

---
https://claude.ai/code/session_01S54HNcp8WzkXYhhrVEVxxc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * `--mixed` 모드로 Codex와 Claude를 함께 사용하는 세션을 지원합니다.
  * 역할별(메인/서브에이전트/혼합 메인) 모델 선택이 모드에 따라 적용됩니다.
  * `claudex-login --claude`로 Claude 전용 OAuth 로그인 흐름을 추가했습니다.

* **개선 사항**
  * 세션 시작 전 자격증명 세트와 `/v1/models` 카탈로그를 모드 기준으로 검증합니다.
  * 지원되지 않는 옵션 조합(예: `--mixed`와 특정 조합)은 안전하게 거부합니다.
  * 컨텍스트 자동 압축 동작이 mixed 모드 규칙에 맞게 조정됩니다.

* **테스트**
  * mixed 모드 계약 및 로그인/런처 경계 케이스를 포함해 테스트 범위를 확대했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
