### PR TITLE
chore(shell): ls=eza -la 별칭 제거 — LLM의 POSIX ls 가정 실수 방지

### DIFF
--- a/modules/shared/programs/shell/default.nix
+++ b/modules/shared/programs/shell/default.nix
@@ -105,8 +105,9 @@ in
   # Shell aliases (공통)
   home.shellAliases = {
     # 파일 목록 (eza 사용)
+    # ls는 alias하지 않는다 — LLM이 ls를 POSIX ls로 가정하고 실행해
+    # eza 출력/옵션 차이로 실수를 유발했음 (#1119)
     l = "eza -l";
-    ls = "eza -la";
     ll = "eza -la";
 
     # broot: tree 스타일 출력


### PR DESCRIPTION
## Summary

- `ls = "eza -la"` shell alias 한 줄을 제거한다 — LLM(Bash tool 등)이 `ls`를 POSIX `ls`로 가정하고 실행하다 eza의 출력 포맷/옵션 차이로 무증상 실수를 일으키는 문제의 근본 원인 제거.
- `l`/`ll`(eza) alias는 유지하여 사람의 대화형 사용 편의는 보존한다.

Closes #1119

## 기존 문제/배경

`home.shellAliases`에서 `ls`가 `eza -la`로 alias되어 있었다 (initial commit부터 존재하는 편의 alias). 사람이 대화형으로 쓸 때는 문제가 없지만, LLM 에이전트의 Bash tool은 하네스가 대화형 셸 snapshot을 주입하는 환경에서 이 alias를 그대로 물려받는다.

**문제**: LLM은 `ls`를 POSIX `ls`로 가정한다. 실제로는 eza가 실행되므로 다음과 같은 실수가 반복 발생했다:

- eza가 지원하지 않는 POSIX/GNU `ls` 옵션을 넘겨 실패
- `-la`가 항상 적용된 출력 포맷을 파싱하다 스크립트가 무증상 빈 출력으로 실패
- 매 세션 `command ls`/`zsh -fc` 우회를 기억해야 하는 반복 비용 (프로젝트 메모리에 함정 항목으로 관리 중이었음)

## CIR (Change Intent Record)

- **제거 대상**: `ls = "eza -la"` alias 1줄. initial commit부터 존재하던 편의 alias로, 특정 이슈/PR로 도입된 방어 로직이 아니라 초기 셋업 시의 취향성 설정이다.
- **제거 이유**: LLM 에이전트 시대에 `ls`라는 보편 명령의 의미를 바꾸는 alias는 편익보다 실수 비용이 크다는 것이 반복 관측됨 (#1119). `l`/`ll`은 eza 전용 이름이라 POSIX 가정 충돌이 없으므로 유지.
- 재도입 방지를 위해 코드 옆에 인라인 주석으로 제거 근거를 남겼다.

**trade-off**: 사람이 손으로 `ls`를 칠 때 eza의 컬러/아이콘 출력을 잃는다. 동일 출력이 필요하면 `ll`(= `eza -la`)을 쓰면 되므로 실질 손실은 타이핑 1글자 수준.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `ls` alias 제거 | `ls`는 시스템 ls 그대로, `l`/`ll`만 eza | LLM의 POSIX 가정과 실제 동작 일치, 근본 해결 | 대화형에서 `ls` 기본 출력이 밋밋해짐 | ✅ |
| 메모리/문서로 우회 지속 | `command ls` 사용을 메모리 항목으로 안내 | 코드 무변경 | 세션마다 재발, 우회를 잊으면 무증상 실패 지속 | ❌ |
| 비대화형 셸에서만 alias 제외 | interactive 여부로 조건 분기 | 사람/LLM 모두 만족 (이론상) | LLM 하네스가 대화형 snapshot을 주입해 경계가 새는 것이 관측된 환경 — 신뢰 불가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/shell/default.nix` | 수정 | `ls = "eza -la"` alias 제거 + 재도입 방지 인라인 주석 추가 |

### 핵심 코드

```nix
# BEFORE
l = "eza -l";
ls = "eza -la";
ll = "eza -la";

# AFTER
# ls는 alias하지 않는다 — LLM이 ls를 POSIX ls로 가정하고 실행해
# eza 출력/옵션 차이로 실수를 유발했음 (#1119)
l = "eza -l";
ll = "eza -la";
```

## 참고 레퍼런스

- Issue #1119 — LLM이 `ls`가 eza alias임을 몰라 실수하는 문제 보고 (스크린샷 증빙 포함)

## Human Test Plan

### 정상 동작 검증

1. 이 브랜치에서 `nrs`로 설정을 적용한 뒤 새 셸을 연다.
   - **기대**: 빌드/activation이 성공한다.
   - **실패 시**: `nrs` preview 출력에서 shell alias 관련 diff를 확인한다.

2. 새 셸에서 `type ls`를 실행한다 (Negative 검증).
   - **기대**: alias가 아니다 — 시스템 `ls` 바이너리 경로가 출력된다 (`ls is /…/ls`).
   - **실패 시**: 이전 세대 설정이 남은 것 — 새 셸인지 확인하고 home-manager generation을 점검한다.

3. `ls -1` 등 POSIX 옵션을 실행한다.
   - **기대**: 시스템 ls가 POSIX 의미대로 동작한다 (eza 포맷/컬러 출력 아님).
   - **실패 시**: `type ls` 결과와 `home.shellAliases` 적용 상태를 대조한다.

### Regression 검증

4. `type l`과 `type ll`을 실행한다.
   - **기대**: 각각 `eza -l`, `eza -la` alias로 유지되어 있다.
   - **실패 시**: `modules/shared/programs/shell/default.nix`의 shellAliases 블록을 확인한다 — 이번 변경은 `ls` 한 줄만 제거해야 한다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * `ls` 별칭을 제거하여 기본 POSIX `ls`를 그대로 사용하도록 변경했습니다.
  * 간편한 목록 확인을 위해 `l` 별칭은 `eza -l`로 유지했습니다.
  * 셸 별칭 사용 방식에 대한 안내 주석을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->