### PR TITLE
feat(nixos): generic private job runner — 로컬 정의 작업의 스케줄 실행 + 실패 알림

### DIFF
--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -51,10 +51,6 @@
     opnixServiceAccountExpirySource = ../secrets/opnix-service-account-expiry.txt;
     # opnix SA token agenix secret — opnix/default.nix가 tokenFile 등록에 사용
     opnixServiceAccountTokenAge = ../secrets/opnix-service-account-token.age;
-    # private job runner의 HOME 상대 경로 (runner·sync 두 스크립트가 env로 공유
-    # — 하드코딩 중복 금지). 작업 정의·로그는 기기 로컬 소유라 절대경로가 아니다.
-    privateJobsDefinitions = ".local/private-jobs";
-    privateJobsState = ".local/state/private-jobs";
   };
 
   # ═══════════════════════════════════════════════════════════════

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -51,6 +51,10 @@
     opnixServiceAccountExpirySource = ../secrets/opnix-service-account-expiry.txt;
     # opnix SA token agenix secret — opnix/default.nix가 tokenFile 등록에 사용
     opnixServiceAccountTokenAge = ../secrets/opnix-service-account-token.age;
+    # private job runner의 HOME 상대 경로 (runner·sync 두 스크립트가 env로 공유
+    # — 하드코딩 중복 금지). 작업 정의·로그는 기기 로컬 소유라 절대경로가 아니다.
+    privateJobsDefinitions = ".local/private-jobs";
+    privateJobsState = ".local/state/private-jobs";
   };
 
   # ═══════════════════════════════════════════════════════════════

--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -102,10 +102,12 @@
     ./programs/smartd.nix # S.M.A.R.T. 디스크 건강 모니터링 (Pushover 알림)
     ./programs/temp-monitor # lm-sensors 온도 모니터링 (5분마다, Pushover 알림)
     ./programs/pushover-purge-reminder.nix # Backup archive 6개월 보관 만료 reminder (2026-12-01 1회성)
+    ./programs/private-job-runner # 로컬 정의 작업의 user timer 실행 + 실패 알림 (generic)
     ./options/homeserver.nix # Docker/Podman 기반 홈서버 서비스 (mkOption)
   ];
 
   # 홈서버 서비스 활성화 (mkEnableOption 기본값 false)
+  homeserver.privateJobRunner.enable = true; # generic private job runner (작업 정의는 기기 로컬)
   homeserver.immich.enable = true;
   homeserver.uptimeKuma.enable = true;
   homeserver.immichCleanup.enable = true; # Claude Code Temp 앨범 매일 전체 삭제

--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -102,7 +102,6 @@
     ./programs/smartd.nix # S.M.A.R.T. 디스크 건강 모니터링 (Pushover 알림)
     ./programs/temp-monitor # lm-sensors 온도 모니터링 (5분마다, Pushover 알림)
     ./programs/pushover-purge-reminder.nix # Backup archive 6개월 보관 만료 reminder (2026-12-01 1회성)
-    ./programs/private-job-runner # 로컬 정의 작업의 user timer 실행 + 실패 알림 (generic)
     ./options/homeserver.nix # Docker/Podman 기반 홈서버 서비스 (mkOption)
   ];
 

--- a/modules/nixos/options/homeserver.nix
+++ b/modules/nixos/options/homeserver.nix
@@ -9,6 +9,10 @@
 
 {
   options.homeserver = {
+    privateJobRunner = {
+      enable = lib.mkEnableOption "generic private job runner (로컬 정의 작업의 user timer 실행)";
+    };
+
     immich = {
       enable = lib.mkEnableOption "Immich photo backup service";
       port = lib.mkOption {
@@ -319,5 +323,6 @@
     ../programs/opnix-rotate.nix # SA token 90일 rotation 알림 (opnix.enable 게이팅)
     ../programs/codex-remote-control.nix # Codex mobile remote-control app-server 회귀 방지
     ../programs/claude-remote-control.nix # Claude Code RC bridge version-drift 감시
+    ../programs/private-job-runner # generic private job runner (작업 정의는 기기 로컬)
   ];
 }

--- a/modules/nixos/programs/private-job-runner/default.nix
+++ b/modules/nixos/programs/private-job-runner/default.nix
@@ -8,8 +8,11 @@
 # 로컬 작업 규약 (기기에서 사람이 준비):
 #   ~/.local/private-jobs/<slug>/run.sh    실행 진입점 — owner 본인·실행 가능·
 #                                          symlink 및 group/world-writable 금지
-#   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 1줄 (예: "Sat 03:00")
-#                                          — 같은 소유·링크 기준 적용
+#   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 — 정확히 1줄 파일
+#                                          (초과 내용은 오류), 같은 소유·링크 기준
+#   상위 사슬(~/.local/private-jobs 및 각 job 디렉터리)도 같은 기준이다: owner
+#   본인·비 symlink(상위 경로 포함)·group/world-writable 금지 — 로그 상태 사슬
+#   (~/.local/state/private-jobs 이하)은 0700/0600까지 요구한다.
 #   <slug>는 ^[a-z0-9][a-z0-9-]{0,63}$ 의 중립 문자열만 — 작업 실체를 드러내지 않는 이름.
 #   로그: ~/.local/state/private-jobs/<slug>/logs/<run-id>.log (0700/0600, bounded retention)
 #   알림: 실패 시 unit의 ExecStopPost가 user-scope Pushover(~/.config/pushover/share)로
@@ -108,8 +111,9 @@ in
           # 실패 알림의 단일 소유자 — runner 내부 알림은 timeout·강제 종료 경로에서
           # 증발하므로 종료 후 훅에서만 판정·발송한다 ($SERVICE_RESULT 기반).
           ExecStopPost = "${notifyApp}/bin/private-job-notify %i";
-          # bounded timeout — 개별 작업의 자체 상한(현행 최대 6h급)보다 넉넉한
-          # 최후 방어선이다. 초과 시 control-group 전체가 정리된다(잔존 자식 0).
+          # bounded timeout — "야간 무인 배치가 하루 업무 시작 전에 끝난다"는
+          # 보수 상한으로, 특정 작업의 상한이 이를 넘으면 이 값만 조정한다.
+          # 초과 시 control-group 전체가 정리된다(잔존 자식 0).
           TimeoutStartSec = "8h";
         };
         environment = commonEnvironment;
@@ -120,6 +124,9 @@ in
         serviceConfig = hardening // {
           Type = "oneshot";
           ExecStart = "${syncApp}/bin/private-jobs-sync";
+          # 정의 오류(exit 3 규약 — 개별 통지 완료)는 건너뛰고 비정형 실패만
+          # 통지한다 (mkdir·daemon-reload 실패 등 set -e 경로).
+          ExecStopPost = "${notifyApp}/bin/private-job-notify sync-service";
           TimeoutStartSec = "5min";
         };
         environment = commonEnvironment;
@@ -130,8 +137,8 @@ in
         wantedBy = [ "timers.target" ];
         timerConfig = {
           # 부팅 2분 뒤 최초 sync가 runtime timer를 재생성하고(재부팅 복구 경로),
-          # 15분 간격은 "정의 변경이 다음 스케줄 전에 반영"과 스캔 비용의 절충이다
-          # (주기 작업은 시간 단위라 15분 지연은 무해).
+          # 15분 간격은 "정의 변경이 OnCalendar 최소 단위(시간 규모) 안에 반영"과
+          # 스캔 비용의 절충이다 — 더 촘촘한 반영이 필요하면 이 값만 줄인다.
           OnBootSec = "2min";
           OnUnitActiveSec = "15min";
         };

--- a/modules/nixos/programs/private-job-runner/default.nix
+++ b/modules/nixos/programs/private-job-runner/default.nix
@@ -8,8 +8,9 @@
 # 로컬 작업 규약 (기기에서 사람이 준비):
 #   ~/.local/private-jobs/<slug>/run.sh    실행 진입점 — owner 본인·실행 가능·
 #                                          symlink 및 group/world-writable 금지
-#   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 — 정확히 1줄 파일
-#                                          (초과 내용은 오류), 같은 소유·링크 기준
+#   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 1줄 파일 (뒤따르는
+#                                          공백 줄만 허용, 그 외 초과 내용은 오류),
+#                                          같은 소유·링크 기준
 #   상위 사슬(~/.local/private-jobs 및 각 job 디렉터리)도 같은 기준이다: owner
 #   본인·비 symlink(상위 경로 포함)·group/world-writable 금지 — 로그 상태 사슬
 #   (~/.local/state/private-jobs 이하)은 0700/0600까지 요구한다.
@@ -18,6 +19,8 @@
 #   알림: 실패 시 unit의 ExecStopPost가 user-scope Pushover(~/.config/pushover/share)로
 #   generic 필드(slug·invocation·result·exit)만 발송 — run당 외부 알림 1회는 이
 #   runner 인프라가 소유하므로 개별 작업 래퍼는 자체 push 알림을 배선하지 않는다.
+#   예외 하나: sync의 "정의 오류"는 sync가 marker dedupe와 함께 직접 통지하고,
+#   ExecStopPost는 그 경우(SYNC_HANDLED_EXIT)를 건너뛴다 — 비정형 실패 전담.
 #
 # 동작: private-jobs-sync(user timer)가 로컬 정의를 스캔해 runtime unit 영역에
 # private-job-<slug>.timer(Persistent=true)를 생성·정리하고, 각 timer는 template
@@ -69,7 +72,12 @@ let
     pkgs.curl
   ];
 
+  # sync의 "정의 오류(개별 통지 완료)" exit 값 — 생산(sync)과 소비(notify)가
+  # 이 한 곳의 값을 env로 공유한다.
+  syncHandledExit = "3";
+
   commonEnvironment = {
+    SYNC_HANDLED_EXIT = syncHandledExit;
     PRIVATE_JOB_LIB = toString privateJobLib;
     PUSHOVER_LIB = toString pushoverLib;
     PUSHOVER_CRED_FILE = pushoverCredPath;
@@ -110,10 +118,10 @@ in
           ExecStart = "${runnerApp}/bin/private-job-run %i";
           # 실패 알림의 단일 소유자 — runner 내부 알림은 timeout·강제 종료 경로에서
           # 증발하므로 종료 후 훅에서만 판정·발송한다 ($SERVICE_RESULT 기반).
-          ExecStopPost = "${notifyApp}/bin/private-job-notify %i";
-          # bounded timeout — "야간 무인 배치가 하루 업무 시작 전에 끝난다"는
-          # 보수 상한으로, 특정 작업의 상한이 이를 넘으면 이 값만 조정한다.
-          # 초과 시 control-group 전체가 정리된다(잔존 자식 0).
+          ExecStopPost = "${notifyApp}/bin/private-job-notify %i job";
+          # bounded timeout — 이 runner가 보장하는 절대 상한이다: 이보다 오래
+          # 걸리는 작업은 이 인프라의 대상이 아니며, 그런 요구가 생기면 이 값
+          # 한 곳만 조정한다. 초과 시 control-group 전체가 정리된다(잔존 자식 0).
           TimeoutStartSec = "8h";
         };
         environment = commonEnvironment;
@@ -124,9 +132,9 @@ in
         serviceConfig = hardening // {
           Type = "oneshot";
           ExecStart = "${syncApp}/bin/private-jobs-sync";
-          # 정의 오류(exit 3 규약 — 개별 통지 완료)는 건너뛰고 비정형 실패만
-          # 통지한다 (mkdir·daemon-reload 실패 등 set -e 경로).
-          ExecStopPost = "${notifyApp}/bin/private-job-notify sync-service";
+          # 정의 오류(SYNC_HANDLED_EXIT — 개별 통지 완료)는 건너뛰고 비정형
+          # 실패만 통지한다 (mkdir·daemon-reload 실패 등 set -e 경로).
+          ExecStopPost = "${notifyApp}/bin/private-job-notify sync-service sync";
           TimeoutStartSec = "5min";
         };
         environment = commonEnvironment;
@@ -137,8 +145,8 @@ in
         wantedBy = [ "timers.target" ];
         timerConfig = {
           # 부팅 2분 뒤 최초 sync가 runtime timer를 재생성하고(재부팅 복구 경로),
-          # 15분 간격은 "정의 변경이 OnCalendar 최소 단위(시간 규모) 안에 반영"과
-          # 스캔 비용의 절충이다 — 더 촘촘한 반영이 필요하면 이 값만 줄인다.
+          # 15분은 "정의 변경이 반영되기까지의 지연 상한"이다 — 더 촘촘한 반영이
+          # 필요하면 이 값만 줄인다 (스캔 자체는 저비용이라 하한 제약은 없다).
           OnBootSec = "2min";
           OnUnitActiveSec = "15min";
         };

--- a/modules/nixos/programs/private-job-runner/default.nix
+++ b/modules/nixos/programs/private-job-runner/default.nix
@@ -5,7 +5,7 @@
 # Nix eval은 로컬 작업 디렉터리를 읽지 않는다(readDir/readFile/pathExists 금지) —
 # discovery·스케줄은 sync 스크립트의 런타임 스캔만 소유한다.
 #
-# 로컬 작업 규약 (기기에서 사람이 준비, 경로 상수는 libraries/constants.nix):
+# 로컬 작업 규약 (기기에서 사람이 준비):
 #   ~/.local/private-jobs/<slug>/run.sh    실행 진입점 — owner 본인·실행 가능·
 #                                          symlink 및 group/world-writable 금지
 #   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 1줄 (예: "Sat 03:00")
@@ -25,42 +25,53 @@
   lib,
   pkgs,
   username,
-  constants,
   ...
 }:
 
 let
   cfg = config.homeserver.privateJobRunner;
+  # 옵션 선언은 다른 homeserver.* 서비스와 같이 options/homeserver.nix가 소유한다
+  # — 이 모듈은 구현만 갖는다 (중앙 모듈 import에 포함되는 단일 경로 유지).
   pushoverLib = pkgs.writeText "pushover-lib.sh" (
     builtins.readFile ../../../shared/scripts/lib/pushover.sh
   );
+  privateJobLib = pkgs.writeText "private-job-lib.sh" (builtins.readFile ./lib.sh);
+  # 두 스크립트가 공유하는 HOME 상대 경로 — env로 한 번만 주입한다 (스크립트별
+  # 하드코딩은 discovery와 실행이 다른 디렉터리를 보는 drift를 만든다). 이 모듈
+  # 밖 소비자가 없으므로 전역 constants가 아니라 여기가 소유한다.
+  privateJobsDefinitions = ".local/private-jobs";
+  privateJobsState = ".local/state/private-jobs";
   # user-scope Pushover 자격 (HM secrets가 배치하는 ~/.config/pushover/share) —
   # 경로만 참조한다. root-scope(age.secrets)와 달리 user unit이 읽을 수 있다.
   pushoverCredPath = "%h/.config/pushover/share";
 
