### PR TITLE
fix(nrs): darwin no-change·pre-rebuild 경로에 HM gcroot 안전장치 추가

### DIFF
--- a/modules/darwin/scripts/nrs.sh
+++ b/modules/darwin/scripts/nrs.sh
@@ -242,7 +242,12 @@ main() {
             echo ""
             log_info "✅ No changes to apply. Skipping rebuild."
             log_info "  (Use 'nrs --force' to force full rebuild including activation scripts)"
-            maybe_relink_or_restore
+            # Safety: HM gcroot가 유효할 때만 실행 — gcroot 파손 시 Phase 1(rm)만 되고
+            # Phase 2(restore) 실패하여 심링크 유실 방지. 이 경로는 rebuild 없이
+            # 종료되므로 HM activation이 심링크를 재생성할 기회도 없다.
+            if [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
+                maybe_relink_or_restore
+            fi
             repair_codex_config_drift_no_changes
             release_nrs_lock_after_no_changes
             return 0
@@ -262,9 +267,12 @@ main() {
     # - main: maybe_relink_or_restore() → stale worktree symlink 제거 + nix store 복원
     # - worktree: worktree 심링크 직접 제거 + nrs-relink restore로 기존 entry 복원
     #   (activation 성공 후 maybe_relink_or_restore()가 다시 worktree로 relink)
-    if rebuild_is_main_flake; then
+    # Safety: HM gcroot가 유효할 때만 실행 — gcroot 파손 시 Phase 1(rm)만 되고
+    # Phase 2(restore) 실패하여 심링크 유실 방지 (NixOS wrapper와 동일 guard)
+    if rebuild_is_main_flake \
+       && [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
         maybe_relink_or_restore
-    else
+    elif ! rebuild_is_main_flake; then
         prepare_worktree_symlinks_for_rebuild
     fi
     run_darwin_rebuild

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -167,6 +167,8 @@ run_test "skill-usage-report missing log errors" test_skill_usage_report_missing
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 run_test "darwin nrs no-change activates when Codex artifact missing" test_darwin_nrs_no_changes_activates_when_codex_artifact_missing
+run_test "darwin nrs no-change skips relink without HM gcroot" test_darwin_nrs_no_changes_skips_relink_without_hm_gcroot
+run_test "darwin nrs no-change restores when HM gcroot present" test_darwin_nrs_no_changes_restores_when_hm_gcroot_present
 run_test "install-lefthook cleans up redundant local core.hooksPath" test_install_lefthook_cleanup_local_redundant
 run_test "install-lefthook preserves custom local core.hooksPath" test_install_lefthook_preserves_custom_local
 run_test "install-lefthook is silent on clean state" test_install_lefthook_silent_on_clean_state

--- a/tests/suites/rebuild-nrs.sh
+++ b/tests/suites/rebuild-nrs.sh
@@ -700,6 +700,113 @@ EOF
   assert_user_codex_hooks_pruned "$home_dir"
 }
 
+# darwin no-change gcroot guard fixture — caller의 local 변수(sandbox/home_dir/repo_root/
+# worktree_root/stub_dir/current_target/relink_log/lock_file)를 bash dynamic scoping으로 채운다.
+# main repo에서 no-change nrs를 돌리되, stale worktree 심링크 probe를 심어 guard가 없으면
+# maybe_relink_or_restore의 Phase 1(rm) + restore가 반드시 실행되는 상태를 만든다.
+setup_darwin_no_change_gcroot_fixture() {
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stub-bin"
+  current_target="$sandbox/current-system"
+  relink_log="$sandbox/nrs-relink.log"
+  lock_file="$sandbox/nrs-state"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  worktree_root="$repo_root/.claude/worktrees/feature_one"
+  install_deployed_layout "$sandbox" "$repo_root"
+  install_platform_nrs_entrypoint "$sandbox" darwin
+  install_codex_managed_artifact_fixture "$home_dir"
+  install_recording_nrs_relink "$home_dir"
+
+  mkdir -p "$stub_dir" "$current_target" "$home_dir/.claude"
+  rm -f "$lock_file"
+
+  # stale worktree probe: main 경로 _remove_worktree_symlinks가 매칭하는 심링크
+  ln -sf "$worktree_root/CLAUDE.md" "$home_dir/.claude/CLAUDE.md"
+
+  cat > "$stub_dir/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+"$@"
+EOF
+  cat > "$stub_dir/darwin-rebuild" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  build)
+    ln -sfn "${DARWIN_CURRENT_SYSTEM:?}" ./result
+    ;;
+  switch)
+    :
+    ;;
+  *)
+    echo "unexpected darwin-rebuild subcommand: $1" >&2
+    exit 1
+    ;;
+esac
+EOF
+  cat > "$stub_dir/nvd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "stub nvd diff"
+EOF
+  local real_readlink
+  real_readlink="$(command -v readlink)"
+  cat > "$stub_dir/readlink" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "/run/current-system" ]]; then
+  printf '%s\n' "\${DARWIN_CURRENT_SYSTEM:?}"
+else
+  "$real_readlink" "\$@"
+fi
+EOF
+  chmod +x "$stub_dir/sudo" "$stub_dir/darwin-rebuild" "$stub_dir/nvd" "$stub_dir/readlink"
+}
+
+run_darwin_no_change_gcroot_nrs() {
+  HOME="$home_dir" \
+  PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
+  DARWIN_CURRENT_SYSTEM="$current_target" \
+  NRS_LOCK_FILE="$lock_file" \
+  NRS_RELINK_LOG="$relink_log" \
+  bash -c '
+    set -euo pipefail
+    cd "'"$repo_root"'"
+    "'"$home_dir/.local/bin/nrs"'"
+  ' 2>&1
+}
+
+test_darwin_nrs_no_changes_skips_relink_without_hm_gcroot() {
+  local sandbox home_dir repo_root worktree_root stub_dir current_target relink_log lock_file output
+  setup_darwin_no_change_gcroot_fixture
+
+  output=$(run_darwin_no_change_gcroot_nrs)
+
+  assert_contains "$output" "No changes to apply"
+  assert_not_contains "$output" "Restoring symlinks to nix store chain"
+  [[ ! -s "$relink_log" ]] || fail "expected no-change nrs without HM gcroot to skip nrs-relink"
+  [[ -L "$home_dir/.claude/CLAUDE.md" ]] || fail "expected stale worktree symlink to be left untouched without HM gcroot"
+  [[ ! -e "$lock_file" ]] || fail "expected nrs lock file to be removed after no-change early return"
+}
+
+test_darwin_nrs_no_changes_restores_when_hm_gcroot_present() {
+  local sandbox home_dir repo_root worktree_root stub_dir current_target relink_log lock_file output
+  setup_darwin_no_change_gcroot_fixture
+  mkdir -p "$home_dir/.local/state/home-manager/gcroots"
+  touch "$home_dir/.local/state/home-manager/gcroots/current-home"
+
+  output=$(run_darwin_no_change_gcroot_nrs)
+
+  assert_contains "$output" "No changes to apply"
+  assert_contains "$output" "Restoring symlinks to nix store chain"
+  assert_file_contains "$relink_log" "restore"
+  [[ ! -L "$home_dir/.claude/CLAUDE.md" ]] || fail "expected stale worktree symlink to be removed when HM gcroot is present"
+}
+
 test_darwin_nrs_no_changes_activates_when_codex_artifact_missing() {
   local sandbox home_dir repo_root stub_dir output current_target switch_log lock_file
   sandbox=$(new_sandbox)


### PR DESCRIPTION
## Summary

- Darwin `nrs`의 NO_CHANGES 경로와 pre-rebuild main flake 경로에 NixOS wrapper와 동일한 Home Manager gcroot 존재 체크를 추가해, gcroot 파손 시 심링크 영구 유실을 방지한다.
- 회귀 테스트 2건으로 gcroot 부재 시 relink skip·stale 심링크 보존, gcroot 존재 시 restore 실행을 고정한다.

Closes #290

## 기존 문제/배경

`maybe_relink_or_restore`는 Phase 1(stale worktree symlink 제거) → Phase 2(`nrs-relink` restore) 순으로 동작한다. HM gcroot(`~/.local/state/home-manager/gcroots/current-home`)가 없거나 깨진 상태에서는 Phase 1만 성공하고 Phase 2가 실패할 수 있다.

- **NO_CHANGES 경로**: rebuild 없이 종료되므로, restore 실패 시 HM activation이 심링크를 재생성할 기회가 없어 영구 drift로 남는다.
- **pre-rebuild main flake 경로**: 같은 유형의 공백이 있었다.
- NixOS wrapper는 이미 pre-rebuild 경로에서 gcroot 존재를 확인한 뒤에만 restore를 실행한다 (PR #261). Darwin에만 동일 guard가 없었다.

## CIR (Change Intent Record)

- **v1** (PR #261): NixOS `nrs.sh` pre-rebuild 경로에 gcroot guard와 함께 `maybe_relink_or_restore` 도입 — Darwin 쪽은 대응 guard 없이 유지됨.
- **v2** (이번 변경): 이슈 #290 백로그 재검증에서 Darwin 공백 확인. 단순 중복 guard vs rebuild common helper 추출 중, diff가 작은 단순 guard를 채택.

**trade-off**: guard 조건이 darwin/nixos 두 파일에 중복되지만, 2줄짜리 조건을 위한 helper 추출은 과설계(YAGNI). 조건이 더 늘어나면 그때 추출한다.

**범위 제외** (이슈 Boundaries): post-rebuild `maybe_relink_or_restore` 호출은 rebuild 직후 gcroot가 항상 유효하므로 변경하지 않는다. `nrs-relink` 내부 복구 정책, NixOS wrapper 동작, lock 획득/해제 순서도 범위 밖.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 단순 중복 guard | darwin 두 호출부에 gcroot 존재 체크 인라인 | diff 최소, NixOS wrapper와 동형이라 대조 쉬움 | 조건이 2개 파일에 중복 | ✅ |
| rebuild common helper 추출 | 공용 helper로 추출해 양쪽 wrapper가 호출 | 중복 제거 | 2줄 조건 대비 과설계, 공용 라이브러리로 변경 범위 확대 | ❌ |
| nrs-relink 내부 방어 | restore 실패 시 Phase 1(rm) 롤백 | 호출부 수정 불필요 | `nrs-relink` 내부 정책은 이슈 범위 밖, 롤백 로직 복잡 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/scripts/nrs.sh` | 수정 | NO_CHANGES·pre-rebuild main 경로에 HM gcroot 존재 체크 추가 |
| `tests/suites/rebuild-nrs.sh` | 수정 | darwin no-change gcroot guard fixture + 회귀 테스트 2건 |
| `tests/shell-script-tests.sh` | 수정 | 새 테스트 2건 등록 |

### 핵심 코드

```bash
# NO_CHANGES 경로 — gcroot가 유효할 때만 relink/restore
if [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
    maybe_relink_or_restore
fi

# pre-rebuild main flake 경로 — NixOS wrapper와 동일 guard
if rebuild_is_main_flake \
   && [[ -e "$HOME/.local/state/home-manager/gcroots/current-home" ]]; then
    maybe_relink_or_restore
elif ! rebuild_is_main_flake; then
    prepare_worktree_symlinks_for_rebuild
fi
```

pre-rebuild 경로에서 기존 `if/else` 구조를 유지하면 "main flake + gcroot 부재"가 worktree 분기(`prepare_worktree_symlinks_for_rebuild`)로 잘못 흘러가므로, `elif ! rebuild_is_main_flake`로 분리해 그 경우 아무것도 하지 않게 했다.

테스트 fixture는 stale worktree 심링크 probe(`~/.claude/CLAUDE.md` → worktree 경로)를 심어 guard가 없으면 Phase 1(rm)이 반드시 실행되는 상태를 만든 뒤 검증한다:

- gcroot 부재: `nrs-relink` 미호출 + stale 심링크 보존 + no-change lock 해제 유지
- gcroot 존재: restore 실행 + stale 심링크 제거 (기존 동작 regression 없음)

## 참고 레퍼런스

- Issue #290 — Darwin NO_CHANGES 경로 gcroot 안전장치 누락 보고 (2026-07-03 백로그 재검증)
- PR #261 — NixOS `nrs.sh` pre-rebuild `maybe_relink_or_restore` + gcroot guard 도입 (이번 변경의 비교 기준)

## Human Test Plan

### 자동 테스트

1. `tests/run-shell-script-tests.sh`를 실행한다.
   - **기대**: "darwin nrs no-change skips relink without HM gcroot", "darwin nrs no-change restores when HM gcroot present"를 포함해 전체 통과.
   - **실패 시**: `tests/suites/rebuild-nrs.sh`의 `setup_darwin_no_change_gcroot_fixture` stub 경로(sudo/darwin-rebuild/nvd/readlink)를 확인한다.
2. `tests/run-eval-tests.sh`와 `nix flake check`를 실행한다.
   - **기대**: 모두 성공 (이번 변경은 shell 스크립트만 수정하므로 eval/flake regression 없음).

### 수동 검증 (macOS)

3. gcroot가 정상 존재하는 상태에서 변경 없는 커밋으로 `nrs`를 실행한다.
   - **기대**: "No changes to apply" 후 기존과 동일하게 relink/restore가 수행된다 (regression 없음).
   - **실패 시**: `ls -l ~/.local/state/home-manager/gcroots/current-home` 존재를 확인한다.
4. **Negative**: gcroot를 임시로 옮긴 뒤(`mv ~/.local/state/home-manager/gcroots/current-home{,.bak}`) no-change `nrs`를 실행한다.
   - **기대**: "Restoring symlinks to nix store chain" 로그가 출력되지 않고, `$HOME` 아래 기존 심링크가 건드려지지 않는다.
   - **실패 시**: guard 조건의 경로 오타를 확인한다. 확인 후 gcroot를 원복한다(`mv ~/.local/state/home-manager/gcroots/current-home{.bak,}`).
5. **Regression**: worktree에서 `nrs`를 실행한다.
   - **기대**: worktree 심링크 준비 경로가 기존대로 동작하고 rebuild가 정상 완료된다.
   - **실패 시**: pre-rebuild 분기의 `elif ! rebuild_is_main_flake` 조건을 확인한다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * macOS에서 변경 사항이 없을 때 Home Manager의 유효한 GC 루트가 있는 경우에만 링크 복원 작업을 수행합니다.
  * GC 루트가 없으면 불필요한 복원 작업을 건너뛰어 오래되거나 잘못된 심볼릭 링크가 유지되는 문제를 방지합니다.

* **테스트**
  * GC 루트가 있는 경우와 없는 경우의 `nrs` 동작을 검증하는 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->