### PR TITLE
chore(claudex): mixedMainModel을 claude-opus-4-8로 교체 (fable 7/20 만료 대응)

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -103,7 +103,7 @@ git status --short --branch
   - wrapper-owned settings 파일로 `CLAUDE_CODE_EXTRA_BODY`를 고정해 user/project settings의 request-body override를 중화한다. variant는 두 개이며 모두 pinned Nix store 파일이다 — 기본 variant는 `{}`, fast variant는 `{"service_tier":"priority"}`.
   - 빈 CLI fallback 목록으로 settings의 `fallbackModel`을 마스킹하고, wrapper-owned `CLAUDE_CODE_EFFORT_LEVEL`을 다시 설정한다.
   - loopback catalog에서 세션의 main model(및 mixed에서는 subagent model까지)을 확인한 뒤 `$HOME/.local/bin/claude`를 실행한다.
-  - model 계약은 역할별로 고정한다: default 모드 main = `gpt-5.6-sol`, 모든 모드의 subagent(`CLAUDE_CODE_SUBAGENT_MODEL`) = `gpt-5.6-sol`, `--mixed` 모드 main = `claude-fable-5`. 사용자 `--model` override는 여전히 거부된다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
+  - model 계약은 역할별로 고정한다: default 모드 main = `gpt-5.6-sol`, 모든 모드의 subagent(`CLAUDE_CODE_SUBAGENT_MODEL`) = `gpt-5.6-sol`, `--mixed` 모드 main = `claude-opus-4-8`. 사용자 `--model` override는 여전히 거부된다. 이 고정은 **세션 시작값**이다 — 세션 중 `/model` 전환(CLI 기능)으로 카탈로그의 다른 모델로 바꿀 수 있음이 실측됐다(2026-07-17). 구독 플랜의 모델 정책 변화 시 pin 재조정은 #1130이 추적한다. effort는 기본 `high`이며, 명시적 `claudex --effort <low|medium|high|xhigh|max|ultra>` 인자만 세션 값을 바꾼다. `ultra`는 pinned CLI가 argv에서 warn-then-ignore하므로 env 값으로만 전달한다.
   - `--mixed`(불리언; `--mixed=<값>` 거부)는 혼합 fleet 세션을 연다: main은 proxy의 claude credential로 서빙되는 Claude 모델, 서브에이전트는 그대로 gpt. mixed는 canonical auth에 codex+claude credential이 모두 있어야 시작되고(`claudex-login --claude`로 추가), `--mixed --fast` 조합은 fail-closed로 거부된다(fast 티어는 Codex 백엔드 전용 request-body knob).
   - Codex fast 티어는 불리언 `claudex --fast` 인자만 켠다(`--fast=<값>`은 거부). wrapper가 fast settings variant를 선택해 request body에 `service_tier`를 주입하며, 값은 온-와이어 canonical id인 `"priority"`(카탈로그 id `priority`, 표시명 "Fast")를 사용해 proxy 변환기의 `"fast"` 별칭 매핑에 의존하지 않는다. Claude CLI에는 대응 argv가 없으므로(자체 fastMode는 Anthropic 직접 API 전용 별개 기능) argv 재발행은 없다.
   - `--dangerously-skip-permissions`로 실행해 세션이 항상 bypassPermissions로 시작한다 (pinned CLI는 시작 플래그 없이 세션 중 bypass 전환이 불가능). 이 계약이 조용히 뒤집히지 않도록 사용자 인자의 `--permission-mode`도 wrapper-owned 옵션으로 거부한다.
@@ -130,7 +130,7 @@ git status --short --branch
 | Proxy | CLIProxyAPI `7.2.73`, Darwin arm64 |
 | Bind | `127.0.0.1:8317` |
 | 모델 (default main / subagent) | `gpt-5.6-sol` / `gpt-5.6-sol` |
