### PR TITLE
feat(claudex): miniPC(NixOS) 확장 — linux pin·flock 통일·XDG state

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -3,7 +3,7 @@
 ## TL;DR
 
 - **상황**: Claude Code 요청을 로컬 CLIProxyAPI를 통해 Codex OAuth 모델로 보내는 선언형 Stage 1 PoC가 실제 Gate B를 통과했다.
-- **현재 상태**: 두 Darwin 호스트를 허용하는 descriptor schema 2가 적용됐고, device OAuth → pinned foreground proxy → `claudex` headless completion → clean shutdown을 실측했다. Gate B 뒤 `run-da for_pr` 1·2·3라운드의 확정 finding을 모두 반영했으며 현재 변경셋은 required-CI 통합 러너, `nrs`, AI compatibility, hostile settings/host-auth E2E를 통과했다. R4 수렴 판정과 Standards/Spec pre-commit review도 merge-blocker 없이 끝났다.
+- **현재 상태**: 두 Darwin 호스트와 NixOS 호스트(`greenhead-minipc`)를 허용하는 descriptor schema 2가 적용됐고, device OAuth → pinned foreground proxy → `claudex` headless completion → clean shutdown을 실측했다. Gate B 뒤 `run-da for_pr` 1·2·3라운드의 확정 finding을 모두 반영했으며 현재 변경셋은 required-CI 통합 러너, `nrs`, AI compatibility, hostile settings/host-auth E2E를 통과했다. R4 수렴 판정과 Standards/Spec pre-commit review도 merge-blocker 없이 끝났다.
 - **다음 액션**: 수정 배치를 커밋하고, remote branch 갱신 여부를 결정한다.
 - **Blockers**: Stage 1 Gate B blocker는 없다. launchd/activation을 추가하는 Stage 2는 별도 사용자 승인 전까지 범위 밖이다.
 
@@ -74,13 +74,13 @@ git status --short --branch
   - Darwin Home Manager에 `../shared/programs/claudex`를 import한다.
 - `modules/shared/programs/claudex/default.nix`
   - 호스트 enable gate, state 경로, loopback 주소, 포트, 모델, runtime package, descriptor를 선언한다.
-  - 모든 Darwin 호스트에는 descriptor와 runtime library가 생긴다.
+  - 모듈을 import한 모든 호스트(darwin·nixos)에는 대상 여부와 무관하게 descriptor와 runtime library가 생긴다.
   - enable된 호스트에만 `claudex`, `claudex-login`, `claudex-status`, proxy launcher가 노출된다.
   - Stage 1에는 launchd와 activation이 의도적으로 없다.
 - `modules/shared/programs/claudex/package.nix`
   - CLIProxyAPI prebuilt archive를 고정하고 release layout을 검증한 뒤 바이너리 하나만 설치한다.
 - `modules/shared/programs/claudex/cli-proxy-api-pin.json`
-  - 버전 `7.2.73`, Darwin arm64 asset, SRI를 고정한다.
+  - 버전 `7.2.73`과 플랫폼별 asset(darwin arm64 / linux amd64) SRI를 고정한다. linux prebuilt는 glibc 동적 링크에 FHS interpreter를 달고 오므로 `autoPatchelfHook`으로 interpreter를 nix store로 재작성해야 실행되고, darwin은 Mach-O 서명 보존을 위해 `dontPatchELF`를 유지한다 (의도된 플랫폼 비대칭이며 eval 테스트가 잠근다).
 - `modules/shared/programs/claudex/files/verify-release-layout.sh`
   - archive 최상위 5개 항목의 이름과 type을 정확히 검증한다.
 
@@ -127,17 +127,18 @@ git status --short --branch
 
 | 항목 | 값 |
 |---|---|
