### PR TITLE
fix(ai): Skill usage telemetry를 최소 수집 계약으로 전환

### DIFF
--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -55,16 +55,26 @@ _is_64_hex() {
   [ "${#1}" -eq 64 ]
 }
 
+# GNU/BSD stat 겸용 파일 mode 조회 (예: "600").
+_file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null
+}
+
 # 기존 파일이 owner-only 계약(regular file·비심링크·소유자·mode 600)을 만족하는지 검증.
 # mode만 어긋나면 600 교정을 시도하고, 교정 불가·심링크·타소유는 이벤트를 포기한다
 # (fail-closed — umask는 신규 inode에만 적용되므로 기존 파일은 매 실행 검증해야 한다).
 _ensure_owner_only_file() {
   [ -f "$1" ] && [ ! -L "$1" ] && [ -O "$1" ] || return 1
-  case "$(stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null)" in
+  # macOS ACL은 POSIX mode와 별개 권한 축이라 %a/%Lp 검사에 잡히지 않는다 —
+  # owner-only 보장 전에 제거한다 (chmod -N은 ACL이 없어도 성공, 실패 시 fail-closed).
+  if [ "$(uname)" = "Darwin" ]; then
+    /bin/chmod -N "$1" 2>/dev/null || return 1
+  fi
+  case "$(_file_mode "$1")" in
     600) return 0 ;;
   esac
   chmod 600 "$1" 2>/dev/null || return 1
-  [ "$(stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null)" = "600" ]
+  [ "$(_file_mode "$1")" = "600" ]
 }
 
 # key가 없으면 32-byte random을 hex로 한 번만 생성 (same-directory temp + atomic rename).

--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -28,6 +28,11 @@ AGENT_ID=$(printf '%s' "$INPUT" | hook_parse_json_path '.agent_id // empty')
 
 SKILL=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.skill // empty')
 [ -z "$SKILL" ] && exit 0
+# 스킬명 문법 검증 — 제어문자·개행·과대 길이가 v2 이벤트와 report 출력을 오염시키지 않게 한다.
+case "$SKILL" in
+  *[!A-Za-z0-9._:-]*) exit 0 ;;
+esac
+[ "${#SKILL}" -le 128 ] || exit 0
 
 SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
 

--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # PreToolUse Hook: 스킬 호출 빈도 로깅
-# Thariq(Anthropic) gist 기반 — session_id, repo context 추가
+# Thariq(Anthropic) gist 기반 — privacy-safe v2 JSONL schema (#1099)
 #
-# Log format (TSV): timestamp user session_id repo skill args
-# scripts/ai/skill-usage-report.sh consumes this column order; update both files together.
-# 예: 1742302800	greenhead	abc123	nixos-config	managing-minipc	""
+# Log format (v2 JSONL, 한 줄 한 event):
+#   {"schema_version":2,"event_type":"skill_invocation","ts":<epoch>,"runtime":"claude-main","skill":"<name>","session_key":"<64 lowercase hex>"}
+# scripts/ai/skill-usage-report.sh consumes this schema; update both files together.
+# legacy TSV rows는 report가 read-only로 계속 읽는다 (기존 로그 rewrite 금지).
+#
+# 금지 필드: user, repo, args, prompt, cwd/path, raw session id, agent id.
+# session_key는 owner-only 32-byte random local key(~/.claude/skill-usage.key)와
+# session id를 stdin으로 이어 SHA-256한 per-host pseudonym이다.
+# key 생성/읽기/hash 실패 시 raw id fallback 없이 event를 건너뛴다.
 
 command -v jq >/dev/null 2>&1 || exit 0
 
@@ -23,17 +29,63 @@ AGENT_ID=$(printf '%s' "$INPUT" | hook_parse_json_path '.agent_id // empty')
 SKILL=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.skill // empty')
 [ -z "$SKILL" ] && exit 0
 
-ARGS=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.args // ""')
 SESSION_ID=$(printf '%s' "$INPUT" | hook_parse_session_id)
-REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || true)
 
-# 로그 파일 owner-only 권한 (민감 args 보호)
+# 로그/키 파일 owner-only 권한 (pseudonym 연결 키 보호)
 umask 077
 SKILL_USAGE_LOG="${SKILL_USAGE_LOG:-$HOME/.claude/skill-usage.log}"
+SKILL_USAGE_KEY="${SKILL_USAGE_KEY:-$HOME/.claude/skill-usage.key}"
 
-printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
-  "$(date -u +%s)" "$USER" "${SESSION_ID:-unknown}" \
-  "${REPO:-unknown}" "$SKILL" "$ARGS" \
-  >> "$SKILL_USAGE_LOG" 2>/dev/null || true
+# stdin을 SHA-256해 64 lowercase hex 출력. 도구 부재 시 실패 (caller가 event skip).
+_sha256_stdin_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+# <value>가 64 lowercase hex인지 검증
+_is_64_hex() {
+  case "$1" in
+    *[!0-9a-f]*|"") return 1 ;;
+  esac
+  [ "${#1}" -eq 64 ]
+}
+
+# key가 없으면 32-byte random을 hex로 한 번만 생성 (same-directory temp + atomic rename).
+# key material은 argv/stdout/stderr에 노출하지 않는다.
+if [ ! -f "$SKILL_USAGE_KEY" ]; then
+  KEY_TMP=$(mktemp "$(dirname "$SKILL_USAGE_KEY")/.skill-usage.key.XXXXXX" 2>/dev/null) || exit 0
+  if ! head -c 32 /dev/urandom | od -An -v -tx1 | tr -d ' \n' > "$KEY_TMP" 2>/dev/null; then
+    rm -f "$KEY_TMP"
+    exit 0
+  fi
+  chmod 600 "$KEY_TMP" 2>/dev/null || { rm -f "$KEY_TMP"; exit 0; }
+  # 경합으로 다른 프로세스가 먼저 만들었으면 mv -n이 no-op — 그쪽 key를 쓴다
+  mv -n "$KEY_TMP" "$SKILL_USAGE_KEY" 2>/dev/null || true
+  rm -f "$KEY_TMP"
+fi
+
+LOCAL_KEY=$(cat "$SKILL_USAGE_KEY" 2>/dev/null) || exit 0
+_is_64_hex "$LOCAL_KEY" || exit 0
+
+# raw session id는 저장하지 않는다 — key‖id를 stdin으로 이어 SHA-256한 pseudonym만 기록
+SESSION_KEY=$(printf '%s%s' "$LOCAL_KEY" "$SESSION_ID" | _sha256_stdin_hex) || exit 0
+_is_64_hex "$SESSION_KEY" || exit 0
+
+EVENT=$(jq -cn \
+  --argjson ts "$(date -u +%s)" \
+  --arg skill "$SKILL" \
+  --arg session_key "$SESSION_KEY" \
+  '{schema_version: 2, event_type: "skill_invocation", ts: $ts,
+    runtime: "claude-main", skill: $skill, session_key: $session_key}' \
+  2>/dev/null) || exit 0
+[ -n "$EVENT" ] || exit 0
+
+printf '%s\n' "$EVENT" >> "$SKILL_USAGE_LOG" 2>/dev/null || exit 0
+chmod 600 "$SKILL_USAGE_LOG" 2>/dev/null || true
 
 exit 0