+  # 실행 책임별로 의존을 분리해 선언한다 — 합집합 공유는 한 책임의 의존 추가가
+  # 나머지 실행기까지 자동 확장되는 결합을 만든다.
   mkApp =
-    name: src:
+    name: src: deps:
     pkgs.writeShellApplication {
       inherit name;
-      runtimeInputs = with pkgs; [
-        coreutils
-        curl
-        gnugrep
-        systemd
-      ];
+      runtimeInputs = deps;
       text = builtins.readFile src;
     };
-  runnerApp = mkApp "private-job-run" ./runner.sh;
-  syncApp = mkApp "private-jobs-sync" ./sync.sh;
-  notifyApp = mkApp "private-job-notify" ./notify.sh;
+  runnerApp = mkApp "private-job-run" ./runner.sh [ pkgs.coreutils ];
+  syncApp = mkApp "private-jobs-sync" ./sync.sh [
+    pkgs.coreutils
+    pkgs.curl
+    pkgs.gnugrep
+    pkgs.systemd
+  ];
+  notifyApp = mkApp "private-job-notify" ./notify.sh [
+    pkgs.coreutils
+    pkgs.curl
+  ];
 
   commonEnvironment = {
+    PRIVATE_JOB_LIB = toString privateJobLib;
     PUSHOVER_LIB = toString pushoverLib;
     PUSHOVER_CRED_FILE = pushoverCredPath;
-    # 두 스크립트가 공유하는 HOME 상대 경로 — 하드코딩 중복은 discovery와 실행이
-    # 서로 다른 디렉터리를 보게 되는 drift를 만든다 (SoT: constants.paths).
-    PRIVATE_JOBS_DEFINITIONS = constants.paths.privateJobsDefinitions;
-    PRIVATE_JOBS_STATE = constants.paths.privateJobsState;
+    PRIVATE_JOBS_DEFINITIONS = privateJobsDefinitions;
+    PRIVATE_JOBS_STATE = privateJobsState;
   };
 
   # user unit hardening 공통값. RestrictNamespaces는 의도적으로 켜지 않는다 —
@@ -81,10 +92,6 @@ let
   };
 in
 {
-  options.homeserver.privateJobRunner = {
-    enable = lib.mkEnableOption "generic private job runner (로컬 정의 작업의 user timer 실행)";
-  };
-
   # linger는 mkIf 밖에서 enable 값을 그대로 선언한다 — mkIf 안에 두면 비활성화 시
   # 옵션이 null(미관리)로 돌아가 이미 실행된 enable-linger 상태가 잔존한다.
   # 파급 주의: linger는 이 runner만이 아니라 사용자 user manager 전체를 로그인

--- a/modules/nixos/programs/private-job-runner/default.nix
+++ b/modules/nixos/programs/private-job-runner/default.nix
@@ -5,16 +5,18 @@
 # Nix eval은 로컬 작업 디렉터리를 읽지 않는다(readDir/readFile/pathExists 금지) —
 # discovery·스케줄은 sync 스크립트의 런타임 스캔만 소유한다.
 #
-# 로컬 작업 규약 (기기에서 사람이 준비):
-#   ~/.local/private-jobs/<slug>/run.sh    실행 진입점 (0700, owner 본인, symlink 금지)
+# 로컬 작업 규약 (기기에서 사람이 준비, 경로 상수는 libraries/constants.nix):
+#   ~/.local/private-jobs/<slug>/run.sh    실행 진입점 — owner 본인·실행 가능·
+#                                          symlink 및 group/world-writable 금지
 #   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 1줄 (예: "Sat 03:00")
+#                                          — 같은 소유·링크 기준 적용
 #   <slug>는 ^[a-z0-9][a-z0-9-]{0,63}$ 의 중립 문자열만 — 작업 실체를 드러내지 않는 이름.
 #   로그: ~/.local/state/private-jobs/<slug>/logs/<run-id>.log (0700/0600, bounded retention)
-#   알림: 실패 시 runner가 user-scope Pushover(~/.config/pushover/share)로 generic
-#   필드(slug·run id·exit class)만 발송 — run당 외부 알림 1회는 runner가 소유하므로
-#   개별 작업 래퍼는 자체 push 알림을 배선하지 않는다.
+#   알림: 실패 시 unit의 ExecStopPost가 user-scope Pushover(~/.config/pushover/share)로
+#   generic 필드(slug·invocation·result·exit)만 발송 — run당 외부 알림 1회는 이
+#   runner 인프라가 소유하므로 개별 작업 래퍼는 자체 push 알림을 배선하지 않는다.
 #
-# 동작: private-jobs-sync(user timer, 부팅 2분 후 + 15분 간격)가 로컬 정의를 스캔해
+# 동작: private-jobs-sync(user timer)가 로컬 정의를 스캔해 runtime unit 영역에
 # private-job-<slug>.timer(Persistent=true)를 생성·정리하고, 각 timer는 template
 # unit private-job@<slug>.service → runner를 발화한다. linger로 로그인 세션 없이도
 # user manager가 부팅부터 상주한다.
@@ -23,6 +25,7 @@
   lib,
   pkgs,
   username,
+  constants,
   ...
 }:
 
@@ -35,29 +38,29 @@ let
   # 경로만 참조한다. root-scope(age.secrets)와 달리 user unit이 읽을 수 있다.
   pushoverCredPath = "%h/.config/pushover/share";
 
-  runnerApp = pkgs.writeShellApplication {
-    name = "private-job-run";
-    runtimeInputs = with pkgs; [
-      coreutils
-      curl
-    ];
-    text = builtins.readFile ./runner.sh;
-  };
-
-  syncApp = pkgs.writeShellApplication {
-    name = "private-jobs-sync";
-    runtimeInputs = with pkgs; [
-      coreutils
-      curl
-      gnugrep
-      systemd
-    ];
-    text = builtins.readFile ./sync.sh;
-  };
+  mkApp =
+    name: src:
+    pkgs.writeShellApplication {
+      inherit name;
+      runtimeInputs = with pkgs; [
+        coreutils
+        curl
+        gnugrep
+        systemd
+      ];
+      text = builtins.readFile src;
+    };
+  runnerApp = mkApp "private-job-run" ./runner.sh;
+  syncApp = mkApp "private-jobs-sync" ./sync.sh;
+  notifyApp = mkApp "private-job-notify" ./notify.sh;
 
   commonEnvironment = {
     PUSHOVER_LIB = toString pushoverLib;
     PUSHOVER_CRED_FILE = pushoverCredPath;
+    # 두 스크립트가 공유하는 HOME 상대 경로 — 하드코딩 중복은 discovery와 실행이
+    # 서로 다른 디렉터리를 보게 되는 drift를 만든다 (SoT: constants.paths).
+    PRIVATE_JOBS_DEFINITIONS = constants.paths.privateJobsDefinitions;
+    PRIVATE_JOBS_STATE = constants.paths.privateJobsState;
   };
 
   # user unit hardening 공통값. RestrictNamespaces는 의도적으로 켜지 않는다 —
@@ -82,41 +85,50 @@ in
     enable = lib.mkEnableOption "generic private job runner (로컬 정의 작업의 user timer 실행)";
   };
 
-  config = lib.mkIf cfg.enable {
-    # 로그인 세션 없이도 user manager·timer가 부팅부터 상주해야 무인 스케줄이 성립한다.
-    users.users.${username}.linger = true;
-
-    systemd.user.services."private-job@" = {
-      description = "private job %i";
-      # 작업은 네트워크를 쓸 수 있다(수집·push류) — user unit에는
-      # network-online.target이 없으므로 보수적으로 기본 target 이후로만 둔다.
-      serviceConfig = hardening // {
-        Type = "oneshot";
-        ExecStart = "${runnerApp}/bin/private-job-run %i";
-        # bounded timeout — 개별 작업의 자체 타임아웃보다 넉넉한 최후 상한이다.
-        # 초과 시 control-group 전체가 정리된다(잔존 자식 0).
-        TimeoutStartSec = "8h";
+  # linger는 mkIf 밖에서 enable 값을 그대로 선언한다 — mkIf 안에 두면 비활성화 시
+  # 옵션이 null(미관리)로 돌아가 이미 실행된 enable-linger 상태가 잔존한다.
+  # 파급 주의: linger는 이 runner만이 아니라 사용자 user manager 전체를 로그인
+  # 전부터 상주시킨다 — ssh-agent 등 기존 user 서비스도 로그인 없이 시작되고
+  # 로그아웃 후 유지된다 (수용 근거는 PR #1142 CIR — 무인 스케줄의 전제 조건).
+  config = lib.mkMerge [
+    { users.users.${username}.linger = cfg.enable; }
+    (lib.mkIf cfg.enable {
+      systemd.user.services."private-job@" = {
+        description = "private job %i";
+        serviceConfig = hardening // {
+          Type = "oneshot";
+          ExecStart = "${runnerApp}/bin/private-job-run %i";
+          # 실패 알림의 단일 소유자 — runner 내부 알림은 timeout·강제 종료 경로에서
+          # 증발하므로 종료 후 훅에서만 판정·발송한다 ($SERVICE_RESULT 기반).
+          ExecStopPost = "${notifyApp}/bin/private-job-notify %i";
+          # bounded timeout — 개별 작업의 자체 상한(현행 최대 6h급)보다 넉넉한
+          # 최후 방어선이다. 초과 시 control-group 전체가 정리된다(잔존 자식 0).
+          TimeoutStartSec = "8h";
+        };
+        environment = commonEnvironment;
       };
-      environment = commonEnvironment;
-    };
 
-    systemd.user.services."private-jobs-sync" = {
-      description = "sync private job definitions to user timers";
-      serviceConfig = hardening // {
-        Type = "oneshot";
-        ExecStart = "${syncApp}/bin/private-jobs-sync";
-        TimeoutStartSec = "5min";
+      systemd.user.services."private-jobs-sync" = {
+        description = "sync private job definitions to user timers";
+        serviceConfig = hardening // {
+          Type = "oneshot";
+          ExecStart = "${syncApp}/bin/private-jobs-sync";
+          TimeoutStartSec = "5min";
+        };
+        environment = commonEnvironment;
       };
-      environment = commonEnvironment;
-    };
 
-    systemd.user.timers."private-jobs-sync" = {
-      description = "periodic private job definition sync";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnBootSec = "2min";
-        OnUnitActiveSec = "15min";
+      systemd.user.timers."private-jobs-sync" = {
+        description = "periodic private job definition sync";
+        wantedBy = [ "timers.target" ];
+        timerConfig = {
+          # 부팅 2분 뒤 최초 sync가 runtime timer를 재생성하고(재부팅 복구 경로),
+          # 15분 간격은 "정의 변경이 다음 스케줄 전에 반영"과 스캔 비용의 절충이다
+          # (주기 작업은 시간 단위라 15분 지연은 무해).
+          OnBootSec = "2min";
+          OnUnitActiveSec = "15min";
+        };
       };
-    };
-  };
+    })
+  ];
 }

--- a/modules/nixos/programs/private-job-runner/default.nix
+++ b/modules/nixos/programs/private-job-runner/default.nix
@@ -1,0 +1,122 @@
+# Generic private job runner — 로컬 정의 작업의 스케줄 실행 + 실패 알림 (#1135)
+#
+# 이 모듈은 특정 작업을 알지 못한다. 작업 정의·이름·스케줄·시크릿·로그 내용은 전부
+# 기기 로컬(비추적) 소유이며, repo·store·CI·PR 어디에도 작업 실체가 나타나지 않는다.
+# Nix eval은 로컬 작업 디렉터리를 읽지 않는다(readDir/readFile/pathExists 금지) —
+# discovery·스케줄은 sync 스크립트의 런타임 스캔만 소유한다.
+#
+# 로컬 작업 규약 (기기에서 사람이 준비):
+#   ~/.local/private-jobs/<slug>/run.sh    실행 진입점 (0700, owner 본인, symlink 금지)
+#   ~/.local/private-jobs/<slug>/schedule  systemd OnCalendar 식 1줄 (예: "Sat 03:00")
+#   <slug>는 ^[a-z0-9][a-z0-9-]{0,63}$ 의 중립 문자열만 — 작업 실체를 드러내지 않는 이름.
+#   로그: ~/.local/state/private-jobs/<slug>/logs/<run-id>.log (0700/0600, bounded retention)
+#   알림: 실패 시 runner가 user-scope Pushover(~/.config/pushover/share)로 generic
+#   필드(slug·run id·exit class)만 발송 — run당 외부 알림 1회는 runner가 소유하므로
+#   개별 작업 래퍼는 자체 push 알림을 배선하지 않는다.
+#
+# 동작: private-jobs-sync(user timer, 부팅 2분 후 + 15분 간격)가 로컬 정의를 스캔해
+# private-job-<slug>.timer(Persistent=true)를 생성·정리하고, 각 timer는 template
+# unit private-job@<slug>.service → runner를 발화한다. linger로 로그인 세션 없이도
+# user manager가 부팅부터 상주한다.
+{
+  config,
+  lib,
+  pkgs,
+  username,
+  ...
+}:
+
+let
+  cfg = config.homeserver.privateJobRunner;
+  pushoverLib = pkgs.writeText "pushover-lib.sh" (
+    builtins.readFile ../../../shared/scripts/lib/pushover.sh
+  );
+  # user-scope Pushover 자격 (HM secrets가 배치하는 ~/.config/pushover/share) —
+  # 경로만 참조한다. root-scope(age.secrets)와 달리 user unit이 읽을 수 있다.
+  pushoverCredPath = "%h/.config/pushover/share";
+
+  runnerApp = pkgs.writeShellApplication {
+    name = "private-job-run";
+    runtimeInputs = with pkgs; [
+      coreutils
+      curl
+    ];
+    text = builtins.readFile ./runner.sh;
+  };
+
+  syncApp = pkgs.writeShellApplication {
+    name = "private-jobs-sync";
+    runtimeInputs = with pkgs; [
+      coreutils
+      curl
+      gnugrep
+      systemd
+    ];
+    text = builtins.readFile ./sync.sh;
+  };
+
+  commonEnvironment = {
+    PUSHOVER_LIB = toString pushoverLib;
+    PUSHOVER_CRED_FILE = pushoverCredPath;
+  };
+
+  # user unit hardening 공통값. RestrictNamespaces는 의도적으로 켜지 않는다 —
+  # 일부 작업의 하위 도구(sandbox형 CLI)가 user namespace 생성을 요구하며, 이는
+  # da-weekly-report의 실측 선례와 같은 제약이다. 이 선택은 eval-tests가 고정한다.
+  hardening = {
+    UMask = "0077";
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    ProtectSystem = "full";
+    ProtectKernelTunables = true;
+    ProtectControlGroups = true;
+    RestrictSUIDSGID = true;
+    LockPersonality = true;
+    ProtectClock = true;
+    RestrictRealtime = true;
+    KillMode = "control-group";
+  };
+in
+{
+  options.homeserver.privateJobRunner = {
+    enable = lib.mkEnableOption "generic private job runner (로컬 정의 작업의 user timer 실행)";
+  };
+
+  config = lib.mkIf cfg.enable {
+    # 로그인 세션 없이도 user manager·timer가 부팅부터 상주해야 무인 스케줄이 성립한다.
+    users.users.${username}.linger = true;
+
+    systemd.user.services."private-job@" = {
+      description = "private job %i";
+      # 작업은 네트워크를 쓸 수 있다(수집·push류) — user unit에는
+      # network-online.target이 없으므로 보수적으로 기본 target 이후로만 둔다.
+      serviceConfig = hardening // {
+        Type = "oneshot";
+        ExecStart = "${runnerApp}/bin/private-job-run %i";
+        # bounded timeout — 개별 작업의 자체 타임아웃보다 넉넉한 최후 상한이다.
+        # 초과 시 control-group 전체가 정리된다(잔존 자식 0).
+        TimeoutStartSec = "8h";
+      };
+      environment = commonEnvironment;
+    };
+
+    systemd.user.services."private-jobs-sync" = {
+      description = "sync private job definitions to user timers";
+      serviceConfig = hardening // {
+        Type = "oneshot";
+        ExecStart = "${syncApp}/bin/private-jobs-sync";
+        TimeoutStartSec = "5min";
+      };
+      environment = commonEnvironment;
+    };
+
+    systemd.user.timers."private-jobs-sync" = {
+      description = "periodic private job definition sync";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "2min";
+        OnUnitActiveSec = "15min";
+      };
+    };
+  };
+}

