### PR TITLE
feat(shell): op_get 무인 SA 폴백 — 원격/LLM 세션의 1Password 승인 hang 제거

### DIFF
--- a/.claude/skills/managing-secrets/references/1password.md
+++ b/.claude/skills/managing-secrets/references/1password.md
@@ -74,9 +74,9 @@ SSOT: `modules/shared/programs/shell/darwin.nix`.
 
 1. `OP_SERVICE_ACCOUNT_TOKEN` env가 이미 있으면 그대로 `op read` (SA env가 account를 결정 — `--account` 미전달).
 2. Mac SA token(`~/.config/op/sa-token-mac`, 방식 B #873 재사용)이 읽히면 SA로 `op read` — biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3단계로 넘어간다. LLM이 프롬프트 없이 읽어야 할 시크릿은 Automation vault에 두면 이 경로를 탄다.
-3. biometric(데스크탑 앱 연동) — 대화형 전용. 무인 판정(stdin/stderr 비TTY · SSH 원격 세션 · 에이전트/CI 하네스 env: `CI`/`CLAUDECODE`/`CODEX_CI`/`CODEX_PROGRAMMATIC`)이 하나라도 참이면 시도 없이 명확히 실패한다(fail-fast) — 비대화형 `op read`는 Mac 화면에만 뜨는 승인을 기다리며 무한 hang하기 때문(#1041). 사람이 화면 앞에 있는 예외 상황만 `OP_GET_BIOMETRIC=1`로 명시 우회한다.
+3. biometric(데스크탑 앱 연동) — **기본 차단(positive-gate)**. SA 경로 실패 시 시도 없이 fail-fast한다 — `op read`의 승인 팝업은 Mac 로컬 화면에만 떠서 무인·원격 컨텍스트에서 진입하면 무한 hang하기 때문(#1041). TTY denylist로는 표식 없는 PTY 자동화를 못 잡으므로(gh-auth가 같은 이유로 biometric fallback을 제거한 #876 F3 선례), 사람이 Mac 화면 앞에 있을 때만 켜는 `OP_GET_BIOMETRIC=1 op_get ...` opt-in에서만 biometric을 허용한다.
 
-SA 경로(1·2단계)는 서브셸에서 `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`을 제거하고 실행한다 — Connect env가 SA token보다 우선하는 op 공식 우선순위 때문이며, 이 repo는 Connect 서버 미도입(NG-1)이라 잔존 Connect env는 항상 오염이다. 경로 단일 소스는 `constants.onePassword.saTokenMacRelPath`.
+SA 경로(1·2단계)는 서브셸에서 `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`을 제거하고 SA token은 `env`로 감싼 단일 command subtree에만 주입한다 — Connect env가 SA token보다 우선하는 op 공식 우선순위 때문이며, 이 repo는 Connect 서버 미도입(NG-1)이라 잔존 Connect env는 항상 오염이다. 같은 계약을 `gh-pat-mac`(darwin.nix)도 공유한다. 경로 단일 소스는 `constants.onePassword.saTokenMacRelPath`.
 
 회귀 핀: `tests/eval-tests.nix` Test D18 (SA 경로 상수 배선 + `OP_GET_BIOMETRIC` opt-in 마커).
 

--- a/.claude/skills/managing-secrets/references/1password.md
+++ b/.claude/skills/managing-secrets/references/1password.md
@@ -74,9 +74,11 @@ SSOT: `modules/shared/programs/shell/darwin.nix`.
 
 1. `OP_SERVICE_ACCOUNT_TOKEN` env가 이미 있으면 그대로 `op read` (SA env가 account를 결정 — `--account` 미전달).
 2. Mac SA token(`~/.config/op/sa-token-mac`, 방식 B #873 재사용)이 읽히면 SA로 `op read` — biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3단계로 넘어간다. LLM이 프롬프트 없이 읽어야 할 시크릿은 Automation vault에 두면 이 경로를 탄다.
-3. biometric(데스크탑 앱 연동) — 대화형 전용. stdin·stderr 모두 non-TTY면 무인으로 판정하고 시도 없이 명확히 실패한다(fail-fast) — 비대화형 `op read`는 Mac 화면에만 뜨는 승인을 기다리며 무한 hang하기 때문(#1041). 한계: PTY를 받은 자동화는 TTY 판정상 대화형으로 보인다.
+3. biometric(데스크탑 앱 연동) — 대화형 전용. 무인 판정(stdin/stderr 비TTY · SSH 원격 세션 · 에이전트/CI 하네스 env: `CI`/`CLAUDECODE`/`CODEX_CI`/`CODEX_PROGRAMMATIC`)이 하나라도 참이면 시도 없이 명확히 실패한다(fail-fast) — 비대화형 `op read`는 Mac 화면에만 뜨는 승인을 기다리며 무한 hang하기 때문(#1041). 사람이 화면 앞에 있는 예외 상황만 `OP_GET_BIOMETRIC=1`로 명시 우회한다.
 
-회귀 핀: `tests/eval-tests.nix` Test D18 (SA 폴백 배선 + 비대화형 biometric 차단 가드).
+SA 경로(1·2단계)는 서브셸에서 `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`을 제거하고 실행한다 — Connect env가 SA token보다 우선하는 op 공식 우선순위 때문이며, 이 repo는 Connect 서버 미도입(NG-1)이라 잔존 Connect env는 항상 오염이다. 경로 단일 소스는 `constants.onePassword.saTokenMacRelPath`.
+
+회귀 핀: `tests/eval-tests.nix` Test D18 (SA 경로 상수 배선 + `OP_GET_BIOMETRIC` opt-in 마커).
 
 SSOT: `libraries/constants.nix`(onePassword), `modules/shared/programs/shell/default.nix`(op_get), `modules/shared/programs/shell/darwin.nix`(gh 무인).
 

--- a/.claude/skills/managing-secrets/references/1password.md
+++ b/.claude/skills/managing-secrets/references/1password.md
@@ -68,7 +68,17 @@ SSOT: `modules/shared/programs/shell/darwin.nix`.
 - MiniPC: op CLI를 직접 쓰지 않고 opnix(Go SDK)가 `op://Automation/github-pat`을 `/run/opnix/<user>/github-pat`으로 materialize한다(`OP_SERVICE_ACCOUNT_TOKEN`이 account 결정). 아래 라우팅은 Mac/수동 op CLI 경로 기준.
 - 라우팅: 자동화/시스템 토큰 = `Automation` vault(`github-pat` 등), 디바이스 SSH 키 = `SSH` vault(`mac-ssh`/`emergency-ssh`; `mobile-ssh`는 Termius keychain이라 제외), 개인 항목 = `Personal` vault. SA(Automation read-only)는 SSH vault `op read` 차단.
 
-SSOT: `libraries/constants.nix`(onePassword), `modules/shared/programs/shell/darwin.nix`.
+### op_get 해석 순서 (SA-first, 무인 폴백)
+
+`op_get <name> <field> [<vault>]`(zsh initContent, `modules/shared/programs/shell/default.nix`)는 3단계로 해석한다:
+
+1. `OP_SERVICE_ACCOUNT_TOKEN` env가 이미 있으면 그대로 `op read` (SA env가 account를 결정 — `--account` 미전달).
+2. Mac SA token(`~/.config/op/sa-token-mac`, 방식 B #873 재사용)이 읽히면 SA로 `op read` — biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3단계로 넘어간다. LLM이 프롬프트 없이 읽어야 할 시크릿은 Automation vault에 두면 이 경로를 탄다.
+3. biometric(데스크탑 앱 연동) — 대화형 전용. stdin·stderr 모두 non-TTY면 무인으로 판정하고 시도 없이 명확히 실패한다(fail-fast) — 비대화형 `op read`는 Mac 화면에만 뜨는 승인을 기다리며 무한 hang하기 때문(#1041). 한계: PTY를 받은 자동화는 TTY 판정상 대화형으로 보인다.
+
+회귀 핀: `tests/eval-tests.nix` Test D18 (SA 폴백 배선 + 비대화형 biometric 차단 가드).
+
+SSOT: `libraries/constants.nix`(onePassword), `modules/shared/programs/shell/default.nix`(op_get), `modules/shared/programs/shell/darwin.nix`(gh 무인).
 
 ## SSH device key 운영 (#866 닫힘 — mobile-ssh 단일 공유 키)
 

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -180,6 +180,10 @@
     # ~/.1password/agent.sock symlink는 자동생성되지 않아 group container 경로를 직접 쓴다.
     # 사용처: ssh IdentityAgent(modules/darwin/programs/ssh) + ssh() preflight(shell/darwin.nix).
     agentSocketRelPath = "Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock";
+    # Mac 전용 SA token의 배포 경로 (home 상대) — 단일 소스.
+    # 배포: modules/shared/programs/secrets(agenix path), 소비: gh-pat-mac(shell/darwin.nix) ·
+    # op_get(shell/default.nix). literal 분산 시 경로 정책 변경이 배포/소비 경계를 따로 움직인다.
+    saTokenMacRelPath = ".config/op/sa-token-mac";
     # 1Password 백그라운드 기동 인자 (단일 소스). -g 포커스 유지, -j hidden, --silent 메인창 억제.
     # launchd 자동 기동은 [ "/usr/bin/open" ] ++ openArgs (절대경로), shell preflight 복구는
     # `open ${escapeShellArgs openArgs}`로 공유한다 — flag 변경 시 한 곳만 고친다.

--- a/modules/shared/programs/secrets/default.nix
+++ b/modules/shared/programs/secrets/default.nix
@@ -5,6 +5,7 @@
   pkgs,
   lib,
   hostType,
+  constants,
   ...
 }:
 
@@ -79,7 +80,9 @@
     // lib.optionalAttrs (pkgs.stdenv.isDarwin && hostType == "personal") {
       opnix-service-account-token-mac = {
         file = ../../../../secrets/opnix-service-account-token-mac.age;
-        path = "${config.xdg.configHome}/op/sa-token-mac";
+        # 경로 단일 소스: constants.onePassword.saTokenMacRelPath — 소비자(gh-pat-mac·op_get)는
+        # $HOME 기준으로 같은 상수를 조립하므로 xdg.configHome이 아닌 homeDirectory로 고정한다.
+        path = "${config.home.homeDirectory}/${constants.onePassword.saTokenMacRelPath}";
         mode = "0400";
       };
     };

--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -33,7 +33,7 @@ let
       case "$_c" in ghp_*|github_pat_*) printf '%s' "$_c"; exit 0 ;; esac
     fi
     rm -f "$_cache" 2>/dev/null
-    _sa="$HOME/.config/op/sa-token-mac"
+    _sa="$HOME/${constants.onePassword.saTokenMacRelPath}"
     [ -r "$_sa" ] || exit 0
     command -v op >/dev/null 2>&1 || exit 0
     _tok=$(OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline \

--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -36,7 +36,9 @@ let
     _sa="$HOME/${constants.onePassword.saTokenMacRelPath}"
     [ -r "$_sa" ] || exit 0
     command -v op >/dev/null 2>&1 || exit 0
-    _tok=$(OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline \
+    # OP_CONNECT_HOST/TOKEN은 op 공식 우선순위상 SA token보다 우선하므로 서브셸에서 제거한다
+    # (op_get과 동일 계약 — repo는 Connect 서버 미도입 NG-1이라 잔존 Connect env는 항상 오염).
+    _tok=$(unset OP_CONNECT_HOST OP_CONNECT_TOKEN; OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline \
            "op://${constants.onePassword.vaults.automation}/github-pat/token" 2>/dev/null || true)
     case "$_tok" in ghp_*|github_pat_*) ;; *) exit 0 ;; esac
     ( umask 077; printf '%s' "$_tok" > "$_cache.tmp.$$" && mv -f "$_cache.tmp.$$" "$_cache" )

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -398,12 +398,13 @@ in
           # _sa_timeout: 무인 셸 대기 상한 — SaaS 왕복 지연은 흡수하되 hang으로 오인되기 전에
           #    실패한다(coreutils timeout 가용 시에만 — macOS 기본엔 없음. SA 경로는 앱 연동이
           #    없어 biometric 승인 대기 자체가 구조적으로 없다).
-          # SA token은 op 프로세스 env로만 전달한다(셸 env 미상주). env로 명령 하나를 감싸 SA token이
-          # 그 command subtree(op, 또는 timeout→op)에만 상속되게 한다 — timeout 부모 셸엔 미주입.
+          # SA token은 op 프로세스에만 주입한다(셸 env 미상주). env를 op 바로 앞에 두어 env가
+          # token과 함께 op를 exec하게 한다 — timeout을 쓸 때도 `timeout … env … op` 순서라
+          # timeout 프로세스에는 token이 상속되지 않는다(`env … timeout` 순서면 timeout도 보유).
           local _sa="$HOME/${constants.onePassword.saTokenMacRelPath}" _sa_state="token-missing" _rc=0 _sa_timeout=20
           if [ -r "$_sa" ]; then
             if command -v timeout >/dev/null 2>&1; then
-              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; env OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" timeout "$_sa_timeout" op read --no-newline "$ref")
+              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; timeout "$_sa_timeout" env OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref")
             else
               (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; env OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref")
             fi

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -363,9 +363,9 @@ in
       #   2) Mac SA token(~/.config/op/sa-token-mac, 방식 B #873 재사용)이 읽히면 SA로 op read —
       #      biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation
       #      read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3)으로 넘어간다.
-      #   3) biometric(데스크탑 앱 연동, 새 터미널마다 Touch ID) — 대화형 전용. 무인 판정(비TTY ·
-      #      SSH 원격 · 에이전트/CI 하네스 env)이 하나라도 참이면 승인 대기 hang(#1041) 대신
-      #      fail-fast하고, OP_GET_BIOMETRIC=1 명시 opt-in으로만 우회한다(#876 F3 정합).
+      #   3) biometric(데스크탑 앱 연동, 새 터미널마다 Touch ID) — 기본 차단. SA 실패 시 승인 대기
+      #      hang(#1041) 대신 fail-fast하고, 사람이 화면 앞일 때만 OP_GET_BIOMETRIC=1 opt-in으로
+      #      허용한다(TTY 판정은 표식 없는 PTY 자동화를 못 잡으므로 positive-gate — #876 F3 정합).
       # MiniPC는 op CLI 미설치(127 guard) — opnix materialization이 대체(Phase 3).
       #─────────────────────────────────────────────────────────────────────────
       ''
@@ -398,30 +398,29 @@ in
           # _sa_timeout: 무인 셸 대기 상한 — SaaS 왕복 지연은 흡수하되 hang으로 오인되기 전에
           #    실패한다(coreutils timeout 가용 시에만 — macOS 기본엔 없음. SA 경로는 앱 연동이
           #    없어 biometric 승인 대기 자체가 구조적으로 없다).
+          # SA token은 op 프로세스 env로만 전달한다(셸 env 미상주). env로 명령 하나를 감싸 SA token이
+          # 그 command subtree(op, 또는 timeout→op)에만 상속되게 한다 — timeout 부모 셸엔 미주입.
           local _sa="$HOME/${constants.onePassword.saTokenMacRelPath}" _sa_state="token-missing" _rc=0 _sa_timeout=20
           if [ -r "$_sa" ]; then
             if command -v timeout >/dev/null 2>&1; then
-              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" timeout "$_sa_timeout" op read --no-newline "$ref")
+              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; env OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" timeout "$_sa_timeout" op read --no-newline "$ref")
             else
-              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref")
+              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; env OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref")
             fi
             _rc=$?
             [ "$_rc" -eq 0 ] && return 0
             _sa_state="op rc=$_rc"
           fi
-          # 3) biometric 대화형 폴백 — 무인 컨텍스트에서는 시도하지 않는다(fail-fast, #1041).
-          #    무인 판정: 비TTY(stdin/stderr 어느 쪽이든), SSH 원격 세션(승인 팝업이 로컬 화면
-          #    전용이라 원격에선 보이지 않음), 알려진 에이전트/CI 하네스 env(PTY가 있어도 무인 —
-          #    gh-auth가 biometric fallback을 제거한 #876 F3과 같은 근거).
-          #    stdout은 판정에 안 쓴다 — 대화형 $(op_get ...) 명령 치환도 stdout이 파이프다.
-          #    사람이 화면 앞에 있는 예외 상황만 OP_GET_BIOMETRIC=1로 명시 우회한다.
+          # 3) biometric 대화형 폴백 — 기본 차단(positive-gate). op read의 biometric 승인 팝업은
+          #    Mac 로컬 화면에만 뜨므로, 무인·원격 컨텍스트에서 진입하면 승인 대기로 무한 hang한다(#1041).
+          #    TTY denylist(비TTY·SSH·에이전트 env)로는 표식 없는 PTY 자동화를 못 잡는다 —
+          #    gh-auth가 같은 이유로 biometric fallback을 통째로 제거한 #876 F3의 선례에 맞춰,
+          #    사람이 화면 앞에 있을 때만 켜는 OP_GET_BIOMETRIC=1 opt-in에서만 biometric을 허용한다.
+          #    (denylist 신호는 미설정 시 진단 문구로만 활용 — 판정 게이트가 아니다.)
           #    --account: 멀티 계정(개인+회사) 환경에서 개인 account 고정 (multiple accounts 에러 방지).
           if [ "''${OP_GET_BIOMETRIC:-}" != "1" ]; then
-            if [ ! -t 0 ] || [ ! -t 2 ] || [ -n "''${SSH_CONNECTION:-}" ] || [ -n "''${CI:-}" ] \
-              || [ -n "''${CLAUDECODE:-}" ] || [ -n "''${CODEX_CI:-}" ] || [ -n "''${CODEX_PROGRAMMATIC:-}" ]; then
-              echo "Error: op_get 무인 컨텍스트 — SA 경로 실패($_sa_state). biometric은 무인에서 승인 대기 hang(#1041)이라 차단한다. 항목을 Automation vault로 옮기거나, 사람이 화면 앞에 있으면 OP_GET_BIOMETRIC=1로 우회하라." >&2
-              return 1
-            fi
+            echo "Error: op_get SA 경로 실패($_sa_state), biometric은 기본 차단됨 — 무인/원격에서 승인 팝업이 로컬 화면 전용이라 hang(#1041)한다. 항목을 SA 도달 범위(Automation vault)로 옮기거나, 사람이 Mac 화면 앞에 있으면 OP_GET_BIOMETRIC=1 op_get ...으로 실행하라." >&2
+            return 1
           fi
           op read --no-newline --account "${constants.onePassword.account}" "$ref"
         }

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -363,9 +363,9 @@ in
       #   2) Mac SA token(~/.config/op/sa-token-mac, 방식 B #873 재사용)이 읽히면 SA로 op read —
       #      biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation
       #      read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3)으로 넘어간다.
-      #   3) biometric(데스크탑 앱 연동, 새 터미널마다 Touch ID) — 대화형 전용. 비대화형 op read는
-      #      Mac 화면에만 뜨는 승인을 기다리며 무한 hang하므로(#1041) TTY 없으면 시도하지 않고
-      #      명확히 실패한다(fail-fast). 한계: PTY를 받은 자동화는 TTY 판정상 대화형으로 보인다.
+      #   3) biometric(데스크탑 앱 연동, 새 터미널마다 Touch ID) — 대화형 전용. 무인 판정(비TTY ·
+      #      SSH 원격 · 에이전트/CI 하네스 env)이 하나라도 참이면 승인 대기 hang(#1041) 대신
+      #      fail-fast하고, OP_GET_BIOMETRIC=1 명시 opt-in으로만 우회한다(#876 F3 정합).
       # MiniPC는 op CLI 미설치(127 guard) — opnix materialization이 대체(Phase 3).
       #─────────────────────────────────────────────────────────────────────────
       ''
@@ -385,30 +385,43 @@ in
           # password/credential 필드도 값을 그대로 반환 (item get의 기본 redact + --reveal 불필요).
           # --no-newline: 후행 개행 제거 — GH_TOKEN 등 env 주입 시 정확.
           local ref="op://$vault/$name/$field"
-          # 1) 호출자 SA env 우선 (opnix systemd env 등).
+          # 1) 호출자 SA env 우선 (opnix systemd env 등). OP_CONNECT_HOST/TOKEN은 op 공식
+          #    우선순위상 SA token보다 우선하므로 서브셸에서 제거한다 — 이 repo는 Connect 서버
+          #    미도입(PRD #780 NG-1)이라 잔존 Connect env는 항상 오염이며, 제거해야 조회 주체가
+          #    SA임이 보장된다.
           if [ -n "''${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
-            op read --no-newline "$ref"
+            (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; op read --no-newline "$ref")
             return $?
           fi
           # 2) Mac SA token 무인 경로 — gh-pat-mac(#873)과 동일하게 SA token을 op 프로세스 env로만
-          #    전달한다(셸 env 미상주). timeout은 네트워크 지연 방어(coreutils 가용 시에만 — macOS
-          #    기본엔 없음; SA 경로는 앱 연동이 없어 biometric 승인 hang 자체가 구조적으로 없다).
-          local _sa="$HOME/.config/op/sa-token-mac" _rc=1
+          #    전달한다(셸 env 미상주). Connect env 제거는 1)과 동일 근거.
+          # _sa_timeout: 무인 셸 대기 상한 — SaaS 왕복 지연은 흡수하되 hang으로 오인되기 전에
+          #    실패한다(coreutils timeout 가용 시에만 — macOS 기본엔 없음. SA 경로는 앱 연동이
+          #    없어 biometric 승인 대기 자체가 구조적으로 없다).
+          local _sa="$HOME/${constants.onePassword.saTokenMacRelPath}" _sa_state="token-missing" _rc=0 _sa_timeout=20
           if [ -r "$_sa" ]; then
             if command -v timeout >/dev/null 2>&1; then
-              OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" timeout 20 op read --no-newline "$ref"
+              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" timeout "$_sa_timeout" op read --no-newline "$ref")
             else
-              OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref"
+              (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref")
             fi
             _rc=$?
             [ "$_rc" -eq 0 ] && return 0
+            _sa_state="op rc=$_rc"
           fi
-          # 3) biometric 대화형 폴백 — stdin/stderr 모두 TTY가 아니면 무인으로 판정하고 차단한다.
-          #    (stdout 기준은 안 됨 — 대화형 $(op_get ...) 명령 치환도 stdout이 파이프다.)
+          # 3) biometric 대화형 폴백 — 무인 컨텍스트에서는 시도하지 않는다(fail-fast, #1041).
+          #    무인 판정: 비TTY(stdin/stderr 어느 쪽이든), SSH 원격 세션(승인 팝업이 로컬 화면
+          #    전용이라 원격에선 보이지 않음), 알려진 에이전트/CI 하네스 env(PTY가 있어도 무인 —
+          #    gh-auth가 biometric fallback을 제거한 #876 F3과 같은 근거).
+          #    stdout은 판정에 안 쓴다 — 대화형 $(op_get ...) 명령 치환도 stdout이 파이프다.
+          #    사람이 화면 앞에 있는 예외 상황만 OP_GET_BIOMETRIC=1로 명시 우회한다.
           #    --account: 멀티 계정(개인+회사) 환경에서 개인 account 고정 (multiple accounts 에러 방지).
-          if [ ! -t 0 ] && [ ! -t 2 ]; then
-            echo "Error: op_get 비대화형 실패 — SA 경로 불가(sa-token 부재 또는 op rc=$_rc), biometric은 TTY 없이는 승인 대기 hang(#1041)이라 차단. 항목이 SA 도달 범위(Automation vault)에 있는지 확인하거나 대화형 셸에서 실행하라." >&2
-            return 1
+          if [ "''${OP_GET_BIOMETRIC:-}" != "1" ]; then
+            if [ ! -t 0 ] || [ ! -t 2 ] || [ -n "''${SSH_CONNECTION:-}" ] || [ -n "''${CI:-}" ] \
+              || [ -n "''${CLAUDECODE:-}" ] || [ -n "''${CODEX_CI:-}" ] || [ -n "''${CODEX_PROGRAMMATIC:-}" ]; then
+              echo "Error: op_get 무인 컨텍스트 — SA 경로 실패($_sa_state). biometric은 무인에서 승인 대기 hang(#1041)이라 차단한다. 항목을 Automation vault로 옮기거나, 사람이 화면 앞에 있으면 OP_GET_BIOMETRIC=1로 우회하라." >&2
+              return 1
+            fi
           fi
           op read --no-newline --account "${constants.onePassword.account}" "$ref"
         }

--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -355,10 +355,18 @@ in
       ''
 
       #─────────────────────────────────────────────────────────────────────────
-      # 1Password op_get helper (PRD #780)
+      # 1Password op_get helper (PRD #780; 무인 SA 폴백은 #1041/#1094 인접 DX 개선)
       # op_get <name> <field> [<vault>] — vault 기본값은 constants.onePassword.vaults.automation
-      # macOS는 1Password 데스크탑 biometric authorization (새 터미널마다 필요; 10분 inactivity 세션·사용 시 refresh·12시간 hard limit). MiniPC는 OP_SERVICE_ACCOUNT_TOKEN
-      # (opnix가 systemd EnvironmentFile로 주입, Phase 3) 기반.
+      # 해석 순서 (SA-first):
+      #   1) OP_SERVICE_ACCOUNT_TOKEN이 이미 있으면 그대로 op read (SA env가 account를 결정하므로
+      #      --account 미전달 — SA 모드와 --account는 상호 배타).
+      #   2) Mac SA token(~/.config/op/sa-token-mac, 방식 B #873 재사용)이 읽히면 SA로 op read —
+      #      biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation
+      #      read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3)으로 넘어간다.
+      #   3) biometric(데스크탑 앱 연동, 새 터미널마다 Touch ID) — 대화형 전용. 비대화형 op read는
+      #      Mac 화면에만 뜨는 승인을 기다리며 무한 hang하므로(#1041) TTY 없으면 시도하지 않고
+      #      명확히 실패한다(fail-fast). 한계: PTY를 받은 자동화는 TTY 판정상 대화형으로 보인다.
+      # MiniPC는 op CLI 미설치(127 guard) — opnix materialization이 대체(Phase 3).
       #─────────────────────────────────────────────────────────────────────────
       ''
         op_get() {
@@ -375,10 +383,34 @@ in
           fi
           # op read: 1Password 공식 권장 secret reference URI 방식 (단일 필드 값 조회 표준 경로).
           # password/credential 필드도 값을 그대로 반환 (item get의 기본 redact + --reveal 불필요).
-          # --account: op CLI 멀티 계정(개인+회사) 환경에서 개인 account 고정 (multiple accounts 에러 방지).
-          #   MiniPC는 OP_SERVICE_ACCOUNT_TOKEN이 account를 결정하므로 Phase 3에서 호환성 재확인.
           # --no-newline: 후행 개행 제거 — GH_TOKEN 등 env 주입 시 정확.
-          op read --no-newline --account "${constants.onePassword.account}" "op://$vault/$name/$field"
+          local ref="op://$vault/$name/$field"
+          # 1) 호출자 SA env 우선 (opnix systemd env 등).
+          if [ -n "''${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+            op read --no-newline "$ref"
+            return $?
+          fi
+          # 2) Mac SA token 무인 경로 — gh-pat-mac(#873)과 동일하게 SA token을 op 프로세스 env로만
+          #    전달한다(셸 env 미상주). timeout은 네트워크 지연 방어(coreutils 가용 시에만 — macOS
+          #    기본엔 없음; SA 경로는 앱 연동이 없어 biometric 승인 hang 자체가 구조적으로 없다).
+          local _sa="$HOME/.config/op/sa-token-mac" _rc=1
+          if [ -r "$_sa" ]; then
+            if command -v timeout >/dev/null 2>&1; then
+              OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" timeout 20 op read --no-newline "$ref"
+            else
+              OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref"
+            fi
+            _rc=$?
+            [ "$_rc" -eq 0 ] && return 0
+          fi
+          # 3) biometric 대화형 폴백 — stdin/stderr 모두 TTY가 아니면 무인으로 판정하고 차단한다.
+          #    (stdout 기준은 안 됨 — 대화형 $(op_get ...) 명령 치환도 stdout이 파이프다.)
+          #    --account: 멀티 계정(개인+회사) 환경에서 개인 account 고정 (multiple accounts 에러 방지).
+          if [ ! -t 0 ] && [ ! -t 2 ]; then
+            echo "Error: op_get 비대화형 실패 — SA 경로 불가(sa-token 부재 또는 op rc=$_rc), biometric은 TTY 없이는 승인 대기 hang(#1041)이라 차단. 항목이 SA 도달 범위(Automation vault)에 있는지 확인하거나 대화형 셸에서 실행하라." >&2
+            return 1
+          fi
+          op read --no-newline --account "${constants.onePassword.account}" "$ref"
         }
       ''
 

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -653,19 +653,20 @@ let
             && !claudexActivationReferencesRuntime;
         }
         {
-          # op_get 무인 SA 폴백(#1041/#1094 인접 DX) 회귀 핀 — 두 불변식을 잠근다:
-          # (1) SA token 파일 경로가 op_get에 배선되어 있어야 함 (무인 경로 존재).
-          # (2) 비대화형(stdin·stderr 모두 non-TTY)에서 biometric op read를 차단하는 가드가
-          #     존재해야 함 — 이 가드가 사라지면 원격/LLM 셸의 op_get이 승인 대기 hang으로 회귀한다.
-          name = "Test D18 ${hostName}: op_get 무인 SA 폴백 배선 + 비대화형 biometric 차단 가드가 initContent에 있어야 함";
+          # op_get 무인 SA 폴백(#1041/#1094 인접 DX) 회귀 핀 — 구현 형태가 아니라 계약 마커를 잠근다:
+          # (1) SA token 경로 상수(constants.onePassword.saTokenMacRelPath)가 initContent에 배선됨
+          #     (무인 경로 존재 — 경로는 상수와 동일 소스이므로 경로 정책 변경에도 테스트가 따라간다).
+          # (2) biometric opt-in 플래그(OP_GET_BIOMETRIC)가 존재 — 이 마커가 사라지면 무인 컨텍스트
+          #     biometric 차단 가드가 통째로 제거된 것이므로 원격/LLM 셸의 승인 대기 hang 회귀다.
+          name = "Test D18 ${hostName}: op_get 무인 SA 폴백 배선 + biometric opt-in 가드 마커가 initContent에 있어야 함";
           cond =
             hasHost
             && (
               let
                 zshInit = hm.programs.zsh.initContent;
               in
-              nixpkgsLib.hasInfix ".config/op/sa-token-mac" zshInit
-              && nixpkgsLib.hasInfix "[ ! -t 0 ] && [ ! -t 2 ]" zshInit
+              nixpkgsLib.hasInfix constants.onePassword.saTokenMacRelPath zshInit
+              && nixpkgsLib.hasInfix "OP_GET_BIOMETRIC" zshInit
             );
         }
       ]

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -652,6 +652,22 @@ let
             && claudexActivationNames == [ ]
             && !claudexActivationReferencesRuntime;
         }
+        {
+          # op_get 무인 SA 폴백(#1041/#1094 인접 DX) 회귀 핀 — 두 불변식을 잠근다:
+          # (1) SA token 파일 경로가 op_get에 배선되어 있어야 함 (무인 경로 존재).
+          # (2) 비대화형(stdin·stderr 모두 non-TTY)에서 biometric op read를 차단하는 가드가
+          #     존재해야 함 — 이 가드가 사라지면 원격/LLM 셸의 op_get이 승인 대기 hang으로 회귀한다.
+          name = "Test D18 ${hostName}: op_get 무인 SA 폴백 배선 + 비대화형 biometric 차단 가드가 initContent에 있어야 함";
+          cond =
+            hasHost
+            && (
+              let
+                zshInit = hm.programs.zsh.initContent;
+              in
+              nixpkgsLib.hasInfix ".config/op/sa-token-mac" zshInit
+              && nixpkgsLib.hasInfix "[ ! -t 0 ] && [ ! -t 2 ]" zshInit
+            );
+        }
       ]
     ) expectedDarwinHosts
   );


### PR DESCRIPTION
## Summary

- `op_get`(1Password 시크릿 조회 헬퍼)에 **SA-first 무인 폴백**을 추가해, LLM·비대화형·원격 셸에서 biometric 승인 팝업(Mac 로컬 화면 전용)을 기다리며 무한 hang하던 DX 문제를 제거한다.
- biometric 폴백을 **기본 차단(positive-gate)** 으로 두고, 사람이 Mac 화면 앞에 있을 때만 켜는 `OP_GET_BIOMETRIC=1` opt-in에서만 허용한다.
- SA 경로의 Connect env 오염 차단·토큰 프로세스 스코프 한정을 `op_get`과 기존 `gh-pat-mac`에 일관 적용한다.

## 기존 문제 / 배경

`op_get`은 지금까지 Mac에서 항상 1Password 데스크탑 biometric(Touch ID) 경로로만 시크릿을 읽었다. 이 승인 팝업은 **Mac 로컬 화면에만** 뜨기 때문에, 다음 상황에서 세션이 무한 대기한다:

- 외출 중 휴대폰에서 원격으로 LLM(Claude/Codex) 세션을 돌릴 때 `op_get`을 호출하면, 승인 팝업이 사용자가 볼 수 없는 Mac 화면에 떠서 세션이 진행 불가 상태가 된다.
- 비대화형 자동화가 `op_get`을 부를 때마다 Touch ID를 요구해, 무인 파이프가 멈춘다.

이 저장소는 이미 gh 무인 인증에서 같은 문제를 **Service Account token 경로**로 해결한 선례(방식 B)를 갖고 있다. SA token은 1Password SaaS에 직접 인증하므로 데스크탑 앱·잠금·원격 여부와 무관하다. 이 PR은 그 검증된 패턴을 범용 `op_get`으로 일반화한다. 관련 미결 이슈 `#1041`(op read 비대화형 hang 함정)의 근본 상환에 해당한다.

## CIR (Change Intent Record)

**발견 경위**: 원격 세션에서 1Password 시크릿 참조 시 승인 팝업 hang을 겪는다는 사용자 요구에서 출발했다. 조사 결과 hang의 원인이 되는 "권한 팝업"은 실제로 두 개의 서로 다른 게이트 — ① `op read` biometric, ② SSH agent 서명 승인 — 임을 확인했고, 이 PR은 그중 ①만 다룬다(②는 별도 트랙 `#1094`/plan 029).

**설계 의도**: "팝업을 끄기"가 아니라 "팝업이 필요 없는 좁은 신원(SA token)을 우선 사용"하는 방향을 택했다. SA의 도달 범위는 Automation vault read-only로 이미 고정되어 있어(`#874`에서 확립한 blast radius 불변식), LLM이 프롬프트 없이 읽어야 할 시크릿을 Automation vault에 두면 자동으로 무인 경로를 탄다. Personal·SSH vault는 SA가 닿지 못하는 것이 버그가 아니라 방어선이므로, 그 경계를 넓히지 않는다.

**해석 순서(SA-first)**:
1. 호출자가 이미 `OP_SERVICE_ACCOUNT_TOKEN`을 갖고 있으면 그대로 사용.
2. Mac SA token 파일(방식 B에서 배포 중인 자산 재사용)이 읽히면 SA로 조회 — biometric 0회.
3. 그래도 실패하면 biometric은 **기본 차단**하고 `OP_GET_BIOMETRIC=1` opt-in에서만 허용.

**대안 검토 및 방향 전환**:
- biometric 무인 차단의 초기 구현은 "무인 하네스 env denylist(비TTY·SSH·CI·에이전트 env)"였으나, 이는 표식 없이 PTY를 물고 도는 자동화를 잡지 못한다. 과거 gh 무인 인증에서 바로 이 이유로 biometric fallback을 통째로 제거한 선례가 있어(`#876`), 같은 원칙에 맞춰 **positive-gate(기본 차단 + 명시 opt-in)** 로 뒤집었다. denylist 신호는 판정 게이트가 아니라 진단 문구로만 남긴다.
- SA 경로는 `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`을 서브셸에서 제거하고 실행한다. op 공식 우선순위상 Connect env가 SA token보다 우선하는데, 이 저장소는 1Password Connect 서버를 도입하지 않으므로(PRD `#780` NG-1) 잔존 Connect env는 항상 오염이다. 같은 계약을 기존 `gh-pat-mac`에도 적용해 두 SA 소비자를 일치시켰다.
- SA token은 `env`를 op 바로 앞에 두어 op 프로세스에만 상속시킨다. `timeout`을 쓸 때도 `timeout … env … op` 순서라 timeout 프로세스에는 토큰이 주입되지 않는다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| biometric 팝업 자체를 끄기 / 승인 무제한 기억 | 1Password 앱 설정에서 승인 요구를 완화 | 코드 변경 없음 | 잠금·재부팅 후 무효(외출 중 기본 상태), 보안 경계 전면 약화, 선언적 관리 밖 | ❌ |
| SA-first 무인 폴백 (op_get 일반화) | 방식 B의 SA token 경로를 op_get으로 확장 | biometric 0회, 잠금·원격 무관, 기존 자산 재사용, blast radius 불변 | vault 라우팅 이해 필요(Automation 한정) | ✅ |
| biometric 무인 차단: env denylist | 알려진 무인 하네스 env를 나열해 차단 | 구현 단순 | 표식 없는 PTY 자동화를 못 잡음(`#876`이 밟은 지뢰) | ❌ |
| biometric 무인 차단: positive-gate | 기본 차단 + `OP_GET_BIOMETRIC=1` opt-in | 안전한 경로만 여는 구조, PTY 자동화도 안전 | 사람이 화면 앞일 때 플래그 필요 | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/shell/default.nix` | `op_get`을 SA-first 3단계 해석으로 재작성. Connect env 서브셸 제거, biometric positive-gate, `env`로 토큰을 op 프로세스에 한정 |
| `modules/shared/programs/shell/darwin.nix` | `gh-pat-mac`의 SA 조회에도 동일 Connect env 제거 적용 (계약 일치) |
| `libraries/constants.nix` | `onePassword.saTokenMacRelPath` 신설 — SA token 경로 단일 소스 |
| `modules/shared/programs/secrets/default.nix` | SA token 배포 경로를 위 상수로 조립 (literal 분산 제거) |
| `tests/eval-tests.nix` | Test D18 신설 — SA 경로 상수 배선 + `OP_GET_BIOMETRIC` opt-in 마커를 계약 기준으로 회귀 핀 |
| `.claude/skills/managing-secrets/references/1password.md` | op_get 해석 순서·Connect env 계약·biometric positive-gate 문서화 |

핵심 해석 순서:

```zsh
op_get() {
  # ...
  local ref="op://$vault/$name/$field"
  # 1) 호출자 SA env 우선 (Connect env는 op 우선순위상 SA보다 우선 → 제거)
  if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
    (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; op read --no-newline "$ref"); return $?
  fi
  # 2) Mac SA token 무인 경로 — env를 op 앞에 두어 timeout 프로세스엔 토큰 미주입
  local _sa="$HOME/${saTokenMacRelPath}" _sa_state="token-missing" _rc=0 _sa_timeout=20
  if [ -r "$_sa" ]; then
    (unset OP_CONNECT_HOST OP_CONNECT_TOKEN; timeout "$_sa_timeout" env OP_SERVICE_ACCOUNT_TOKEN="$(cat "$_sa")" op read --no-newline "$ref")
    _rc=$?; [ "$_rc" -eq 0 ] && return 0; _sa_state="op rc=$_rc"
  fi
  # 3) biometric 기본 차단(positive-gate) — 사람이 화면 앞일 때만 opt-in
  if [ "${OP_GET_BIOMETRIC:-}" != "1" ]; then
    echo "Error: op_get SA 경로 실패($_sa_state), biometric 기본 차단 …" >&2; return 1
  fi
  op read --no-newline --account "${account}" "$ref"
}
```

## 참고 레퍼런스

- `#1041` — op read 비대화형 hang 등 1Password 함정 문서화 이슈 (이 PR이 근본 상환)
- `#1094` / plan 029 — SSH agent 승인 hang (별도 게이트, 이 PR scope 밖)
- `#873` — 방식 B(Mac SA token → github-pat 무인 발급). 이 PR이 재사용하는 SA token 경로의 원천
- `#876` — gh-auth biometric fallback 제거. positive-gate 결정의 선례
- `#874` — SA blast radius = Automation vault read-only 불변식
- PRD `#780` NG-1 — 1Password Connect 서버 미도입 결정
- [op 공식: Connect env가 SA token보다 우선](https://www.1password.dev/service-accounts/use-with-1password-cli)

## Human Test Plan

전제: `nrs`로 배포 후 새 셸 세션.

1. **무인 원격 시나리오 (핵심)**: 외출 상태를 흉내 내 1Password 데스크탑을 잠근 채, 원격/비대화형 셸에서 Automation vault 항목을 `op_get <name> <field>`로 조회.
   - 기대: biometric 팝업 없이 값이 즉시 반환된다(SA 경로). 이전에는 팝업 대기로 hang했다.
2. **SA 도달 범위 밖**: Personal 또는 SSH vault 항목을 무인 셸에서 `op_get <name> <field> Personal`로 조회.
   - 기대: SA 권한 오류 후 `Error: op_get SA 경로 실패 …, biometric 기본 차단` 메시지로 **즉시 실패**(hang 없음). 메시지가 "Automation vault로 옮기거나 OP_GET_BIOMETRIC=1로 실행하라"를 안내한다.
3. **사람이 화면 앞 예외**: Mac 로컬 대화형 터미널에서 `OP_GET_BIOMETRIC=1 op_get <personal-item> <field> Personal`.
   - 기대: biometric 팝업이 뜨고 Touch ID 승인 후 값 반환.
4. **기존 gh 무인 인증 회귀 없음**: 새 셸에서 `gh api user`가 `greenheadHQ`를 반환.
   - 기대: `gh-pat-mac` 경로 정상(Connect env 제거가 회귀를 만들지 않음).
5. **회귀 게이트**: `bash tests/run-eval-tests.sh`가 전부 통과 (Test D18 포함).

실패 시 진단: (1)이 여전히 hang하면 `~/.config/op/sa-token-mac` 배포 여부(`ls -l`)와 SA token 만료(`secrets/opnix-service-account-expiry-mac.txt`)를 확인한다. (2)가 hang하면 positive-gate가 배포 안 된 것이므로 `nrs` 재실행 후 새 셸. (4)가 실패하면 `gh-pat-mac`의 Connect env 제거가 원인인지 `OP_CONNECT_HOST` 환경 잔존을 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 1Password 조회가 서비스 계정 토큰을 우선 사용하도록 개선되었습니다.
  * macOS에서 무인 환경의 비밀값 조회와 자동 대체 경로를 지원합니다.
  * 생체 인증은 기본 차단되며, 필요할 때만 선택적으로 활성화할 수 있습니다.
  * Connect 설정과의 충돌을 방지해 올바른 인증 경로를 사용합니다.

* **문서**
  * 1Password 인증 우선순위, 토큰 재사용 및 생체 인증 정책을 상세히 안내합니다.

* **버그 수정**
  * macOS 비밀값 및 GitHub 인증 토큰 경로 처리를 일관되게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->