--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -85,12 +85,21 @@ _ensure_owner_only_file() {
 # key가 없으면 32-byte random을 hex로 한 번만 생성 (same-directory temp + atomic rename).
 # key material은 argv/stdout/stderr에 노출하지 않는다.
 if [ ! -f "$SKILL_USAGE_KEY" ]; then
+  # 경로가 디렉터리·심링크 등 비정상 inode면 생성 자체를 포기한다 —
+  # mv -n이 디렉터리 내부로 이동해 호출마다 key 파일을 누적시키는 경로 차단.
+  if [ -e "$SKILL_USAGE_KEY" ] || [ -L "$SKILL_USAGE_KEY" ]; then
+    exit 0
+  fi
   KEY_TMP=$(mktemp "$(dirname "$SKILL_USAGE_KEY")/.skill-usage.key.XXXXXX" 2>/dev/null) || exit 0
+  # macOS file_inherit ACL은 새 파일에 상속된다 — key 기록 전에 제거해 노출 창을 없앤다.
+  if [ "$(uname)" = "Darwin" ]; then
+    /bin/chmod -N "$KEY_TMP" 2>/dev/null || { rm -f "$KEY_TMP"; exit 0; }
+  fi
+  chmod 600 "$KEY_TMP" 2>/dev/null || { rm -f "$KEY_TMP"; exit 0; }
   if ! head -c 32 /dev/urandom | od -An -v -tx1 | tr -d ' \n' > "$KEY_TMP" 2>/dev/null; then
     rm -f "$KEY_TMP"
     exit 0
   fi
-  chmod 600 "$KEY_TMP" 2>/dev/null || { rm -f "$KEY_TMP"; exit 0; }
   # 경합으로 다른 프로세스가 먼저 만들었으면 mv -n이 no-op — 그쪽 key를 쓴다
   mv -n "$KEY_TMP" "$SKILL_USAGE_KEY" 2>/dev/null || true
   rm -f "$KEY_TMP"

--- a/modules/shared/programs/claude/files/hooks/log-skill.sh
+++ b/modules/shared/programs/claude/files/hooks/log-skill.sh
@@ -55,6 +55,18 @@ _is_64_hex() {
   [ "${#1}" -eq 64 ]
 }
 
+# 기존 파일이 owner-only 계약(regular file·비심링크·소유자·mode 600)을 만족하는지 검증.
+# mode만 어긋나면 600 교정을 시도하고, 교정 불가·심링크·타소유는 이벤트를 포기한다
+# (fail-closed — umask는 신규 inode에만 적용되므로 기존 파일은 매 실행 검증해야 한다).
+_ensure_owner_only_file() {
+  [ -f "$1" ] && [ ! -L "$1" ] && [ -O "$1" ] || return 1
+  case "$(stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null)" in
+    600) return 0 ;;
+  esac
+  chmod 600 "$1" 2>/dev/null || return 1
+  [ "$(stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null)" = "600" ]
+}
+
 # key가 없으면 32-byte random을 hex로 한 번만 생성 (same-directory temp + atomic rename).
 # key material은 argv/stdout/stderr에 노출하지 않는다.
 if [ ! -f "$SKILL_USAGE_KEY" ]; then
@@ -69,6 +81,8 @@ if [ ! -f "$SKILL_USAGE_KEY" ]; then
   rm -f "$KEY_TMP"
 fi
 
+# 읽기 전 trust boundary 검증 — 심링크 치환·권한 완화된 기존 key는 사용하지 않는다.
+_ensure_owner_only_file "$SKILL_USAGE_KEY" || exit 0
 LOCAL_KEY=$(cat "$SKILL_USAGE_KEY" 2>/dev/null) || exit 0
 _is_64_hex "$LOCAL_KEY" || exit 0
 
@@ -85,7 +99,12 @@ EVENT=$(jq -cn \
   2>/dev/null) || exit 0
 [ -n "$EVENT" ] || exit 0
 
+# append 전에 0600으로 미리 생성해 umask worst-case의 사후 chmod 의존을 제거하고,
+# 기존 파일이면 owner-only 계약을 검증한다 (실패 시 이벤트 포기).
+if [ ! -e "$SKILL_USAGE_LOG" ] && [ ! -L "$SKILL_USAGE_LOG" ]; then
+  ( umask 077; : >> "$SKILL_USAGE_LOG" ) 2>/dev/null || exit 0
+fi
+_ensure_owner_only_file "$SKILL_USAGE_LOG" || exit 0
 printf '%s\n' "$EVENT" >> "$SKILL_USAGE_LOG" 2>/dev/null || exit 0
-chmod 600 "$SKILL_USAGE_LOG" 2>/dev/null || true
 
 exit 0

