### PR TITLE
feat(ssh): 무인 세션의 minipc SSH outer deadline — 원격 1Password 승인 hang 제거

### DIFF
--- a/.claude/skills/managing-secrets/references/1password.md
+++ b/.claude/skills/managing-secrets/references/1password.md
@@ -74,7 +74,7 @@ SSOT: `modules/shared/programs/shell/darwin.nix`.
 
 1. `OP_SERVICE_ACCOUNT_TOKEN` env가 이미 있으면 그대로 `op read` (SA env가 account를 결정 — `--account` 미전달).
 2. Mac SA token(`~/.config/op/sa-token-mac`, 방식 B #873 재사용)이 읽히면 SA로 `op read` — biometric 0회, 데스크탑 앱·잠금·원격 여부 무관(SaaS 직행). SA 도달 범위(Automation read-only) 밖 vault(Personal/SSH)는 권한 오류로 즉시 실패하고 3단계로 넘어간다. LLM이 프롬프트 없이 읽어야 할 시크릿은 Automation vault에 두면 이 경로를 탄다.
-3. biometric(데스크탑 앱 연동) — **기본 차단(positive-gate)**. SA 경로 실패 시 시도 없이 fail-fast한다 — `op read`의 승인 팝업은 Mac 로컬 화면에만 떠서 무인·원격 컨텍스트에서 진입하면 무한 hang하기 때문(#1041). TTY denylist로는 표식 없는 PTY 자동화를 못 잡으므로(gh-auth가 같은 이유로 biometric fallback을 제거한 #876 F3 선례), 사람이 Mac 화면 앞에 있을 때만 켜는 `OP_GET_BIOMETRIC=1 op_get ...` opt-in에서만 biometric을 허용한다.
+3. biometric(데스크탑 앱 연동) — 기본 차단(positive-gate). SA 경로 실패 시 시도 없이 fail-fast한다 — `op read`의 승인 팝업은 Mac 로컬 화면에만 떠서 무인·원격 컨텍스트에서 진입하면 무한 hang하기 때문(#1041). TTY denylist로는 표식 없는 PTY 자동화를 못 잡으므로(gh-auth가 같은 이유로 biometric fallback을 제거한 #876 F3 선례), 사람이 Mac 화면 앞에 있을 때만 켜는 `OP_GET_BIOMETRIC=1 op_get ...` opt-in에서만 biometric을 허용한다.
 
 SA 경로(1·2단계)는 서브셸에서 `OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`을 제거하고 SA token은 `env`로 감싼 단일 command subtree에만 주입한다 — Connect env가 SA token보다 우선하는 op 공식 우선순위 때문이며, 이 repo는 Connect 서버 미도입(NG-1)이라 잔존 Connect env는 항상 오염이다. 같은 계약을 `gh-pat-mac`(darwin.nix)도 공유한다. 경로 단일 소스는 `constants.onePassword.saTokenMacRelPath`.
 

--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -159,8 +159,9 @@ in
     # 1Password가 미실행/잠금이면 agent가 mac-ssh를 못 줘 ssh가 구 키로 폴백→Permission denied가
     # 난다. 그 순간 원인·복구를 안내하고 1Password를 자동 기동한 뒤 agent 복구를 짧게 대기한다.
     # 평시엔 launchd 자동 기동(modules/darwin/programs/ssh)이 socket을 살려두므로 이 경로는
-    # 수동 quit/크래시 등 잔여 케이스 전용이다. interactive 셸 전용(non-interactive 자동화는
-    # 이 맥락을 아는 호출자가 쓰고, GUI open 팝업이 부적절하므로 raw ssh로 통과).
+    # 수동 quit/크래시 등 잔여 케이스 전용이다. 대화형은 앱 기동 + Touch ID 잠금해제 대기를,
+    # 무인(원격/LLM)은 앱 대기를 건너뛰고 서명에 outer deadline을 걸어 세션 무한 hang을 막는다
+    # (#1094 — 승인 UI가 Mac 로컬 화면 전용이라 원격에선 보이지 않는 대기가 된다).
     # personal 전용 — minipc matchBlock/launchd와 스코프 일치(work Mac은 Tailnet 미소속이라 무관).
     # 대상 판정은 전부 `ssh -G "$@"`에 위임한다 — 수동 옵션 파싱은 ssh의 방대한 옵션 공간(메타모드·
     # user@host·-W·포트·alias·remote command)을 못 따라가 미탐·오탐이 난다. ssh -G는 -O/-W/-G 등과도
@@ -186,8 +187,24 @@ in
           if [[ -n "$_cpath" && "$_cpath" != none ]] && command ssh -O check -S "$_cpath" "${minipcHostIP}" 2>/dev/null; then
             _master_active=1
           fi
+          # 무인 컨텍스트 판정(#1094 — 원격/LLM 세션의 1Password 승인 hang 제거).
+          # 1Password SSH agent의 승인·잠금해제 UI는 Mac 로컬 화면에만 뜨므로, 사람이 화면 앞에
+          # 없는 원격/무인 세션에서는 그 대기가 보이지 않는 무한 hang이 된다. op_get의 무인 판정과
+          # 같은 신호(비TTY·SSH 원격·에이전트/CI 하네스 env)를 쓴다 — 대화형 Ghostty는 _headless=0.
+          local _headless=0
+          if [ ! -t 0 ] || [ ! -t 2 ] || [ -n "''${SSH_CONNECTION:-}" ] || [ -n "''${CI:-}" ] \
+            || [ -n "''${CLAUDECODE:-}" ] || [ -n "''${CODEX_CI:-}" ] || [ -n "''${CODEX_PROGRAMMATIC:-}" ]; then
+            _headless=1
+          fi
           if (( ! _master_active )) \
             && ! SSH_AUTH_SOCK="$_sock" ssh-add -L 2>/dev/null | grep -qF "$_b64"; then
+            if (( _headless )); then
+              # 무인: Touch ID 잠금해제가 불가하므로 앱 기동·대기가 무의미하다. 즉시 bounded 실패.
+              print -u2 "✗ ssh minipc 차단(무인): 1Password SSH agent에 mac-ssh 키가 없습니다 — 데스크탑 미실행/잠금 추정."
+              print -u2 "   무인 세션은 Touch ID 잠금해제가 불가하므로 대기 없이 종료합니다."
+              print -u2 "   대안: Mac에서 1Password 잠금해제 후 재시도, 또는 무인 전용 경로(준비 시 minipc-headless) 사용."
+              return 1
+            fi
             # Touch ID 잠금 해제 대기 상한(초) — interactive shell을 오래 막지 않도록. tries = timeout / interval.
             local _poll_interval=0.5 _timeout_seconds=15
             local _max_tries=$(( _timeout_seconds / _poll_interval ))
@@ -220,6 +237,24 @@ in
           # 여기 걸리지 않는다. master 재사용(_master_active) 경로는 서명이 없어 제외한다.
           if (( ! _master_active )); then
             local _rc
+            if (( _headless )) && command -v timeout >/dev/null 2>&1; then
+              # 무인 outer deadline(#1094) — 서명 승인 팝업이 로컬 화면 전용이라 원격/무인에선
+              # 무한 대기가 된다. 상한을 걸어 세션이 bounded time 안에 복귀하게 한다. 이 값은
+              # 인증 정책과 독립된 불변식이다(어떤 인증안을 택해도 유지). 대화형 경로엔 적용하지
+              # 않는다(사람이 Touch ID로 승인 가능). timeout 부재 시 degraded(기존 동작).
+              local _ssh_deadline=20
+              timeout "$_ssh_deadline" command ssh "$@"
+              _rc=$?
+              if (( _rc == 124 )); then
+                print -u2 "✗ ssh minipc 시간 초과(''${_ssh_deadline}s, 무인) — 1Password SSH 서명 승인 대기 가능성(승인 UI는 Mac 로컬 화면에만 표시)."
+                print -u2 "   Mac에서 1Password 잠금해제/승인 후 재시도, 또는 무인 전용 경로(준비 시 minipc-headless) 사용."
+              elif (( _rc == 255 )); then
+                print -u2 "✗ ssh minipc 실패(exit 255 — 원인은 위 stderr 참조)."
+                print -u2 "   1Password SSH agent 서명 실패라면: Mac에서 1Password 완전 재시작 후 재시도."
+                print -u2 "   그래도 안 되면(서버측 키 문제 등): ssh ${emergencyHost}  (passphrase 직접 입력)."
+              fi
+              return $_rc
+            fi
             command ssh "$@"
             _rc=$?
             if (( _rc == 255 )); then

--- a/modules/shared/programs/shell/darwin.nix
+++ b/modules/shared/programs/shell/darwin.nix
@@ -242,8 +242,12 @@ in
               # 무한 대기가 된다. 상한을 걸어 세션이 bounded time 안에 복귀하게 한다. 이 값은
               # 인증 정책과 독립된 불변식이다(어떤 인증안을 택해도 유지). 대화형 경로엔 적용하지
               # 않는다(사람이 Touch ID로 승인 가능). timeout 부재 시 degraded(기존 동작).
+              # command 토큰 없이 ssh를 직접 준다 — timeout은 외부 프로세스라 execvp로 PATH의
+              # ssh 바이너리를 찾으며 zsh 함수 재귀가 발생하지 않는다(비-timeout 경로의 `command
+              # ssh`는 함수 재귀 회피용이지만 여기선 불필요). `timeout … command ssh`는 macOS에서
+              # /usr/bin/command 실행파일에 우연히 의존해 동작할 뿐이라 이식성이 취약하다.
               local _ssh_deadline=20
-              timeout "$_ssh_deadline" command ssh "$@"
+              timeout "$_ssh_deadline" ssh "$@"
               _rc=$?
               if (( _rc == 124 )); then
                 print -u2 "✗ ssh minipc 시간 초과(''${_ssh_deadline}s, 무인) — 1Password SSH 서명 승인 대기 가능성(승인 UI는 Mac 로컬 화면에만 표시)."

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -669,6 +669,27 @@ let
               && nixpkgsLib.hasInfix "OP_GET_BIOMETRIC" zshInit
             );
         }
+        {
+          # ssh() 무인 outer deadline(#1094) 회귀 핀 — 계약 마커를 잠근다:
+          # (1) 무인 판정에 _headless 신호가 존재 (대화형/무인 분기),
+          # (2) 서명 요청에 timeout 기반 outer deadline이 존재 — 이 마커가 사라지면 원격/무인
+          #     세션의 ssh minipc가 1Password 서명 승인 대기로 무한 hang하는 회귀다.
+          # personal 호스트에서만 ssh() preflight가 정의되므로 hostType 조건과 정합한다.
+          name = "Test D19 ${hostName}: ssh() 무인 outer deadline 마커(_headless + timeout)가 initContent에 있어야 함";
+          cond =
+            hasHost
+            && (
+              let
+                zshInit = hm.programs.zsh.initContent;
+              in
+              # work 호스트(ssh preflight 미정의)는 마커 부재가 정상 — personal에서만 강제.
+              if nixpkgsLib.hasInfix "ssh minipc preflight" zshInit then
+                nixpkgsLib.hasInfix "_headless" zshInit
+                && nixpkgsLib.hasInfix "timeout \"$_ssh_deadline\"" zshInit
+              else
+                true
+            );
+        }
       ]
     ) expectedDarwinHosts
   );

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -684,8 +684,7 @@ let
               in
               # work 호스트(ssh preflight 미정의)는 마커 부재가 정상 — personal에서만 강제.
               if nixpkgsLib.hasInfix "ssh minipc preflight" zshInit then
