### PR TITLE
feat(nrs): add --help flag with usage output

### DIFF
--- a/.claude/skills/understanding-nix/references/troubleshooting.md
+++ b/.claude/skills/understanding-nix/references/troubleshooting.md
@@ -245,7 +245,7 @@ nrs
 
 ## 상세 에러 확인
 
-`nrs`는 `--offline` / `--force` / `--cores N`만 받으므로 `--show-trace`를 전달할 수 없습니다.
+`nrs`는 `--offline` / `--force` / `--cores N` / `--help`만 받으므로 `--show-trace`를 전달할 수 없습니다 (전체 목록은 `nrs --help`).
 스택 추적이 필요하면 switch 없이 빌드만 실행합니다 (호스트명은 `scutil --get LocalHostName`):
 
 ```bash

--- a/.claude/skills/understanding-nix/references/troubleshooting.md
+++ b/.claude/skills/understanding-nix/references/troubleshooting.md
@@ -245,7 +245,7 @@ nrs
 
 ## 상세 에러 확인
 
-`nrs`는 `--offline` / `--force` / `--cores N` / `--help`만 받으므로 `--show-trace`를 전달할 수 없습니다 (전체 목록은 `nrs --help`).
+`nrs`는 `--offline` / `--force` / `--cores N` / `-h`/`--help`만 받으므로 `--show-trace`를 전달할 수 없습니다 (전체 목록은 `nrs --help`).
 스택 추적이 필요하면 switch 없이 빌드만 실행합니다 (호스트명은 `scutil --get LocalHostName`):
 
 ```bash

--- a/modules/darwin/scripts/nrp.sh
+++ b/modules/darwin/scripts/nrp.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 
 # shellcheck disable=SC2034  # REBUILD_CMD는 source된 rebuild-common.sh에서 사용
 REBUILD_CMD="darwin-rebuild"
+# shellcheck disable=SC2034  # REBUILD_MODE는 source된 rebuild-common.sh의 usage 분기에서 사용
+REBUILD_MODE="preview"
 # shellcheck source=/dev/null  # 런타임에 ~/.local/lib/rebuild-common.sh 로딩
 source "$HOME/.local/lib/rebuild-common.sh"
 parse_args "$@"

--- a/modules/darwin/scripts/nrp.sh
+++ b/modules/darwin/scripts/nrp.sh
@@ -5,6 +5,7 @@
 # 사용법 (공용 usage의 요약 — 전체는 nrp --help):
 #   nrp           # 일반 미리보기
 #   nrp --offline # 오프라인 미리보기
+#   nrp --cores 2 # 코어 제한 미리보기
 #   nrp --help    # 사용법 출력
 
 set -euo pipefail

--- a/modules/darwin/scripts/nrp.sh
+++ b/modules/darwin/scripts/nrp.sh
@@ -2,9 +2,10 @@
 # darwin-rebuild preview-only script
 # 빌드 후 변경사항만 미리보기 (switch 없이)
 #
-# 사용법:
+# 사용법 (공용 usage의 요약 — 전체는 nrp --help):
 #   nrp           # 일반 미리보기
 #   nrp --offline # 오프라인 미리보기
+#   nrp --help    # 사용법 출력
 
 set -euo pipefail
 

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -6,6 +6,7 @@
 #   nrs           # 일반 rebuild
 #   nrs --offline # 오프라인 rebuild (빠름)
 #   nrs --force   # NO_CHANGES 스킵 우회 (activation scripts 강제 재실행)