--- a/scripts/ai/skill-usage-report.sh
+++ b/scripts/ai/skill-usage-report.sh
@@ -96,8 +96,11 @@ rows: dict[str, dict[str, int]] = defaultdict(
 # v2 event contract (log-skill.sh와 동기 유지): exact 6-key set + exact types.
 V2_KEYS = {"schema_version", "event_type", "ts", "runtime", "skill", "session_key"}
 SESSION_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
+# writer(log-skill.sh)의 스킬명 문법과 동기 유지 — 제어문자가 TSV 출력 행을 위조하지 못하게 한다.
+SKILL_RE = re.compile(r"[A-Za-z0-9._:-]{1,128}")
 # datetime.fromtimestamp() 변환 가능 범위를 파싱 단계에서 강제한다 —
 # 범위 밖 행이 report 전체를 OverflowError로 중단시키지 않도록 skip 계약을 지킨다.
+# 하한 1: 집계기의 first==0 미초기화 sentinel과의 충돌을 차단한다 (epoch 0 비지원).
 TS_MAX = 253402300799  # 9999-12-31T23:59:59Z
 
 
@@ -113,11 +116,11 @@ def parse_v2_event(line: str) -> tuple[int, str] | None:
         return None
     if event["event_type"] != "skill_invocation":
         return None
-    if type(event["ts"]) is not int or not (0 <= event["ts"] <= TS_MAX):
+    if type(event["ts"]) is not int or not (1 <= event["ts"] <= TS_MAX):
         return None
     if not isinstance(event["runtime"], str) or not event["runtime"]:
         return None
-    if not isinstance(event["skill"], str) or not event["skill"]:
+    if not isinstance(event["skill"], str) or not SKILL_RE.fullmatch(event["skill"]):
         return None
     if not isinstance(event["session_key"], str) or not SESSION_KEY_RE.fullmatch(
         event["session_key"]
@@ -146,7 +149,7 @@ with open(log_path, "r", encoding="utf-8", errors="replace", newline="") as hand
                 timestamp = int(fields[0])
             except ValueError:
                 continue
-            if not 0 <= timestamp <= TS_MAX:
+            if not 1 <= timestamp <= TS_MAX:
                 continue
 
             skill = fields[4]

--- a/scripts/ai/skill-usage-report.sh
+++ b/scripts/ai/skill-usage-report.sh
@@ -96,6 +96,9 @@ rows: dict[str, dict[str, int]] = defaultdict(
 # v2 event contract (log-skill.sh와 동기 유지): exact 6-key set + exact types.
 V2_KEYS = {"schema_version", "event_type", "ts", "runtime", "skill", "session_key"}
 SESSION_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
+# datetime.fromtimestamp() 변환 가능 범위를 파싱 단계에서 강제한다 —
+# 범위 밖 행이 report 전체를 OverflowError로 중단시키지 않도록 skip 계약을 지킨다.
+TS_MAX = 253402300799  # 9999-12-31T23:59:59Z
 
 
 def parse_v2_event(line: str) -> tuple[int, str] | None:
@@ -110,13 +113,13 @@ def parse_v2_event(line: str) -> tuple[int, str] | None:
         return None
     if event["event_type"] != "skill_invocation":
         return None
-    if type(event["ts"]) is not int:
+    if type(event["ts"]) is not int or not (0 <= event["ts"] <= TS_MAX):
         return None
     if not isinstance(event["runtime"], str) or not event["runtime"]:
         return None
     if not isinstance(event["skill"], str) or not event["skill"]:
         return None
-    if not isinstance(event["session_key"], str) or not SESSION_KEY_RE.match(
+    if not isinstance(event["session_key"], str) or not SESSION_KEY_RE.fullmatch(
         event["session_key"]
     ):
         return None
@@ -142,6 +145,8 @@ with open(log_path, "r", encoding="utf-8", errors="replace", newline="") as hand
             try:
                 timestamp = int(fields[0])
             except ValueError:
+                continue
+            if not 0 <= timestamp <= TS_MAX:
                 continue
 
             skill = fields[4]

--- a/scripts/ai/skill-usage-report.sh
+++ b/scripts/ai/skill-usage-report.sh
@@ -3,8 +3,9 @@
 # Usage: scripts/ai/skill-usage-report.sh [--log PATH] [--since YYYY-MM-DD]
 # Usage: scripts/ai/skill-usage-report.sh --log ~/skill-usage.log --since 2026-01-01
 #
-# Consumes the TSV emitted by modules/shared/programs/claude/files/hooks/log-skill.sh.
-# Column definitions live in that hook; this parser depends on that order.
+# Consumes the log emitted by modules/shared/programs/claude/files/hooks/log-skill.sh.
+# Rows starting with "{" are strict v2 JSONL events; other rows are legacy TSV
+# (read-only compatibility). Schema definitions live in that hook; update together.
 set -euo pipefail
 
 DEFAULT_LOG="${HOME}/.claude/skill-usage.log"
@@ -65,9 +66,11 @@ command -v python3 >/dev/null 2>&1 || die "python3 is required"
 python3 - "$log_file" "$since_date" <<'PY'
 from __future__ import annotations
 
+import json
+import re
+import sys
 from collections import defaultdict
 from datetime import date, datetime, time, timezone
-import sys
 
 log_path = sys.argv[1]
 since_arg = sys.argv[2]
@@ -90,25 +93,62 @@ rows: dict[str, dict[str, int]] = defaultdict(
     lambda: {"count": 0, "first": 0, "recent": 0}
 )
 
+# v2 event contract (log-skill.sh와 동기 유지): exact 6-key set + exact types.
+V2_KEYS = {"schema_version", "event_type", "ts", "runtime", "skill", "session_key"}
+SESSION_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def parse_v2_event(line: str) -> tuple[int, str] | None:
+    """Strict v2 JSONL row -> (timestamp, skill). Malformed rows are skipped."""
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(event, dict) or set(event) != V2_KEYS:
+        return None
+    if type(event["schema_version"]) is not int or event["schema_version"] != 2:
+        return None
+    if event["event_type"] != "skill_invocation":
+        return None
+    if type(event["ts"]) is not int:
+        return None
+    if not isinstance(event["runtime"], str) or not event["runtime"]:
+        return None
+    if not isinstance(event["skill"], str) or not event["skill"]:
+        return None
+    if not isinstance(event["session_key"], str) or not SESSION_KEY_RE.match(
+        event["session_key"]
+    ):
+        return None
+    return event["ts"], event["skill"]
+
+
 with open(log_path, "r", encoding="utf-8", errors="replace", newline="") as handle:
     for raw_line in handle:
         line = raw_line.rstrip("\n")
         if not line:
             continue
-        fields = line.split("\t")
-        if len(fields) < 5:
-            continue
 
-        try:
-            timestamp = int(fields[0])
-        except ValueError:
-            continue
+        if line.startswith("{"):
+            parsed = parse_v2_event(line)
+            if parsed is None:
+                continue
+            timestamp, skill = parsed
+        else:
+            fields = line.split("\t")
+            if len(fields) < 5:
+                continue
+
+            try:
+                timestamp = int(fields[0])
+            except ValueError:
+                continue
+
+            skill = fields[4]
+            if not skill:
+                continue
 
         if since_epoch is not None and timestamp < since_epoch:
-            continue
-
-        skill = fields[4]
-        if not skill:
             continue
 
         row = rows[skill]

--- a/scripts/ai/skill-usage-report.sh
+++ b/scripts/ai/skill-usage-report.sh
@@ -16,7 +16,7 @@ usage() {
   cat <<'EOF'
 Usage: skill-usage-report.sh [--log PATH] [--since YYYY-MM-DD]
 
-Summarize Claude Skill usage from the log-skill.sh TSV log.
+Summarize Claude Skill usage from the log-skill.sh log (v2 JSONL events + legacy TSV rows).
 EOF
 }
 

--- a/scripts/ai/skill-usage-report.sh
+++ b/scripts/ai/skill-usage-report.sh
@@ -153,7 +153,9 @@ with open(log_path, "r", encoding="utf-8", errors="replace", newline="") as hand
                 continue
 
             skill = fields[4]
-            if not skill:
+            # legacy TSV도 동일 스킬명 문법을 강제한다 — v2와 같은 출력 경로를 공유하므로
+            # 제어문자·과대 길이가 보고서 행을 조작하지 못하게 한다.
+            if not SKILL_RE.fullmatch(skill):
                 continue
 
         if since_epoch is not None and timestamp < since_epoch:

--- a/tests/fixtures/shell-scripts/skill-usage-report.mixed.log
+++ b/tests/fixtures/shell-scripts/skill-usage-report.mixed.log
@@ -1,0 +1,7 @@
+1767225600	tester	sid-a	nixos-config	managing-minipc	boot
+{"schema_version":2,"event_type":"skill_invocation","ts":1767355200,"runtime":"claude-main","skill":"run-da","session_key":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}
+1769934600	tester	sid-c	nixos-config	managing-minipc	check
+{"schema_version":2,"event_type":"skill_invocation","ts":1770147900,"runtime":"claude-main","skill":"configuring-codex","session_key":"cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"}
+1770147900	tester	sid-e	nixos-config	run-da	both
+not-a-timestamp	tester	sid-f	nixos-config	ignored-skill	ignored
+{"schema_version":2,"event_type":"other_event","ts":1770147900,"runtime":"claude-main","skill":"ignored-skill","session_key":"abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea"}

--- a/tests/fixtures/shell-scripts/skill-usage-report.v2.jsonl
+++ b/tests/fixtures/shell-scripts/skill-usage-report.v2.jsonl
@@ -1,0 +1,10 @@
+{"schema_version":2,"event_type":"skill_invocation","ts":1767225600,"runtime":"claude-main","skill":"managing-minipc","session_key":"abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1767355200,"runtime":"claude-main","skill":"run-da","session_key":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1769934600,"runtime":"claude-main","skill":"managing-minipc","session_key":"abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1770147900,"runtime":"claude-main","skill":"configuring-codex","session_key":"cafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00d"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1770147900,"runtime":"claude-main","skill":"run-da","session_key":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}
+{"schema_version":1,"event_type":"skill_invocation","ts":1770147900,"runtime":"claude-main","skill":"ignored-skill","session_key":"abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1770147900,"runtime":"claude-main","skill":"ignored-skill","session_key":"NOT-LOWERCASE-HEX"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1770147900,"runtime":"claude-main","skill":"ignored-skill","session_key":"abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea","args":"extra-key-must-be-rejected"}
+{"schema_version":2,"event_type":"skill_invocation","ts":"1770147900","runtime":"claude-main","skill":"ignored-skill","session_key":"abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea"}
+{"schema_version":2,"event_type":"skill_invocation","ts":1770147900,

--- a/tests/lib/test-common.sh
+++ b/tests/lib/test-common.sh
@@ -234,6 +234,6 @@ sys.exit(0 if a == b else 1)
 PY
 }
 # GNU `stat -c` / BSD `stat -f` 를 모두 지원하는 helper. "%a"/"%p" 3자리 octal을 반환.
-_codex_config_file_mode() {
+_portable_file_mode() {
   stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
 }

--- a/tests/lib/test-common.sh
+++ b/tests/lib/test-common.sh
@@ -235,5 +235,7 @@ PY
 }
 # GNU `stat -c` / BSD `stat -f` 를 모두 지원하는 helper. "%a"/"%p" 3자리 octal을 반환.
 _portable_file_mode() {
-  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+  # BSD fallback은 /usr/bin/stat 절대경로 — PATH 재해석으로 GNU stat이 -f를 오해석하는 것 방지
+  # (repo CLAUDE.md "macOS BSD vs GNU 도구 라우팅" 규칙).
+  stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null
 }

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -175,6 +175,9 @@ run_test "warn-skill-version-stamps --from-head detects stale HEAD" test_warn_sk
 run_test "warn-skill-version-stamps warns on unparseable stamp" test_warn_skill_version_stamps_warns_on_unparseable_stamp
 run_test "skill-usage-report aggregates sample TSV" test_skill_usage_report_aggregates_sample_tsv
 run_test "skill-usage-report --since filters sample TSV" test_skill_usage_report_since_filters_sample_tsv
+run_test "skill-usage-report v2 JSONL matches legacy aggregation" test_skill_usage_report_v2_jsonl_matches_legacy_aggregation
+run_test "skill-usage-report mixed log matches legacy aggregation" test_skill_usage_report_mixed_log_matches_legacy_aggregation
+run_test "skill-usage-report leaves input log unchanged" test_skill_usage_report_does_not_modify_input_log
 run_test "skill-usage-report missing log errors" test_skill_usage_report_missing_log_errors
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
@@ -232,7 +235,9 @@ run_test "fragile-hardcoding-guard line count word order independent" test_fragi
 run_test "fragile-hardcoding-guard line count true positive preserved" test_fragile_hardcoding_guard_line_count_true_positive_preserved
 run_test "fragile-hardcoding-guard edit true positive preserved" test_fragile_hardcoding_guard_edit_true_positive_preserved
 run_test "fragile-hardcoding-guard empty and malformed input noop" test_fragile_hardcoding_guard_empty_and_malformed_input_noop
-run_test "log-skill normal input logs usage" test_log_skill_hook_normal_input_logs_usage
+run_test "log-skill normal input logs v2 event" test_log_skill_hook_normal_input_logs_v2_event
+run_test "log-skill session key is stable pseudonym" test_log_skill_hook_session_key_is_stable_pseudonym
+run_test "log-skill invalid key skips event without fallback" test_log_skill_hook_invalid_key_skips_event_without_fallback
 run_test "log-skill empty malformed and subagent noop" test_log_skill_hook_empty_malformed_and_subagent_noop
 run_test "nrs-session-cleanup empty malformed and nonrepo noop" test_nrs_session_cleanup_hook_empty_malformed_and_nonrepo_input_noop
 run_test "plans-gc removes old transient buffer" test_plans_gc_hook_removes_old_transient_buffer

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -179,6 +179,7 @@ run_test "skill-usage-report v2 JSONL matches legacy aggregation" test_skill_usa
 run_test "skill-usage-report mixed log matches legacy aggregation" test_skill_usage_report_mixed_log_matches_legacy_aggregation
 run_test "skill-usage-report leaves input log unchanged" test_skill_usage_report_does_not_modify_input_log
 run_test "skill-usage-report missing log errors" test_skill_usage_report_missing_log_errors
+run_test "skill-usage-report skill grammar parity with writer" test_skill_usage_report_skill_grammar_parity_with_writer
 run_test "darwin nrs offline force smoke" test_darwin_nrs_offline_force_smoke
 run_test "darwin nrs no-change releases worktree lock" test_darwin_nrs_no_changes_releases_worktree_lock
 run_test "darwin nrs no-change activates when Codex artifact missing" test_darwin_nrs_no_changes_activates_when_codex_artifact_missing

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -236,6 +236,8 @@ run_test "fragile-hardcoding-guard line count true positive preserved" test_frag
 run_test "fragile-hardcoding-guard edit true positive preserved" test_fragile_hardcoding_guard_edit_true_positive_preserved
 run_test "fragile-hardcoding-guard empty and malformed input noop" test_fragile_hardcoding_guard_empty_and_malformed_input_noop
 run_test "log-skill normal input logs v2 event" test_log_skill_hook_normal_input_logs_v2_event
+run_test "log-skill repairs loose log mode before append" test_log_skill_hook_repairs_loose_log_mode
+run_test "log-skill skips symlinked pseudonym key" test_log_skill_hook_skips_symlinked_key
 run_test "log-skill session key is stable pseudonym" test_log_skill_hook_session_key_is_stable_pseudonym
 run_test "log-skill invalid key skips event without fallback" test_log_skill_hook_invalid_key_skips_event_without_fallback
 run_test "log-skill empty malformed and subagent noop" test_log_skill_hook_empty_malformed_and_subagent_noop

--- a/tests/suites/claude-hook-runtime-adoption.sh
+++ b/tests/suites/claude-hook-runtime-adoption.sh
@@ -78,8 +78,8 @@ test_log_skill_hook_normal_input_logs_v2_event() {
   assert_not_contains "$line" "sid-raw-1"
   assert_not_contains "$line" "$(cat "$key")"
   # log/key 모두 owner-only 0600
-  [[ "$(_codex_config_file_mode "$log")" == "600" ]] || fail "expected usage log mode 600"
-  [[ "$(_codex_config_file_mode "$key")" == "600" ]] || fail "expected pseudonym key mode 600"
+  [[ "$(_portable_file_mode "$log")" == "600" ]] || fail "expected usage log mode 600"
+  [[ "$(_portable_file_mode "$key")" == "600" ]] || fail "expected pseudonym key mode 600"
 }
 
 test_log_skill_hook_repairs_loose_log_mode() {
@@ -96,7 +96,7 @@ test_log_skill_hook_repairs_loose_log_mode() {
     '{"session_id":"sid-mode-1","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
   [[ -z "$out" ]] || fail "unexpected hook output: $out"
   [[ "$(wc -l < "$log")" -eq 2 ]] || fail "expected appended event after mode repair"
-  [[ "$(_codex_config_file_mode "$log")" == "600" ]] || fail "expected loose log mode repaired to 600"
+  [[ "$(_portable_file_mode "$log")" == "600" ]] || fail "expected loose log mode repaired to 600"
 }
 
 test_log_skill_hook_skips_symlinked_key() {

--- a/tests/suites/claude-hook-runtime-adoption.sh
+++ b/tests/suites/claude-hook-runtime-adoption.sh
@@ -82,6 +82,41 @@ test_log_skill_hook_normal_input_logs_v2_event() {
   [[ "$(_codex_config_file_mode "$key")" == "600" ]] || fail "expected pseudonym key mode 600"
 }
 
+test_log_skill_hook_repairs_loose_log_mode() {
+  # 기존 파일은 umask가 지켜주지 않는다 — 0644로 남은 log를 600으로 교정한 뒤에만 기록해야 한다.
+  local sandbox home out log
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  log="$home/.claude/skill-usage.log"
+  printf '%s\n' '{"schema_version":2,"event_type":"skill_invocation"}' > "$log"
+  chmod 644 "$log"
+
+  out=$(_chra_run_hook "log-skill.sh" \
+    '{"session_id":"sid-mode-1","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "unexpected hook output: $out"
+  [[ "$(wc -l < "$log")" -eq 2 ]] || fail "expected appended event after mode repair"
+  [[ "$(_codex_config_file_mode "$log")" == "600" ]] || fail "expected loose log mode repaired to 600"
+}
+
+test_log_skill_hook_skips_symlinked_key() {
+  # 심링크로 치환된 key는 trust boundary 위반 — 이벤트를 포기하고 아무 것도 기록하지 않는다.
+  local sandbox home out log key target
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  key="$home/.claude/skill-usage.key"
+  log="$home/.claude/skill-usage.log"
+  target="$sandbox/planted-key"
+  printf '%s' "abad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1deaabad1dea" > "$target"
+  ln -s "$target" "$key"
+
+  out=$(_chra_run_hook "log-skill.sh" \
+    '{"session_id":"sid-sym-1","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "unexpected hook output: $out"
+  [ ! -e "$log" ] || fail "expected no event when key is a symlink"
+}
+
 test_log_skill_hook_session_key_is_stable_pseudonym() {
   local sandbox home out log k1 k2 k3
   sandbox=$(new_sandbox)

--- a/tests/suites/claude-hook-runtime-adoption.sh
+++ b/tests/suites/claude-hook-runtime-adoption.sh
@@ -40,31 +40,95 @@ _chra_marker_path() {
     bash -c '. "$SESSION_STATE_LIB"; marker_path_for_cwd "$CWD_FOR_MARKER"'
 }
 
-test_log_skill_hook_normal_input_logs_usage() {
-  local sandbox home input out log line
+test_log_skill_hook_normal_input_logs_v2_event() {
+  local sandbox home input out log key line keyset
   sandbox=$(new_sandbox)
   home="$sandbox/home"
   mkdir -p "$home/.claude"
+  # synthetic credential-shaped placeholder + tab/newline — raw args는 log에 절대 남지 않아야 한다
   input=$(jq -n \
-    --arg sid "sid-1" \
+    --arg sid "sid-raw-1" \
     --arg skill "managing-minipc" \
-    --arg args "arg value" \
+    --arg args $'--token FAKE-PLACEHOLDER-SECRET\tline2\nline3' \
     '{session_id:$sid,tool_input:{skill:$skill,args:$args}}')
   out=$(_chra_run_hook "log-skill.sh" "$input" HOME="$home" USER="tester")
   [[ -z "$out" ]] || fail "expected log-skill normal input to produce no stdout, got: $out"
   log="$home/.claude/skill-usage.log"
+  key="$home/.claude/skill-usage.key"
   [ -f "$log" ] || fail "expected log-skill to create usage log"
+  [ -f "$key" ] || fail "expected log-skill to create pseudonym key"
+  [[ "$(wc -l < "$log")" -eq 1 ]] || fail "expected exactly one v2 event line"
   line=$(cat "$log")
-  assert_contains "$line" $'tester\tsid-1'
-  assert_contains "$line" $'\tmanaging-minipc\targ value'
+  # 한 줄 valid JSON + exact 6-key set + exact types (Target event contract)
+  printf '%s' "$line" | jq -e . >/dev/null || fail "expected v2 event to be valid JSON: $line"
+  keyset=$(printf '%s' "$line" | jq -r 'keys_unsorted | join(",")')
+  [[ "$keyset" == "schema_version,event_type,ts,runtime,skill,session_key" ]] || \
+    fail "unexpected v2 key set: $keyset"
+  printf '%s' "$line" | jq -e '
+    .schema_version == 2
+    and .event_type == "skill_invocation"
+    and (.ts | type == "number")
+    and .runtime == "claude-main"
+    and .skill == "managing-minipc"
+    and (.session_key | type == "string" and test("^[0-9a-f]{64}$"))
+  ' >/dev/null || fail "v2 event contract violated: $line"
+  # 금지 필드 부재: args placeholder / user / repo / raw session id / key material
+  assert_not_contains "$line" "FAKE-PLACEHOLDER-SECRET"
+  assert_not_contains "$line" "tester"
+  assert_not_contains "$line" "sid-raw-1"
+  assert_not_contains "$line" "$(cat "$key")"
+  # log/key 모두 owner-only 0600
+  [[ "$(_codex_config_file_mode "$log")" == "600" ]] || fail "expected usage log mode 600"
+  [[ "$(_codex_config_file_mode "$key")" == "600" ]] || fail "expected pseudonym key mode 600"
 }
 
-test_log_skill_hook_empty_malformed_and_subagent_noop() {
-  local sandbox home input out log
+test_log_skill_hook_session_key_is_stable_pseudonym() {
+  local sandbox home out log k1 k2 k3
   sandbox=$(new_sandbox)
   home="$sandbox/home"
   mkdir -p "$home/.claude"
   log="$home/.claude/skill-usage.log"
+
+  out=$(_chra_run_hook "log-skill.sh" \
+    '{"session_id":"sid-stable-1","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "unexpected hook output: $out"
+  out=$(_chra_run_hook "log-skill.sh" \
+    '{"session_id":"sid-stable-1","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "unexpected hook output: $out"
+  out=$(_chra_run_hook "log-skill.sh" \
+    '{"session_id":"sid-stable-2","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "unexpected hook output: $out"
+
+  k1=$(sed -n 1p "$log" | jq -r .session_key)
+  k2=$(sed -n 2p "$log" | jq -r .session_key)
+  k3=$(sed -n 3p "$log" | jq -r .session_key)
+  [[ "$k1" == "$k2" ]] || fail "expected same session id to map to same session_key"
+  [[ "$k1" != "$k3" ]] || fail "expected different session ids to map to different session_keys"
+}
+
+test_log_skill_hook_invalid_key_skips_event_without_fallback() {
+  local sandbox home out log key
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  log="$home/.claude/skill-usage.log"
+  key="$home/.claude/skill-usage.key"
+  # key 읽기/검증 실패 시 raw id fallback 없이 event를 건너뛴다
+  printf 'not-64-lowercase-hex\n' > "$key"
+
+  out=$(_chra_run_hook "log-skill.sh" \
+    '{"session_id":"sid-raw-2","tool_input":{"skill":"run-da"}}' HOME="$home" USER="tester")
+  [[ -z "$out" ]] || fail "expected invalid key to noop, got: $out"
+  [ ! -e "$log" ] || fail "expected invalid key to skip event without raw-id fallback"
+}
+
+test_log_skill_hook_empty_malformed_and_subagent_noop() {
+  local sandbox home input out log key
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  log="$home/.claude/skill-usage.log"
+  key="$home/.claude/skill-usage.key"
 
   out=$(_chra_run_hook "log-skill.sh" "" HOME="$home" USER="tester")
   [[ -z "$out" ]] || fail "expected log-skill empty stdin to noop, got: $out"
@@ -78,6 +142,7 @@ test_log_skill_hook_empty_malformed_and_subagent_noop() {
   out=$(_chra_run_hook "log-skill.sh" "$input" HOME="$home" USER="tester")
   [[ -z "$out" ]] || fail "expected log-skill subagent input to noop, got: $out"
   [ ! -e "$log" ] || fail "expected log-skill subagent input not to create log"
+  [ ! -e "$key" ] || fail "expected noop paths not to create pseudonym key"
 }
 
 test_nrs_session_cleanup_hook_empty_malformed_and_nonrepo_input_noop() {

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -358,12 +358,12 @@ test_claudex_runtime_api_and_private_state() {
     || fail "lock failure still entered the state mutation callback"
 
   _claudex_prepare_fixture_state "$sandbox"
-  [[ "$(_codex_config_file_mode "$state")" == "700" ]] || fail "claudex state mode must be 0700"
-  [[ "$(_codex_config_file_mode "$state/auth")" == "700" ]] || fail "claudex auth mode must be 0700"
-  [[ "$(_codex_config_file_mode "$state/work")" == "700" ]] || fail "claudex work mode must be 0700"
-  [[ "$(_codex_config_file_mode "$state/client-api-key")" == "600" ]] || fail "claudex key mode must be 0600"
-  [[ "$(_codex_config_file_mode "$state/config.yaml")" == "600" ]] || fail "claudex config mode must be 0600"
-  [[ "$(_codex_config_file_mode "$state/state.lock")" == "600" ]] || fail "claudex lock mode must be 0600"
+  [[ "$(_portable_file_mode "$state")" == "700" ]] || fail "claudex state mode must be 0700"
+  [[ "$(_portable_file_mode "$state/auth")" == "700" ]] || fail "claudex auth mode must be 0700"
+  [[ "$(_portable_file_mode "$state/work")" == "700" ]] || fail "claudex work mode must be 0700"
+  [[ "$(_portable_file_mode "$state/client-api-key")" == "600" ]] || fail "claudex key mode must be 0600"
+  [[ "$(_portable_file_mode "$state/config.yaml")" == "600" ]] || fail "claudex config mode must be 0600"
+  [[ "$(_portable_file_mode "$state/state.lock")" == "600" ]] || fail "claudex lock mode must be 0600"
   grep -Eq '^[0-9a-f]{64}$' "$state/client-api-key" || fail "claudex key must be 64 lowercase hex bytes"
   jq -e \
     --arg auth "$state/auth" \
@@ -408,7 +408,7 @@ test_claudex_runtime_api_and_private_state() {
     || fail "changed config content did not atomically replace its inode"
   jq -e --arg key "$replacement_key" '.["api-keys"] == [$key]' "$state/config.yaml" >/dev/null \
     || fail "changed config did not contain the replacement API key"
-  [[ "$(_codex_config_file_mode "$state/config.yaml")" == "600" ]] \
+  [[ "$(_portable_file_mode "$state/config.yaml")" == "600" ]] \
     || fail "changed config lost mode 0600"
   key_before="$replacement_key"
 

--- a/tests/suites/codex-config.sh
+++ b/tests/suites/codex-config.sh
@@ -194,7 +194,7 @@ test_codex_config_sync_noop_preserves_bytes() {
   [[ "$first_hash" == "$second_hash" ]] \
     || fail "sync_noop_preserves_bytes: bytes changed between first and second sync"
 
-  mode_after=$(_codex_config_file_mode "$target")
+  mode_after=$(_portable_file_mode "$target")
   [[ "$mode_after" == "600" ]] \
     || fail "sync_noop_preserves_bytes: mode=$mode_after (expected 600)"
 }
@@ -219,7 +219,7 @@ test_codex_config_sync_rejects_bad_mode() {
   [[ -n "$second_stderr" ]] \
     || fail "sync_rejects_bad_mode: expected summary log on write, stderr empty"
 
-  mode_after=$(_codex_config_file_mode "$target")
+  mode_after=$(_portable_file_mode "$target")
   [[ "$mode_after" == "600" ]] \
     || fail "sync_rejects_bad_mode: mode=$mode_after after sync (expected 600)"
 }
@@ -249,7 +249,7 @@ test_codex_config_sync_rejects_symlink() {
 
   [[ -L "$target" ]] && fail "sync_rejects_symlink: target is still a symlink after sync"
   [[ -f "$target" ]] || fail "sync_rejects_symlink: target is not a regular file after sync"
-  mode_after=$(_codex_config_file_mode "$target")
+  mode_after=$(_portable_file_mode "$target")
   [[ "$mode_after" == "600" ]] \
     || fail "sync_rejects_symlink: mode=$mode_after after sync (expected 600)"
 }

--- a/tests/suites/plugin-manifest.sh
+++ b/tests/suites/plugin-manifest.sh
@@ -221,7 +221,7 @@ assert not any(
     for e in disabled_entries
 ), disabled_entries
 PY
-  mode_after=$(_codex_config_file_mode "$manifest")
+  mode_after=$(_portable_file_mode "$manifest")
   [[ "$mode_after" == "600" ]] \
     || fail "expected Claude plugin manifest mode 600 after inheritance, got: $mode_after"
 }

--- a/tests/suites/skill-usage-report.sh
+++ b/tests/suites/skill-usage-report.sh
@@ -41,7 +41,41 @@ test_skill_usage_report_v2_jsonl_matches_legacy_aggregation() {
   output=$(bash "$(_skill_usage_report_script)" --log "$FIXTURE_DIR/skill-usage-report.v2.jsonl")
   expected=$(cat "$FIXTURE_DIR/skill-usage-report.expected")
   [[ "$output" == "$expected" ]] || fail "unexpected v2-only skill usage report output: $output"
-  assert_not_contains "$output" "extra-key-must-be-rejected"
+}
+
+# writer(log-skill.sh)와 parser(skill-usage-report.sh)의 스킬명 문법 계약 parity —
+# 경계값이 양쪽에서 동일하게 수락/거부되는지 검증해 한쪽만 수정되는 drift를 잡는다.
+test_skill_usage_report_skill_grammar_parity_with_writer() {
+  local sandbox home log ok128 bad129 v2log output
+  sandbox=$(new_sandbox)
+  home="$sandbox/home"
+  mkdir -p "$home/.claude"
+  log="$home/.claude/skill-usage.log"
+  ok128=$(printf 'a%.0s' {1..128})
+  bad129=$(printf 'a%.0s' {1..129})
+
+  # writer: 유효 경계(128자)는 기록, 초과(129자)·제어문자는 거부
+  for skill in "run-da" "$ok128"; do
+    printf '%s' "$(jq -cn --arg s "$skill" '{session_id:"sid-parity",tool_input:{skill:$s}}')" | \
+      env HOOK_RUNTIME_LIB="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" \
+      HOME="$home" bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/log-skill.sh"
+  done
+  for skill in "$bad129" $'bad\nskill'; do
+    printf '%s' "$(jq -cn --arg s "$skill" '{session_id:"sid-parity",tool_input:{skill:$s}}')" | \
+      env HOOK_RUNTIME_LIB="$REPO_ROOT/modules/shared/programs/claude/files/lib/hook-runtime.sh" \
+      HOME="$home" bash "$REPO_ROOT/modules/shared/programs/claude/files/hooks/log-skill.sh"
+  done
+  [[ "$(wc -l < "$log")" -eq 2 ]] || fail "writer grammar boundary mismatch: $(cat "$log")"
+
+  # parser: writer가 기록한 두 행은 집계되고, 수기로 주입한 초과 길이 v2 행은 skip된다
+  v2log="$sandbox/v2.jsonl"
+  cp "$log" "$v2log"
+  printf '%s\n' "$(jq -cn --arg s "$bad129" \
+    '{schema_version:2,event_type:"skill_invocation",ts:1742302800,runtime:"claude-main",skill:$s,session_key:("ab" * 32)}')" >> "$v2log"
+  output=$(bash "$(_skill_usage_report_script)" --log "$v2log")
+  assert_contains "$output" "run-da"
+  assert_contains "$output" "$ok128"
+  assert_not_contains "$output" "$bad129"
 }
 
 test_skill_usage_report_mixed_log_matches_legacy_aggregation() {

--- a/tests/suites/skill-usage-report.sh
+++ b/tests/suites/skill-usage-report.sh
@@ -10,6 +10,16 @@ _skill_usage_report_fixture() {
   printf '%s\n' "$FIXTURE_DIR/skill-usage-report.tsv"
 }
 
+_skill_usage_report_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    fail "neither sha256sum nor shasum available for skill-usage-report test hashing"
+  fi
+}
+
 test_skill_usage_report_aggregates_sample_tsv() {
   local output expected
   output=$(bash "$(_skill_usage_report_script)" --log "$(_skill_usage_report_fixture)")
@@ -22,6 +32,38 @@ test_skill_usage_report_since_filters_sample_tsv() {
   output=$(bash "$(_skill_usage_report_script)" --log "$(_skill_usage_report_fixture)" --since 2026-02-01)
   expected=$(cat "$FIXTURE_DIR/skill-usage-report.since.expected")
   [[ "$output" == "$expected" ]] || fail "unexpected filtered skill usage report output: $output"
+}
+
+# v2 JSONL fixture는 legacy TSV fixture와 같은 (ts, skill) 이벤트를 담는다 —
+# malformed rows(wrong schema_version, invalid session_key, extra key, broken JSON)는 skip.
+test_skill_usage_report_v2_jsonl_matches_legacy_aggregation() {
+  local output expected
+  output=$(bash "$(_skill_usage_report_script)" --log "$FIXTURE_DIR/skill-usage-report.v2.jsonl")
+  expected=$(cat "$FIXTURE_DIR/skill-usage-report.expected")
+  [[ "$output" == "$expected" ]] || fail "unexpected v2-only skill usage report output: $output"
+  assert_not_contains "$output" "extra-key-must-be-rejected"
+}
+
+test_skill_usage_report_mixed_log_matches_legacy_aggregation() {
+  local output expected
+  output=$(bash "$(_skill_usage_report_script)" --log "$FIXTURE_DIR/skill-usage-report.mixed.log")
+  expected=$(cat "$FIXTURE_DIR/skill-usage-report.expected")
+  [[ "$output" == "$expected" ]] || fail "unexpected mixed skill usage report output: $output"
+
+  output=$(bash "$(_skill_usage_report_script)" --log "$FIXTURE_DIR/skill-usage-report.mixed.log" --since 2026-02-01)
+  expected=$(cat "$FIXTURE_DIR/skill-usage-report.since.expected")
+  [[ "$output" == "$expected" ]] || fail "unexpected filtered mixed skill usage report output: $output"
+}
+
+test_skill_usage_report_does_not_modify_input_log() {
+  local sandbox copy before after
+  sandbox=$(new_sandbox)
+  copy="$sandbox/skill-usage.log"
+  cat "$(_skill_usage_report_fixture)" "$FIXTURE_DIR/skill-usage-report.v2.jsonl" > "$copy"
+  before=$(_skill_usage_report_sha256 "$copy")
+  bash "$(_skill_usage_report_script)" --log "$copy" >/dev/null
+  after=$(_skill_usage_report_sha256 "$copy")
+  [[ "$before" == "$after" ]] || fail "expected report to leave input log bytes unchanged"
 }
 
 test_skill_usage_report_missing_log_errors() {

--- a/tests/suites/wt-create-codex.sh
+++ b/tests/suites/wt-create-codex.sh
@@ -353,7 +353,7 @@ assert data["model"] == "test-model", data
 PY
 
   assert_line_count "$config_file" "[projects.\"$new_worktree\"]" 1
-  mode_after=$(_codex_config_file_mode "$config_file")
+  mode_after=$(_portable_file_mode "$config_file")
   [[ "$mode_after" == "600" ]] \
     || fail "expected Codex config mode 600 after trust registration, got: $mode_after"
 }


### PR DESCRIPTION
## Summary

- Skill 사용 로깅 hook이 저장하던 자유형 `args`·`user`·`repo`·raw session id 수집을 제거하고, versioned minimal event(v2 JSONL)로 전환한다 — 보고서가 실제로 쓰는 정보(timestamp, skill)만 남긴다.
- session 구분은 raw id 대신 owner-only 로컬 키와 SHA-256으로 만든 per-host pseudonym(`session_key`)으로 유지하며, 키 처리 실패 시 raw id fallback 없이 event를 건너뛴다.
- 기존 legacy TSV 로그는 rewrite 없이 read-only로 계속 집계된다 (mixed log 지원).

Closes #1099

## 기존 문제/배경

`log-skill.sh`는 Skill PreToolUse hook으로 스킬 호출을 `~/.claude/skill-usage.log`에 TSV로 기록해 왔다. 이때 `tool_input.args`(자유형 인자), `$USER`, repo 이름, raw session id까지 저장했지만, 소비자인 `scripts/ai/skill-usage-report.sh`는 timestamp와 skill name만 사용한다.

**문제**: 보고서가 쓰지도 않는 자유형 payload가 로그에 남는다. 스킬 인자에는 경로·프롬프트 조각 같은 민감 정보가 섞일 수 있어, 사용량 판단이 불필요한 개인정보 수집에 기대는 구조였다. 수집 계약을 먼저 최소화해야 이후의 보고/퇴역 판단(coverage 판정은 부모 이슈 #1075 계열의 후속 plan 소관)이 안전한 입력 위에 설 수 있다.

## CIR (Change Intent Record)

- **v1** (머지된 기존 hook): Thariq(Anthropic) gist 기반 TSV 로깅에 session id·repo context를 추가해 도입 — 당시엔 로그 활용 범위가 미정이어서 넓게 수집했다.
- **v2** (이번 변경): 보고서의 실제 소비 필드가 timestamp·skill 뿐임이 확인되어, 수집 계약을 exact 6-key versioned event로 최소화. raw args는 redaction이 아니라 **수집 자체를 제거**한다 (이슈 #1099의 STOP 조건 — regex redaction으로 보존하는 방향 명시적 기각).
- 제거 대상인 `args`/`user`/`repo`/raw session id 컬럼은 v1에서 의도적으로 도입된 것이며, 제거 근거는 "소비자 없음 + privacy 리스크"다. 세션 구분 신호는 pseudonym으로 보존해 기능 회귀를 막았다.

**trade-off**: `session_key`는 per-host 키 기반이라 host 간 join이 불가능하고, 키 파일이 유실되면 이전 pseudonym과의 연속성이 끊긴다. 이는 privacy를 위해 의도한 속성이다 (사용량 집계는 skill/ts만으로 충분).

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| raw args regex redaction | args를 계속 저장하되 민감 패턴만 마스킹 | 기존 스키마 유지 | 패턴 누락 시 유출, 소비자 없는 데이터를 계속 수집 | ❌ |
| raw session id 유지 | session 컬럼만 그대로 두고 args만 제거 | 구현 단순 | raw id 자체가 correlate 가능한 식별자 | ❌ |
| 기존 로그 migration rewrite | 전체 로그를 v2로 일괄 변환 | 파서 단일화 | 기존 bytes 파괴 — 이슈의 STOP 조건 위반 | ❌ |
| v2 JSONL + legacy read-only 혼합 파싱 | 새 writes만 v2 append, `{` 시작 행은 strict v2·나머지는 legacy TSV로 읽음 | 기존 로그 무손상, 수집 최소화, 스키마 버전 명시 | 파서가 두 포맷을 유지해야 함 | ✅ |
| session_key = HMAC 유사 keyed hash | 32-byte random 로컬 키‖session id를 SHA-256한 pseudonym | raw id 미저장, host 내 세션 구분 유지 | 키 유실 시 연속성 단절 (의도된 속성) | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claude/files/hooks/log-skill.sh` | 수정 | ARGS/USER/REPO 수집 삭제, v2 JSONL event `jq -cn` serialize, pseudonym 키 생성(umask 077 + same-dir temp + atomic `mv -n`), log/key 0600 강제 |
| `scripts/ai/skill-usage-report.sh` | 수정 | `{` 시작 행은 strict v2 JSON(exact 6-key set + type 검증), 나머지는 legacy TSV로 파싱 — 출력 계약 `skill count first_used recent_used` 유지 |
| `tests/suites/claude-hook-runtime-adoption.sh` | 수정 | v2 event contract 검증, 금지 필드 부재(Negative), pseudonym 안정성, invalid key 시 no-fallback skip, 파일 mode 600 검증 |
| `tests/suites/skill-usage-report.sh` | 수정 | v2-only/mixed fixture가 legacy 집계와 동일한지, 입력 로그 bytes 무변경(read-only) 검증 |
| `tests/fixtures/shell-scripts/skill-usage-report.v2.jsonl` | 추가 | valid v2 rows + malformed rows(wrong version, invalid session_key, extra key, type mismatch, broken JSON) |
| `tests/fixtures/shell-scripts/skill-usage-report.mixed.log` | 추가 | legacy TSV와 v2 JSONL 혼재 fixture |
| `tests/shell-script-tests.sh` | 수정 | 신규 테스트 6건 등록 (기존 1건은 v2 계약 검증으로 대체) |

### 핵심 코드

```bash
# BEFORE: 자유형 payload 포함 TSV
ARGS=$(printf '%s' "$INPUT" | hook_parse_json_path '.tool_input.args // ""')
REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || true)
printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
  "$(date -u +%s)" "$USER" "${SESSION_ID:-unknown}" \
  "${REPO:-unknown}" "$SKILL" "$ARGS" >> "$SKILL_USAGE_LOG"

# AFTER: exact 6-key versioned event — 금지 필드(user/repo/args/raw sid) 미수집
SESSION_KEY=$(printf '%s%s' "$LOCAL_KEY" "$SESSION_ID" | _sha256_stdin_hex) || exit 0
EVENT=$(jq -cn \
  --argjson ts "$(date -u +%s)" \
  --arg skill "$SKILL" \
  --arg session_key "$SESSION_KEY" \
  '{schema_version: 2, event_type: "skill_invocation", ts: $ts,
    runtime: "claude-main", skill: $skill, session_key: $session_key}') || exit 0
printf '%s\n' "$EVENT" >> "$SKILL_USAGE_LOG" 2>/dev/null || exit 0
chmod 600 "$SKILL_USAGE_LOG" 2>/dev/null || true
```

키 생성/읽기/hash 중 하나라도 실패하면 raw id fallback 없이 `exit 0`으로 event를 건너뛴다 — 실패 경로가 privacy를 후퇴시키지 않는다. 키 생성 경합은 `mv -n`으로 해소한다 (먼저 만든 쪽의 키 사용). subagent 제외(`agent_id` 존재 시 noop)는 기존 동작을 유지한다.

## 참고 레퍼런스

- Issue #1099 — 이 PR이 구현하는 plan (Target event contract, STOP 조건 포함)
- Issue #1075 — 부모 이슈 (skill telemetry 개선 계열; collector coverage는 후속 plan 소관으로 이 PR 범위 밖)
- Thariq(Anthropic) gist — 원 hook의 기반 (hook 헤더 주석에 명시)

## Human Test Plan

### 정상 동작 검증

1. 아무 스킬이나 호출한 뒤 `tail -1 ~/.claude/skill-usage.log | jq .`를 실행한다.
   - **기대**: valid JSON이며 key set이 정확히 `schema_version, event_type, ts, runtime, skill, session_key` 6개, `session_key`는 64 lowercase hex.
   - **실패 시**: `~/.claude/skill-usage.key` 존재·내용(64 hex) 확인 후 hook을 sample stdin으로 수동 실행해 exit code를 본다.

2. `scripts/ai/skill-usage-report.sh`를 실행한다.
   - **기대**: legacy TSV 행과 새 v2 행이 함께 집계되고, 출력 컬럼은 기존과 동일한 `skill count first_used recent_used`.
   - **실패 시**: `bash tests/suites/skill-usage-report.sh`로 fixture 기반 재현.

### Negative 검증 (old 값·아티팩트 부재)

3. `tail -5 ~/.claude/skill-usage.log`에서 새로 추가된 행을 확인한다.
   - **기대**: 새 행에 사용자명, repo 이름, 스킬 인자 원문, raw session id가 없다. `rg -n 'tool_input.*args|ARGS=' modules/shared/programs/claude/files/hooks/log-skill.sh`가 0 match.
   - **실패 시**: hook 배포 경로가 구버전인지 확인한다 (rebuild 필요 여부).

4. `stat -c %a ~/.claude/skill-usage.log ~/.claude/skill-usage.key` (macOS 시스템 도구라면 `/usr/bin/stat -f %Lp`)를 실행한다.
   - **기대**: 둘 다 `600`.

### 엣지 케이스 / regression

5. 테스트 sandbox에서 key 파일을 64-hex가 아닌 내용으로 바꾸고 hook을 실행한다 (`tests/suites/claude-hook-runtime-adoption.sh`의 invalid-key 테스트가 자동화 커버).
   - **기대**: event가 기록되지 않는다 — raw id fallback 없음.

6. 기존 legacy 로그 파일에 report를 실행해도 파일 bytes가 변하지 않는다 (read-only 계약).
   - **기대**: 실행 전후 checksum 동일. `bash tests/run-shell-script-tests.sh` 전체 exit 0.
   - **실패 시**: `tests/suites/skill-usage-report.sh`의 무변경 테스트로 격리 재현.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 스킬 사용 로그를 privacy-safe JSONL v2 이벤트로 전환하고, 세션은 익명화된 `session_key`로만 기록합니다.
  * 로그/키 파일 권한을 엄격히(0600) 유지하며, 키/스키마/스킬 형식 검증에 실패하면 이벤트를 스킵합니다.
* **호환성**
  * 사용량 리포트는 v2 JSONL과 레거시 TSV(및 혼합 로그)를 함께 처리하며, 기간별 집계 출력은 유지됩니다.
* **테스트**
  * v2·혼합 로그 집계 일치, 입력 무변경, 문법/권한 복구, noop 시 로그·키 미생성 검증을 추가·확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->