-| Proxy | CLIProxyAPI `7.2.73`, Darwin arm64 |
+| Proxy | CLIProxyAPI `7.2.73` — darwin arm64 / linux amd64 (플랫폼별 asset·SRI pin) |
 | Bind | `127.0.0.1:8317` |
 | 모델 (default main / subagent) | `gpt-5.6-sol` / `gpt-5.6-sol` |
 | 모델 (mixed main) | `claude-opus-4-8` (`claudex --mixed`; descriptor `.model`은 default main alias; 재조정 트리거 #1130) |
-| Runtime state | `$HOME/Library/Application Support/claudex` |
+| Runtime state | darwin: `$HOME/Library/Application Support/claudex` · linux: `$HOME/.local/state/claudex` (XDG) |
 | Descriptor | `$HOME/.config/claudex/runtime.json`, schema `2` |
-| Enabled hosts | `greenhead-MacBookPro`, `work-MacBookPro` |
+| Enabled hosts | `greenhead-MacBookPro`, `work-MacBookPro`, `greenhead-minipc` |
 | Claude 실행 파일 | `$HOME/.local/bin/claude` |
 | Service label | `org.nix-community.home.claudex-proxy` |
 | Context window override | `CLAUDE_CODE_MAX_CONTEXT_TOKENS=258000` + `CLAUDE_CODE_AUTO_COMPACT_WINDOW=258000` (wrapper-owned; upstream 임시 하향 추종, 단일 상수 공유). mixed에서는 AUTO_COMPACT_WINDOW 미발행 |
-| Stage 1 service | 없음; foreground launcher만 존재 |
+| Stage 1 service | 없음; foreground launcher만 존재. status의 `service` 필드는 darwin에서 launchd 조회 결과(`missing`), linux에서 `n/a` |
+| 상태 잠금 | `flock` fd 모드(`-x -w`) — darwin은 nixpkgs `flock`(discoteq), linux는 `util-linux`. 양 플랫폼 단일 코드 경로 |
 
 보안·정합성 불변식:
 
@@ -170,7 +171,7 @@ git status --short --branch
 ### 알려진 한계·리스크와 롤백
 
 - **벤더 정책 의존 (전략 리스크)**: 이 브릿지는 Claude Code에 non-Anthropic 모델을 loopback proxy로 연결한다. Codex OAuth entitlement 쪽은 upstream 튜토리얼에서 공개적으로 안내된 경로지만, Anthropic 또는 OpenAI가 언제든 이 조합을 차단할 수 있다. 즉 이 경계의 수명은 두 벤더의 정책에 종속되며, 기술적 완성도와 무관하게 외부 요인으로 무력화될 수 있다.
-  - **롤백 경로**: 차단이 관측되면 `default.nix`의 `targetHosts` allowlist에서 해당 호스트를 빼고 `nrs`를 실행한다. 그러면 활성 Home Manager generation에서 네 실행 surface와 CLIProxyAPI enabled-only closure 노출이 즉시 제거되고 descriptor와 runtime library metadata만 남는다(`lib.optionalAttrs enabled` 경계). 단, 이전 generation과 CLIProxyAPI Nix store 경로 자체는 garbage collection 전까지 store에 남으므로, 로컬 잔여물까지 정리하려면 generation 정리와 `nix-collect-garbage` 실행이 별도로 필요하다. credential/state는 repo 밖 `$HOME/Library/Application Support/claudex`에만 있으므로 그 디렉터리를 지우면 로컬 흔적도 제거된다. 일반 `claude` 설정과 인증은 애초에 건드리지 않으므로 별도 복구가 필요 없다.
+  - **롤백 경로**: 차단이 관측되면 `default.nix`의 `targetHosts` allowlist에서 해당 호스트를 빼고 `nrs`를 실행한다. 그러면 활성 Home Manager generation에서 네 실행 surface와 CLIProxyAPI enabled-only closure 노출이 즉시 제거되고 descriptor와 runtime library metadata만 남는다(`lib.optionalAttrs enabled` 경계). 단, 이전 generation과 CLIProxyAPI Nix store 경로 자체는 garbage collection 전까지 store에 남으므로, 로컬 잔여물까지 정리하려면 generation 정리와 `nix-collect-garbage` 실행이 별도로 필요하다. credential/state는 repo 밖 state 디렉터리(darwin `$HOME/Library/Application Support/claudex`, linux `$HOME/.local/state/claudex`)에만 있으므로 그 디렉터리를 지우면 로컬 흔적도 제거된다. 일반 `claude` 설정과 인증은 애초에 건드리지 않으므로 별도 복구가 필요 없다.
 - **subagent effort 세밀 제어 불가 (기능 한계)**: wrapper는 `CLAUDE_CODE_SUBAGENT_MODEL`로 subagent 모델만 고정 모델에 맞추고, effort는 세션 단위 값 하나(기본 `high`, `claudex --effort`로 조정 가능)를 세션 전체가 공유한다. subagent effort만 별도로 낮추는 수단은 여전히 없다(pinned Claude Code CLI 자체의 제약). 대량 fan-out 워크플로우에서 토큰 소모가 부담이면 세션 effort 자체를 낮춰서 실행한다.
 - **context 사용률 표시는 근사치 (기능 한계)**: pinned proxy는 SSE `message_start`에 usage `{input_tokens:0, output_tokens:0}`을 하드코딩한다 (Codex Responses API가 스트림 시작 시점에 usage를 주지 않기 때문; 실제 값은 `message_delta`에만 실림). upstream은 동일 보고(router-for-me/CLIProxyAPI#1700)를 수정 거부로 닫았고 v7.2.77까지 이 변환기는 변경이 없다. pinned CLI(2.1.210 실측)는 각 assistant 메시지에 `message_start` 스냅샷을 박제하고 "usage 합>0인 마지막 assistant 메시지"를 컨텍스트 추적 anchor로 삼으므로, 이 경로에서는 anchor가 없어 **문자수 기반 로컬 추정으로 fallback**한다(과대 경향). 여기에 미인식 모델의 200k 기본 가정이 겹치면 statusline이 조기에 "100% context used"로 포화한다. wrapper-owned `CLAUDE_CODE_MAX_CONTEXT_TOKENS=258000`은 분모를 실효 한계로 교정하는 완화이며, 분자(로컬 추정)의 오차는 남으므로 **표시되는 %는 근사치다** — auto-compact가 실제보다 이르게 발동할 수 있으나 한계 초과(400) 방향으로는 안전하다. `258000` 자체도 임시값이다: 모델은 372k로 출시됐으나 OpenAI가 과금 버그 수정 중 제품 한계를 임시 하향했고(공지 272k, Codex 앱 실측 258k — 2026-07-15) 재상향을 예고했다. 재상향이 반영되면 이 값을 재조정한다([#1113](https://github.com/greenheadHQ/nixos-config/issues/1113)로 추적). 재검증 명령: proxy ready 상태에서 `claudex -p --output-format stream-json --verbose` 출력의 assistant 이벤트 `message.usage`가 `0/0`이면 upstream 동작이 그대로인 것이고, Codex 앱의 컨텍스트 창 표시가 현재 실효 한계의 진실 원천이다.
 - **auto-compact는 별도 env 채널이 필요 (기능 한계 → 해소)**: `CLAUDE_CODE_MAX_CONTEXT_TOKENS`는 표시용 분모만 바꾸고, pinned CLI(2.1.210)의 auto-compact 메인 경로는 compact window의 **source**가 "auto"면(로컬 세션 가드) compact를 비활성화한다. 미인식 모델은 내장 window 테이블에 없어 명시 채널 없이는 source가 항상 "auto"이므로, claudex 세션은 auto-compact가 구조적으로 꺼져 있었다 — statusline이 "N% until auto-compact" 대신 "N% context used"로 표시되는 것이 가시적 증상이다. wrapper가 `CLAUDE_CODE_AUTO_COMPACT_WINDOW`(공식 env 채널, 유효 100k–1M)를 같은 값으로 재발행해 source를 "env"로 전환하고 임계 검사(≈ window − 출력예약 − 13k)를 활성화한다. 참고로 한계 초과 시 에러 기반 회복도 기대할 수 없다: 백엔드 API 실제 한계는 372k 스펙에 가깝고(360k 요청 200 성공 — 2026-07-15 실측), 초과 400이 나더라도 pinned proxy는 upstream 문구를 그대로 전달할 뿐 Anthropic 정식 문구로 재작성하지 않는다. 활성화는 A/B로 실측 완료(2026-07-15): `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=1` + 2턴 stream-json 멀티턴에서 새 wrapper는 `status:"compacting"` 이벤트를 발동(미니 대화라 `too_few_groups`로 요약은 실패 — 트리거 사슬 동작 증거로 충분), 동일 조건에서 `AUTO_COMPACT_WINDOW`만 뺀 대조군은 compact 신호가 전무했다. 대화형 세션의 가시 신호는 statusline "% until auto-compact" 표기 전환이다.
@@ -369,7 +370,8 @@ Stage 1 descriptor는 Stage 2 전용 launch-agent 필드를 미리 노출하지 
 먼저 기존 canonical auth 파일 수만 확인하고 내용은 출력하지 않는다.
 
 ```bash
-auth_dir="$HOME/Library/Application Support/claudex/auth"
+# state 경로는 플랫폼마다 다르므로(darwin: Library/Application Support, linux: XDG) descriptor에서 읽는다
+auth_dir="$(jq -r .authDir "$HOME/.config/claudex/runtime.json")"
 find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print 2>/dev/null | wc -l
 ```
 
@@ -414,7 +416,7 @@ Nix runtime contract나 generated config가 실제로 달라졌다면 기존 for
 ```bash
 descriptor="$HOME/.config/claudex/runtime.json"
 expected_proxy="$(jq -r .proxyExecutable "$descriptor")"
-pid="$(/usr/sbin/lsof -tiTCP:8317 -sTCP:LISTEN)"
+pid="$(lsof -tiTCP:8317 -sTCP:LISTEN)"  # darwin은 /usr/sbin/lsof, NixOS는 PATH의 lsof가 잡힌다
 test -n "$pid"
 ps -p "$pid" -o pid=,command=
 printf 'expected=%s\n' "$expected_proxy"
@@ -435,13 +437,13 @@ claudex-status
 Stage 1의 foreground 실행에서는 다음이 기대된다.
 
 ```text
-service=missing
+service=missing   # darwin 기준. linux에서는 service=n/a
 auth=ready
 proxy=ready
 catalog=ready
 ```
 
-launchd가 아직 없으므로 `service=missing`은 정상이다. auth/proxy/catalog가 ready이면 status 명령은 exit `0`이며 foreground Stage 1 readiness gate로 사용할 수 있다.
+Stage 1에는 서비스 유닛이 없으므로 darwin의 `service=missing`은 정상이다. linux에는 조회할 launchd 도메인 자체가 없어 `service=n/a`를 출력한다(값만 다르고 readiness 판정에는 관여하지 않는다). auth/proxy/catalog가 ready이면 status 명령은 exit `0`이며 foreground Stage 1 readiness gate로 사용할 수 있다.
 
 ### Headless completion
 
@@ -473,7 +475,7 @@ CLAUDEX_E2E_OK
 Terminal A에서 `Ctrl-C`로 foreground proxy를 종료한다. 무차별 `pkill`은 사용하지 않는다.
 
 ```bash
-/usr/sbin/lsof -nP -iTCP:8317 -sTCP:LISTEN
+lsof -nP -iTCP:8317 -sTCP:LISTEN  # darwin은 /usr/sbin/lsof, NixOS는 PATH의 lsof가 잡힌다
 claudex-login
 find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print | wc -l
 ```
@@ -525,7 +527,7 @@ git diff --cached --stat
 git diff --cached
 ```
 
-인증 state는 repo 밖 `$HOME/Library/Application Support/claudex`에만 있어야 한다. 의도하지 않은 로컬 경로, 개인·조직 식별 정보, 브라우저 정보가 diff에 보이면 커밋하지 않는다.
+인증 state는 repo 밖 state 디렉터리(darwin `$HOME/Library/Application Support/claudex`, linux `$HOME/.local/state/claudex`)에만 있어야 한다. 의도하지 않은 로컬 경로, 개인·조직 식별 정보, 브라우저 정보가 diff에 보이면 커밋하지 않는다.
 
 ## 12. 남아 있는 미지와 Stage 2 조건
 

--- a/flake.nix
+++ b/flake.nix
@@ -238,6 +238,11 @@
               gitleaks
               shellcheck
               bats
+              # claudex 테스트 fixture는 도구를 $(command -v openssl)로 해석한다. macOS는 시스템
+              # /usr/bin/openssl이 항상 잡혀 이 누락이 가려졌지만 NixOS에는 그 경로가 없어,
+              # claudex가 Linux 배포 대상이 되면서 8개 스위트가 "rand: command not found"로 죽었다.
+              # 양 플랫폼에 동일한 openssl을 제공해 테스트가 호스트 OS에 의존하지 않게 한다.
+              openssl
               pythonRuntimes.pythonWithTomlkit
               inputs.agenix.packages.${system}.default
             ];

--- a/modules/nixos/home.nix
+++ b/modules/nixos/home.nix
@@ -28,6 +28,7 @@ in
     # 공유 프로그램 (공통)
     ../shared/programs/broot
     ../shared/programs/claude # Claude Code 설정
+    ../shared/programs/claudex # Claude Code -> Codex loopback PoC (target host only)
     ../shared/programs/codex # Codex CLI 호환 레이어
     ../shared/programs/direnv # 디렉토리별 개발 환경 자동 활성화
     ../shared/programs/git

--- a/modules/shared/programs/claudex/cli-proxy-api-pin.json
+++ b/modules/shared/programs/claudex/cli-proxy-api-pin.json
@@ -1,11 +1,15 @@
 {
-  "_comment": "CLIProxyAPI PoC pin. Upstream release metadata and checksums.txt were verified for v7.2.73; the binary is never executed during Stage 1 validation.",
+  "_comment": "CLIProxyAPI PoC pin. Upstream release metadata and checksums.txt were verified for v7.2.73 on both platforms; the binary is never executed during Stage 1 validation. The linux asset is the plugin-enabled variant, matching darwin (upstream also ships *_no-plugin tarballs, which are deliberately not pinned).",
   "version": "7.2.73",
   "tag": "v7.2.73",
   "platforms": {
     "aarch64-darwin": {
       "asset": "CLIProxyAPI_7.2.73_darwin_aarch64.tar.gz",
       "hash": "sha256-72ZsH3E+lEsk6OIFzoBhN+pxjnuFnlUz8BXo+KmNYqY="
+    },
+    "x86_64-linux": {
+      "asset": "CLIProxyAPI_7.2.73_linux_amd64.tar.gz",
+      "hash": "sha256-fHlZsGoG/r8ftzEC0yP8BuwT8L3D1O6MPAdyoVqgIkY="
     }
   }
 }

--- a/modules/shared/programs/claudex/default.nix
+++ b/modules/shared/programs/claudex/default.nix
@@ -15,10 +15,18 @@ let
   targetHosts = [
     "greenhead-MacBookPro"
     "work-MacBookPro"
+    "greenhead-minipc"
   ];
   enabled = builtins.elem hostname targetHosts;
+  isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
   homeDir = config.home.homeDirectory;
-  stateDir = "${homeDir}/Library/Application Support/claudex";
+  # macOS keeps its Application Support convention; Linux follows the XDG state directory.
+  # Both stay under $HOME, so the symlinked-ancestor guard in the runtime applies unchanged.
+  stateDir =
+    if isDarwin then
+      "${homeDir}/Library/Application Support/claudex"
+    else
+      "${homeDir}/.local/state/claudex";
   authDir = "${stateDir}/auth";
   configFile = "${stateDir}/config.yaml";
   apiKeyFile = "${stateDir}/client-api-key";
@@ -144,8 +152,17 @@ let
     sleepBin = "${pkgs.coreutils}/bin/sleep";
     envBin = "${pkgs.coreutils}/bin/env";
     idBin = "${pkgs.coreutils}/bin/id";
-    lockfBin = "/usr/bin/lockf";
-    launchctlBin = "/bin/launchctl";
+    # The state lock uses flock's fd mode on both platforms. nixpkgs ships a darwin flock
+    # (discoteq), already relied on by claude-rc-maint, so the lock contract, its argv, and its
+    # tests stay single-path across macOS and NixOS. macOS /usr/bin/lockf is deliberately no
+    # longer used: its flags are not interchangeable with flock's (lockf -s means silent,
+    # flock -s means a *shared* lock, and the timeout flag is -t vs -w), so keeping both would
+    # fork the one code path that guards all state mutation.
+    flockBin = if isDarwin then "${pkgs.flock}/bin/flock" else "${pkgs.util-linux}/bin/flock";
+    # Stage 1 ships no service unit on either platform, so this probe only ever reports the
+    # absence of a launchd agent. Linux gets an empty value and the status command reports
+    # service=n/a rather than implying knowledge of a systemd unit that does not exist.
+    launchctlBin = if isDarwin then "/bin/launchctl" else "";
     inherit
       bindHost
       defaultMainModel

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -31,7 +31,7 @@ if [ "@allowTestOverrides@" = "true" ]; then
   CLAUDEX_RM="${CLAUDEX_RM:-@rmBin@}"
   CLAUDEX_SLEEP="${CLAUDEX_SLEEP:-@sleepBin@}"
   CLAUDEX_ENV="${CLAUDEX_ENV:-@envBin@}"
-  CLAUDEX_LOCKF="${CLAUDEX_LOCKF:-@lockfBin@}"
+  CLAUDEX_FLOCK="${CLAUDEX_FLOCK:-@flockBin@}"
   CLAUDEX_LAUNCHCTL="${CLAUDEX_LAUNCHCTL:-@launchctlBin@}"
   CLAUDEX_ID="${CLAUDEX_ID:-@idBin@}"
 else
@@ -47,7 +47,7 @@ else
   CLAUDEX_RM="@rmBin@"
   CLAUDEX_SLEEP="@sleepBin@"
   CLAUDEX_ENV="@envBin@"
-  CLAUDEX_LOCKF="@lockfBin@"
+  CLAUDEX_FLOCK="@flockBin@"
   CLAUDEX_LAUNCHCTL="@launchctlBin@"
   CLAUDEX_ID="@idBin@"
 fi
@@ -448,8 +448,10 @@ _claudex_credential_path_of_type() (
 )
 
 # Run a command or shell function under the canonical state lock. The descriptor and state
-# live on local APFS; /usr/bin/lockf's fd mode gives us kernel-backed exclusion without a
-# stale-lock cleanup protocol. Tests may inject CLAUDEX_LOCKF.
+# live on a local filesystem; flock's fd mode gives us kernel-backed exclusion without a
+# stale-lock cleanup protocol, identically on macOS (discoteq flock) and NixOS (util-linux
+# flock). -x is stated explicitly so the exclusive contract does not rest on flock's default.
+# Tests may inject CLAUDEX_FLOCK.
 with_state_lock() (
   local lock_mode
   umask 077
@@ -467,7 +469,7 @@ with_state_lock() (
     exit 1
   fi
   exec 9>"$CLAUDEX_STATE_LOCK" || exit 1
-  if ! "$CLAUDEX_LOCKF" -s -t "$CLAUDEX_LOCK_TIMEOUT_SECONDS" 9; then
+  if ! "$CLAUDEX_FLOCK" -x -w "$CLAUDEX_LOCK_TIMEOUT_SECONDS" 9; then
     _claudex_error "timed out waiting for the state lock"
     exit 1
   fi

--- a/modules/shared/programs/claudex/files/claudex-status.sh
+++ b/modules/shared/programs/claudex/files/claudex-status.sh
@@ -15,9 +15,16 @@ auth_state="missing"
 proxy_state="unreachable"
 catalog_state="unavailable"
 
-domain="gui/$($CLAUDEX_ID -u)"
-if "$CLAUDEX_LAUNCHCTL" print "$domain/$CLAUDEX_LABEL" >/dev/null 2>&1; then
-  service_state="present"
+# Stage 1 declares no service unit on either platform. Darwin still probes launchd so an
+# out-of-band agent would remain visible here; Linux has no launchd domain to ask and reports
+# n/a rather than "missing", which would imply a unit was expected but not found.
+if [ -n "$CLAUDEX_LAUNCHCTL" ]; then
+  domain="gui/$($CLAUDEX_ID -u)"
+  if "$CLAUDEX_LAUNCHCTL" print "$domain/$CLAUDEX_LABEL" >/dev/null 2>&1; then
+    service_state="present"
+  fi
+else
+  service_state="n/a"
 fi
 
 if [ -d "$CLAUDEX_AUTH_DIR" ] && [ ! -L "$CLAUDEX_AUTH_DIR" ]; then

--- a/modules/shared/programs/claudex/package.nix
+++ b/modules/shared/programs/claudex/package.nix
@@ -15,6 +15,7 @@ let
   platform =
     pin.platforms.${system}
       or (throw "cli-proxy-api: unsupported system '${system}' (supported: ${lib.concatStringsSep ", " (builtins.attrNames pin.platforms)})");
+  inherit (stdenvNoCC.hostPlatform) isLinux;
 in
 stdenvNoCC.mkDerivation {
   pname = "cli-proxy-api";
@@ -45,8 +46,16 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
+  # The linux release binary is dynamically linked against glibc and carries the FHS
+  # interpreter /lib64/ld-linux-x86-64.so.2, which does not exist on NixOS, so it must be
+  # patched to run at all (measured on v7.2.73 linux_amd64). autoPatchelfHook rewrites the
+  # interpreter and RPATH from buildInputs. Darwin keeps dontPatchELF so the Mach-O signature
+  # on the prebuilt binary is preserved untouched.
+  nativeBuildInputs = lib.optionals isLinux [ pkgs.autoPatchelfHook ];
+  buildInputs = lib.optionals isLinux [ pkgs.stdenv.cc.cc.lib ];
+
   dontStrip = true;
-  dontPatchELF = true;
+  dontPatchELF = !isLinux;
 
   meta = {
     description = "CLIProxyAPI pinned binary for the declarative claudex PoC";

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -27,6 +27,7 @@ let
   claudexTargetHosts = [
     "greenhead-MacBookPro"
     "work-MacBookPro"
+    "greenhead-minipc"
   ];
   darwinHostNames = builtins.attrNames darwinCfgs;
   unexpectedDarwinHosts = builtins.filter (
@@ -89,6 +90,9 @@ let
     system:
     let
       fakeStorePath = name: "/nix/store/00000000000000000000000000000000-${name}";
+      # package.nix branches on the host platform to patch the linux ELF interpreter, so the
+      # fake platform has to answer isLinux/isDarwin the way a real nixpkgs platform would.
+      isLinux = nixpkgsLib.hasSuffix "-linux" system;
     in
     {
       fetchurl = attrs: attrs;
@@ -96,11 +100,17 @@ let
         concatStringsSep = builtins.concatStringsSep;
         licenses.mit = "MIT";
         sourceTypes.binaryNativeCode = "binaryNativeCode";
+        optionals = nixpkgsLib.optionals;
       };
       stdenvNoCC = {
-        hostPlatform = { inherit system; };
+        hostPlatform = {
+          inherit system isLinux;
+          isDarwin = !isLinux;
+        };
         mkDerivation = attrs: attrs;
       };
+      autoPatchelfHook = fakeStorePath "auto-patchelf-hook";
+      stdenv.cc.cc.lib = fakeStorePath "gcc-lib";
       gnutar = fakeStorePath "gnutar";
       findutils = fakeStorePath "findutils";
       coreutils = fakeStorePath "coreutils";
@@ -109,9 +119,14 @@ let
   claudexPackage = import ../modules/shared/programs/claudex/package.nix {
     pkgs = fakeClaudexPkgs "aarch64-darwin";
   };
+  claudexLinuxPackage = import ../modules/shared/programs/claudex/package.nix {
+    pkgs = fakeClaudexPkgs "x86_64-linux";
+  };
+  # aarch64-linux keeps probing the unsupported-system throw: upstream does publish an asset
+  # for it, but no host needs it, so it stays unpinned and must still fail loudly.
   claudexUnsupportedPackage = builtins.tryEval (
     (import ../modules/shared/programs/claudex/package.nix {
-      pkgs = fakeClaudexPkgs "x86_64-linux";
+      pkgs = fakeClaudexPkgs "aarch64-linux";
     }).src.url
   );
 
@@ -942,13 +957,19 @@ let
       cond = unexpectedDarwinHosts == [ ];
     }
     {
-      name = "Test D18: CLIProxyAPI pin은 검증한 v7.2.73 darwin-arm64 자산과 해시여야 함";
+      name = "Test D18: CLIProxyAPI pin은 검증한 v7.2.73 darwin-arm64/linux-amd64 자산과 해시여야 함";
       cond =
         claudexPin.version == "7.2.73"
         && claudexPin.tag == "v7.2.73"
-        && builtins.attrNames claudexPin.platforms == [ "aarch64-darwin" ]
+        &&
+          builtins.attrNames claudexPin.platforms == [
+            "aarch64-darwin"
+            "x86_64-linux"
+          ]
         && claudexPin.platforms.aarch64-darwin.asset == "CLIProxyAPI_7.2.73_darwin_aarch64.tar.gz"
         && claudexPin.platforms.aarch64-darwin.hash == "sha256-72ZsH3E+lEsk6OIFzoBhN+pxjnuFnlUz8BXo+KmNYqY="
+        && claudexPin.platforms.x86_64-linux.asset == "CLIProxyAPI_7.2.73_linux_amd64.tar.gz"
+        && claudexPin.platforms.x86_64-linux.hash == "sha256-fHlZsGoG/r8ftzEC0yP8BuwT8L3D1O6MPAdyoVqgIkY="
         && claudexPackage.pname == "cli-proxy-api"
         && claudexPackage.version == "7.2.73"
         &&
@@ -956,10 +977,30 @@ let
           == "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.73/CLIProxyAPI_7.2.73_darwin_aarch64.tar.gz"
         && claudexPackage.src.hash == "sha256-72ZsH3E+lEsk6OIFzoBhN+pxjnuFnlUz8BXo+KmNYqY="
         && claudexPackage.meta.mainProgram == "cli-proxy-api"
-        && claudexPackage.meta.platforms == [ "aarch64-darwin" ]
+        &&
+          claudexPackage.meta.platforms == [
+            "aarch64-darwin"
+            "x86_64-linux"
+          ]
         && nixpkgsLib.hasInfix "verify-release-layout.sh" claudexPackage.installPhase
         && nixpkgsLib.hasInfix "install -Dm755 unpacked/cli-proxy-api" claudexPackage.installPhase
         && claudexUnsupportedPackage.success == false;
+    }
+    {
+      # 의도된 플랫폼 비대칭을 잠근다: linux prebuilt는 glibc 동적 링크에 FHS interpreter
+      # (/lib64/ld-linux-x86-64.so.2)를 달고 오므로 NixOS에서 patch 없이는 실행 자체가 불가하고,
+      # darwin prebuilt는 반대로 Mach-O 서명을 건드리면 안 되므로 patch를 끈 채 둬야 한다.
+      name = "Test D18b: claudex linux 패키지는 linux-amd64 자산을 ELF patch 경로로 설치해야 함";
+      cond =
+        claudexLinuxPackage.src.url
+        == "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.73/CLIProxyAPI_7.2.73_linux_amd64.tar.gz"
+        && claudexLinuxPackage.src.hash == "sha256-fHlZsGoG/r8ftzEC0yP8BuwT8L3D1O6MPAdyoVqgIkY="
+        && claudexLinuxPackage.dontPatchELF == false
+        && claudexLinuxPackage.nativeBuildInputs != [ ]
+        && claudexLinuxPackage.buildInputs != [ ]
+        && claudexPackage.dontPatchELF == true
+        && claudexPackage.nativeBuildInputs == [ ]
+        && claudexPackage.buildInputs == [ ];
     }
     {
       name = "Test D19: claudex config base는 runtime slot을 비우고 관리/플러그인/로그/통계를 꺼야 함";

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -15,6 +15,22 @@ _CLAUDEX_EXPECTED_DEFAULT_MAIN_MODEL=gpt-5.6-sol
 _CLAUDEX_EXPECTED_SUBAGENT_MODEL=gpt-5.6-sol
 _CLAUDEX_EXPECTED_MIXED_MAIN_MODEL=claude-opus-4-8
 
+# claudex-login과 claudex-proxy-launcher는 프록시를 `env -i ... PATH=/usr/bin:/bin:/usr/sbin:/sbin`
+# 으로 실행해 상속 환경을 격리한다. NixOS에는 그 PATH에 bash가 없어 `#!/usr/bin/env bash` shebang이
+# 해석되지 않으므로, 그 경계 아래서 실행되는 fake 프록시의 shebang만 절대 경로로 고정한다.
+# production 프록시는 절대 store 경로의 바이너리라 PATH에 의존하지 않으며, 격리 계약(env -i와
+# 제한된 PATH) 자체는 손대지 않으므로 테스트가 검증하는 경계는 그대로다.
+_claudex_pin_proxy_shebang() {
+  local target="$1" tmp bash_bin
+  bash_bin="$(command -v bash)"
+  tmp="$(mktemp)"
+  {
+    printf '#!%s\n' "$bash_bin"
+    tail -n +2 "$target"
+  } > "$tmp"
+  mv "$tmp" "$target"
+}
+
 _claudex_assert_no_placeholders() {
   local path="$1"
   if grep -Eq '@[A-Za-z_][A-Za-z0-9_-]*@' "$path"; then
@@ -42,7 +58,7 @@ _claudex_materialize_runtime() {
   local allow_test_overrides="${CLAUDEX_FIXTURE_ALLOW_TEST_OVERRIDES:-true}"
   local declared_home="${CLAUDEX_FIXTURE_DECLARED_HOME:-$destination-home}"
   local curl_bin="${CLAUDEX_FIXTURE_CURL_BIN:-$(command -v curl)}"
-  local lockf_bin="${CLAUDEX_FIXTURE_LOCKF_BIN:-/usr/bin/lockf}"
+  local flock_bin="${CLAUDEX_FIXTURE_FLOCK_BIN:-/usr/bin/flock}"
   local launchctl_bin="${CLAUDEX_FIXTURE_LAUNCHCTL_BIN:-/bin/launchctl}"
   local bind_host="${CLAUDEX_FIXTURE_BIND_HOST:-127.0.0.1}"
   local port="${CLAUDEX_FIXTURE_PORT:-8317}"
@@ -82,7 +98,7 @@ _claudex_materialize_runtime() {
     -e "s|@sleepBin@|$(command -v sleep)|g" \
     -e "s|@envBin@|$(command -v env)|g" \
     -e "s|@idBin@|$(command -v id)|g" \
-    -e "s|@lockfBin@|$lockf_bin|g" \
+    -e "s|@flockBin@|$flock_bin|g" \
     -e "s|@launchctlBin@|$launchctl_bin|g" \
     -e "s|@bindHost@|$bind_host|g" \
     -e "s|@port@|$port|g" \
@@ -140,7 +156,7 @@ _claudex_fixture() {
     "$root/files/config-template.json" "$generated/config-template.json"
   _claudex_write_wrapper_settings "$wrapper_settings"
   _claudex_write_wrapper_settings_fast "$wrapper_settings_fast"
-  cat > "$sandbox/fake-lockf" <<'EOF'
+  cat > "$sandbox/fake-flock" <<'EOF'
 #!/usr/bin/env bash
 [ -z "${CLAUDEX_FAKE_LOCK_LOG:-}" ] || printf '%s\n' "$@" >> "$CLAUDEX_FAKE_LOCK_LOG"
 [ "${CLAUDEX_FAKE_LOCK_FAIL:-0}" != 1 ] || exit 1
@@ -150,7 +166,8 @@ EOF
 #!/usr/bin/env bash
 exit 99
 EOF
-  chmod +x "$sandbox/fake-lockf" "$fake_proxy"
+  _claudex_pin_proxy_shebang "$fake_proxy"
+  chmod +x "$sandbox/fake-flock" "$fake_proxy"
 
   _claudex_materialize_runtime \
     "$generated/claudex-runtime.sh" "$generated/config-template.json"
@@ -174,8 +191,16 @@ _claudex_production_fixture() {
   local launchctl_bin="$sandbox/production-launchctl"
   local wrapper_settings="$generated/wrapper-settings.json"
   local wrapper_settings_fast="$generated/wrapper-settings-fast.json"
-  local jq_bin
+  local jq_bin sort_bin mkdir_bin chmod_bin
   jq_bin="$(command -v jq)"
+  # 이 fake는 launcher/login이 `env -i ... PATH=/usr/bin:/bin:/usr/sbin:/sbin`으로 실행하므로
+  # 본문이 PATH로 도구를 찾을 수 없다(NixOS에는 그 경로에 coreutils가 없다). jq와 같은 방식으로
+  # 생성 시점에 절대 경로를 박아 넣어, 격리 계약을 완화하지 않고도 fake가 어디서든 동작하게 한다.
+  # fake 안에서 PATH를 넓히지 않는 이유: 이 fake는 자신이 받은 env 스냅샷을 기록해 격리를
+  # 증명하는데, PATH를 손대면 그 스냅샷이 오염되어 검증 대상 자체가 흐려진다.
+  sort_bin="$(command -v sort)"
+  mkdir_bin="$(command -v mkdir)"
+  chmod_bin="$(command -v chmod)"
   mkdir -p "$generated" "$declared_home/.local/bin"
   _claudex_write_wrapper_settings "$wrapper_settings"
   _claudex_write_wrapper_settings_fast "$wrapper_settings_fast"
@@ -203,28 +228,29 @@ while [ "\$#" -gt 0 ]; do
   esac
 done
 if [ "\$device" = true ]; then
-  env | sort > "$sandbox/production-login.env"
+  env | "$sort_bin" > "$sandbox/production-login.env"
   printf 'home=%s\n' "\$HOME" > "$sandbox/production-login.log"
   printf 'arg=%s\n' "\${args[@]}" >> "$sandbox/production-login.log"
   auth_dir="\$("$jq_bin" -r '.["auth-dir"]' "\$config")"
-  mkdir -p "\$auth_dir"
-  chmod 700 "\$auth_dir"
+  "$mkdir_bin" -p "\$auth_dir"
+  "$chmod_bin" 700 "\$auth_dir"
   printf '%s' '{"type":"codex","access_token":"prod-access","refresh_token":"prod-refresh"}' > "\$auth_dir/codex-production.json"
-  chmod 600 "\$auth_dir/codex-production.json"
+  "$chmod_bin" 600 "\$auth_dir/codex-production.json"
   exit 0
 fi
-env | sort > "$sandbox/production-launcher.env"
+env | "$sort_bin" > "$sandbox/production-launcher.env"
 printf 'home=%s\n' "\$HOME" > "$sandbox/production-launcher.log"
 printf 'cwd=%s\n' "\$PWD" >> "$sandbox/production-launcher.log"
 printf 'arg=%s\n' "\${args[@]}" >> "$sandbox/production-launcher.log"
 exit 17
 EOF
+  _claudex_pin_proxy_shebang "$proxy"
   chmod +x "$curl_bin" "$launchctl_bin" "$proxy"
 
   CLAUDEX_FIXTURE_ALLOW_TEST_OVERRIDES=false \
     CLAUDEX_FIXTURE_DECLARED_HOME="$declared_home" \
     CLAUDEX_FIXTURE_CURL_BIN="$curl_bin" \
-    CLAUDEX_FIXTURE_LOCKF_BIN="$sandbox/fake-lockf" \
+    CLAUDEX_FIXTURE_FLOCK_BIN="$sandbox/fake-flock" \
     CLAUDEX_FIXTURE_LAUNCHCTL_BIN="$launchctl_bin" \
     _claudex_materialize_runtime "$runtime" "$sandbox/generated/config-template.json"
   local script
@@ -240,7 +266,7 @@ _claudex_prepare_fixture_state() {
   local sandbox="$1"
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$sandbox/state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     bash -c 'source "$1"; prepare_state' _ "$sandbox/generated/claudex-runtime.sh"
 }
 
@@ -299,7 +325,7 @@ test_claudex_runtime_api_and_private_state() {
   symlink_home="$sandbox/symlink-home"
   mkdir -p "$symlink_home" "$sandbox/external-library"
   ln -s "$sandbox/external-library" "$symlink_home/Library"
-  if HOME="$symlink_home" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  if HOME="$symlink_home" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     bash -c 'source "$1"; prepare_state' _ "$runtime" >/dev/null 2>&1; then
     fail "prepare_state accepted a symlinked default-state ancestor"
   fi
@@ -309,16 +335,21 @@ test_claudex_runtime_api_and_private_state() {
   rm -rf "$sandbox/lock-failure"
   if HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$sandbox/lock-failure" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
-    CLAUDEX_FAKE_LOCK_LOG="$sandbox/lockf.argv" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
+    CLAUDEX_FAKE_LOCK_LOG="$sandbox/flock.argv" \
     CLAUDEX_FAKE_LOCK_FAIL=1 \
     bash -c 'source "$1"; prepare_state' _ "$runtime" >/dev/null 2>&1; then
     fail "prepare_state continued after lock acquisition failed"
   fi
-  grep -Fqx -- "-s" "$sandbox/lockf.argv" || fail "lockf must receive -s"
-  grep -Fqx -- "-t" "$sandbox/lockf.argv" || fail "lockf must receive -t"
-  assert_file_contains "$sandbox/lockf.argv" "10"
-  assert_file_contains "$sandbox/lockf.argv" "9"
+  grep -Fqx -- "-x" "$sandbox/flock.argv" || fail "flock must receive -x (exclusive lock)"
+  grep -Fqx -- "-w" "$sandbox/flock.argv" || fail "flock must receive -w (lock timeout)"
+  # -s is a *shared* lock in flock (it meant "silent" in the macOS lockf this replaced), so
+  # passing it would silently downgrade the exclusive state-lock contract to a shared one.
+  if grep -Fqx -- "-s" "$sandbox/flock.argv"; then
+    fail "flock must never receive -s: that acquires a shared lock, not an exclusive one"
+  fi
+  assert_file_contains "$sandbox/flock.argv" "10"
+  assert_file_contains "$sandbox/flock.argv" "9"
   [[ ! -e "$sandbox/lock-failure/client-api-key" ]] \
     || fail "lock failure still entered the state mutation callback"
 
@@ -413,7 +444,7 @@ test_claudex_runtime_derived_contract() {
 
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     bash -c 'source "$1"; prepare_state' _ "$runtime"
   jq -e \
     '.host == "127.0.0.42" and .port == 18317 and .pprof.addr == "127.0.0.42:18316"' \
@@ -555,7 +586,7 @@ EOF
   set +e
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" \
     ANTHROPIC_BASE_URL="https://hostile.invalid" \
     ANTHROPIC_API_KEY="hostile" \
@@ -643,7 +674,7 @@ EOF
   set +e
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" \
     CLAUDE_CODE_EFFORT_LEVEL=low \
     "$wrapper" --effort xhigh -- literal-prompt
@@ -657,7 +688,7 @@ EOF
   set +e
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" \
     "$wrapper" --effort=medium -- literal-prompt
   rc=$?
@@ -671,7 +702,7 @@ EOF
   set +e
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" \
     "$wrapper" --effort ultra -- literal-prompt
   rc=$?
@@ -703,7 +734,7 @@ EOF
   set +e
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" \
     CLAUDE_CODE_EXTRA_BODY='{"service_tier":"hostile"}' \
     "$wrapper" --fast -- literal-prompt
@@ -725,7 +756,7 @@ EOF
   set +e
   HOME="$sandbox/home" \
     CLAUDEX_STATE_DIR="$state" \
-    CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" \
     "$wrapper" --fast --effort low -- literal-prompt
   rc=$?
@@ -781,7 +812,7 @@ EOF
   chmod +x "$sandbox/home/.local/bin/claude"
 
   # --mixed refuses to start without a claude credential (fail-closed, before exec).
-  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" --mixed -- literal-prompt >/dev/null 2>&1; then
     fail "--mixed started without a claude credential"
   fi
@@ -793,7 +824,7 @@ EOF
 
   # Mixed happy path: Claude main model on argv, gpt subagent env, no auto-compact window.
   set +e
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" --mixed -- literal-prompt
   rc=$?
   set -e
@@ -808,7 +839,7 @@ EOF
   # auto-compact window export.
   rm -f "$sandbox/claude.log"
   set +e
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" -- literal-prompt
   rc=$?
   set -e
@@ -832,7 +863,7 @@ EOF
 
   # Mixed fails when the catalog lacks the mixed main model (subagent-only catalog).
   _claudex_make_ready_curl "$sandbox"
-  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     CLAUDEX_CURL="$sandbox/fake-curl" "$wrapper" --mixed -- literal-prompt >/dev/null 2>&1; then
     fail "--mixed accepted a catalog without the mixed main model"
   fi
@@ -848,7 +879,7 @@ test_claudex_launcher_and_login_use_fake_boundaries() {
   jq_bin="$(command -v jq)"
   _claudex_fixture "$sandbox"
 
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$launcher" --prepare-only
   [[ ! -e "$proxy_log" ]] || fail "--prepare-only invoked the proxy"
   _claudex_add_valid_credential "$state"
@@ -862,6 +893,7 @@ printf 'deploy=%s\n' "\${DEPLOY-unset}" >> "$proxy_log"
 printf 'arg=%s\n' "\$@" >> "$proxy_log"
 exit 17
 EOF
+  _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
   chmod +x "$sandbox/fake-cli-proxy-api"
   _claudex_materialize_command \
     "$REPO_ROOT/modules/shared/programs/claudex/files/claudex-proxy-launcher.sh" \
@@ -875,7 +907,7 @@ EOF
   set +e
   (
     cd "$sandbox/caller"
-    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
       HOME_JWT=hostile PGSTORE_DSN=hostile DEPLOY=hostile "$launcher"
   )
   rc=$?
@@ -893,7 +925,7 @@ EOF
   rm -f "$proxy_log"
   : > "$state/work/.env"
   set +e
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" "$launcher" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" "$launcher" \
     >/dev/null 2>&1
   rc=$?
   set -e
@@ -917,6 +949,7 @@ printf '%s' '{"type":"codex","access_token":"stage-access","refresh_token":"stag
 chmod 600 "\$auth_dir/codex-stage.json"
 exit 0
 EOF
+  _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
   chmod +x "$sandbox/fake-cli-proxy-api"
   _claudex_materialize_command \
     "$REPO_ROOT/modules/shared/programs/claudex/files/claudex-login.sh" \
@@ -924,7 +957,7 @@ EOF
     "$sandbox/fake-cli-proxy-api" "$sandbox/generated/config-template.json" \
     "$sandbox/generated/wrapper-settings.json"
   chmod +x "$login"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" "$login" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" "$login" \
     >/dev/null
   [[ "$(find "$state/auth" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "1" ]] \
     || fail "device login did not promote exactly one credential"
@@ -937,7 +970,7 @@ EOF
     fail "login staging directory leaked after promotion"
   fi
   rm -f "$proxy_log"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" "$login" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" "$login" \
     >/dev/null
   [[ ! -e "$proxy_log" ]] || fail "existing canonical credential triggered another device login"
 
@@ -962,8 +995,9 @@ printf '%s' '{"type":"claude","access_token":"claude-access","refresh_token":"cl
 chmod 600 "\$auth_dir/claude-stage.json"
 exit 0
 EOF
+  _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
   chmod +x "$sandbox/fake-cli-proxy-api"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$login" --claude >/dev/null
   assert_file_contains "$proxy_log" "arg=--claude-login"
   [[ "$(find "$state/auth" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "2" ]] \
@@ -975,10 +1009,10 @@ EOF
 
   # Both login paths are idempotent per credential type once their entry exists.
   rm -f "$proxy_log"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$login" --claude >/dev/null
   [[ ! -e "$proxy_log" ]] || fail "existing claude credential triggered another claude login"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$login" >/dev/null
   [[ ! -e "$proxy_log" ]] || fail "coexisting claude credential broke the no-arg login no-op"
 
@@ -994,7 +1028,7 @@ EOF
   # (codex-only and claude-only are legitimate mid-login states; the old full-set assert
   # made this path fail after the move).
   rm -rf "$state/auth"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$login" --claude >/dev/null || fail "claude-first login into an empty auth dir failed"
   [[ "$(find "$state/auth" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "1" ]] \
     || fail "claude-first login did not leave exactly one credential"
@@ -1006,12 +1040,12 @@ EOF
   printf '%s' '{"type":"gemini","access_token":"x","refresh_token":"y"}' \
     > "$state/auth/gemini-bad.json"
   chmod 600 "$state/auth/gemini-bad.json"
-  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$login" --claude >/dev/null 2>&1; then
     fail "login reported ready despite a malformed sibling entry"
   fi
   rm -f "$proxy_log"
-  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_LOCKF="$sandbox/fake-lockf" \
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
     "$login" >/dev/null 2>&1; then
     fail "codex login proceeded despite a malformed sibling entry"
   fi

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -20,6 +20,9 @@ _CLAUDEX_EXPECTED_MIXED_MAIN_MODEL=claude-opus-4-8
 # 해석되지 않으므로, 그 경계 아래서 실행되는 fake 프록시의 shebang만 절대 경로로 고정한다.
 # production 프록시는 절대 store 경로의 바이너리라 PATH에 의존하지 않으며, 격리 계약(env -i와
 # 제한된 PATH) 자체는 손대지 않으므로 테스트가 검증하는 경계는 그대로다.
+# 함수 이름대로 shebang만 바꾼다: 조립은 임시 파일에서 하되 대상에는 truncate 후 덮어쓰기로
+# 되돌려, 대상의 inode와 mode/권한을 보존한다. `mv`로 교체하면 임시 파일의 속성이 대상을
+# 덮어써서, 이미 실행 비트가 설정된 파일에 적용할 경우 그 비트를 조용히 잃는다.
 _claudex_pin_proxy_shebang() {
   local target="$1" tmp bash_bin
   bash_bin="$(command -v bash)"
@@ -28,7 +31,8 @@ _claudex_pin_proxy_shebang() {
     printf '#!%s\n' "$bash_bin"
     tail -n +2 "$target"
   } > "$tmp"
-  mv "$tmp" "$target"
+  cat "$tmp" > "$target"
+  rm -f "$tmp"
 }
 
 _claudex_assert_no_placeholders() {


### PR DESCRIPTION
## Summary

- claudex를 darwin 전용에서 **NixOS(greenhead-minipc)까지 확장**한다. miniPC에서 실제 세션을 열어 `gpt-5.6-sol` 응답까지 실측 확인했다.
- macOS 결합 네 곳(바이너리 pin, ELF interpreter, state lock, state 경로)을 해소한다. 그중 state lock은 분기 대신 **flock으로 통일**해 양 플랫폼이 단일 코드 경로를 쓰게 한다.
- devShell의 openssl 누락으로 Linux에서 claudex 테스트 8건이 죽던 갭을 함께 메운다 — claudex가 Linux 배포 대상이 되면서 비로소 검증을 막게 된 문제다.

## 기존 문제/배경

claudex 코드는 `modules/shared/programs/claudex/`에 있지만, 이 저장소에서 "shared 디렉터리에 있다"는 것은 위치일 뿐 배포 대상과 무관하다. 공유는 각 플랫폼 home.nix가 명시적으로 import할 때만 일어나며, claudex는 `modules/darwin/home.nix`에서만 import되고 있었다.

그 결과 miniPC는 **3중으로 배제**되어 있었다.

1. `modules/nixos/home.nix`에 claudex import 자체가 없음
2. 모듈 내부 `targetHosts`에 `greenhead-minipc`가 없어 `enabled = false`
3. pin에 `x86_64-linux` 항목이 없어 `package.nix`가 eval 단계에서 `throw`

import와 게이트를 뚫어도 macOS 하드결합이 남는다.

| 결합 | 값 | Linux에서의 문제 |
|---|---|---|
| 상태 잠금 | `/usr/bin/lockf` | BSD 전용, Linux에 존재하지 않음 |
| 서비스 조회 | `/bin/launchctl` | launchd 개념 자체가 macOS 고유 |
| 상태 경로 | `~/Library/Application Support/claudex` | Linux 관례(XDG)와 불일치 |
| 바이너리 pin | `aarch64-darwin` 단독 | eval 단계에서 unsupported system throw |

또한 upstream Linux prebuilt는 glibc 동적 링크에 FHS interpreter(`/lib64/ld-linux-x86-64.so.2`)를 달고 오는데, NixOS에는 그 경로가 존재하지 않아 **빌드가 성공해도 실행이 불가능**했다. 이 사실은 정적 분석으로는 드러나지 않고, 릴리스 tarball을 받아 `file`로 확인해서야 알 수 있었다.

## CIR (Change Intent Record)

**운용 범위 결정 — Stage 1 parity 유지 (이번 변경)**
miniPC는 상시 가동 서버라 프록시를 systemd user 서비스로 상시 기동하는 선택지가 있었으나, 대화형 SSH 사용을 전제로 **foreground 수동 기동(Stage 1)** 을 유지하기로 했다. miniPC만 서비스화하면 두 플랫폼의 claudex가 서로 다른 생명주기를 갖게 되어, 이후 Stage 2 설계(#1108)가 "이미 갈라진 두 구현을 다시 합치는" 부채가 된다. 서비스화는 양쪽을 동시에 다루는 편이 낫다는 판단이다.

**상태 잠금 — lockf 분기 유지에서 flock 통일로 전환 (이번 변경)**
처음에는 darwin을 건드리지 않고 Linux만 flock을 쓰는 분기를 검토했다. 그러나 두 도구는 플래그 의미가 겹치지 않는다 — `lockf -s`는 silent이지만 `flock -s`는 **shared lock**이고, timeout 플래그도 `-t` vs `-w`로 다르다. 분기를 유지하면 모든 상태 변경을 지키는 단 하나의 경로가 둘로 갈리고, 한쪽에 잘못된 플래그가 들어가면 배타 잠금이 조용히 공유 잠금으로 격하될 수 있다. 이 저장소에는 이미 claude-rc-maint가 darwin에서 nixpkgs flock(discoteq 빌드)을 사용하는 선례가 있고, claudex의 잠금 관용구(`exec 9>lock` 후 fd 잠금)도 원래 flock 스타일이라 전환이 자연스러웠다. **trade-off**: macOS의 잠금 백엔드가 교체되므로 회귀 위험을 감수하며, 대신 실제 배타성(보유 중 경쟁자 차단, 해제 후 재획득)을 실측으로 검증했다.

**ELF 처리 — 실측으로 방향 확정 (이번 변경)**
Linux prebuilt가 정적 링크라면 기존 `dontPatchELF = true`를 그대로 쓸 수 있었다. 릴리스 tarball을 받아 확인한 결과 glibc 동적 링크였고, 따라서 `autoPatchelfHook`이 필수로 판명됐다. darwin은 Mach-O 서명을 보존해야 하므로 `dontPatchELF`를 유지해야 한다 — 즉 이 비대칭은 우연이 아니라 두 플랫폼의 요구가 정반대인 결과이며, 회귀로 되돌려지지 않도록 eval 테스트로 잠갔다.

**런처 PATH — 확장하지 않기로 결정 (이번 변경)**
런처는 `env -i`로 환경을 비우고 `PATH=/usr/bin:/bin:/usr/sbin:/sbin`만 준다. NixOS에서 이 PATH는 사실상 비어 있어, Linux 검증 중 테스트의 fake 프록시가 shebang과 coreutils를 찾지 못해 실패했다. 그러나 실제 프록시는 절대 store 경로로 실행되어 PATH에 의존하지 않으며(실측에서 정상 기동 확인), 제한된 PATH는 의도된 보안 격리다. 근거 없이 PATH를 넓히는 것은 격리 완화이므로, **production 코드는 그대로 두고 테스트 fake 쪽만** 절대 경로를 쓰도록 고쳤다. 다만 프록시가 향후 런타임에 PATH 도구를 shell-out하게 되면 Linux에서만 깨질 수 있으므로, 이 제약은 알려진 한계로 남는다.

**devShell openssl — 범위에 포함 (이번 변경)**
Linux 테스트 실패 8건의 원인은 devShell에 openssl이 없어 fixture의 `$(command -v openssl)`이 빈 값이 된 것이었다. patch 없는 main에서도 동일하게 실패하는 기존 갭이지만, claudex가 darwin 전용이던 시절에는 Linux에서 claudex 테스트를 돌릴 이유가 없어 무해했다. 배포 대상을 넓히면 검증 대상도 함께 넓혀야 하므로 이번 변경에 포함했다.

## ADR

**상태 잠금 백엔드**

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| darwin lockf 유지 + Linux만 flock | 플랫폼별로 다른 도구와 인자 | macOS 무변경, 회귀 위험 0 | 상태 변경을 지키는 경로가 2개로 분기, 플래그 의미가 정반대라 오적용 시 배타→공유 격하가 조용히 발생 | ❌ |
| 양 플랫폼 flock 통일 | 단일 도구·단일 인자(`-x -w`) | 코드·테스트 단일 경로, 저장소 내 darwin flock 선례 존재 | macOS 잠금 백엔드 교체 → 실측 회귀 검증 필요 | ✅ |

**프록시 생명주기**

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Stage 1 parity (foreground 수동) | Mac과 동일하게 필요 시 기동 | 양 플랫폼 대칭 유지, 변경 표면 최소 | 세션마다 프록시를 직접 띄워야 함 | ✅ |
| systemd user 서비스 상시 기동 | miniPC에서 프록시를 상시 유지 | 상시 가동 서버 특성에 부합 | Stage 2 설계를 한쪽 플랫폼에서 선행 확정, 생명주기 비대칭 부채 | ❌ |

**런처 PATH (NixOS에서 사실상 빈 PATH)**

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| production PATH 확장 | Linux에서 시스템 프로필 경로 추가 | fake·실제 모두 도구 접근 가능 | 의도된 보안 격리를 근거 없이 완화 | ❌ |
| 테스트 fake만 절대 경로 | fake의 shebang·coreutils를 생성 시점에 고정 | 격리 계약을 유지한 채 테스트가 호스트 OS에 비의존 | 프록시가 향후 PATH 도구를 쓰면 별도 대응 필요 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claudex/cli-proxy-api-pin.json` | 수정 | `x86_64-linux` asset/해시 추가 (upstream checksums.txt 대조) |
| `modules/shared/programs/claudex/package.nix` | 수정 | Linux에 `autoPatchelfHook`, `dontPatchELF`를 플랫폼 분기 |
| `modules/shared/programs/claudex/default.nix` | 수정 | `targetHosts`에 miniPC 추가, `stateDir`/lock/launchctl 분기 |
| `modules/shared/programs/claudex/files/claudex-runtime.sh` | 수정 | 잠금을 flock fd 모드(`-x -w`)로 전환, 변수 개명 |
| `modules/shared/programs/claudex/files/claudex-status.sh` | 수정 | launchctl 조회를 darwin 한정, Linux는 `service=n/a` |
| `modules/nixos/home.nix` | 수정 | claudex 모듈 import 배선 |
| `flake.nix` | 수정 | devShell에 `openssl` 추가 |
| `tests/eval-tests.nix` | 수정 | pin/platforms 단언 갱신, fake pkgs에 플랫폼 속성 추가, 비대칭 잠금 테스트 신규 |
| `tests/suites/claudex.sh` | 수정 | flock 인자 검증, fake 프록시 절대 경로 고정 |

### 핵심 코드

플랫폼 분기 (`default.nix`) — 잠금은 도구 경로만 갈리고 호출 인자는 단일하다.

```nix
stateDir =
  if isDarwin then
    "${homeDir}/Library/Application Support/claudex"
  else
    "${homeDir}/.local/state/claudex";

flockBin = if isDarwin then "${pkgs.flock}/bin/flock" else "${pkgs.util-linux}/bin/flock";
launchctlBin = if isDarwin then "/bin/launchctl" else "";
```

잠금 호출 (`claudex-runtime.sh`) — `-x`를 명시해 배타 계약이 flock 기본값에 의존하지 않게 한다.

```bash
# BEFORE (macOS 전용): lockf -s(silent) -t(timeout)
if ! "$CLAUDEX_LOCKF" -s -t "$CLAUDEX_LOCK_TIMEOUT_SECONDS" 9; then

# AFTER (양 플랫폼): flock -x(exclusive) -w(timeout)
if ! "$CLAUDEX_FLOCK" -x -w "$CLAUDEX_LOCK_TIMEOUT_SECONDS" 9; then
```

ELF 처리 (`package.nix`) — 두 플랫폼의 요구가 정반대다.

```nix
nativeBuildInputs = lib.optionals isLinux [ pkgs.autoPatchelfHook ];
buildInputs = lib.optionals isLinux [ pkgs.stdenv.cc.cc.lib ];
dontStrip = true;
dontPatchELF = !isLinux;  # darwin은 Mach-O 서명 보존, linux는 interpreter 재작성 필수
```

테스트는 `-s` 오적용까지 금지한다 (`tests/suites/claudex.sh`).

```bash
grep -Fqx -- "-x" "$sandbox/flock.argv" || fail "flock must receive -x (exclusive lock)"
grep -Fqx -- "-w" "$sandbox/flock.argv" || fail "flock must receive -w (lock timeout)"
if grep -Fqx -- "-s" "$sandbox/flock.argv"; then
  fail "flock must never receive -s: that acquires a shared lock, not an exclusive one"
fi
```

## 참고 레퍼런스

- PR #1129 — 혼합 fleet Stage 1.5, 현재 모델/credential 계약의 출처
- Issue #1108 — Stage 2 전 미검증 egress·credential refresh 경계 조사. 프록시 서비스화는 이 이슈 범위이며 본 PR은 의도적으로 다루지 않는다
- `modules/nixos/lib/claude-rc-maint-package.nix` — darwin에서 nixpkgs flock을 사용하는 기존 선례. 본 PR의 flock 통일 판단 근거
- [CLIProxyAPI releases](https://github.com/router-for-me/CLIProxyAPI/releases/tag/v7.2.73) — 핀 대상 릴리스. linux_amd64 asset 및 checksums.txt 출처

## Human Test Plan

### miniPC 정상 동작 검증

1. miniPC에서 `claudex-status`를 실행한다.
   - **기대**: `service=n/a`, `auth`/`proxy`/`catalog` 상태가 출력된다. 로그인·프록시 기동 전이면 `auth=missing`으로 exit 1.
   - **실패 시**: `~/.config/claudex/runtime.json`의 `enabled`가 `true`이고 `stateDir`이 `~/.local/state/claudex`인지 확인한다.

2. `claudex-login`으로 Codex OAuth를 완료한 뒤 프록시를 기동하고 `claudex-status`를 다시 실행한다.
   - **기대**: `auth=ready`, `proxy=ready`, `catalog=ready`이며 exit 0.
   - **실패 시**: 프록시 로그에서 `API server started successfully on: 127.0.0.1:8317`이 있는지, credential 파일 권한이 `0600`(디렉터리 `0700`)인지 확인한다.

3. miniPC에서 `claudex -p "Reply with exactly: PING" --output-format json`을 실행한다.
   - **기대**: `"model": "gpt-5.6-sol"`, `"is_error": false`, 응답 본문이 정상 반환된다.
   - **실패 시**: 프록시가 살아 있는지, catalog에 해당 모델이 있는지(`claudex-status`의 `catalog`) 확인한다.

### Negative 검증 (구 구현 잔재 부재)

4. 배포된 런타임에서 구 잠금 도구 참조가 사라졌는지 확인한다.
   - **기대**: 배포된 `claudex-runtime.sh`에 `/usr/bin/lockf` 참조가 없고, 잠금 호출이 `-x -w` 형태다. Linux에서는 `CLAUDEX_LAUNCHCTL`이 빈 값이다.
   - **실패 시**: 해당 호스트에서 재빌드가 실제로 적용됐는지(새 store 경로인지) 확인한다.

5. miniPC에 macOS 규약 경로가 생기지 않았는지 확인한다.
   - **기대**: `~/Library/Application Support/claudex`가 존재하지 않고, 상태가 `~/.local/state/claudex` 아래에만 만들어진다.
   - **실패 시**: `stateDir` 분기가 `pkgs.stdenv.hostPlatform.isDarwin` 기준으로 평가되는지 확인한다.

### Mac regression 검증

6. Mac에서 `claudex-status`와 기존 claudex 세션을 실행한다.
   - **기대**: 기존과 동일하게 동작하며, 상태 경로는 `~/Library/Application Support/claudex` 그대로다. 잠금 백엔드만 flock으로 교체된다.
   - **실패 시**: 동시 실행으로 배타 잠금이 유지되는지 확인한다 — 한 프로세스가 잠금을 보유한 동안 다른 프로세스는 타임아웃되어야 하며, 둘 다 성공하면 `-s`(shared)가 잘못 전달된 것이다.

7. 양 플랫폼에서 테스트 스위트를 실행한다.
   - **기대**: Mac과 miniPC 모두 shell 스크립트 테스트와 eval 테스트가 실패 0으로 통과한다.
   - **실패 시**: Linux에서 `rand: command not found`가 보이면 devShell 밖에서 실행한 것이므로 devShell 안에서 재실행한다.

### 본 PR에서 실측 완료된 항목

- Mac: 포맷/lint, eval 테스트, `flake check --all-systems`, shell 테스트 218건, darwin-system 빌드, flock 배타 잠금 동작
- miniPC: eval 테스트, shell 테스트 248건, home-manager 빌드, ELF interpreter 재작성 확인, 실제 배포, OAuth 로그인, 상태 전부 ready, 실제 세션에서 `gpt-5.6-sol` 응답


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - Claudex 실행 대상 호스트가 확장되었고, 상태 위치/런타임 경로가 플랫폼별로 정리되었습니다.
- **개선 사항**
  - 상태 잠금이 `lockf`에서 `flock` 기반으로 전환되어 플랫폼 간 동작이 일관화되었습니다.
  - macOS 서비스 상태 확인은 필요할 때만 수행되도록 안정화되었습니다.
  - Linux에서 CLIProxyAPI 핀/바이너리 패치 관련 검증이 강화되었습니다.
- **문서/테스트**
  - Stage 1 절차와 검증 범위가 업데이트되었고, 관련 테스트 케이스가 정교화되었습니다.
- **기타**
  - 개발 셸에 `openssl`이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->