+#   nrs --help    # 사용법 출력
 
 set -euo pipefail
 

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -190,7 +190,7 @@ run_darwin_rebuild() {
 
     local rc=0
     # shellcheck disable=SC2086
-    sudo "$REBUILD_CMD" switch --flake "$FLAKE_PATH" $OFFLINE_FLAG || rc=$?
+    sudo "$REBUILD_CMD" switch --flake "$FLAKE_PATH" $OFFLINE_FLAG $CORES_FLAG || rc=$?
 
     if [[ "$rc" -ne 0 ]]; then
         log_error "❌ darwin-rebuild switch failed (exit code: $rc)"

--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 
 # shellcheck disable=SC2034  # REBUILD_CMD는 source된 rebuild-common.sh에서 사용
 REBUILD_CMD="darwin-rebuild"
+# shellcheck disable=SC2034  # REBUILD_MODE는 source된 rebuild-common.sh의 usage 분기에서 사용
+REBUILD_MODE="switch"
 # shellcheck source=/dev/null  # 런타임에 ~/.local/lib/rebuild-common.sh 로딩
 source "$HOME/.local/lib/rebuild-common.sh"
 parse_args "$@"

--- a/modules/nixos/scripts/nrp.sh
+++ b/modules/nixos/scripts/nrp.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # nixos-rebuild preview script (build only, no switch)
 #
-# 사용법:
-#   nrp                       # 미리보기
+# 사용법 (공용 usage의 요약 — 전체는 nrp --help):
+#   nrp                       # 미리보기 (소스 빌드는 경고만, 항상 진행)
 #   nrp --offline             # 오프라인 미리보기 (빠름)
-#   nrp --force               # 소스 빌드 경고 무시
-#   nrp --force --cores 2    # 코어 제한으로 진행
+#   nrp --cores 2             # 코어 제한으로 진행
+#   nrp --help                # 사용법 출력
 
 set -euo pipefail
 

--- a/modules/nixos/scripts/nrp.sh
+++ b/modules/nixos/scripts/nrp.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 
 # shellcheck disable=SC2034  # REBUILD_CMD는 source된 rebuild-common.sh에서 사용
 REBUILD_CMD="nixos-rebuild"
+# shellcheck disable=SC2034  # REBUILD_MODE는 source된 rebuild-common.sh의 usage 분기에서 사용
+REBUILD_MODE="preview"
 # shellcheck source=/dev/null  # 런타임에 ~/.local/lib/rebuild-common.sh 로딩
 source "$HOME/.local/lib/rebuild-common.sh"
 parse_args "$@"

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -6,6 +6,7 @@
 #   nrs --offline             # 오프라인 rebuild (빠름)
 #   nrs --force               # 소스 빌드 경고 무시
 #   nrs --force --cores 2    # 코어 제한으로 진행
+#   nrs --help                # 사용법 출력
 
 set -euo pipefail
 

--- a/modules/nixos/scripts/nrs.sh
+++ b/modules/nixos/scripts/nrs.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 
 # shellcheck disable=SC2034  # REBUILD_CMD는 source된 rebuild-common.sh에서 사용
 REBUILD_CMD="nixos-rebuild"
+# shellcheck disable=SC2034  # REBUILD_MODE는 source된 rebuild-common.sh의 usage 분기에서 사용
+REBUILD_MODE="switch"
 # shellcheck source=/dev/null  # 런타임에 ~/.local/lib/rebuild-common.sh 로딩
 source "$HOME/.local/lib/rebuild-common.sh"
 parse_args "$@"

--- a/modules/shared/scripts/README.md
+++ b/modules/shared/scripts/README.md
@@ -34,6 +34,10 @@
 
 ## Rebuild Contract
 
+- Caller-declared inputs (source 전에 진입점이 선언):
+  `REBUILD_CMD` (필수, `darwin-rebuild` | `nixos-rebuild`),
+  `REBUILD_MODE` (선택, `switch` | `preview`, 기본 `switch` — usage의 wrapper 설명과
+  `--force` 노출을 결정하며, 환경 상속 오염을 막기 위해 모든 진입점이 명시 선언한다)
 - Public rebuild helpers:
   `parse_args`, `log_info`, `log_warn`, `log_error`, `worktree_symlink_guard`,
   `acquire_nrs_lock`, `release_nrs_lock`, `release_nrs_lock_after_no_changes`,
@@ -63,7 +67,7 @@
 - Top-level entrypoints stay thin. New runtime logic belongs in a helper file unless it is dispatch/help text.
 - Helpers are grouped by change reason, not by arbitrary line counts.
 - Loader source order is part of the contract. The ordered helper manifest in each top-level entrypoint is the single source of truth for helper membership and load order.
-- If a new helper is added under an existing helper directory, update the entrypoint helper manifest and tests together. `modules/shared/programs/shell/default.nix` only needs changes for new top-level entrypoints or new helper directories. New deployment entries must add a `register_*` call in `install_deployed_layout()` or `install_platform_nrs_entrypoint()`.
+- If a new helper is added under an existing helper directory, update the entrypoint helper manifest and tests together. `modules/shared/programs/shell/default.nix` only needs changes for new top-level entrypoints or new helper directories. New deployment entries must add a `register_*` call in `install_deployed_layout()` or `install_platform_rebuild_entrypoint()`.
 - `tests/shell-script-tests.sh` must stay hermetic and recursive-layout aware: it should ignore host Git hooks/config and mirror the deployed helper tree shape, not a flat copy.
 - Tests must exercise the deployed layout, not only the repo-local path. `tests/shell-script-tests.sh` should validate both the expected Home Manager wiring and runtime smoke paths.
 - Public surface smoke를 유지하되, ordered helper manifest/order contract를 검증하는 최소 fixture test도 유지한다.

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -89,6 +89,21 @@ extract_oos_entries() {
 # --help는 usage 출력 후 exit 0 — LLM/사용자가 사용법을 실행으로 발견할 수 있게 한다 (#1138).
 #───────────────────────────────────────────────────────────────────────────────
 _print_rebuild_usage() {
+    # nrp 진입점에서 --force는 실동작이 없으므로 (darwin: NO_CHANGES 분기 없음,
+    # nixos: 항상 --warn-only) usage에서 제외해 명령별 실제 계약만 안내한다.
+    if [[ "${0##*/}" == nrp* ]]; then
+        cat <<EOF
+Usage: ${0##*/} [--offline] [--cores N]
+
+${REBUILD_CMD} preview wrapper (switch 없음)
+
+Options:
+  --offline    오프라인 rebuild (substituter 미사용, 빠름)
+  --cores N    빌드 코어 수 제한 (nixos-rebuild 전용)
+  -h, --help   이 도움말 출력 후 종료
+EOF
+        return
+    fi
     cat <<EOF
 Usage: ${0##*/} [--offline] [--force] [--cores N]
 

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -86,7 +86,22 @@ extract_oos_entries() {
 
 #───────────────────────────────────────────────────────────────────────────────
 # 인수 파싱 (OFFLINE_FLAG, FORCE_FLAG, CORES_FLAG 설정)
+# --help는 usage 출력 후 exit 0 — LLM/사용자가 사용법을 실행으로 발견할 수 있게 한다 (#1138).
 #───────────────────────────────────────────────────────────────────────────────
+_print_rebuild_usage() {
+    cat <<EOF
+Usage: ${0##*/} [--offline] [--force] [--cores N]
+
+${REBUILD_CMD} wrapper (preview 포함)
+
+Options:
+  --offline    오프라인 rebuild (substituter 미사용, 빠름)
+  --force      NO_CHANGES 스킵 우회 (darwin) / 소스 빌드 경고 무시 (nixos)
+  --cores N    빌드 코어 수 제한 (nixos-rebuild 전용)
+  -h, --help   이 도움말 출력 후 종료
+EOF
+}
+
 # shellcheck disable=SC2034  # Public flags are consumed by callers/helpers after parse_args.
 parse_args() {
     OFFLINE_FLAG=""
@@ -101,7 +116,8 @@ parse_args() {
                 [[ ! "$2" =~ ^[0-9]+$ ]] && { log_error "--cores: positive integer required"; exit 1; }
                 (( 10#$2 < 1 )) && { log_error "--cores: positive integer required"; exit 1; }
                 CORES_FLAG="--cores $2"; shift ;;
-            *) log_error "Unknown argument: $1"; exit 1 ;;
+            -h|--help) _print_rebuild_usage; exit 0 ;;
+            *) log_error "Unknown argument: $1"; _print_rebuild_usage >&2; exit 1 ;;
         esac
         shift
     done

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -89,30 +89,24 @@ extract_oos_entries() {
 # --help는 usage 출력 후 exit 0 — LLM/사용자가 사용법을 실행으로 발견할 수 있게 한다 (#1138).
 #───────────────────────────────────────────────────────────────────────────────
 _print_rebuild_usage() {
-    # nrp 진입점에서 --force는 실동작이 없으므로 (darwin: NO_CHANGES 분기 없음,
-    # nixos: 항상 --warn-only) usage에서 제외해 명령별 실제 계약만 안내한다.
-    if [[ "${0##*/}" == nrp* ]]; then
-        cat <<EOF
-Usage: ${0##*/} [--offline] [--cores N]
-
-${REBUILD_CMD} preview wrapper (switch 없음)
-
-Options:
-  --offline    오프라인 rebuild (substituter 미사용, 빠름)
-  --cores N    빌드 코어 수 제한 (nixos-rebuild 전용)
-  -h, --help   이 도움말 출력 후 종료
-EOF
-        return
+    # 진입점이 REBUILD_MODE=preview를 선언하면 (nrp) 실동작 없는 --force를
+    # usage에서 제외한다 (darwin nrp: NO_CHANGES 분기 없음, nixos nrp: 항상 --warn-only).
+    local synopsis="[--offline] [--force] [--cores N]"
+    local desc="${REBUILD_CMD} wrapper (preview 포함)"
+    local force_help=$'\n  --force      NO_CHANGES 스킵 우회 (darwin) / 소스 빌드 경고 무시 (nixos)'
+    if [[ "${REBUILD_MODE:-switch}" == "preview" ]]; then
+        synopsis="[--offline] [--cores N]"
+        desc="${REBUILD_CMD} preview wrapper (switch 없음)"
+        force_help=""
     fi
     cat <<EOF
-Usage: ${0##*/} [--offline] [--force] [--cores N]
+Usage: ${0##*/} ${synopsis}
 
-${REBUILD_CMD} wrapper (preview 포함)
+${desc}
 
 Options:
-  --offline    오프라인 rebuild (substituter 미사용, 빠름)
-  --force      NO_CHANGES 스킵 우회 (darwin) / 소스 빌드 경고 무시 (nixos)
-  --cores N    빌드 코어 수 제한 (nixos-rebuild 전용)
+  --offline    오프라인 rebuild (substituter 미사용, 빠름)${force_help}
+  --cores N    빌드 코어 수 제한
   -h, --help   이 도움말 출력 후 종료
 EOF
 }
@@ -132,7 +126,7 @@ parse_args() {
                 (( 10#$2 < 1 )) && { log_error "--cores: positive integer required"; exit 1; }
                 CORES_FLAG="--cores $2"; shift ;;
             -h|--help) _print_rebuild_usage; exit 0 ;;
-            *) log_error "Unknown argument: $1"; _print_rebuild_usage >&2; exit 1 ;;
+            *) log_error "Unknown argument: $1" >&2; _print_rebuild_usage >&2; exit 1 ;;
         esac
         shift
     done

--- a/modules/shared/scripts/lib/rebuild/common.sh
+++ b/modules/shared/scripts/lib/rebuild/common.sh
@@ -90,25 +90,22 @@ extract_oos_entries() {
 #───────────────────────────────────────────────────────────────────────────────
 _print_rebuild_usage() {
     # 진입점이 REBUILD_MODE=preview를 선언하면 (nrp) 실동작 없는 --force를
-    # usage에서 제외한다 (darwin nrp: NO_CHANGES 분기 없음, nixos nrp: 항상 --warn-only).
-    local synopsis="[--offline] [--force] [--cores N]"
-    local desc="${REBUILD_CMD} wrapper (preview 포함)"
-    local force_help=$'\n  --force      NO_CHANGES 스킵 우회 (darwin) / 소스 빌드 경고 무시 (nixos)'
-    if [[ "${REBUILD_MODE:-switch}" == "preview" ]]; then
+    # usage와 parser 양쪽에서 제외한다 (darwin nrp: NO_CHANGES 분기 없음,
+    # nixos nrp: 항상 --warn-only). 배열 원소 하나 = 출력 행 하나.
+    local mode="${REBUILD_MODE:-switch}"
+    local synopsis desc
+    local -a option_lines=('  --offline    오프라인 rebuild (substituter 미사용, 빠름)')
+    if [[ "$mode" == "preview" ]]; then
         synopsis="[--offline] [--cores N]"
         desc="${REBUILD_CMD} preview wrapper (switch 없음)"
-        force_help=""
+    else
+        synopsis="[--offline] [--force] [--cores N]"
+        desc="${REBUILD_CMD} wrapper (preview 포함)"
+        option_lines+=('  --force      NO_CHANGES 스킵 우회 (darwin) / 소스 빌드 경고 무시 (nixos)')
     fi
-    cat <<EOF
-Usage: ${0##*/} ${synopsis}
-
-${desc}
-
-Options:
-  --offline    오프라인 rebuild (substituter 미사용, 빠름)${force_help}
-  --cores N    빌드 코어 수 제한
-  -h, --help   이 도움말 출력 후 종료
-EOF
+    option_lines+=('  --cores N    빌드 코어 수 제한' '  -h, --help   이 도움말 출력 후 종료')
+    printf 'Usage: %s %s\n\n%s\n\nOptions:\n' "${0##*/}" "$synopsis" "$desc"
+    printf '%s\n' "${option_lines[@]}"
 }
 
 # shellcheck disable=SC2034  # Public flags are consumed by callers/helpers after parse_args.
@@ -119,7 +116,14 @@ parse_args() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --offline) OFFLINE_FLAG="--offline" ;;
-            --force)   FORCE_FLAG=true ;;
+            --force)
+                # preview 진입점에서는 무동작 인터페이스이므로 usage와 동일하게 거부한다.
+                if [[ "${REBUILD_MODE:-switch}" == "preview" ]]; then
+                    log_error "--force is not supported by ${0##*/} (preview mode)" >&2
+                    _print_rebuild_usage >&2
+                    exit 1
+                fi
+                FORCE_FLAG=true ;;
             --cores)
                 [[ -z "${2:-}" || "$2" =~ ^-- ]] && { log_error "--cores requires a number"; exit 1; }
                 [[ ! "$2" =~ ^[0-9]+$ ]] && { log_error "--cores: positive integer required"; exit 1; }

--- a/modules/shared/scripts/rebuild-common.sh
+++ b/modules/shared/scripts/rebuild-common.sh
@@ -6,6 +6,9 @@
 #
 # 필수 변수:
 #   REBUILD_CMD - "darwin-rebuild" 또는 "nixos-rebuild"
+# 선택 변수:
+#   REBUILD_MODE - "switch"(기본) 또는 "preview" — usage 표기와 --force 노출 결정.
+#                  환경 상속 오염 방지를 위해 모든 진입점이 명시 선언한다.
 #
 # caller-facing 제공 함수:
 #   parse_args, log_info, log_warn, log_error,

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -34,6 +34,7 @@ run_test "rebuild-common exports public API" test_rebuild_common_exports_public_
 run_test "parse_args unknown argument shows usage and fails" test_parse_args_unknown_argument_shows_usage_and_fails
 run_test "nixos nrs --help prints usage" test_nixos_nrs_help_flag_prints_usage
 run_test "darwin nrs -h alias prints usage" test_darwin_nrs_h_alias_prints_usage
+run_test "nrs --help ignores inherited REBUILD_MODE" test_nrs_help_ignores_inherited_rebuild_mode
 run_test "nrp --help usage omits inert --force" test_nrp_help_usage_omits_force_flag
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
 run_test "worktree relink skips non-TTY without opt-in" test_worktree_relink_skips_non_tty_without_opt_in

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -33,6 +33,7 @@ run_test "managed plugin skill helper rejects duplicate matches" test_managed_pl
 run_test "rebuild-common exports public API" test_rebuild_common_exports_public_api
 run_test "parse_args unknown argument shows usage and fails" test_parse_args_unknown_argument_shows_usage_and_fails
 run_test "nixos nrs --help prints usage" test_nixos_nrs_help_flag_prints_usage
+run_test "nrp --help usage omits inert --force" test_nrp_help_usage_omits_force_flag
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
 run_test "worktree relink skips non-TTY without opt-in" test_worktree_relink_skips_non_tty_without_opt_in
 run_test "worktree relink opt-in allows non-TTY" test_worktree_relink_opt_in_allows_non_tty

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -33,6 +33,7 @@ run_test "managed plugin skill helper rejects duplicate matches" test_managed_pl
 run_test "rebuild-common exports public API" test_rebuild_common_exports_public_api
 run_test "parse_args unknown argument shows usage and fails" test_parse_args_unknown_argument_shows_usage_and_fails
 run_test "nixos nrs --help prints usage" test_nixos_nrs_help_flag_prints_usage
+run_test "darwin nrs -h alias prints usage" test_darwin_nrs_h_alias_prints_usage
 run_test "nrp --help usage omits inert --force" test_nrp_help_usage_omits_force_flag
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
 run_test "worktree relink skips non-TTY without opt-in" test_worktree_relink_skips_non_tty_without_opt_in

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -31,6 +31,8 @@ run_test "wt help uses deployed helper layout" test_wt_help_from_deployed_layout
 run_test "wt wrapper ignores runtime HOME for real script" test_wt_wrapper_ignores_runtime_home_for_real_script
 run_test "managed plugin skill helper rejects duplicate matches" test_managed_plugin_skill_link_requires_single_match
 run_test "rebuild-common exports public API" test_rebuild_common_exports_public_api
+run_test "parse_args unknown argument shows usage and fails" test_parse_args_unknown_argument_shows_usage_and_fails
+run_test "nixos nrs --help prints usage" test_nixos_nrs_help_flag_prints_usage
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
 run_test "worktree relink skips non-TTY without opt-in" test_worktree_relink_skips_non_tty_without_opt_in
 run_test "worktree relink opt-in allows non-TTY" test_worktree_relink_opt_in_allows_non_tty

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -36,6 +36,7 @@ run_test "nixos nrs --help prints usage" test_nixos_nrs_help_flag_prints_usage
 run_test "darwin nrs -h alias prints usage" test_darwin_nrs_h_alias_prints_usage
 run_test "nrs --help ignores inherited REBUILD_MODE" test_nrs_help_ignores_inherited_rebuild_mode
 run_test "nrp --help usage omits inert --force" test_nrp_help_usage_omits_force_flag
+run_test "nrp rejects inert --force flag" test_nrp_rejects_force_flag
 run_test "detect_worktree switches to active worktree" test_detect_worktree_uses_current_worktree_path
 run_test "worktree relink skips non-TTY without opt-in" test_worktree_relink_skips_non_tty_without_opt_in
 run_test "worktree relink opt-in allows non-TTY" test_worktree_relink_opt_in_allows_non_tty

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -210,6 +210,57 @@ test_rebuild_common_exports_public_api() {
   assert_contains "$output" "repair_codex_config_drift_no_changes"
 }
 
+test_parse_args_unknown_argument_shows_usage_and_fails() {
+  local sandbox output rc
+  sandbox=$(new_sandbox)
+  install_deployed_layout "$sandbox"
+
+  rc=0
+  output=$(
+    HOME="$sandbox/home" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$sandbox/home/.local/lib/rebuild-common.sh"'"
+      parse_args --bogus
+    ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" -eq 1 ]] || fail "expected parse_args --bogus to exit 1 (actual: $rc)"
+  assert_contains "$output" "Unknown argument: --bogus"
+  assert_contains "$output" "Usage:"
+}
+
+test_nixos_nrs_help_flag_prints_usage() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_platform_nrs_entrypoint "$sandbox" nixos
+
+  # --help는 parse_args에서 exit 0 하므로 rebuild/sudo stub 없이 안전하게 실행된다.
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/nrs"'" --help
+    ' 2>&1
+  )
+
+  assert_contains "$output" "Usage: nrs"
+  assert_contains "$output" "--offline"
+  assert_contains "$output" "--cores N"
+  assert_not_contains "$output" "Applying changes"
+  assert_not_contains "$output" "Unknown argument"
+}
+
 test_detect_worktree_uses_current_worktree_path() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -106,8 +106,8 @@ install_codex_managed_artifact_fixture() {
     "$home_dir/.codex/lib/pinning-patterns.sh"
 }
 
-install_platform_nrs_entrypoint() {
-  local sandbox="$1" platform="$2"
+install_platform_rebuild_entrypoint() {
+  local sandbox="$1" platform="$2" command="$3"
   local home_dir="$sandbox/home"
   local generated_dir="$sandbox/generated"
 
@@ -118,46 +118,27 @@ install_platform_nrs_entrypoint() {
     darwin)
       register_copy_exec \
         "$REPO_ROOT/modules/shared/programs/shell/darwin.nix" \
-        ".local/bin/nrs" \
-        '${darwinScriptsDir}/nrs.sh' \
-        "modules/darwin/scripts/nrs.sh"
+        ".local/bin/$command" \
+        '${darwinScriptsDir}/'"$command"'.sh' \
+        "modules/darwin/scripts/$command.sh"
       ;;
     nixos)
       register_copy_exec \
         "$REPO_ROOT/modules/shared/programs/shell/nixos.nix" \
-        ".local/bin/nrs" \
-        '${nixosScriptsDir}/nrs.sh' \
-        "modules/nixos/scripts/nrs.sh"
+        ".local/bin/$command" \
+        '${nixosScriptsDir}/'"$command"'.sh' \
+        "modules/nixos/scripts/$command.sh"
       ;;
-    *) fail "unknown platform for nrs entrypoint: $platform" ;;
+    *) fail "unknown platform for $command entrypoint: $platform" ;;
   esac
 }
 
+install_platform_nrs_entrypoint() {
+  install_platform_rebuild_entrypoint "$1" "$2" nrs
+}
+
 install_platform_nrp_entrypoint() {
-  local sandbox="$1" platform="$2"
-  local home_dir="$sandbox/home"
-  local generated_dir="$sandbox/generated"
-
-  mkdir -p "$home_dir/.local/bin" "$generated_dir"
-
-  # shellcheck disable=SC2016  # Literal Nix source strings.
-  case "$platform" in
-    darwin)
-      register_copy_exec \
-        "$REPO_ROOT/modules/shared/programs/shell/darwin.nix" \
-        ".local/bin/nrp" \
-        '${darwinScriptsDir}/nrp.sh' \
-        "modules/darwin/scripts/nrp.sh"
-      ;;
-    nixos)
-      register_copy_exec \
-        "$REPO_ROOT/modules/shared/programs/shell/nixos.nix" \
-        ".local/bin/nrp" \
-        '${nixosScriptsDir}/nrp.sh' \
-        "modules/nixos/scripts/nrp.sh"
-      ;;
-    *) fail "unknown platform for nrp entrypoint: $platform" ;;
-  esac
+  install_platform_rebuild_entrypoint "$1" "$2" nrp
 }
 
 install_recording_nrs_relink() {
@@ -317,6 +298,34 @@ test_darwin_nrs_h_alias_prints_usage() {
   assert_contains "$output" "--force"
   assert_contains "$output" "--cores N"
   assert_not_contains "$output" "Unknown argument"
+}
+
+test_nrs_help_ignores_inherited_rebuild_mode() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_platform_nrs_entrypoint "$sandbox" nixos
+
+  # 진입점의 REBUILD_MODE=switch 명시 선언이 호출 환경에서 상속된 값을 덮는다.
+  output=$(
+    HOME="$home_dir" \
+    REBUILD_MODE="preview" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/nrs"'" --help
+    ' 2>&1
+  )
+
+  assert_contains "$output" "Usage: nrs"
+  assert_contains "$output" "--force"
+  assert_not_contains "$output" "preview wrapper"
 }
 
 test_nrp_help_usage_omits_force_flag() {

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -355,6 +355,34 @@ test_nrp_help_usage_omits_force_flag() {
   assert_not_contains "$output" "--force"
 }
 
+test_nrp_rejects_force_flag() {
+  local sandbox home_dir repo_root output rc
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_platform_nrp_entrypoint "$sandbox" nixos
+
+  # preview 진입점에서 --force는 usage뿐 아니라 parser에서도 거부된다.
+  rc=0
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/nrp"'" --force
+    ' 2>&1
+  ) || rc=$?
+
+  [[ "$rc" -eq 1 ]] || fail "expected nrp --force to exit 1 (actual: $rc)"
+  assert_contains "$output" "--force is not supported"
+  assert_contains "$output" "Usage: nrp"
+}
+
 test_detect_worktree_uses_current_worktree_path() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -133,6 +133,33 @@ install_platform_nrs_entrypoint() {
   esac
 }
 
+install_platform_nrp_entrypoint() {
+  local sandbox="$1" platform="$2"
+  local home_dir="$sandbox/home"
+  local generated_dir="$sandbox/generated"
+
+  mkdir -p "$home_dir/.local/bin" "$generated_dir"
+
+  # shellcheck disable=SC2016  # Literal Nix source strings.
+  case "$platform" in
+    darwin)
+      register_copy_exec \
+        "$REPO_ROOT/modules/shared/programs/shell/darwin.nix" \
+        ".local/bin/nrp" \
+        '${darwinScriptsDir}/nrp.sh' \
+        "modules/darwin/scripts/nrp.sh"
+      ;;
+    nixos)
+      register_copy_exec \
+        "$REPO_ROOT/modules/shared/programs/shell/nixos.nix" \
+        ".local/bin/nrp" \
+        '${nixosScriptsDir}/nrp.sh' \
+        "modules/nixos/scripts/nrp.sh"
+      ;;
+    *) fail "unknown platform for nrp entrypoint: $platform" ;;
+  esac
+}
+
 install_recording_nrs_relink() {
   local home_dir="$1"
   mkdir -p "$home_dir/.local/bin"
@@ -211,25 +238,28 @@ test_rebuild_common_exports_public_api() {
 }
 
 test_parse_args_unknown_argument_shows_usage_and_fails() {
-  local sandbox output rc
+  local sandbox stdout_file stderr_file rc
   sandbox=$(new_sandbox)
   install_deployed_layout "$sandbox"
+  stdout_file="$sandbox/parse-args.out"
+  stderr_file="$sandbox/parse-args.err"
 
+  # 오류 메시지와 usage는 stderr 계약이다 — stdout/stderr를 분리 캡처해 스트림 회귀를 감지한다.
   rc=0
-  output=$(
-    HOME="$sandbox/home" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      REBUILD_CMD="nixos-rebuild"
-      source "'"$sandbox/home/.local/lib/rebuild-common.sh"'"
-      parse_args --bogus
-    ' 2>&1
-  ) || rc=$?
+  HOME="$sandbox/home" \
+  PATH="$FIXTURE_DIR/bin:$PATH" \
+  bash -c '
+    set -euo pipefail
+    REBUILD_CMD="nixos-rebuild"
+    source "'"$sandbox/home/.local/lib/rebuild-common.sh"'"
+    parse_args --bogus
+  ' > "$stdout_file" 2> "$stderr_file" || rc=$?
 
   [[ "$rc" -eq 1 ]] || fail "expected parse_args --bogus to exit 1 (actual: $rc)"
-  assert_contains "$output" "Unknown argument: --bogus"
-  assert_contains "$output" "Usage:"
+  assert_contains "$(cat "$stderr_file")" "Unknown argument: --bogus"
+  assert_contains "$(cat "$stderr_file")" "Usage:"
+  [[ -s "$stdout_file" ]] && fail "expected empty stdout for unknown argument (got: $(cat "$stdout_file"))"
+  return 0
 }
 
 test_nixos_nrs_help_flag_prints_usage() {
@@ -261,24 +291,58 @@ test_nixos_nrs_help_flag_prints_usage() {
   assert_not_contains "$output" "Unknown argument"
 }
 
-test_nrp_help_usage_omits_force_flag() {
-  local sandbox output
+test_darwin_nrs_h_alias_prints_usage() {
+  local sandbox home_dir repo_root output
   sandbox=$(new_sandbox)
-  install_deployed_layout "$sandbox"
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
 
-  # _print_rebuild_usage는 ${0##*/}로 진입점을 구분한다 — bash -c의 후속 인자로 $0=nrp 지정.
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_platform_nrs_entrypoint "$sandbox" darwin
+
+  # darwin 진입점 + 짧은 alias -h도 동일 usage 계약을 따른다.
   output=$(
-    HOME="$sandbox/home" \
+    HOME="$home_dir" \
     PATH="$FIXTURE_DIR/bin:$PATH" \
     bash -c '
       set -euo pipefail
-      REBUILD_CMD="nixos-rebuild"
-      source "'"$sandbox/home/.local/lib/rebuild-common.sh"'"
-      _print_rebuild_usage
-    ' nrp 2>&1
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/nrs"'" -h
+    ' 2>&1
+  )
+
+  assert_contains "$output" "Usage: nrs"
+  assert_contains "$output" "--force"
+  assert_contains "$output" "--cores N"
+  assert_not_contains "$output" "Unknown argument"
+}
+
+test_nrp_help_usage_omits_force_flag() {
+  local sandbox home_dir repo_root output
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_platform_nrp_entrypoint "$sandbox" nixos
+
+  # 실제 nrp 진입점 실행 — REBUILD_MODE=preview 선언이 usage에서 무효 --force를 제외한다.
+  output=$(
+    HOME="$home_dir" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      cd "'"$repo_root"'"
+      "'"$home_dir/.local/bin/nrp"'" --help
+    ' 2>&1
   )
 
   assert_contains "$output" "Usage: nrp"
+  assert_contains "$output" "--cores N"
   assert_not_contains "$output" "--force"
 }
 

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -261,6 +261,27 @@ test_nixos_nrs_help_flag_prints_usage() {
   assert_not_contains "$output" "Unknown argument"
 }
 
+test_nrp_help_usage_omits_force_flag() {
+  local sandbox output
+  sandbox=$(new_sandbox)
+  install_deployed_layout "$sandbox"
+
+  # _print_rebuild_usage는 ${0##*/}로 진입점을 구분한다 — bash -c의 후속 인자로 $0=nrp 지정.
+  output=$(
+    HOME="$sandbox/home" \
+    PATH="$FIXTURE_DIR/bin:$PATH" \
+    bash -c '
+      set -euo pipefail
+      REBUILD_CMD="nixos-rebuild"
+      source "'"$sandbox/home/.local/lib/rebuild-common.sh"'"
+      _print_rebuild_usage
+    ' nrp 2>&1
+  )
+
+  assert_contains "$output" "Usage: nrp"
+  assert_not_contains "$output" "--force"
+}
+
 test_detect_worktree_uses_current_worktree_path() {
   local sandbox home_dir repo_root worktree_root output
   sandbox=$(new_sandbox)

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -243,27 +243,38 @@ test_parse_args_unknown_argument_shows_usage_and_fails() {
   return 0
 }
 
-test_nixos_nrs_help_flag_prints_usage() {
-  local sandbox home_dir repo_root output
+# usage/도움말 계열 테스트 공용 fixture — sandbox를 만들고 배포 진입점을 설치한 뒤
+# ENTRYPOINT_FIXTURE_HOME / ENTRYPOINT_FIXTURE_REPO 전역을 설정한다.
+# 이 계열은 parse_args 단계에서 종료되므로 rebuild/sudo stub 없이 안전하게 실행된다.
+prepare_rebuild_entrypoint_fixture() {
+  local platform="$1" command="$2"
+  local sandbox
   sandbox=$(new_sandbox)
-  home_dir="$sandbox/home"
-  repo_root="$sandbox/repo"
+  ENTRYPOINT_FIXTURE_HOME="$sandbox/home"
+  ENTRYPOINT_FIXTURE_REPO="$sandbox/repo"
+  create_git_fixture_repo "$ENTRYPOINT_FIXTURE_REPO"
+  ENTRYPOINT_FIXTURE_REPO="$(cd "$ENTRYPOINT_FIXTURE_REPO" && pwd -P)"
+  install_deployed_layout "$sandbox" "$ENTRYPOINT_FIXTURE_REPO"
+  install_platform_rebuild_entrypoint "$sandbox" "$platform" "$command"
+}
 
-  create_git_fixture_repo "$repo_root"
-  repo_root="$(cd "$repo_root" && pwd -P)"
-  install_deployed_layout "$sandbox" "$repo_root"
-  install_platform_nrs_entrypoint "$sandbox" nixos
+# 준비된 fixture에서 배포 진입점을 실행한다 (stdout+stderr 병합 반환).
+# 시나리오별 환경변수는 호출 앞에 붙인다: REBUILD_MODE=preview run_deployed_rebuild_entrypoint nrs --help
+run_deployed_rebuild_entrypoint() {
+  local command="$1"; shift
+  HOME="$ENTRYPOINT_FIXTURE_HOME" \
+  PATH="$FIXTURE_DIR/bin:$PATH" \
+  bash -c '
+    set -euo pipefail
+    cd "'"$ENTRYPOINT_FIXTURE_REPO"'"
+    "'"$ENTRYPOINT_FIXTURE_HOME/.local/bin/$command"'" "$@"
+  ' _ "$@" 2>&1
+}
 
-  # --help는 parse_args에서 exit 0 하므로 rebuild/sudo stub 없이 안전하게 실행된다.
-  output=$(
-    HOME="$home_dir" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/nrs"'" --help
-    ' 2>&1
-  )
+test_nixos_nrs_help_flag_prints_usage() {
+  local output
+  prepare_rebuild_entrypoint_fixture nixos nrs
+  output=$(run_deployed_rebuild_entrypoint nrs --help)
 
   assert_contains "$output" "Usage: nrs"
   assert_contains "$output" "--offline"
@@ -273,26 +284,10 @@ test_nixos_nrs_help_flag_prints_usage() {
 }
 
 test_darwin_nrs_h_alias_prints_usage() {
-  local sandbox home_dir repo_root output
-  sandbox=$(new_sandbox)
-  home_dir="$sandbox/home"
-  repo_root="$sandbox/repo"
-
-  create_git_fixture_repo "$repo_root"
-  repo_root="$(cd "$repo_root" && pwd -P)"
-  install_deployed_layout "$sandbox" "$repo_root"
-  install_platform_nrs_entrypoint "$sandbox" darwin
-
+  local output
+  prepare_rebuild_entrypoint_fixture darwin nrs
   # darwin 진입점 + 짧은 alias -h도 동일 usage 계약을 따른다.
-  output=$(
-    HOME="$home_dir" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/nrs"'" -h
-    ' 2>&1
-  )
+  output=$(run_deployed_rebuild_entrypoint nrs -h)
 
   assert_contains "$output" "Usage: nrs"
   assert_contains "$output" "--force"
@@ -301,27 +296,10 @@ test_darwin_nrs_h_alias_prints_usage() {
 }
 
 test_nrs_help_ignores_inherited_rebuild_mode() {
-  local sandbox home_dir repo_root output
-  sandbox=$(new_sandbox)
-  home_dir="$sandbox/home"
-  repo_root="$sandbox/repo"
-
-  create_git_fixture_repo "$repo_root"
-  repo_root="$(cd "$repo_root" && pwd -P)"
-  install_deployed_layout "$sandbox" "$repo_root"
-  install_platform_nrs_entrypoint "$sandbox" nixos
-
+  local output
+  prepare_rebuild_entrypoint_fixture nixos nrs
   # 진입점의 REBUILD_MODE=switch 명시 선언이 호출 환경에서 상속된 값을 덮는다.
-  output=$(
-    HOME="$home_dir" \
-    REBUILD_MODE="preview" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/nrs"'" --help
-    ' 2>&1
-  )
+  output=$(REBUILD_MODE="preview" run_deployed_rebuild_entrypoint nrs --help)
 
   assert_contains "$output" "Usage: nrs"
   assert_contains "$output" "--force"
@@ -329,26 +307,10 @@ test_nrs_help_ignores_inherited_rebuild_mode() {
 }
 
 test_nrp_help_usage_omits_force_flag() {
-  local sandbox home_dir repo_root output
-  sandbox=$(new_sandbox)
-  home_dir="$sandbox/home"
-  repo_root="$sandbox/repo"
-
-  create_git_fixture_repo "$repo_root"
-  repo_root="$(cd "$repo_root" && pwd -P)"
-  install_deployed_layout "$sandbox" "$repo_root"
-  install_platform_nrp_entrypoint "$sandbox" nixos
-
+  local output
+  prepare_rebuild_entrypoint_fixture nixos nrp
   # 실제 nrp 진입점 실행 — REBUILD_MODE=preview 선언이 usage에서 무효 --force를 제외한다.
-  output=$(
-    HOME="$home_dir" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/nrp"'" --help
-    ' 2>&1
-  )
+  output=$(run_deployed_rebuild_entrypoint nrp --help)
 
   assert_contains "$output" "Usage: nrp"
   assert_contains "$output" "--cores N"
@@ -356,27 +318,11 @@ test_nrp_help_usage_omits_force_flag() {
 }
 
 test_nrp_rejects_force_flag() {
-  local sandbox home_dir repo_root output rc
-  sandbox=$(new_sandbox)
-  home_dir="$sandbox/home"
-  repo_root="$sandbox/repo"
-
-  create_git_fixture_repo "$repo_root"
-  repo_root="$(cd "$repo_root" && pwd -P)"
-  install_deployed_layout "$sandbox" "$repo_root"
-  install_platform_nrp_entrypoint "$sandbox" nixos
-
+  local output rc
+  prepare_rebuild_entrypoint_fixture nixos nrp
   # preview 진입점에서 --force는 usage뿐 아니라 parser에서도 거부된다.
   rc=0
-  output=$(
-    HOME="$home_dir" \
-    PATH="$FIXTURE_DIR/bin:$PATH" \
-    bash -c '
-      set -euo pipefail
-      cd "'"$repo_root"'"
-      "'"$home_dir/.local/bin/nrp"'" --force
-    ' 2>&1
-  ) || rc=$?
+  output=$(run_deployed_rebuild_entrypoint nrp --force) || rc=$?
 
   [[ "$rc" -eq 1 ]] || fail "expected nrp --force to exit 1 (actual: $rc)"
   assert_contains "$output" "--force is not supported"


### PR DESCRIPTION
## Summary

- `nrs`에 `-h`/`--help` 플래그를 추가하여 사용법을 실행으로 발견할 수 있게 한다 — LLM 에이전트와 사용자가 소스 주석을 열지 않고도 옵션을 확인할 수 있다.
- Unknown argument 에러 시에도 usage를 stderr로 함께 출력하여 오타 후 바로 올바른 사용법으로 복구할 수 있게 한다.

Closes #1138

## 기존 문제/배경

`nrs`는 `--offline`, `--force`, `--cores N` 옵션을 받지만 사용법을 출력하는 경로가 없었다. 옵션 설명은 `modules/darwin/scripts/nrs.sh`와 `modules/nixos/scripts/nrs.sh` 상단 주석에만 존재했다.

**문제**: LLM 에이전트가 관례적으로 `nrs --help`를 실행하면 `Unknown argument: --help`로 exit 1 하며, 올바른 사용법에 대한 어떤 힌트도 주지 않는다 (이슈 #1138 스크린샷의 실제 관측 장면). CLI의 표준 발견 경로(`--help`)가 막혀 있어, 사용법을 알려면 소스 파일을 직접 열어야 했다.

## CIR (Change Intent Record)

- **v1** (이번 변경): usage 출력을 플랫폼별 진입점(`nrs.sh` 2벌)이 아닌 공유 라이브러리 `rebuild/common.sh`의 `parse_args` 옆에 배치. 인수 파싱과 usage 텍스트가 같은 파일에 살아 옵션 추가 시 drift가 구조적으로 어렵다. unknown argument 분기에서도 같은 usage를 stderr로 재사용한다.

**trade-off**: usage 텍스트가 darwin/nixos 공용 1벌이라 플랫폼 전용 옵션(`--cores`는 nixos 전용, `--force` 의미 차이)은 옵션 설명 문구에 병기하는 방식으로 표현한다. 플랫폼별로 완전히 정확한 usage를 원하면 조건 분기가 필요하지만, 옵션 3개 규모에서는 병기가 더 단순하다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 공유 `parse_args`에 usage 통합 | `rebuild/common.sh`에 `_print_rebuild_usage` + `-h\|--help` 케이스 추가 | 1곳 유지보수, unknown argument 경로에서 재사용, 양 플랫폼 자동 적용 | 플랫폼 전용 옵션을 문구로 병기해야 함 | ✅ |
| 플랫폼별 `nrs.sh`에 각각 usage 하드코딩 | darwin/nixos 진입점에 usage 함수 2벌 | 플랫폼별 정확한 옵션 목록 | 2벌 drift 위험, `parse_args`와 옵션 목록 분리 | ❌ |
| 헤더 주석 자동 파싱 출력 | 파일 상단 주석을 `sed`로 추출해 출력 | 주석과 usage 단일 소스 | 배포 레이아웃에서 주석 위치·형식 결합, 취약한 파싱 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/scripts/lib/rebuild/common.sh` | 수정 | `_print_rebuild_usage` 함수 추가, `parse_args`에 `-h\|--help` 케이스(usage 출력 후 exit 0), unknown argument 시 usage를 stderr로 병행 출력 |
| `modules/darwin/scripts/nrs.sh` | 수정 | 헤더 주석에 `nrs --help` 사용례 추가 |
| `modules/nixos/scripts/nrs.sh` | 수정 | 헤더 주석에 `nrs --help` 사용례 추가 |
| `tests/shell-script-tests.sh` | 수정 | 신규 테스트 2개 등록 |
| `tests/suites/rebuild-nrs.sh` | 수정 | unknown argument usage 출력·exit 1 검증, nixos 진입점 `--help` end-to-end 검증 추가 |

### 핵심 코드

```bash
# parse_args 케이스 추가 (rebuild/common.sh)
-h|--help) _print_rebuild_usage; exit 0 ;;
*) log_error "Unknown argument: $1"; _print_rebuild_usage >&2; exit 1 ;;
```

```
Usage: nrs [--offline] [--force] [--cores N]

Options:
  --offline    오프라인 rebuild (substituter 미사용, 빠름)
  --force      NO_CHANGES 스킵 우회 (darwin) / 소스 빌드 경고 무시 (nixos)
  --cores N    빌드 코어 수 제한 (nixos-rebuild 전용)
  -h, --help   이 도움말 출력 후 종료
```

`--help`는 `parse_args` 단계에서 exit 0 하므로 preview·rebuild·sudo 등 어떤 부수효과도 발생하기 전에 종료된다.

## 참고 레퍼런스

- Issue #1138 — LLM이 `nrs --help` 실행 시 Unknown argument로 실패하는 장면 보고 (스크린샷)

## Human Test Plan

### 정상 동작 검증

1. `nrs --help`를 실행한다.
   - **기대**: `Usage: nrs ...`와 옵션 목록이 출력되고 exit 0. rebuild/preview는 시작되지 않는다.
   - **실패 시**: 배포된 `~/.local/lib/rebuild-common.sh`가 최신인지 확인한다 (`nrs` 재배포 필요 여부).
2. `nrs -h`를 실행한다.
   - **기대**: 1번과 동일한 출력.
   - **실패 시**: `parse_args`의 `-h|--help` 케이스 매칭을 확인한다.

### 에러 경로 검증

3. `nrs --bogus`를 실행한다.
   - **기대**: `Unknown argument: --bogus` 에러와 함께 usage가 stderr로 출력되고 exit 1.
   - **실패 시**: unknown argument 분기의 `_print_rebuild_usage >&2` 호출을 확인한다.

### Regression 검증

4. 인자 없이 `nrs`를 실행한다.
   - **기대**: 기존과 동일하게 preview 포함 rebuild 흐름이 진행된다 (usage가 끼어들지 않음).
   - **실패 시**: `parse_args`의 while 루프에서 인자 없는 경로가 변경되지 않았는지 확인한다.
5. `tests/shell-script-tests.sh`를 실행한다.
   - **기대**: 신규 테스트 2개("parse_args unknown argument shows usage and fails", "nixos nrs --help prints usage")를 포함해 전체 통과.
   - **실패 시**: `tests/suites/rebuild-nrs.sh`의 fixture(`install_deployed_layout`, `install_platform_nrs_entrypoint`) 경로를 확인한다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * `nrs --help`/`nrs -h`에서 지원 옵션을 확인할 수 있고, `REBUILD_MODE=preview` 영향 없이 도움말이 일관되게 표시됩니다.
  * `nrp --help`도 제공되며 미리보기 관련 옵션 위주로 안내됩니다.
* **버그 수정**
  * 알 수 없는 인자 입력 시 오류와 함께 사용법이 추가로 표시되며 실패합니다.
  * 미리보기 모드에서는 `nrs --force`가 거부되고, `nrp --force`도 거부됩니다.
  * Darwin 전환 시 `--cores` 인자가 반영됩니다.
* **문서**
  * `nrs` 사용 제약 및 미지원 옵션 안내를 더 구체화했습니다.
* **테스트**
  * 도움말/알 수 없는 인자/환경값 영향/미지원 플래그 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->