-                nixpkgsLib.hasInfix "_headless" zshInit
-                && nixpkgsLib.hasInfix "timeout \"$_ssh_deadline\"" zshInit
+                nixpkgsLib.hasInfix "_headless" zshInit && nixpkgsLib.hasInfix "timeout \"$_ssh_deadline\"" zshInit
               else
                 true
             );


### PR DESCRIPTION
## Summary

- 원격/LLM 세션의 `ssh minipc`가 1Password SSH agent 서명 승인을 40초+ 기다리며 무한 hang하던 문제(#1094)를 제거한다.
- 기존 `ssh()` preflight 함수에 **무인 판정 + outer deadline**을 추가 — 대화형(사람) 경로는 완전히 기존 동작을 보존하고, 무인일 때만 앱 대기 스킵 + 서명 20초 데드라인을 적용한다.
- 이 저장소의 검증된 runtime binding(shell snapshot이 `ssh()` 함수를 캡처 — op_get·gh와 동일)을 재사용하므로 별도 wrapper·PATH shim이 필요 없다.

## 기존 문제 / 배경

Mac SSH 인증을 1Password SSH agent로 이관한 뒤(Phase 2a), `ssh minipc`의 서명 승인·잠금해제 UI는 **Mac 로컬 화면에만** 뜬다. 사용자가 외출 중 휴대폰에서 원격으로 LLM(Claude/Codex) 세션을 돌리며 `ssh minipc`를 호출하면, 그 승인 팝업이 볼 수 없는 Mac 화면에 떠서 세션이 40초+ 무한 대기한다. `BatchMode`/`ConnectTimeout`은 이 서명 대기 구간을 제한하지 못한다(plan 029 실측).

이 저장소는 이미 op_get·gh 무인 인증에서 "shell snapshot이 함수를 캡처해 LLM Bash 셸까지 커버한다"는 runtime binding을 확립했다. 이번 실측에서 LLM 셸의 `ssh minipc`도 이미 `ssh()` 함수를 거침을 확인했으므로(스냅샷 캡처), 그 함수에 데드라인을 넣는 것이 정확한 해법이다.

## CIR (Change Intent Record)

**발견 경위**: 원격 세션에서 1Password 승인 hang을 겪는다는 사용자 요구. hang의 두 게이트 중 SSH agent 서명 게이트(#1094)를 다룬다(op read 게이트는 별도 PR #1134에서 해결).

**설계 의도 및 대안 검토**:
- plan 029 Step 5는 "단순 zsh 함수는 실제 child ssh에 도달 못 하므로 인정 안 함, runtime binding 증명 필수"를 STOP 조건으로 둔다. 실측으로 **이 저장소에서는 shell snapshot 캡처가 그 binding**임을 확인했다(LLM Bash 셸의 `ssh`가 `ssh()` 함수로 해석됨 — op_get/gh와 같은 메커니즘). 따라서 별도 `ssh-headless` 스크립트·PATH shim(추가 복잡도·대화형 회귀 위험)을 만들지 않고 기존 함수를 확장했다.
- 무인 판정은 op_get의 무인 폴백과 **동일 신호**(비TTY·SSH 원격·에이전트/CI 하네스 env)를 써서 두 경로의 정의를 일치시켰다. 대화형 Ghostty는 `_headless=0`이라 기존 동작이 완전히 보존된다.
- deadline은 인증 정책과 **독립된 불변식**(plan 029 D — 어떤 인증안을 택해도 항상 적용). 이 PR은 D만 담고, 완전 무인 접속(1Password를 우회하는 전용 키, plan 029 C)은 사용자 키 생성이 선행되어야 하므로 후속 단계로 분리했다.

**scope 경계(회귀 방지)**:
- minipc + 1Password socket 대상일 때만 개입한다(GitHub·일반 SSH·장기 작업은 이 분기 밖 → 짧은 timeout에 잘리지 않음).
- ControlMaster 활성 경로는 서명이 불필요하므로 데드라인 미적용(worker pool 재사용 보존, #710).
- emergency(`IdentityAgent none`)·대화형은 영향 없음.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 별도 `ssh-headless` 스크립트 + PATH shim | 새 wrapper를 PATH 최우선에 두어 ssh 가로채기 | 명시적 | 모든 ssh 가로챔(대화형·GitHub·장기 작업 회귀 위험), 추가 복잡도, 여러 launcher에 shim 배선 | ❌ |
| 기존 `ssh()` 함수에 무인 데드라인 | snapshot이 이미 캡처하는 함수를 확장 | binding 이미 확립, minipc scope만 개입, 대화형 완전 보존 | personal hostType 한정(work Mac은 Tailnet 밖이라 무관) | ✅ |
| 1Password 승인 무제한 기억 | 앱 설정으로 승인 완화 | 코드 없음 | 잠금·재부팅 후 무효(외출 중 기본 상태), 보안 약화 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/shell/darwin.nix` | `ssh()` preflight에 무인 판정(`_headless`) 추가. 무인+앱/키 부재 시 대기 스킵·즉시 실패, 무인+서명 시 `timeout 20` outer deadline + exit 124 진단 |
| `tests/eval-tests.nix` | Test D19 신설 — `_headless` + `timeout` 마커를 계약 기준으로 회귀 핀 |

핵심 로직:

```zsh
# 무인 판정 (op_get과 동일 신호)
local _headless=0
if [ ! -t 0 ] || [ ! -t 2 ] || [ -n "${SSH_CONNECTION:-}" ] || [ -n "${CI:-}" ] \
  || [ -n "${CLAUDECODE:-}" ] || [ -n "${CODEX_CI:-}" ] || [ -n "${CODEX_PROGRAMMATIC:-}" ]; then
  _headless=1
fi
# ... 서명 요청 ...
if (( _headless )) && command -v timeout >/dev/null 2>&1; then
  local _ssh_deadline=20
  timeout "$_ssh_deadline" command ssh "$@"
  _rc=$?
  if (( _rc == 124 )); then
    print -u2 "✗ ssh minipc 시간 초과(20s, 무인) — 1Password SSH 서명 승인 대기 가능성 …"
  fi
  ...
fi
```

## 참고 레퍼런스

- `#1094` / plan 029 — 원격 SSH 승인 hang을 DX 우선 정책으로 제거 (이 PR이 D 항목 구현)
- `#1134` — op_get 무인 SA 폴백 (같은 "1Password 승인 hang"의 op read 게이트, 별도 해결)
- `#876` — op_get·gh가 shell snapshot 캡처로 non-interactive 셸을 커버하는 선례 (D의 runtime binding 근거)
- `#710` — ControlMaster worker pool (데드라인이 master 재사용을 깨지 않아야 하는 근거)

## Human Test Plan

전제: `nrs`로 배포 후 **새 Claude Code/Codex 세션** 또는 새 셸(shell snapshot 갱신 필요).

1. **무인 원격 시나리오 (핵심)**: 1Password 데스크탑을 잠근(또는 종료한) 상태로, 원격/LLM 세션에서 `ssh minipc echo ok`.
   - 기대: 40초+ hang 대신 **20초 내에** "✗ ssh minipc 시간 초과(20s, 무인) — 1Password SSH 서명 승인 대기 가능성" 진단 후 종료(exit 124). 이전에는 무한 대기했다.
2. **대화형 회귀 없음 (중요)**: Mac 로컬 Ghostty 대화형 터미널에서 `ssh minipc`.
   - 기대: 기존과 동일하게 동작 — 1Password가 잠겨 있으면 Touch ID 팝업으로 승인, 정상 접속. 데드라인 미적용(장기 세션·긴 원격 명령이 20초에 잘리지 않음).
3. **장기 SSH 작업 회귀 없음**: 대화형에서 `ssh minipc 'sleep 60; echo done'`.
   - 기대: 60초 후 `done` 정상 출력(대화형은 데드라인 없음).
4. **회귀 게이트**: `bash tests/run-eval-tests.sh` 전부 통과(Test D19 포함).

실패 시 진단: (1)이 여전히 hang하면 shell snapshot이 갱신 안 된 것 → 완전히 새 세션에서 재시도. (2)가 팝업 없이 실패하면 대화형인데 `_headless=1`로 오판된 것이므로 `[ -t 0 ]`/`[ -t 2 ]` 상태와 `SSH_CONNECTION` env를 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * macOS Zsh에서 무인(비TTY/원격/CI 등) `ssh minipc` 흐름이 불필요하게 대기하지 않고 즉시 실패하도록 개선했습니다.
  * 무인 환경에서 외부 데드라인을 적용해 시간초과와 일반 실패를 구분한 메시지를 제공하도록 변경했습니다.
  * 대화형과 무인 세션에서 Touch ID 승인 대기 동작 차이를 더 명확히 했습니다.
* **테스트**
  * `ssh minipc preflight` 마커 및 무인 환경의 시간 제한 적용 여부를 호스트별로 검증합니다.
* **문서**
  * 1Password `op_get`의 SA/무인 폴백 및 biometric 사용 조건 문구를 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->