-| 모델 (mixed main) | `claude-fable-5` (`claudex --mixed`; descriptor `.model`은 default main alias) |
+| 모델 (mixed main) | `claude-opus-4-8` (`claudex --mixed`; descriptor `.model`은 default main alias; 재조정 트리거 #1130) |
 | Runtime state | `$HOME/Library/Application Support/claudex` |
 | Descriptor | `$HOME/.config/claudex/runtime.json`, schema `2` |
 | Enabled hosts | `greenhead-MacBookPro`, `work-MacBookPro` |
@@ -158,7 +158,7 @@ git status --short --branch
 
 | 축 | `claudex` (default) | `claudex --mixed` |
 |---|---|---|
-| main model (`--model`) | `gpt-5.6-sol` | `claude-fable-5` |
+| main model (`--model`) | `gpt-5.6-sol` | `claude-opus-4-8` |
 | subagent (`CLAUDE_CODE_SUBAGENT_MODEL`) | `gpt-5.6-sol` | `gpt-5.6-sol` |
 | credential set | codex 1 (claude 0..1 허용) | codex 1 + claude 1 필수 |
 | `CLAUDE_CODE_MAX_CONTEXT_TOKENS` | 258000 | 258000 (비-claude 모델 전용이라 main 무영향) |

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -165,7 +165,7 @@ git status --short --branch
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | 258000 | 미발행 (main의 자체 auto-compact 보존; gpt 서브는 auto-compact 없음) |
 | `--fast` | 허용 | 거부 (exit 2) |
 | catalog 검증 | main 1종 | main + subagent 2종 |
-| claude.ai 커넥터 | 비활성 (auth token이 로그인을 덮음) | 비활성 (동일) |
+| claude.ai 계정 연동 (커넥터·Remote Control) | 비활성 (auth token이 로그인을 덮어 세션이 API Usage Billing으로 취급됨 — 계정에 세션이 등록되지 않아 휴대폰·타 기기 원격 접근 불가, 2026-07-17 실측) | 비활성 (동일) |
 
 ### 알려진 한계·리스크와 롤백
 

--- a/modules/shared/programs/claudex/default.nix
+++ b/modules/shared/programs/claudex/default.nix
@@ -29,8 +29,16 @@ let
   #     below, kept for schema backward compatibility with existing consumers/eval locks).
   #   subagentModel — every mode's CLAUDE_CODE_SUBAGENT_MODEL.
   #   mixedMainModel — the --mixed main model (Claude via the proxy's claude credential).
-  #     claude-fable-5 exists in the pinned proxy's embedded catalog; entitlement is
-  #     confirmed at session start by the wrapper's catalog check, not here.
+  #     The id exists in the pinned proxy's embedded catalog; entitlement is confirmed at
+  #     session start by the wrapper's catalog check, not here.
+  # CIR: mixedMainModel moved from claude-fable-5 to claude-opus-4-8 — Fable 5 is a
+  #     limited-run model on the subscription quota plan (available through 2026-07-20),
+  #     so pinning it made mixed sessions expire with it. This constant is a build-time
+  #     value with no runtime channel by design (the wrapper rejects --model and re-owns
+  #     inherited env), so plan/model-policy changes require editing the sync points
+  #     tracked in issue #1130 and redeploying. Mid-session /model switching to another
+  #     catalog model remains available (user-measured 2026-07-17) — the pin fixes the
+  #     session's starting model, not a session-long invariant.
   # mixedMainModel/subagentModel are deliberately NOT exposed in the descriptor: no
   # consumer exists today, and schema surface grows only with a consumer + schema bump.
   runtimeContract = {
@@ -38,7 +46,7 @@ let
     port = 8317;
     defaultMainModel = "gpt-5.6-sol";
     subagentModel = "gpt-5.6-sol";
-    mixedMainModel = "claude-fable-5";
+    mixedMainModel = "claude-opus-4-8";
     label = "org.nix-community.home.claudex-proxy";
   };
   inherit (runtimeContract)

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -77,7 +77,7 @@ let
     # substitutions exist without a descriptor field (wrapper-internal contract).
     && nixpkgsLib.hasInfix "--replace-fail @defaultMainModel@ ${claudexEnabledDescriptor.model}" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @subagentModel@ gpt-5.6-sol" claudexEnabledRuntimeBuildPhase
-    && nixpkgsLib.hasInfix "--replace-fail @mixedMainModel@ claude-fable-5" claudexEnabledRuntimeBuildPhase
+    && nixpkgsLib.hasInfix "--replace-fail @mixedMainModel@ claude-opus-4-8" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @label@ ${claudexEnabledDescriptor.label}" claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix "--replace-fail @stateDir@ " claudexEnabledRuntimeBuildPhase
     && nixpkgsLib.hasInfix claudexEnabledDescriptor.stateDir claudexEnabledRuntimeBuildPhase

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -13,7 +13,7 @@ _CLAUDEX_EXPECTED_MAX_CONTEXT_TOKENS=258000
 # explicit and future re-tunes atomic.
 _CLAUDEX_EXPECTED_DEFAULT_MAIN_MODEL=gpt-5.6-sol
 _CLAUDEX_EXPECTED_SUBAGENT_MODEL=gpt-5.6-sol
-_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL=claude-fable-5
+_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL=claude-opus-4-8
 
 _claudex_assert_no_placeholders() {
   local path="$1"


### PR DESCRIPTION
## Summary

- `claudex --mixed`의 메인 모델 pin을 `claude-fable-5` → `claude-opus-4-8`로 교체 (동기 지점 4파일 일괄)
- 근거·계약·우회로를 문서화: 빌드타임 pin(런타임 채널 없음), 세션 중 `/model` 전환 가능(사용자 실측), 재조정 트리거 #1130

## 기존 문제/배경

Fable 5는 구독 quota 플랜의 **한정 모델(2026-07-20까지)**인데, PR #1129가 이를 mixed 메인으로 pin했다. wrapper 계약상 이 값은 런타임 변경 채널이 없으므로(--model argv 거부 + env 재소유 + 빌드타임 치환) 만료일 이후 mixed 세션의 시작 모델이 entitlement를 잃는다 — 카탈로그는 embedded 목록이라 시작 체크는 통과하고 첫 completion에서 깨지는 형태가 예상됐다.

## CIR (Change Intent Record)

- 설계 시점에는 "Fable 5가 만료 한정 모델"이라는 플랜 정보가 반영되지 않았다 — 사용자 지적으로 발견. 값 교체와 함께, 이 상수의 수명 관리가 반복 과제임을 인정하고 #1113과 같은 트리거 이슈 패턴(#1130)으로 제도화했다.
- 세션 중 `/model` 전환으로 카탈로그의 다른 claude 모델로 바꿀 수 있음이 실측됐다(2026-07-17, 사용자) — pin은 "시작값"이지 세션 불변식이 아니라는 사실을 CIR 주석과 handoff에 명문화했다 (다음 개발자가 pin을 세션 강제로 오해하지 않도록).

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|---|---|---|---|---|
| 상수 교체 + 트리거 이슈 | 값만 opus로, 수명 관리는 #1130 | 5분 규모, 계약 불변 | 정책 변화 시 재배포 필요 | ✅ |
| `--mixed --main-model <whitelist>` 런타임 옵션 | `--effort` 패턴 재사용 | 재배포 없는 교체 | 지금은 교체 1회뿐 — YAGNI, 반복 시 착수 (#1130에 기록) | ❌ (보류) |

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/shared/programs/claudex/default.nix` | `mixedMainModel = "claude-opus-4-8"` + 교체 근거·런타임 채널 부재·`/model` 실측 CIR |
| `tests/suites/claudex.sh` | `_CLAUDEX_EXPECTED_MIXED_MAIN_MODEL=claude-opus-4-8` |
| `tests/eval-tests.nix` | `@mixedMainModel@` 실값 리터럴 갱신 |
| `docs/claudex-poc-handoff.md` | 모델 계약 서술·고정 계약 표·모드별 기대값 표 + `/model` 전환 실측 문구 |

## 참고 레퍼런스

- 이슈 #1130 (재조정 트리거 — 동기 지점 체크리스트), #1113 (동일 패턴 선례)
- PR #1129 (혼합 fleet 도입)

## 알려진 한계 (이번 작업 중 실측·문서화)

프록시 세션(default·mixed 공통)은 claude.ai **계정 연동 기능이 전부 비활성**된다 — 커넥터(예: Figma·Slack)뿐 아니라 **Claude Code Remote Control**(휴대폰·타 기기 원격 세션 접근)도. 원인은 wrapper의 `ANTHROPIC_AUTH_TOKEN`이 claude.ai 로그인을 덮어 세션이 API Usage Billing(API key 세션)으로 취급되기 때문으로, 계정에 세션이 등록되지 않아 원격 기기가 찾아올 수 없다 (2026-07-17 실측). 우리 쪽 코드로 해소 불가능한 구조적 한계이며 known limitation 이슈 #1132가 기록·완화책(역할 분리, tmux 경유 원격 접근)을 추적한다. handoff 모드별 기대값 표에도 반영됨.

## Human Test Plan

1. `nrs` 후 `claudex --mixed -p "Reply with exactly your model name"` → `claude-opus-4-8`
2. 시작 배너가 Opus를 표시하고, 세션 중 `/model`로 카탈로그의 다른 claude 모델 전환 가능
3. 기존 default 경로 무회귀: `claudex -p` → `CLAUDEX_E2E_OK`

---
https://claude.ai/code/session_01S54HNcp8WzkXYhhrVEVxxc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **변경 사항**
  - 혼합 모드에서 세션 시작 시 고정되는 기본 모델이 `claude-fable-5`에서 `claude-opus-4-8`로 변경되었습니다.
  - 혼합 모드의 모델 전환 규칙 및 동작 기대값(문구/표)이 `claude-opus-4-8` 기준으로 업데이트되었습니다.
  - 모델 설정 변경을 검증하는 테스트 기대치가 함께 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