--- a/modules/nixos/programs/private-job-runner/lib.sh
+++ b/modules/nixos/programs/private-job-runner/lib.sh
@@ -9,7 +9,8 @@ is_valid_slug() {
 }
 
 # 경로 안전성 판정 — 위반 사유를 stdout으로 출력한다 (정상이면 빈 출력. 반환값이
-# 아니라 출력이 계약이다: 호출자가 사유를 로그·알림에 그대로 쓴다).
+# 아니라 출력이 계약이다 — 이름의 "_reason"이 그 계약이다: predicate처럼
+# `if path_violation_reason ...`으로 쓰면 항상 참이 된다).
 #   type: f(regular file) | d(directory) — owner 소유의 FIFO·디렉터리 오배치도
 #         입력 종류 위반으로 잡는다 (head가 정지·즉사하는 경로 차단)
 #   denymask: 거부할 권한 비트(8진) — 실행 입력은 022(group/world-write 금지),
@@ -17,7 +18,7 @@ is_valid_slug() {
 # 검증~사용 사이의 좁은 TOCTOU 창은 남는다: 이 기기의 위협 모델은 "다른 로컬
 # 계정이 없는 단일 사용자 호스트"이고, 이 검증의 목적은 실수로 느슨한 권한·링크가
 # 생긴 상태를 fail-closed로 드러내는 것이다.
-path_violation() { # path label type denymask
+path_violation_reason() { # path label type denymask
   local path="$1" label="$2" type="$3" denymask="$4" perms
   if [ ! -e "$path" ]; then
     printf '%s missing' "$label"
@@ -32,6 +33,16 @@ path_violation() { # path label type denymask
     d) [ -d "$path" ] || { printf '%s is not a directory' "$label"; return 0; } ;;
     *) printf 'internal: unknown type %s' "$type"; return 0 ;;
   esac
+  # 필수 접근권 — 금지 비트만 보면 owner가 읽지 못하는 0300 디렉터리가 통과해
+  # "작업 0건 발견 → 전체 timer 삭제" 같은 조용한 오동작으로 이어진다.
+  if [ ! -r "$path" ]; then
+    printf '%s is not readable by owner' "$label"
+    return 0
+  fi
+  if [ "$type" = "d" ] && [ ! -x "$path" ]; then
+    printf '%s is not searchable by owner' "$label"
+    return 0
+  fi
   if [ ! -O "$path" ]; then
     printf '%s not owned by user' "$label"
     return 0

--- a/modules/nixos/programs/private-job-runner/lib.sh
+++ b/modules/nixos/programs/private-job-runner/lib.sh
@@ -1,0 +1,37 @@
+# shellcheck shell=bash
+# runner·sync가 공유하는 검증 계약 — slug 문법과 경로 안전성의 단일 소유처.
+# 두 스크립트에 각자 구현하면 discovery(sync)와 execution(runner)이 서로 다른
+# 입력을 받아들이는 drift가 생긴다.
+
+# 중립 slug 문법 — 작업 실체를 드러내지 않는 이름만 허용한다.
+is_valid_slug() {
+  [[ "$1" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]
+}
+
+# 경로가 "본인 소유·비 symlink·group/world-write 금지"인지 — 실행·스케줄 입력에
+# 닿는 모든 구성요소에 적용한다. 최종 파일만 검사하면 상위 디렉터리 교체·symlink로
+# 우회된다. 검증~사용 사이의 좁은 TOCTOU 창은 남는다: 이 기기의 위협 모델은
+# "다른 로컬 계정이 없는 단일 사용자 호스트"이고, 이 검증의 목적은 실수로 느슨한
+# 권한·링크가 생긴 상태를 fail-closed로 드러내는 것이다.
+# 반환: 0 정상 / 1 위반 (위반 사유는 stdout — 호출자가 실패 처리 방식을 소유)
+path_violation() { # path label → 위반 사유 출력(없으면 빈 출력)
+  local path="$1" label="$2" perms
+  if [ ! -e "$path" ]; then
+    printf '%s missing' "$label"
+    return 0
+  fi
+  if [ -L "$path" ]; then
+    printf '%s is a symlink' "$label"
+    return 0
+  fi
+  if [ ! -O "$path" ]; then
+    printf '%s not owned by user' "$label"
+    return 0
+  fi
+  perms="$(stat -c %a "$path")"
+  if [ $((8#$perms & 8#022)) -ne 0 ]; then
+    printf '%s is group/world-writable' "$label"
+    return 0
+  fi
+  return 0
+}

--- a/modules/nixos/programs/private-job-runner/lib.sh
+++ b/modules/nixos/programs/private-job-runner/lib.sh
@@ -8,14 +8,17 @@ is_valid_slug() {
   [[ "$1" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]
 }
 
-# 경로가 "본인 소유·비 symlink·group/world-write 금지"인지 — 실행·스케줄 입력에
-# 닿는 모든 구성요소에 적용한다. 최종 파일만 검사하면 상위 디렉터리 교체·symlink로
-# 우회된다. 검증~사용 사이의 좁은 TOCTOU 창은 남는다: 이 기기의 위협 모델은
-# "다른 로컬 계정이 없는 단일 사용자 호스트"이고, 이 검증의 목적은 실수로 느슨한
-# 권한·링크가 생긴 상태를 fail-closed로 드러내는 것이다.
-# 반환: 0 정상 / 1 위반 (위반 사유는 stdout — 호출자가 실패 처리 방식을 소유)
-path_violation() { # path label → 위반 사유 출력(없으면 빈 출력)
-  local path="$1" label="$2" perms
+# 경로 안전성 판정 — 위반 사유를 stdout으로 출력한다 (정상이면 빈 출력. 반환값이
+# 아니라 출력이 계약이다: 호출자가 사유를 로그·알림에 그대로 쓴다).
+#   type: f(regular file) | d(directory) — owner 소유의 FIFO·디렉터리 오배치도
+#         입력 종류 위반으로 잡는다 (head가 정지·즉사하는 경로 차단)
+#   denymask: 거부할 권한 비트(8진) — 실행 입력은 022(group/world-write 금지),
+#             raw 로그 상태 사슬은 077(0700/0600 계약)
+# 검증~사용 사이의 좁은 TOCTOU 창은 남는다: 이 기기의 위협 모델은 "다른 로컬
+# 계정이 없는 단일 사용자 호스트"이고, 이 검증의 목적은 실수로 느슨한 권한·링크가
+# 생긴 상태를 fail-closed로 드러내는 것이다.
+path_violation() { # path label type denymask
+  local path="$1" label="$2" type="$3" denymask="$4" perms
   if [ ! -e "$path" ]; then
     printf '%s missing' "$label"
     return 0
@@ -24,13 +27,25 @@ path_violation() { # path label → 위반 사유 출력(없으면 빈 출력)
     printf '%s is a symlink' "$label"
     return 0
   fi
+  case "$type" in
+    f) [ -f "$path" ] || { printf '%s is not a regular file' "$label"; return 0; } ;;
+    d) [ -d "$path" ] || { printf '%s is not a directory' "$label"; return 0; } ;;
+    *) printf 'internal: unknown type %s' "$type"; return 0 ;;
+  esac
   if [ ! -O "$path" ]; then
     printf '%s not owned by user' "$label"
     return 0
   fi
   perms="$(stat -c %a "$path")"
-  if [ $((8#$perms & 8#022)) -ne 0 ]; then
-    printf '%s is group/world-writable' "$label"
+  if [ $((8#$perms & 8#$denymask)) -ne 0 ]; then
+    printf '%s has forbidden permission bits (%s)' "$label" "$perms"
+    return 0
+  fi
+  # canonical 일치 — 마지막 구성요소의 -L 검사는 상위 디렉터리 symlink를 못 본다.
+  # 상위 어디든 symlink면 realpath가 달라져 여기서 잡힌다 (raw 로그·unit이 선언
+  # 경로 밖으로 흐르는 것 차단).
+  if [ "$(realpath "$path")" != "$path" ]; then
+    printf '%s resolves outside its declared path' "$label"
     return 0
   fi
   return 0

--- a/modules/nixos/programs/private-job-runner/notify.sh
+++ b/modules/nixos/programs/private-job-runner/notify.sh
@@ -6,10 +6,12 @@
 # $EXIT_STATUS를 받으므로, 여기서만 판정해 같은 run에 정확히 1회 보낸다.
 # 알림 내용은 generic 필드(slug·invocation·result·exit)만 — 작업 실체는 싣지 않는다.
 #
-# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE
+# 필요 env (unit이 주입): PRIVATE_JOB_LIB, PUSHOVER_LIB, PUSHOVER_CRED_FILE
 # systemd 제공 env: SERVICE_RESULT, EXIT_CODE, EXIT_STATUS, INVOCATION_ID
 set -euo pipefail
 
+# shellcheck source=/dev/null
+source "$PRIVATE_JOB_LIB"
 # shellcheck source=/dev/null
 source "$PUSHOVER_LIB"
 
@@ -17,6 +19,16 @@ slug="${1:-unknown}"
 result="${SERVICE_RESULT:-unknown}"
 
 if [ "$result" = "success" ]; then
+  exit 0
+fi
+
+# 실행기가 거부한 invalid instance 이름도 외부 채널에는 싣지 않는다 — 이름 자체가
+# 작업 실체를 담을 수 있다 (검증은 runner와 같은 lib 계약).
+is_valid_slug "$slug" || slug="withheld"
+
+# sync가 스스로 판정·통지한 정의 오류(exit 3 규약)는 여기서 다시 보내지 않는다 —
+# run당 외부 알림 1회 계약 (비정형 실패만 이 훅이 담당).
+if [ "${EXIT_STATUS:-}" = "3" ]; then
   exit 0
 fi
 

--- a/modules/nixos/programs/private-job-runner/notify.sh
+++ b/modules/nixos/programs/private-job-runner/notify.sh
@@ -16,6 +16,7 @@ source "$PRIVATE_JOB_LIB"
 source "$PUSHOVER_LIB"
 
 slug="${1:-unknown}"
+kind="${2:-job}" # job | sync — exit-code 해석은 호출자 종류별로 분리된 계약이다
 result="${SERVICE_RESULT:-unknown}"
 
 if [ "$result" = "success" ]; then
@@ -26,9 +27,10 @@ fi
 # 작업 실체를 담을 수 있다 (검증은 runner와 같은 lib 계약).
 is_valid_slug "$slug" || slug="withheld"
 
-# sync가 스스로 판정·통지한 정의 오류(exit 3 규약)는 여기서 다시 보내지 않는다 —
-# run당 외부 알림 1회 계약 (비정형 실패만 이 훅이 담당).
-if [ "${EXIT_STATUS:-}" = "3" ]; then
+# sync가 스스로 판정·통지한 정의 오류(SYNC_HANDLED_EXIT 규약 — 값의 소유는
+# default.nix)는 다시 보내지 않는다. 이 해석은 sync 호출에만 적용된다 — 일반
+# 작업의 같은 exit 값은 평범한 실패이며 알림 대상이다.
+if [ "$kind" = "sync" ] && [ "${EXIT_STATUS:-}" = "${SYNC_HANDLED_EXIT:?}" ]; then
   exit 0
 fi
 

--- a/modules/nixos/programs/private-job-runner/notify.sh
+++ b/modules/nixos/programs/private-job-runner/notify.sh
@@ -1,0 +1,25 @@
+# shellcheck shell=bash
+# private-job@ unit의 ExecStopPost — run 실패 알림의 단일 소유자.
+#
+# runner 내부에서 알림을 보내면 systemd timeout·강제 종료 경로에서 알림이 증발한다.
+# ExecStopPost는 시작 timeout을 포함한 모든 종료 뒤에 실행되고 $SERVICE_RESULT/
+# $EXIT_STATUS를 받으므로, 여기서만 판정해 같은 run에 정확히 1회 보낸다.
+# 알림 내용은 generic 필드(slug·invocation·result·exit)만 — 작업 실체는 싣지 않는다.
+#
+# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE
+# systemd 제공 env: SERVICE_RESULT, EXIT_CODE, EXIT_STATUS, INVOCATION_ID
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "$PUSHOVER_LIB"
+
+slug="${1:-unknown}"
+result="${SERVICE_RESULT:-unknown}"
+
+if [ "$result" = "success" ]; then
+  exit 0
+fi
+
+pushover_send "$PUSHOVER_CRED_FILE" "private job failed" \
+  "job=$slug run=${INVOCATION_ID:0:8} result=$result exit=${EXIT_STATUS:-?}" 1 \
+  || echo "WARNING: failure notification could not be sent" >&2

--- a/modules/nixos/programs/private-job-runner/runner.sh
+++ b/modules/nixos/programs/private-job-runner/runner.sh
@@ -27,7 +27,7 @@ fail() { # detail → failed unit (알림은 ExecStopPost 소유)
 
 assert_safe() { # path label type denymask
   local violation
-  violation="$(path_violation "$1" "$2" "$3" "$4")"
+  violation="$(path_violation_reason "$1" "$2" "$3" "$4")"
   [ -z "$violation" ] || fail "$violation"
 }
 

--- a/modules/nixos/programs/private-job-runner/runner.sh
+++ b/modules/nixos/programs/private-job-runner/runner.sh
@@ -9,9 +9,12 @@
 # 소유한다 — 여기서 알림을 보내면 systemd timeout처럼 이 스크립트가 강제 종료되는
 # 실패 경로에서 알림이 증발하고, 두 곳이 보내면 같은 run에 이중 알림이 된다.
 #
-# 필요 env (unit이 주입): PRIVATE_JOBS_DEFINITIONS, PRIVATE_JOBS_STATE (HOME 상대)
+# 필요 env (unit이 주입): PRIVATE_JOB_LIB, PRIVATE_JOBS_DEFINITIONS, PRIVATE_JOBS_STATE
 set -euo pipefail
 umask 0077
+
+# shellcheck source=/dev/null
+source "$PRIVATE_JOB_LIB"
 
 JOBS_ROOT="$HOME/$PRIVATE_JOBS_DEFINITIONS"
 STATE_ROOT="$HOME/$PRIVATE_JOBS_STATE"
@@ -22,20 +25,10 @@ fail() { # detail → failed unit (알림은 ExecStopPost 소유)
   exit 1
 }
 
-# 경로가 "본인 소유·비 symlink·group/world-write 금지"인지 — 실행할 코드에
-# 닿는 모든 구성요소에 적용한다. 최종 파일만 검사하면 상위 디렉터리 교체·symlink로
-# 우회된다. 검증~실행 사이의 좁은 TOCTOU 창은 남는다: 이 기기의 위협 모델은
-# "다른 로컬 계정이 없는 단일 사용자 호스트"이고, 이 검증의 목적은 실수로 느슨한
-# 권한·링크가 생긴 상태를 fail-closed로 드러내는 것이다.
-assert_safe_path() { # path label
-  local path="$1" label="$2" perms
-  [ -e "$path" ] || fail "$label missing"
-  [ ! -L "$path" ] || fail "$label is a symlink"
-  [ -O "$path" ] || fail "$label not owned by user"
-  perms="$(stat -c %a "$path")"
-  if [ $((8#$perms & 8#022)) -ne 0 ]; then
-    fail "$label is group/world-writable"
-  fi
+assert_safe() { # path label
+  local violation
+  violation="$(path_violation "$1" "$2")"
+  [ -z "$violation" ] || fail "$violation"
 }
 
 main() {
@@ -44,25 +37,29 @@ main() {
   run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 
   # slug는 중립 문자열만 — 경로 탈출·특수문자를 unit 이름 단계에서 차단한다.
-  if ! [[ "$slug" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; then
-    fail "invalid slug"
-  fi
+  is_valid_slug "$slug" || fail "invalid slug"
 
   local job_dir="$JOBS_ROOT/$slug"
   local run_sh="$job_dir/run.sh"
 
   # 작업 부재·검증 실패도 quiet skip이 아니라 failed unit이다 (timer만 남고
   # 작업이 사라진 상태를 조용히 지나치면 스케줄이 죽은 것을 아무도 모른다).
-  assert_safe_path "$JOBS_ROOT" "jobs root"
-  assert_safe_path "$job_dir" "job directory"
-  assert_safe_path "$run_sh" "run.sh"
+  assert_safe "$JOBS_ROOT" "jobs root"
+  assert_safe "$job_dir" "job directory"
+  assert_safe "$run_sh" "run.sh"
   [ -x "$run_sh" ] || fail "run.sh not executable"
-  # canonical 경로가 jobs root 아래인지 — 위 구성요소 검사와 함께 상위 symlink
+  # canonical 경로가 선언 경로와 일치하는지 — 구성요소 검사와 함께 상위 symlink
   # 우회를 이중으로 막는다.
   [ "$(realpath "$run_sh")" = "$run_sh" ] || fail "run.sh resolves outside its declared path"
 
+  # raw 로그가 흐르는 상태 사슬도 실행 입력과 같은 기준으로 검증한다 — umask는
+  # 새 디렉터리에만 적용되므로 기존의 느슨한 모드·symlink는 여기서 fail-closed로
+  # 드러낸다 (계약 밖 경로로의 로그 리다이렉트 차단).
   local log_dir="$STATE_ROOT/$slug/logs"
   mkdir -p "$log_dir"
+  assert_safe "$STATE_ROOT" "state root"
+  assert_safe "$STATE_ROOT/$slug" "state directory"
+  assert_safe "$log_dir" "log directory"
   local log_file="$log_dir/$run_id.log"
 
   # raw stdout/stderr는 journal이 아니라 로컬 0600 파일로만 — unit/journal 표면에는

--- a/modules/nixos/programs/private-job-runner/runner.sh
+++ b/modules/nixos/programs/private-job-runner/runner.sh
@@ -1,36 +1,41 @@
 # shellcheck shell=bash
 # Generic private job 실행기 — systemd user template unit(private-job@<slug>)이 호출한다.
 #
-# 이 실행기는 작업의 내용을 알지 못한다: slug의 로컬 디렉터리에서 run.sh를 실행하고,
-# 로그를 로컬 상태 디렉터리(0700/0600)에 남기며, 실패 시 generic Pushover 알림
-# (opaque slug·run id·exit class만)을 보낸다. 작업 실체·시크릿·로그 내용은 전부
-# 기기 로컬 소유 — 이 repo·store·journal 어디에도 나타나지 않는다.
+# 이 실행기는 작업의 내용을 알지 못한다: slug의 로컬 디렉터리에서 run.sh를 실행하고
+# 로그를 로컬 상태 디렉터리(0700/0600)에 남긴다. 작업 실체·시크릿·로그 내용은 전부
+# 기기 로컬 소유 — repo·store·journal 어디에도 나타나지 않는다.
 #
-# 알림 소유권: 같은 run에 대한 외부 알림은 이 실행기가 소유한다(실패 시 1회).
-# 개별 작업 래퍼는 자체 외부 push 알림을 배선하지 않는 것이 규약이다 — 이중 알림을
-# 만들지 않기 위해서다 (작업 내부 로그·상태 파일은 자유).
+# 실패 알림은 이 스크립트가 아니라 unit의 ExecStopPost(private-job-notify)가
+# 소유한다 — 여기서 알림을 보내면 systemd timeout처럼 이 스크립트가 강제 종료되는
+# 실패 경로에서 알림이 증발하고, 두 곳이 보내면 같은 run에 이중 알림이 된다.
 #
-# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE
+# 필요 env (unit이 주입): PRIVATE_JOBS_DEFINITIONS, PRIVATE_JOBS_STATE (HOME 상대)
 set -euo pipefail
 umask 0077
 
-JOBS_ROOT="$HOME/.local/private-jobs"
-STATE_ROOT="$HOME/.local/state/private-jobs"
+JOBS_ROOT="$HOME/$PRIVATE_JOBS_DEFINITIONS"
+STATE_ROOT="$HOME/$PRIVATE_JOBS_STATE"
 LOG_RETENTION=30 # run 단위 — 주1회 작업 기준 반년 이상의 진단 이력
 
-# shellcheck source=/dev/null
-source "$PUSHOVER_LIB"
-
-notify_failure() { # slug run_id detail
-  # generic 필드만 — 작업 stdout/stderr·경로 내용은 알림에 싣지 않는다.
-  pushover_send "$PUSHOVER_CRED_FILE" "private job failed" "job=$1 run=$2 $3" 1 \
-    || echo "WARNING: failure notification could not be sent" >&2
+fail() { # detail → failed unit (알림은 ExecStopPost 소유)
+  echo "ERROR: $1" >&2
+  exit 1
 }
 
-fail() { # slug run_id detail → 알림 후 failed unit
-  echo "ERROR: $3" >&2
-  notify_failure "$1" "$2" "$3"
-  exit 1
+# 경로가 "본인 소유·비 symlink·group/world-write 금지"인지 — 실행할 코드에
+# 닿는 모든 구성요소에 적용한다. 최종 파일만 검사하면 상위 디렉터리 교체·symlink로
+# 우회된다. 검증~실행 사이의 좁은 TOCTOU 창은 남는다: 이 기기의 위협 모델은
+# "다른 로컬 계정이 없는 단일 사용자 호스트"이고, 이 검증의 목적은 실수로 느슨한
+# 권한·링크가 생긴 상태를 fail-closed로 드러내는 것이다.
+assert_safe_path() { # path label
+  local path="$1" label="$2" perms
+  [ -e "$path" ] || fail "$label missing"
+  [ ! -L "$path" ] || fail "$label is a symlink"
+  [ -O "$path" ] || fail "$label not owned by user"
+  perms="$(stat -c %a "$path")"
+  if [ $((8#$perms & 8#022)) -ne 0 ]; then
+    fail "$label is group/world-writable"
+  fi
 }
 
 main() {
@@ -40,28 +45,21 @@ main() {
 
   # slug는 중립 문자열만 — 경로 탈출·특수문자를 unit 이름 단계에서 차단한다.
   if ! [[ "$slug" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; then
-    fail "invalid" "$run_id" "invalid slug"
+    fail "invalid slug"
   fi
 
   local job_dir="$JOBS_ROOT/$slug"
   local run_sh="$job_dir/run.sh"
 
-  # 작업 디렉터리·스크립트 검증 — symlink escape, 타 owner, group/world-writable을
-  # 거부한다: user unit이 실행할 코드는 본인 소유의 잠긴 파일이어야 한다.
-  # 작업 부재도 quiet skip이 아니라 failed unit + 알림이다 (timer만 남고 작업이
-  # 사라진 상태를 조용히 지나치면 스케줄이 죽은 것을 아무도 모른다).
-  [ -d "$job_dir" ] || fail "$slug" "$run_id" "job directory missing"
-  [ ! -L "$job_dir" ] || fail "$slug" "$run_id" "job directory is a symlink"
-  [ -O "$job_dir" ] || fail "$slug" "$run_id" "job directory not owned by user"
-  [ -f "$run_sh" ] || fail "$slug" "$run_id" "run.sh missing"
-  [ ! -L "$run_sh" ] || fail "$slug" "$run_id" "run.sh is a symlink"
-  [ -O "$run_sh" ] || fail "$slug" "$run_id" "run.sh not owned by user"
-  [ -x "$run_sh" ] || fail "$slug" "$run_id" "run.sh not executable"
-  local perms
-  perms="$(stat -c %a "$run_sh")"
-  if [ $((8#$perms & 8#022)) -ne 0 ]; then
-    fail "$slug" "$run_id" "run.sh is group/world-writable"
-  fi
+  # 작업 부재·검증 실패도 quiet skip이 아니라 failed unit이다 (timer만 남고
+  # 작업이 사라진 상태를 조용히 지나치면 스케줄이 죽은 것을 아무도 모른다).
+  assert_safe_path "$JOBS_ROOT" "jobs root"
+  assert_safe_path "$job_dir" "job directory"
+  assert_safe_path "$run_sh" "run.sh"
+  [ -x "$run_sh" ] || fail "run.sh not executable"
+  # canonical 경로가 jobs root 아래인지 — 위 구성요소 검사와 함께 상위 symlink
+  # 우회를 이중으로 막는다.
+  [ "$(realpath "$run_sh")" = "$run_sh" ] || fail "run.sh resolves outside its declared path"
 
   local log_dir="$STATE_ROOT/$slug/logs"
   mkdir -p "$log_dir"
@@ -81,7 +79,6 @@ main() {
   done
 
   if [ "$rc" -ne 0 ]; then
-    notify_failure "$slug" "$run_id" "exit=$rc"
     echo "run=$run_id job=$slug failed exit=$rc" >&2
     exit "$rc"
   fi

--- a/modules/nixos/programs/private-job-runner/runner.sh
+++ b/modules/nixos/programs/private-job-runner/runner.sh
@@ -25,9 +25,9 @@ fail() { # detail → failed unit (알림은 ExecStopPost 소유)
   exit 1
 }
 
-assert_safe() { # path label
+assert_safe() { # path label type denymask
   local violation
-  violation="$(path_violation "$1" "$2")"
+  violation="$(path_violation "$1" "$2" "$3" "$4")"
   [ -z "$violation" ] || fail "$violation"
 }
 
@@ -44,26 +44,26 @@ main() {
 
   # 작업 부재·검증 실패도 quiet skip이 아니라 failed unit이다 (timer만 남고
   # 작업이 사라진 상태를 조용히 지나치면 스케줄이 죽은 것을 아무도 모른다).
-  assert_safe "$JOBS_ROOT" "jobs root"
-  assert_safe "$job_dir" "job directory"
-  assert_safe "$run_sh" "run.sh"
+  assert_safe "$JOBS_ROOT" "jobs root" d 022
+  assert_safe "$job_dir" "job directory" d 022
+  assert_safe "$run_sh" "run.sh" f 022
   [ -x "$run_sh" ] || fail "run.sh not executable"
-  # canonical 경로가 선언 경로와 일치하는지 — 구성요소 검사와 함께 상위 symlink
-  # 우회를 이중으로 막는다.
-  [ "$(realpath "$run_sh")" = "$run_sh" ] || fail "run.sh resolves outside its declared path"
 
-  # raw 로그가 흐르는 상태 사슬도 실행 입력과 같은 기준으로 검증한다 — umask는
-  # 새 디렉터리에만 적용되므로 기존의 느슨한 모드·symlink는 여기서 fail-closed로
-  # 드러낸다 (계약 밖 경로로의 로그 리다이렉트 차단).
+  # raw 로그가 흐르는 상태 사슬은 0700/0600 계약(077 거부)으로 검증한다 — umask는
+  # 새 객체에만 적용되므로 기존의 느슨한 모드·symlink(상위 포함)는 여기서
+  # fail-closed로 드러낸다 (계약 밖 경로로의 로그 리다이렉트 차단).
   local log_dir="$STATE_ROOT/$slug/logs"
   mkdir -p "$log_dir"
-  assert_safe "$STATE_ROOT" "state root"
-  assert_safe "$STATE_ROOT/$slug" "state directory"
-  assert_safe "$log_dir" "log directory"
+  assert_safe "$STATE_ROOT" "state root" d 077
+  assert_safe "$STATE_ROOT/$slug" "state directory" d 077
+  assert_safe "$log_dir" "log directory" d 077
   local log_file="$log_dir/$run_id.log"
+  # run id는 유니크(UTC초+pid)다 — 같은 이름이 이미 있으면 이상 상태이고, 기존
+  # 파일·symlink 위에 열면 느슨한 모드·링크 대상을 그대로 물려받는다.
+  [ ! -e "$log_file" ] && [ ! -L "$log_file" ] || fail "log file path already occupied"
 
   # raw stdout/stderr는 journal이 아니라 로컬 0600 파일로만 — unit/journal 표면에는
-  # generic run id만 남는다.
+  # generic 식별자(run id·중립 slug)만 남는다.
   echo "run=$run_id job=$slug start"
   local rc=0
   "$run_sh" >"$log_file" 2>&1 || rc=$?

--- a/modules/nixos/programs/private-job-runner/runner.sh
+++ b/modules/nixos/programs/private-job-runner/runner.sh
@@ -1,0 +1,91 @@
+# shellcheck shell=bash
+# Generic private job 실행기 — systemd user template unit(private-job@<slug>)이 호출한다.
+#
+# 이 실행기는 작업의 내용을 알지 못한다: slug의 로컬 디렉터리에서 run.sh를 실행하고,
+# 로그를 로컬 상태 디렉터리(0700/0600)에 남기며, 실패 시 generic Pushover 알림
+# (opaque slug·run id·exit class만)을 보낸다. 작업 실체·시크릿·로그 내용은 전부
+# 기기 로컬 소유 — 이 repo·store·journal 어디에도 나타나지 않는다.
+#
+# 알림 소유권: 같은 run에 대한 외부 알림은 이 실행기가 소유한다(실패 시 1회).
+# 개별 작업 래퍼는 자체 외부 push 알림을 배선하지 않는 것이 규약이다 — 이중 알림을
+# 만들지 않기 위해서다 (작업 내부 로그·상태 파일은 자유).
+#
+# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE
+set -euo pipefail
+umask 0077
+
+JOBS_ROOT="$HOME/.local/private-jobs"
+STATE_ROOT="$HOME/.local/state/private-jobs"
+LOG_RETENTION=30 # run 단위 — 주1회 작업 기준 반년 이상의 진단 이력
+
+# shellcheck source=/dev/null
+source "$PUSHOVER_LIB"
+
+notify_failure() { # slug run_id detail
+  # generic 필드만 — 작업 stdout/stderr·경로 내용은 알림에 싣지 않는다.
+  pushover_send "$PUSHOVER_CRED_FILE" "private job failed" "job=$1 run=$2 $3" 1 \
+    || echo "WARNING: failure notification could not be sent" >&2
+}
+
+fail() { # slug run_id detail → 알림 후 failed unit
+  echo "ERROR: $3" >&2
+  notify_failure "$1" "$2" "$3"
+  exit 1
+}
+
+main() {
+  local slug="${1:-}"
+  local run_id
+  run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+
+  # slug는 중립 문자열만 — 경로 탈출·특수문자를 unit 이름 단계에서 차단한다.
+  if ! [[ "$slug" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; then
+    fail "invalid" "$run_id" "invalid slug"
+  fi
+
+  local job_dir="$JOBS_ROOT/$slug"
+  local run_sh="$job_dir/run.sh"
+
+  # 작업 디렉터리·스크립트 검증 — symlink escape, 타 owner, group/world-writable을
+  # 거부한다: user unit이 실행할 코드는 본인 소유의 잠긴 파일이어야 한다.
+  # 작업 부재도 quiet skip이 아니라 failed unit + 알림이다 (timer만 남고 작업이
+  # 사라진 상태를 조용히 지나치면 스케줄이 죽은 것을 아무도 모른다).
+  [ -d "$job_dir" ] || fail "$slug" "$run_id" "job directory missing"
+  [ ! -L "$job_dir" ] || fail "$slug" "$run_id" "job directory is a symlink"
+  [ -O "$job_dir" ] || fail "$slug" "$run_id" "job directory not owned by user"
+  [ -f "$run_sh" ] || fail "$slug" "$run_id" "run.sh missing"
+  [ ! -L "$run_sh" ] || fail "$slug" "$run_id" "run.sh is a symlink"
+  [ -O "$run_sh" ] || fail "$slug" "$run_id" "run.sh not owned by user"
+  [ -x "$run_sh" ] || fail "$slug" "$run_id" "run.sh not executable"
+  local perms
+  perms="$(stat -c %a "$run_sh")"
+  if [ $((8#$perms & 8#022)) -ne 0 ]; then
+    fail "$slug" "$run_id" "run.sh is group/world-writable"
+  fi
+
+  local log_dir="$STATE_ROOT/$slug/logs"
+  mkdir -p "$log_dir"
+  local log_file="$log_dir/$run_id.log"
+
+  # raw stdout/stderr는 journal이 아니라 로컬 0600 파일로만 — unit/journal 표면에는
+  # generic run id만 남는다.
+  echo "run=$run_id job=$slug start"
+  local rc=0
+  "$run_sh" >"$log_file" 2>&1 || rc=$?
+
+  # bounded retention — 오래된 로그를 지워 로컬 상태가 무한 성장하지 않게 한다.
+  # (파일명은 이 실행기가 만든 run id뿐이라 공백·특수문자가 없다 — ls 파싱 안전)
+  # shellcheck disable=SC2012
+  ls -1t "$log_dir" | tail -n +"$((LOG_RETENTION + 1))" | while IFS= read -r f; do
+    rm -f "$log_dir/$f"
+  done
+
+  if [ "$rc" -ne 0 ]; then
+    notify_failure "$slug" "$run_id" "exit=$rc"
+    echo "run=$run_id job=$slug failed exit=$rc" >&2
+    exit "$rc"
+  fi
+  echo "run=$run_id job=$slug ok"
+}
+
+main "$@"

--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -35,10 +35,19 @@ declare -A error_seen=() # 이번 run에서 관측된 오류 key — 종료 시 
 
 job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한다 (내용이
   # 바뀌면 새 알림, 해소되면 marker가 걷혀 재발 시 다시 알림).
-  local key detail marker
+  local key detail marker err_dir_violation
   key="$(printf '%s' "$1" | tr -c 'a-zA-Z0-9-' '_')"
   detail="$2"
   marker="$ERROR_DIR/$key"
+  # marker 경로가 symlink면 읽지도 쓰지도 않는다 — 링크 대상 파일을 따라가
+  # 임의 경로를 덮어쓸 수 있다.
+  if [ -L "$marker" ]; then
+    echo "ERROR: job=$1 $detail" >&2
+    echo "WARNING: sync-error marker is a symlink — dedupe 생략" >&2
+    sync_failed=1
+    error_seen["$key"]=1
+    return 0
+  fi
   echo "ERROR: job=$1 $detail" >&2
   sync_failed=1
   error_seen["$key"]=1
@@ -47,7 +56,7 @@ job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한
     # "알림 완료"로 남아 같은 오류의 재시도가 영구 억제된다.
     if pushover_send "$PUSHOVER_CRED_FILE" "private job sync error" "job=$1 $detail" 1; then
       mkdir -p "$ERROR_DIR"
-      err_dir_violation="$(path_violation "$ERROR_DIR" "sync error dir" d 077)"
+      err_dir_violation="$(path_violation_reason "$ERROR_DIR" "sync error dir" d 077)"
       if [ -z "$err_dir_violation" ]; then
         printf '%s' "$detail" > "$marker"
       else
@@ -77,7 +86,7 @@ declare -A want=()
 if [ -d "$JOBS_ROOT" ]; then
   # 스캔 대상 루트 자체도 실행 입력이다 — symlink·타 owner·느슨한 권한이면 스캔
   # 전체를 중단한다 (fail-closed).
-  root_violation="$(path_violation "$JOBS_ROOT" "jobs root" d 022)"
+  root_violation="$(path_violation_reason "$JOBS_ROOT" "jobs root" d 022)"
   if [ -n "$root_violation" ]; then
     job_error "jobs-root" "$root_violation"
   else
@@ -88,16 +97,22 @@ if [ -d "$JOBS_ROOT" ]; then
         job_error "$(masked_name "$slug")" "invalid slug directory (name withheld)"
         continue
       fi
-      violation="$(path_violation "${job_dir%/}" "job directory" d 022)"
+      violation="$(path_violation_reason "${job_dir%/}" "job directory" d 022)"
       if [ -n "$violation" ]; then
         job_error "$slug" "$violation"
         continue
       fi
       schedule_file="$job_dir/schedule"
       # schedule도 실행 계약의 입력이다 — run.sh와 같은 소유·링크·권한 기준을 요구한다.
-      violation="$(path_violation "$schedule_file" "schedule" f 022)"
+      violation="$(path_violation_reason "$schedule_file" "schedule" f 022)"
       if [ -n "$violation" ]; then
         job_error "$slug" "schedule: $violation"
+        continue
+      fi
+      # "1줄 파일" 계약을 실제로 검증한다 — 첫 줄만 조용히 소비하면 운영자는
+      # 나머지 내용도 반영됐다고 오해한다.
+      if [ -n "$(sed -n '2,$p' "$schedule_file" | tr -d '[:space:]')" ]; then
+        job_error "$slug" "schedule must be a single line"
         continue
       fi
       schedule="$(head -1 "$schedule_file")"
@@ -148,7 +163,12 @@ for unit_file in "$UNIT_DIR"/private-job-*.timer; do
   slug="${base#private-job-}"
   if [ -z "${want[$slug]:-}" ]; then
     if [ "$(loaded_fragment "$base.timer")" = "$unit_file" ]; then
-      systemctl --user stop "$base.timer" >/dev/null 2>&1 || true
+      # stop이 실패하면 파일을 지우지 않는다 — active timer가 manager 메모리에서
+      # 계속 발화하는 유령 상태를 만들지 않고 다음 sync가 재시도하게 한다.
+      if ! systemctl --user stop "$base.timer" >/dev/null 2>&1; then
+        job_error "$slug" "timer stop failed (unit file preserved for retry)"
+        continue
+      fi
     fi
     rm -f "$unit_file"
     changed=1
@@ -175,5 +195,8 @@ if [ -d "$ERROR_DIR" ]; then
   done
 fi
 
-[ "$sync_failed" -eq 0 ] || exit 1
+# 의도된 실패(정의 오류 등 — 개별 알림 완료)는 exit 3으로 구분한다: unit의
+# ExecStopPost는 이 코드를 보고 이중 알림을 건너뛰고, 비정형 실패(set -e의
+# 다른 종료)만 통지한다.
+[ "$sync_failed" -eq 0 ] || exit 3
 echo "sync ok: ${#want[@]} job(s)"

--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -1,43 +1,51 @@
 # shellcheck shell=bash
-# 로컬 private job 정의(~/.local/private-jobs/<slug>/schedule)를 systemd user
-# timer로 동기화한다 — 작업 discovery·스케줄은 전부 이 런타임 스캔에서만 읽는다.
+# 로컬 private job 정의(<definitions>/<slug>/schedule)를 systemd user timer로
+# 동기화한다 — 작업 discovery·스케줄은 전부 이 런타임 스캔에서만 읽는다.
 # Nix eval은 로컬 작업 디렉터리를 읽지 않으므로 store·repo에는 작업 정보가 0건이다.
 #
-# 생성물: $XDG_CONFIG_HOME/systemd/user/private-job-<slug>.timer (managed 헤더로
-# 표식). 정의가 사라진 timer는 disable 후 삭제한다. schedule이 잘못된 작업은
-# quiet skip이 아니다 — sync-error marker로 1회 알림(정상화 시 marker 해제)하고
-# sync 자체를 failed unit로 끝낸다.
+# 생성물은 user *runtime* unit 영역($XDG_RUNTIME_DIR/systemd/user)에 둔다 —
+# 영속 config 영역에 쓰면 모듈 비활성화·롤백 후 sync가 사라졌을 때 timer를 정리할
+# 주체가 없어 영구 잔존한다. runtime 영역은 재부팅에 소거되고, 활성 상태에서는
+# 부팅 2분 뒤 sync가 재생성한다 (Persistent의 놓친 스케줄 기록은 unit 파일 위치와
+# 무관한 systemd timer stamp가 소유하므로 유지된다). 비활성화 후 재부팅 전까지의
+# 잔존은 수용한다 — 다음 부팅이 소거 지점이다.
 #
-# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE
+# schedule이 잘못된 작업은 quiet skip이 아니다 — 오류 내용 기반 marker로 같은
+# 오류만 억제해 1회 알림(내용이 바뀌면 다시 알림, 해소되면 자동 해제)하고 sync를
+# failed unit로 끝낸다.
+#
+# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE,
+#   PRIVATE_JOBS_DEFINITIONS, PRIVATE_JOBS_STATE (HOME 상대)
 set -euo pipefail
 umask 0077
 
-JOBS_ROOT="$HOME/.local/private-jobs"
-STATE_ROOT="$HOME/.local/state/private-jobs"
-UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+JOBS_ROOT="$HOME/$PRIVATE_JOBS_DEFINITIONS"
+STATE_ROOT="$HOME/$PRIVATE_JOBS_STATE"
+UNIT_DIR="${XDG_RUNTIME_DIR:?}/systemd/user"
+ERROR_DIR="$STATE_ROOT/.sync-errors"
 MANAGED_MARK="# managed by private-jobs-sync"
 
 # shellcheck source=/dev/null
 source "$PUSHOVER_LIB"
 
-changed=0
-invalid=0
+sync_failed=0            # 모든 종류의 sync 오류(정의·enable 실패 포함)의 집계 플래그
+declare -A error_seen=() # 이번 run에서 관측된 오류 key — 종료 시 나머지 marker 해제
 
-job_error() { # slug detail — 같은 오류의 반복 알림은 marker로 dedupe한다
-  local slug="$1" detail="$2"
-  local marker="$STATE_ROOT/$slug/sync-error"
-  echo "ERROR: job=$slug $detail" >&2
-  invalid=1
-  if [ ! -f "$marker" ]; then
-    mkdir -p "$STATE_ROOT/$slug"
-    printf '%s\n' "$detail" > "$marker"
-    pushover_send "$PUSHOVER_CRED_FILE" "private job sync error" "job=$slug $detail" 1 \
+job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한다 (내용이
+  # 바뀌면 새 알림, 해소되면 marker가 걷혀 재발 시 다시 알림).
+  local key detail marker
+  key="$(printf '%s' "$1" | tr -c 'a-zA-Z0-9-' '_')"
+  detail="$2"
+  marker="$ERROR_DIR/$key"
+  echo "ERROR: job=$1 $detail" >&2
+  sync_failed=1
+  error_seen["$key"]=1
+  if [ ! -f "$marker" ] || [ "$(cat "$marker")" != "$detail" ]; then
+    mkdir -p "$ERROR_DIR"
+    printf '%s' "$detail" > "$marker"
+    pushover_send "$PUSHOVER_CRED_FILE" "private job sync error" "job=$1 $detail" 1 \
       || echo "WARNING: sync error notification could not be sent" >&2
   fi
-}
-
-job_ok() { # slug — 오류가 해소되면 marker를 걷어 다음 오류가 다시 알림되게 한다
-  rm -f "$STATE_ROOT/$1/sync-error"
 }
 
 mkdir -p "$UNIT_DIR"
@@ -49,41 +57,43 @@ if [ -d "$JOBS_ROOT" ]; then
     [ -d "$job_dir" ] || continue
     slug="$(basename "$job_dir")"
     if ! [[ "$slug" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; then
-      job_error "invalid" "invalid slug directory"
+      job_error "$slug" "invalid slug directory"
       continue
     fi
     if [ -L "${job_dir%/}" ] || [ ! -O "$job_dir" ]; then
       job_error "$slug" "job directory is a symlink or not owned by user"
       continue
     fi
-    if [ ! -f "$job_dir/schedule" ]; then
-      job_error "$slug" "schedule file missing"
+    schedule_file="$job_dir/schedule"
+    # schedule도 실행 계약의 입력이다 — run.sh와 같은 소유·링크 기준을 요구한다.
+    if [ ! -f "$schedule_file" ] || [ -L "$schedule_file" ] || [ ! -O "$schedule_file" ]; then
+      job_error "$slug" "schedule missing, symlink, or not owned by user"
       continue
     fi
-    schedule="$(head -1 "$job_dir/schedule")"
+    schedule="$(head -1 "$schedule_file")"
     if ! systemd-analyze calendar "$schedule" >/dev/null 2>&1; then
       job_error "$slug" "invalid OnCalendar expression"
       continue
     fi
-    job_ok "$slug"
-    want["$slug"]=1
 
     unit_file="$UNIT_DIR/private-job-$slug.timer"
-    # Persistent=true — 꺼져 있던 동안 놓친 스케줄을 부팅 후 따라잡는다 (재부팅
-    # 복구는 linger + timers.target 재진입과 함께 실기기 smoke가 검증한다).
+    # 같은 이름의 비관리 unit이 이미 있으면 덮지 않는다 — managed 헤더 검사는
+    # 제거 단계만이 아니라 생성 단계에도 적용해야 "사용자 unit 불가침" 계약이 선다.
+    if [ -e "$unit_file" ] && { [ -L "$unit_file" ] || ! head -1 "$unit_file" | grep -qF "$MANAGED_MARK"; }; then
+      job_error "$slug" "timer name collision with unmanaged unit"
+      continue
+    fi
+    want["$slug"]=1
+
     content="$MANAGED_MARK
 [Unit]
-Description=private job timer (%I)
+Description=private job timer ($slug)
 
 [Timer]
 OnCalendar=$schedule
 Persistent=true
 Unit=private-job@$slug.service
-
-[Install]
-WantedBy=timers.target
 "
-    content="${content//%I/$slug}"
     if [ ! -f "$unit_file" ] || [ "$(cat "$unit_file")" != "$(printf '%s' "$content")" ]; then
       printf '%s' "$content" > "$unit_file"
       changed=1
@@ -99,19 +109,31 @@ for unit_file in "$UNIT_DIR"/private-job-*.timer; do
   base="$(basename "$unit_file" .timer)"
   slug="${base#private-job-}"
   if [ -z "${want[$slug]:-}" ]; then
-    systemctl --user disable --now "$base.timer" >/dev/null 2>&1 || true
+    systemctl --user stop "$base.timer" >/dev/null 2>&1 || true
     rm -f "$unit_file"
     changed=1
   fi
 done
 
-if [ "$changed" -eq 1 ]; then
+if [ "${changed:-0}" -eq 1 ]; then
   systemctl --user daemon-reload
 fi
+# runtime unit은 enable(영속 링크)이 아니라 start로 상주시킨다 — 재부팅 후에는
+# 이 sync가 다시 생성·start한다 (부팅 복구 경로).
 for slug in "${!want[@]}"; do
-  systemctl --user enable --now "private-job-$slug.timer" >/dev/null 2>&1 \
-    || job_error "$slug" "timer enable failed"
+  systemctl --user start "private-job-$slug.timer" >/dev/null 2>&1 \
+    || job_error "$slug" "timer start failed"
 done
 
-[ "$invalid" -eq 0 ] || exit 1
+# ── 이번 run에서 관측되지 않은 오류 marker 해제 — 해소된 오류가 재발하면 다시
+# 알림되게 한다.
+if [ -d "$ERROR_DIR" ]; then
+  for marker in "$ERROR_DIR"/*; do
+    [ -f "$marker" ] || continue
+    key="$(basename "$marker")"
+    [ -n "${error_seen[$key]:-}" ] || rm -f "$marker"
+  done
+fi
+
+[ "$sync_failed" -eq 0 ] || exit 1
 echo "sync ok: ${#want[@]} job(s)"

--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -30,6 +30,7 @@ UNIT_DIR="${XDG_RUNTIME_DIR:?}/systemd/user"
 ERROR_DIR="$STATE_ROOT/.sync-errors"
 MANAGED_MARK="# managed by private-jobs-sync"
 
+changed=0                # unit 생성·갱신·삭제 발생 여부 (daemon-reload 필요 판단)
 sync_failed=0            # 정의·collision·start 실패를 포함한 모든 sync 오류의 집계 플래그
 declare -A error_seen=() # 이번 run에서 관측된 오류 key — 종료 시 나머지 marker 해제
 
@@ -39,9 +40,9 @@ job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한
   key="$(printf '%s' "$1" | tr -c 'a-zA-Z0-9-' '_')"
   detail="$2"
   marker="$ERROR_DIR/$key"
-  # marker 경로가 symlink면 읽지도 쓰지도 않는다 — 링크 대상 파일을 따라가
-  # 임의 경로를 덮어쓸 수 있다.
-  if [ -L "$marker" ]; then
+  # marker와 그 부모가 symlink면 읽지도 쓰지도 않는다 — 링크 대상을 따라가
+  # 임의 경로를 읽고 덮어쓸 수 있다.
+  if [ -L "$ERROR_DIR" ] || [ -L "$marker" ]; then
     echo "ERROR: job=$1 $detail" >&2
     echo "WARNING: sync-error marker is a symlink — dedupe 생략" >&2
     sync_failed=1
@@ -80,6 +81,15 @@ loaded_fragment() { # unit-name → FragmentPath (미로드면 빈 출력)
 }
 
 mkdir -p "$UNIT_DIR"
+
+# 발화 대상 template 자체가 shadow되면 모든 작업이 runner·hardening·알림 계약
+# 밖에서 실행된다 — NixOS 선언 경로(store 링크·/etc/systemd/user)가 아니면 전면
+# 중단한다.
+template_fragment="$(loaded_fragment "private-job@.service")"
+case "$template_fragment" in
+  "" | /nix/store/* | /etc/systemd/user/*) : ;;
+  *) job_error "template" "private-job@ template shadowed by unmanaged unit" ;;
+esac
 
 # ── 현재 정의된 작업 → timer 생성/갱신
 declare -A want=()
@@ -129,6 +139,13 @@ if [ -d "$JOBS_ROOT" ]; then
         job_error "$slug" "timer name collision with unmanaged unit"
         continue
       fi
+      # timer가 발화할 service 인스턴스도 shadow 검사 — timer만 검사하면 실행
+      # 자체가 unmanaged unit으로 넘어간다.
+      svc_fragment="$(loaded_fragment "private-job@$slug.service")"
+      case "$svc_fragment" in
+        "" | /nix/store/* | /etc/systemd/user/*) : ;;
+        *) job_error "$slug" "service name collision with unmanaged unit"; continue ;;
+      esac
       # -L을 먼저 본다 — dangling symlink는 -e가 false라 뒤에 두면 검사를 통과해
       # printf가 링크 대상(runtime 영역 밖)에 파일을 만들 수 있다.
       if [ -L "$unit_file" ] || { [ -e "$unit_file" ] && ! head -1 "$unit_file" | grep -qF "$MANAGED_MARK"; }; then
@@ -186,8 +203,9 @@ for slug in "${!want[@]}"; do
 done
 
 # ── 이번 run에서 관측되지 않은 오류 marker 해제 — 해소된 오류가 재발하면 다시
-# 알림되게 한다.
-if [ -d "$ERROR_DIR" ]; then
+# 알림되게 한다 (부모가 symlink면 대상 디렉터리의 파일을 지울 수 있어 건드리지
+# 않는다).
+if [ -d "$ERROR_DIR" ] && [ ! -L "$ERROR_DIR" ]; then
   for marker in "$ERROR_DIR"/*; do
     [ -f "$marker" ] || continue
     key="$(basename "$marker")"
@@ -195,8 +213,8 @@ if [ -d "$ERROR_DIR" ]; then
   done
 fi
 
-# 의도된 실패(정의 오류 등 — 개별 알림 완료)는 exit 3으로 구분한다: unit의
-# ExecStopPost는 이 코드를 보고 이중 알림을 건너뛰고, 비정형 실패(set -e의
-# 다른 종료)만 통지한다.
-[ "$sync_failed" -eq 0 ] || exit 3
+# 의도된 실패(정의 오류 등 — 개별 알림 완료)는 SYNC_HANDLED_EXIT(값 소유:
+# default.nix)로 구분한다: unit의 ExecStopPost는 이 코드를 보고 이중 알림을
+# 건너뛰고, 비정형 실패(set -e의 다른 종료)만 통지한다.
+[ "$sync_failed" -eq 0 ] || exit "${SYNC_HANDLED_EXIT:?}"
 echo "sync ok: ${#want[@]} job(s)"

--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -43,10 +43,19 @@ job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한
   sync_failed=1
   error_seen["$key"]=1
   if [ ! -f "$marker" ] || [ "$(cat "$marker")" != "$detail" ]; then
-    mkdir -p "$ERROR_DIR"
-    printf '%s' "$detail" > "$marker"
-    pushover_send "$PUSHOVER_CRED_FILE" "private job sync error" "job=$1 $detail" 1 \
-      || echo "WARNING: sync error notification could not be sent" >&2
+    # marker는 "알림이 실제로 나간 뒤"에만 기록한다 — 먼저 기록하면 전송 실패가
+    # "알림 완료"로 남아 같은 오류의 재시도가 영구 억제된다.
+    if pushover_send "$PUSHOVER_CRED_FILE" "private job sync error" "job=$1 $detail" 1; then
+      mkdir -p "$ERROR_DIR"
+      err_dir_violation="$(path_violation "$ERROR_DIR" "sync error dir" d 077)"
+      if [ -z "$err_dir_violation" ]; then
+        printf '%s' "$detail" > "$marker"
+      else
+        echo "WARNING: $err_dir_violation — marker 기록 생략" >&2
+      fi
+    else
+      echo "WARNING: sync error notification could not be sent" >&2
+    fi
   fi
 }
 
@@ -68,7 +77,7 @@ declare -A want=()
 if [ -d "$JOBS_ROOT" ]; then
   # 스캔 대상 루트 자체도 실행 입력이다 — symlink·타 owner·느슨한 권한이면 스캔
   # 전체를 중단한다 (fail-closed).
-  root_violation="$(path_violation "$JOBS_ROOT" "jobs root")"
+  root_violation="$(path_violation "$JOBS_ROOT" "jobs root" d 022)"
   if [ -n "$root_violation" ]; then
     job_error "jobs-root" "$root_violation"
   else
@@ -79,14 +88,14 @@ if [ -d "$JOBS_ROOT" ]; then
         job_error "$(masked_name "$slug")" "invalid slug directory (name withheld)"
         continue
       fi
-      violation="$(path_violation "${job_dir%/}" "job directory")"
+      violation="$(path_violation "${job_dir%/}" "job directory" d 022)"
       if [ -n "$violation" ]; then
         job_error "$slug" "$violation"
         continue
       fi
       schedule_file="$job_dir/schedule"
       # schedule도 실행 계약의 입력이다 — run.sh와 같은 소유·링크·권한 기준을 요구한다.
-      violation="$(path_violation "$schedule_file" "schedule")"
+      violation="$(path_violation "$schedule_file" "schedule" f 022)"
       if [ -n "$violation" ]; then
         job_error "$slug" "schedule: $violation"
         continue
@@ -105,7 +114,9 @@ if [ -d "$JOBS_ROOT" ]; then
         job_error "$slug" "timer name collision with unmanaged unit"
         continue
       fi
-      if [ -e "$unit_file" ] && { [ -L "$unit_file" ] || ! head -1 "$unit_file" | grep -qF "$MANAGED_MARK"; }; then
+      # -L을 먼저 본다 — dangling symlink는 -e가 false라 뒤에 두면 검사를 통과해
+      # printf가 링크 대상(runtime 영역 밖)에 파일을 만들 수 있다.
+      if [ -L "$unit_file" ] || { [ -e "$unit_file" ] && ! head -1 "$unit_file" | grep -qF "$MANAGED_MARK"; }; then
         job_error "$slug" "timer name collision with unmanaged runtime file"
         continue
       fi

--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -1,0 +1,117 @@
+# shellcheck shell=bash
+# 로컬 private job 정의(~/.local/private-jobs/<slug>/schedule)를 systemd user
+# timer로 동기화한다 — 작업 discovery·스케줄은 전부 이 런타임 스캔에서만 읽는다.
+# Nix eval은 로컬 작업 디렉터리를 읽지 않으므로 store·repo에는 작업 정보가 0건이다.
+#
+# 생성물: $XDG_CONFIG_HOME/systemd/user/private-job-<slug>.timer (managed 헤더로
+# 표식). 정의가 사라진 timer는 disable 후 삭제한다. schedule이 잘못된 작업은
+# quiet skip이 아니다 — sync-error marker로 1회 알림(정상화 시 marker 해제)하고
+# sync 자체를 failed unit로 끝낸다.
+#
+# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE
+set -euo pipefail
+umask 0077
+
+JOBS_ROOT="$HOME/.local/private-jobs"
+STATE_ROOT="$HOME/.local/state/private-jobs"
+UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+MANAGED_MARK="# managed by private-jobs-sync"
+
+# shellcheck source=/dev/null
+source "$PUSHOVER_LIB"
+
+changed=0
+invalid=0
+
+job_error() { # slug detail — 같은 오류의 반복 알림은 marker로 dedupe한다
+  local slug="$1" detail="$2"
+  local marker="$STATE_ROOT/$slug/sync-error"
+  echo "ERROR: job=$slug $detail" >&2
+  invalid=1
+  if [ ! -f "$marker" ]; then
+    mkdir -p "$STATE_ROOT/$slug"
+    printf '%s\n' "$detail" > "$marker"
+    pushover_send "$PUSHOVER_CRED_FILE" "private job sync error" "job=$slug $detail" 1 \
+      || echo "WARNING: sync error notification could not be sent" >&2
+  fi
+}
+
+job_ok() { # slug — 오류가 해소되면 marker를 걷어 다음 오류가 다시 알림되게 한다
+  rm -f "$STATE_ROOT/$1/sync-error"
+}
+
+mkdir -p "$UNIT_DIR"
+
+# ── 현재 정의된 작업 → timer 생성/갱신
+declare -A want=()
+if [ -d "$JOBS_ROOT" ]; then
+  for job_dir in "$JOBS_ROOT"/*/; do
+    [ -d "$job_dir" ] || continue
+    slug="$(basename "$job_dir")"
+    if ! [[ "$slug" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; then
+      job_error "invalid" "invalid slug directory"
+      continue
+    fi
+    if [ -L "${job_dir%/}" ] || [ ! -O "$job_dir" ]; then
+      job_error "$slug" "job directory is a symlink or not owned by user"
+      continue
+    fi
+    if [ ! -f "$job_dir/schedule" ]; then
+      job_error "$slug" "schedule file missing"
+      continue
+    fi
+    schedule="$(head -1 "$job_dir/schedule")"
+    if ! systemd-analyze calendar "$schedule" >/dev/null 2>&1; then
+      job_error "$slug" "invalid OnCalendar expression"
+      continue
+    fi
+    job_ok "$slug"
+    want["$slug"]=1
+
+    unit_file="$UNIT_DIR/private-job-$slug.timer"
+    # Persistent=true — 꺼져 있던 동안 놓친 스케줄을 부팅 후 따라잡는다 (재부팅
+    # 복구는 linger + timers.target 재진입과 함께 실기기 smoke가 검증한다).
+    content="$MANAGED_MARK
+[Unit]
+Description=private job timer (%I)
+
+[Timer]
+OnCalendar=$schedule
+Persistent=true
+Unit=private-job@$slug.service
+
+[Install]
+WantedBy=timers.target
+"
+    content="${content//%I/$slug}"
+    if [ ! -f "$unit_file" ] || [ "$(cat "$unit_file")" != "$(printf '%s' "$content")" ]; then
+      printf '%s' "$content" > "$unit_file"
+      changed=1
+    fi
+  done
+fi
+
+# ── 정의가 사라진 managed timer 제거 (managed 헤더가 있는 것만 — 사용자가 직접
+# 만든 unit은 건드리지 않는다)
+for unit_file in "$UNIT_DIR"/private-job-*.timer; do
+  [ -f "$unit_file" ] || continue
+  head -1 "$unit_file" | grep -qF "$MANAGED_MARK" || continue
+  base="$(basename "$unit_file" .timer)"
+  slug="${base#private-job-}"
+  if [ -z "${want[$slug]:-}" ]; then
+    systemctl --user disable --now "$base.timer" >/dev/null 2>&1 || true
+    rm -f "$unit_file"
+    changed=1
+  fi
+done
+
+if [ "$changed" -eq 1 ]; then
+  systemctl --user daemon-reload
+fi
+for slug in "${!want[@]}"; do
+  systemctl --user enable --now "private-job-$slug.timer" >/dev/null 2>&1 \
+    || job_error "$slug" "timer enable failed"
+done
+
+[ "$invalid" -eq 0 ] || exit 1
+echo "sync ok: ${#want[@]} job(s)"

--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -14,10 +14,15 @@
 # 오류만 억제해 1회 알림(내용이 바뀌면 다시 알림, 해소되면 자동 해제)하고 sync를
 # failed unit로 끝낸다.
 #
-# 필요 env (unit이 주입): PUSHOVER_LIB, PUSHOVER_CRED_FILE,
+# 필요 env (unit이 주입): PRIVATE_JOB_LIB, PUSHOVER_LIB, PUSHOVER_CRED_FILE,
 #   PRIVATE_JOBS_DEFINITIONS, PRIVATE_JOBS_STATE (HOME 상대)
 set -euo pipefail
 umask 0077
+
+# shellcheck source=/dev/null
+source "$PRIVATE_JOB_LIB"
+# shellcheck source=/dev/null
+source "$PUSHOVER_LIB"
 
 JOBS_ROOT="$HOME/$PRIVATE_JOBS_DEFINITIONS"
 STATE_ROOT="$HOME/$PRIVATE_JOBS_STATE"
@@ -25,10 +30,7 @@ UNIT_DIR="${XDG_RUNTIME_DIR:?}/systemd/user"
 ERROR_DIR="$STATE_ROOT/.sync-errors"
 MANAGED_MARK="# managed by private-jobs-sync"
 
-# shellcheck source=/dev/null
-source "$PUSHOVER_LIB"
-
-sync_failed=0            # 모든 종류의 sync 오류(정의·enable 실패 포함)의 집계 플래그
+sync_failed=0            # 정의·collision·start 실패를 포함한 모든 sync 오류의 집계 플래그
 declare -A error_seen=() # 이번 run에서 관측된 오류 key — 종료 시 나머지 marker 해제
 
 job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한다 (내용이
@@ -48,44 +50,68 @@ job_error() { # key detail — 같은 key의 "같은 내용" 오류만 억제한
   fi
 }
 
+# 이름이 규약 밖인 디렉터리는 그 이름 자체가 작업 실체를 담고 있을 수 있다 —
+# journal·외부 알림에는 실명 대신 이름의 해시 앞 8자만 내보낸다.
+masked_name() { printf 'withheld-%s' "$(printf '%s' "$1" | sha256sum | cut -c1-8)"; }
+
+# runtime 파일 존재만 보면 상위 우선 경로(~/.config, /etc/systemd/user 등)의
+# 동명 unit에 shadow된다 — systemd가 실제로 로드하는 FragmentPath로 판정해
+# "내 runtime 파일이 아닌 unit"을 건드리지 않는다.
+loaded_fragment() { # unit-name → FragmentPath (미로드면 빈 출력)
+  systemctl --user show -p FragmentPath --value "$1" 2>/dev/null || true
+}
+
 mkdir -p "$UNIT_DIR"
 
 # ── 현재 정의된 작업 → timer 생성/갱신
 declare -A want=()
 if [ -d "$JOBS_ROOT" ]; then
-  for job_dir in "$JOBS_ROOT"/*/; do
-    [ -d "$job_dir" ] || continue
-    slug="$(basename "$job_dir")"
-    if ! [[ "$slug" =~ ^[a-z0-9][a-z0-9-]{0,63}$ ]]; then
-      job_error "$slug" "invalid slug directory"
-      continue
-    fi
-    if [ -L "${job_dir%/}" ] || [ ! -O "$job_dir" ]; then
-      job_error "$slug" "job directory is a symlink or not owned by user"
-      continue
-    fi
-    schedule_file="$job_dir/schedule"
-    # schedule도 실행 계약의 입력이다 — run.sh와 같은 소유·링크 기준을 요구한다.
-    if [ ! -f "$schedule_file" ] || [ -L "$schedule_file" ] || [ ! -O "$schedule_file" ]; then
-      job_error "$slug" "schedule missing, symlink, or not owned by user"
-      continue
-    fi
-    schedule="$(head -1 "$schedule_file")"
-    if ! systemd-analyze calendar "$schedule" >/dev/null 2>&1; then
-      job_error "$slug" "invalid OnCalendar expression"
-      continue
-    fi
+  # 스캔 대상 루트 자체도 실행 입력이다 — symlink·타 owner·느슨한 권한이면 스캔
+  # 전체를 중단한다 (fail-closed).
+  root_violation="$(path_violation "$JOBS_ROOT" "jobs root")"
+  if [ -n "$root_violation" ]; then
+    job_error "jobs-root" "$root_violation"
+  else
+    for job_dir in "$JOBS_ROOT"/*/; do
+      [ -d "$job_dir" ] || continue
+      slug="$(basename "$job_dir")"
+      if ! is_valid_slug "$slug"; then
+        job_error "$(masked_name "$slug")" "invalid slug directory (name withheld)"
+        continue
+      fi
+      violation="$(path_violation "${job_dir%/}" "job directory")"
+      if [ -n "$violation" ]; then
+        job_error "$slug" "$violation"
+        continue
+      fi
+      schedule_file="$job_dir/schedule"
+      # schedule도 실행 계약의 입력이다 — run.sh와 같은 소유·링크·권한 기준을 요구한다.
+      violation="$(path_violation "$schedule_file" "schedule")"
+      if [ -n "$violation" ]; then
+        job_error "$slug" "schedule: $violation"
+        continue
+      fi
+      schedule="$(head -1 "$schedule_file")"
+      if ! systemd-analyze calendar "$schedule" >/dev/null 2>&1; then
+        job_error "$slug" "invalid OnCalendar expression"
+        continue
+      fi
 
-    unit_file="$UNIT_DIR/private-job-$slug.timer"
-    # 같은 이름의 비관리 unit이 이미 있으면 덮지 않는다 — managed 헤더 검사는
-    # 제거 단계만이 아니라 생성 단계에도 적용해야 "사용자 unit 불가침" 계약이 선다.
-    if [ -e "$unit_file" ] && { [ -L "$unit_file" ] || ! head -1 "$unit_file" | grep -qF "$MANAGED_MARK"; }; then
-      job_error "$slug" "timer name collision with unmanaged unit"
-      continue
-    fi
-    want["$slug"]=1
+      unit_file="$UNIT_DIR/private-job-$slug.timer"
+      # 같은 이름의 비관리 unit(상위 우선 경로 포함)이 로드되면 덮지도 조작하지도
+      # 않는다 — managed 생성물은 내 runtime 파일이 FragmentPath일 때만 관리한다.
+      fragment="$(loaded_fragment "private-job-$slug.timer")"
+      if [ -n "$fragment" ] && [ "$fragment" != "$unit_file" ]; then
+        job_error "$slug" "timer name collision with unmanaged unit"
+        continue
+      fi
+      if [ -e "$unit_file" ] && { [ -L "$unit_file" ] || ! head -1 "$unit_file" | grep -qF "$MANAGED_MARK"; }; then
+        job_error "$slug" "timer name collision with unmanaged runtime file"
+        continue
+      fi
+      want["$slug"]=1
 
-    content="$MANAGED_MARK
+      content="$MANAGED_MARK
 [Unit]
 Description=private job timer ($slug)
 
@@ -94,22 +120,25 @@ OnCalendar=$schedule
 Persistent=true
 Unit=private-job@$slug.service
 "
-    if [ ! -f "$unit_file" ] || [ "$(cat "$unit_file")" != "$(printf '%s' "$content")" ]; then
-      printf '%s' "$content" > "$unit_file"
-      changed=1
-    fi
-  done
+      if [ ! -f "$unit_file" ] || [ "$(cat "$unit_file")" != "$(printf '%s' "$content")" ]; then
+        printf '%s' "$content" > "$unit_file"
+        changed=1
+      fi
+    done
+  fi
 fi
 
-# ── 정의가 사라진 managed timer 제거 (managed 헤더가 있는 것만 — 사용자가 직접
-# 만든 unit은 건드리지 않는다)
+# ── 정의가 사라진 managed timer 제거 (managed 헤더 + 실제 로드 경로가 내 파일일
+# 때만 stop — 사용자·HM unit은 건드리지 않는다)
 for unit_file in "$UNIT_DIR"/private-job-*.timer; do
   [ -f "$unit_file" ] || continue
   head -1 "$unit_file" | grep -qF "$MANAGED_MARK" || continue
   base="$(basename "$unit_file" .timer)"
   slug="${base#private-job-}"
   if [ -z "${want[$slug]:-}" ]; then
-    systemctl --user stop "$base.timer" >/dev/null 2>&1 || true
+    if [ "$(loaded_fragment "$base.timer")" = "$unit_file" ]; then
+      systemctl --user stop "$base.timer" >/dev/null 2>&1 || true
+    fi
     rm -f "$unit_file"
     changed=1
   fi

--- a/modules/shared/scripts/lib/pushover.sh
+++ b/modules/shared/scripts/lib/pushover.sh
@@ -1,6 +1,10 @@
 # shellcheck shell=bash
 # Shared Pushover transport helper.
 # Callers decide whether a failed notification is fatal or best-effort.
+#
+# 자격(token/user)은 curl argv에 싣지 않는다 — 프로세스 명령행은 같은 호스트의
+# 다른 프로세스가 /proc/<pid>/cmdline으로 읽을 수 있다. `--config -`로 stdin을
+# 통해 전달한다 (claudex-runtime의 기존 선례와 동일 패턴).
 
 pushover_send() {
   local cred_file="$1"
@@ -21,22 +25,16 @@ pushover_send() {
   [ -n "${PUSHOVER_TOKEN:-}" ] || return 1
   [ -n "${PUSHOVER_USER:-}" ] || return 1
 
-  if [ "$#" -ge 5 ]; then
-    curl -sf --proto =https --max-time 10 \
-      --form-string "token=${PUSHOVER_TOKEN}" \
-      --form-string "user=${PUSHOVER_USER}" \
-      --form-string "title=${title}" \
-      --form-string "message=${message}" \
-      --form-string "priority=${priority}" \
-      --form-string "sound=${sound}" \
-      https://api.pushover.net/1/messages.json > /dev/null 2>&1
-  else
-    curl -sf --proto =https --max-time 10 \
-      --form-string "token=${PUSHOVER_TOKEN}" \
-      --form-string "user=${PUSHOVER_USER}" \
-      --form-string "title=${title}" \
-      --form-string "message=${message}" \
-      --form-string "priority=${priority}" \
-      https://api.pushover.net/1/messages.json > /dev/null 2>&1
-  fi
+  {
+    # curl config 문법: 값의 큰따옴표는 \"로 이스케이프해야 한다.
+    printf 'form-string = "token=%s"\n' "${PUSHOVER_TOKEN//\"/\\\"}"
+    printf 'form-string = "user=%s"\n' "${PUSHOVER_USER//\"/\\\"}"
+    printf 'form-string = "title=%s"\n' "${title//\"/\\\"}"
+    printf 'form-string = "message=%s"\n' "${message//\"/\\\"}"
+    printf 'form-string = "priority=%s"\n' "${priority//\"/\\\"}"
+    if [ "$#" -ge 5 ]; then
+      printf 'form-string = "sound=%s"\n' "${sound//\"/\\\"}"
+    fi
+  } | curl -sf --proto =https --max-time 10 -q --config - \
+    https://api.pushover.net/1/messages.json > /dev/null 2>&1
 }

--- a/modules/shared/scripts/lib/pushover.sh
+++ b/modules/shared/scripts/lib/pushover.sh
@@ -25,16 +25,28 @@ pushover_send() {
   [ -n "${PUSHOVER_TOKEN:-}" ] || return 1
   [ -n "${PUSHOVER_USER:-}" ] || return 1
 
+  # curl config의 quoted string 문법에 맞춘 완전 escape — 역슬래시·큰따옴표를
+  # 이스케이프하고 개행·CR·탭은 \n·\r·\t로 인코딩한다(curl이 unquote 시 복원).
+  # 부분 escape는 multiline 메시지를 여러 config 행으로 쪼개 전송을 깨뜨린다.
+  _pushover_cfg_escape() {
+    local v="$1"
+    v="${v//\\/\\\\}"
+    v="${v//\"/\\\"}"
+    v="${v//$'\n'/\\n}"
+    v="${v//$'\r'/\\r}"
+    v="${v//$'\t'/\\t}"
+    printf '%s' "$v"
+  }
+
   {
-    # curl config 문법: 값의 큰따옴표는 \"로 이스케이프해야 한다.
-    printf 'form-string = "token=%s"\n' "${PUSHOVER_TOKEN//\"/\\\"}"
-    printf 'form-string = "user=%s"\n' "${PUSHOVER_USER//\"/\\\"}"
-    printf 'form-string = "title=%s"\n' "${title//\"/\\\"}"
-    printf 'form-string = "message=%s"\n' "${message//\"/\\\"}"
-    printf 'form-string = "priority=%s"\n' "${priority//\"/\\\"}"
+    printf 'form-string = "token=%s"\n' "$(_pushover_cfg_escape "$PUSHOVER_TOKEN")"
+    printf 'form-string = "user=%s"\n' "$(_pushover_cfg_escape "$PUSHOVER_USER")"
+    printf 'form-string = "title=%s"\n' "$(_pushover_cfg_escape "$title")"
+    printf 'form-string = "message=%s"\n' "$(_pushover_cfg_escape "$message")"
+    printf 'form-string = "priority=%s"\n' "$(_pushover_cfg_escape "$priority")"
     if [ "$#" -ge 5 ]; then
-      printf 'form-string = "sound=%s"\n' "${sound//\"/\\\"}"
+      printf 'form-string = "sound=%s"\n' "$(_pushover_cfg_escape "$sound")"
     fi
-  } | curl -sf --proto =https --max-time 10 -q --config - \
+  } | curl -q -sf --proto =https --max-time 10 --config - \
     https://api.pushover.net/1/messages.json > /dev/null 2>&1
 }

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -743,8 +743,8 @@ let
   # ═══════════════════════════════════════════════════════════════
 
   # assert 헬퍼: 메시지와 함께 assertion
-  # ── private job runner (#1135): generic runner 계약 고정 —
-  # 작업 실체는 기기 로컬 소유이므로 여기서는 generic 경로·hardening만 검증한다.
+  # ── private job runner (#1135): generic 계약(unit 경로·hardening·bounded
+  # timeout·sync cadence·linger) 고정 — 작업 실체는 기기 로컬 소유라 여기 없다.
   pjTemplate = nixosCfg.systemd.user.services."private-job@";
   pjSync = nixosCfg.systemd.user.services."private-jobs-sync";
   pjSyncTimer = nixosCfg.systemd.user.timers."private-jobs-sync";

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -742,7 +742,6 @@ let
   # 테스트 실행
   # ═══════════════════════════════════════════════════════════════
 
-  # assert 헬퍼: 메시지와 함께 assertion
   # ── private job runner (#1135): generic 계약(unit 경로·hardening·bounded
   # timeout·sync cadence·linger) 고정 — 작업 실체는 기기 로컬 소유라 여기 없다.
   pjTemplate = nixosCfg.systemd.user.services."private-job@";
@@ -764,6 +763,7 @@ let
     pjTemplate.serviceConfig.TimeoutStartSec == "8h" && pjSync.serviceConfig.TimeoutStartSec == "5min";
   pjLingerOn = nixosCfg.users.users.${constants.username or "greenhead"}.linger or false;
 
+  # assert 헬퍼: 메시지와 함께 assertion
   check =
     msg: cond: rest:
     if cond then rest else builtins.throw "EVAL TEST FAILED: ${msg}";

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -743,6 +743,27 @@ let
   # ═══════════════════════════════════════════════════════════════
 
   # assert 헬퍼: 메시지와 함께 assertion
+  # ── private job runner (#1135): generic runner 계약 고정 —
+  # 작업 실체는 기기 로컬 소유이므로 여기서는 generic 경로·hardening만 검증한다.
+  pjTemplate = nixosCfg.systemd.user.services."private-job@";
+  pjSync = nixosCfg.systemd.user.services."private-jobs-sync";
+  pjSyncTimer = nixosCfg.systemd.user.timers."private-jobs-sync";
+  pjHardeningOk =
+    svc:
+    svc.serviceConfig.UMask == "0077"
+    && svc.serviceConfig.NoNewPrivileges == true
+    && svc.serviceConfig.PrivateTmp == true
+    && svc.serviceConfig.ProtectSystem == "full"
+    && svc.serviceConfig.KillMode == "control-group";
+  # RestrictNamespaces는 의도적으로 미적용이다 — 일부 작업의 하위 도구가 user
+  # namespace를 요구한다 (모듈 주석의 결정을 여기서 고정: 켜면 이 테스트가 깨져
+  # 의도적 재결정을 강제한다).
+  pjNoNamespaceRestriction =
+    !(pjTemplate.serviceConfig ? RestrictNamespaces) && !(pjSync.serviceConfig ? RestrictNamespaces);
+  pjBoundedTimeout =
+    pjTemplate.serviceConfig.TimeoutStartSec == "8h" && pjSync.serviceConfig.TimeoutStartSec == "5min";
+  pjLingerOn = nixosCfg.users.users.${constants.username or "greenhead"}.linger or false;
+
   check =
     msg: cond: rest:
     if cond then rest else builtins.throw "EVAL TEST FAILED: ${msg}";
@@ -1053,6 +1074,29 @@ let
         claudexEnabledDescriptor.enabled == true
         && toString claudexEnabledRuntimeSource == claudexEnabledDescriptor.runtimeLibrary
         && claudexEnabledRuntimeBuildPhaseMatchesDescriptor;
+    }
+    {
+      name = "Test PJ1: private-job@ template·sync unit이 존재하고 공통 hardening(UMask 0077·NoNewPrivileges·PrivateTmp·ProtectSystem full·cgroup kill)을 갖는다";
+      cond = pjHardeningOk pjTemplate && pjHardeningOk pjSync;
+    }
+    {
+      name = "Test PJ2: RestrictNamespaces는 의도적으로 미적용 (하위 도구의 user namespace 요구 — 켜려면 이 테스트와 함께 재결정)";
+      cond = pjNoNamespaceRestriction;
+    }
+    {
+      name = "Test PJ3: bounded timeout — template 8h, sync 5min";
+      cond = pjBoundedTimeout;
+    }
+    {
+      name = "Test PJ4: sync timer가 timers.target에 걸리고 부팅 2분 + 15분 간격으로 돈다";
+      cond =
+        pjSyncTimer.wantedBy == [ "timers.target" ]
+        && pjSyncTimer.timerConfig.OnBootSec == "2min"
+        && pjSyncTimer.timerConfig.OnUnitActiveSec == "15min";
+    }
+    {
+      name = "Test PJ5: linger 활성 — 로그인 세션 없이 user manager가 부팅부터 상주해야 무인 스케줄이 성립";
+      cond = pjLingerOn;
     }
   ]
   ++ darwinIntentTests;

--- a/tests/suites/pushover-helper.sh
+++ b/tests/suites/pushover-helper.sh
@@ -66,11 +66,11 @@ test_pushover_send_success_passes_expected_fields() {
   PATH="$stub_dir:$PATH" pushover_send "$cred" "Test title" "Test message" 1 \
     || fail "pushover_send must succeed when curl succeeds"
 
-  assert_file_contains "$log" "token=token value"
-  assert_file_contains "$log" "user=user value"
-  assert_file_contains "$log" "title=Test title"
-  assert_file_contains "$log" "message=Test message"
-  assert_file_contains "$log" "priority=1"
+  assert_file_contains "$log" "form-string = \"token=token value\""
+  assert_file_contains "$log" "form-string = \"user=user value\""
+  assert_file_contains "$log" "form-string = \"title=Test title\""
+  assert_file_contains "$log" "form-string = \"message=Test message\""
+  assert_file_contains "$log" "form-string = \"priority=1\""
   assert_file_contains "$log" "https://api.pushover.net/1/messages.json"
   assert_not_contains "$(cat "$log")" "sound="
 }
@@ -91,7 +91,7 @@ test_pushover_send_passes_optional_sound() {
   PATH="$stub_dir:$PATH" pushover_send "$cred" "Sound title" "Sound message" 0 "falling" \
     || fail "pushover_send must succeed with optional sound"
 
-  assert_file_contains "$log" "sound=falling"
+  assert_file_contains "$log" "form-string = \"sound=falling\""
 }
 
 test_pushover_send_curl_failure_returns_1() {
@@ -110,5 +110,5 @@ test_pushover_send_curl_failure_returns_1() {
   if PATH="$stub_dir:$PATH" pushover_send "$cred" "Fail title" "Fail message" 0; then
     fail "pushover_send must fail when curl fails"
   fi
-  assert_file_contains "$log" "title=Fail title"
+  assert_file_contains "$log" "form-string = \"title=Fail title\""
 }

--- a/tests/suites/pushover-helper.sh
+++ b/tests/suites/pushover-helper.sh
@@ -16,6 +16,9 @@ _write_pushover_curl_stub() {
 set -euo pipefail
 : "${PUSHOVER_CURL_LOG:?}"
 printf '%s\n' "$@" >> "$PUSHOVER_CURL_LOG"
+# helper는 자격·필드를 argv가 아니라 --config - stdin으로 전달한다 — 함께 기록해야
+# 기존 필드 assertion이 성립한다.
+[ -t 0 ] || cat >> "$PUSHOVER_CURL_LOG"
 exit "${PUSHOVER_CURL_EXIT:-0}"
 EOF_STUB
   chmod +x "$dir/curl"


### PR DESCRIPTION
## Summary

- 로컬 정의 개인 작업을 systemd user timer로 스케줄 실행하고 실패를 Pushover로 알리는 generic runner 신설 (`modules/nixos/programs/private-job-runner/`) — Closes #1135
- 작업의 정의·이름·스케줄·시크릿·로그는 전부 기기 로컬(`~/.local/private-jobs/<slug>/`) 소유 — Nix eval은 로컬을 읽지 않아 repo·store·CI 어디에도 작업 실체가 나타나지 않는다
- eval-tests PJ1~PJ5로 hardening·timeout·timer·linger 계약 고정

## 기존 문제/배경

개인 작업(백업·동기화·수집류)을 miniPC에서 주기 실행하려면 매번 systemd unit을 손으로 만들어야 하고, 실패해도 조용히 지나간다. 작업 내용이 이 public repo에 선언되면 사적 컨텍스트가 노출되므로 작업 정의는 repo 밖에 있어야 한다 (#1135 합의).

## CIR (Change Intent Record)

- **timer 실물 생성(sync) vs 런타임 dispatcher**: 놓친 스케줄의 부팅 후 따라잡기(`Persistent=true`)가 요구라 systemd-native로 job별 실제 timer를 생성하는 sync 방식을 채택 — dispatcher가 calendar 식을 자체 평가하는 방식은 systemd 의미론 재구현이라 기각.
- **eval 격리**: discovery·스케줄은 sync 스크립트의 런타임 스캔만 소유 — 모듈에는 `readDir`/`readFile`/`pathExists`로 로컬 작업 디렉터리를 읽는 코드가 없다 (store에 작업 정보 0건).
- **알림 소유권**: 같은 run의 외부 push 알림은 runner가 소유(실패 시 1회, opaque slug·run id·exit class만). 개별 작업 래퍼는 자체 push 알림을 배선하지 않는 것이 규약 — 이중 알림 차단. sync의 정의 오류 알림은 marker 파일로 dedupe(반복 스캔이 15분마다 알림을 폭주시키지 않게)하되 해소 시 marker를 걷어 재발을 다시 알린다.
- **RestrictNamespaces 미적용**: 일부 작업의 하위 도구(sandbox형 CLI)가 user namespace 생성을 요구한다 — da-weekly-report의 실측 선례와 동일한 제약. 이 선택은 eval-tests PJ2가 고정해, 켜려면 의도적 재결정을 강제한다.
- **작업 부재·정의 오류는 quiet skip 금지**: runner는 run.sh 부재·권한 위반을 failed unit+알림으로, sync는 invalid schedule을 1회 알림+failed unit으로 처리한다 — 스케줄이 죽은 것을 아무도 모르는 상태를 만들지 않는다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| Nix에 작업 선언 | 작업별 systemd unit을 Nix로 선언 | 순수 선언적 | public repo에 사적 작업 노출 | ❌ |
| dispatcher 상주 | 주기 실행 dispatcher가 schedule을 자체 평가 | 파일 생성 없음 | calendar 의미론 재구현, Persistent 부재 | ❌ |
| sync → job별 timer 생성 | 로컬 정의를 스캔해 실제 user timer 생성·정리 | systemd-native(Persistent·OnCalendar), eval 격리 | 생성물 관리 필요(managed 헤더로 한정) | ✅ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/nixos/programs/private-job-runner/default.nix` | 모듈 — template unit `private-job@`(hardening·8h 상한·cgroup kill), sync service+timer(부팅 2분+15분), linger, 로컬 작업 규약 문서(헤더) |
| `.../runner.sh` | slug·디렉터리·run.sh 검증(중립 문자열, symlink·타 owner·group/world-writable 거부) → 로컬 0700/0600 로그 → 실패 시 generic Pushover → bounded retention(30 run) |
| `.../sync.sh` | 로컬 schedule 검증(`systemd-analyze calendar`) → managed timer 생성·정리 → daemon-reload·enable — invalid는 marker dedupe 알림 |
| `modules/nixos/configuration.nix` | 모듈 임포트 + enable |
| `tests/eval-tests.nix` | PJ1(hardening)·PJ2(RestrictNamespaces 미적용 고정)·PJ3(bounded timeout)·PJ4(sync timer)·PJ5(linger) |

## 참고 레퍼런스

- #1135 (합의·AC SoT)
- `modules/nixos/programs/da-weekly-report/default.nix` — hardening·RestrictNamespaces 선례
- `modules/shared/scripts/lib/pushover.sh` — 알림 transport (user-scope cred `~/.config/pushover/share`)

## Human Test Plan

1. `nix eval --impure --file tests/eval-tests.nix` → `true` (PJ1~PJ5 포함).
2. miniPC 배포(`nrs`) 후: `loginctl show-user <user> -p Linger` → `Linger=yes`, `systemctl --user status private-jobs-sync.timer` → active.
3. 중립 slug로 로컬 작업 생성(`~/.local/private-jobs/<slug>/run.sh`+`schedule`) → 다음 sync 주기(≤15분) 후 `systemctl --user list-timers 'private-job-*'`에 timer가 나타나고, 발화 시 `~/.local/state/private-jobs/<slug>/logs/`에 0600 로그가 남는지 확인.
4. run.sh를 exit 1로 바꿔 발화 → Pushover에 generic 실패 알림(slug·run id·exit만) 도착 확인. journal(`journalctl --user -u 'private-job@*'`)에 작업 stdout이 없는지 확인.
5. 재부팅 후 timer가 자동 복귀하고 꺼진 동안 놓친 스케줄이 따라잡히는지(Persistent) 확인 — #1135의 실기기 smoke 완료 조건.

https://claude.ai/code/session_013BeneqQVZmXz5WzGF33esA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈서버의 “비공개 작업 러너”를 선택적으로 활성화하고, 작업 정의 스케줄을 주기적으로 동기화해 자동 실행합니다.
* **보안 및 안정성**
  * 실행 전 작업 식별자/경로와 권한을 엄격히 검증하고, 전용 systemd 사용자 유닛 하드닝으로 격리합니다.
  * 실행 로그를 안전하게 보관(보존 기간 적용)하며, 실패 시 결과와 종료코드가 포함된 Pushover 알림을 전송합니다.
* **테스트**
  * 비공개 작업 러너 유닛 하드닝·타이밍 계약과 Pushover 처리 동작을 추가로 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->