### PR TITLE
feat(skills): 외부 CLI 의존 스킬 버전 스탬프 drift warn-only 경보

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -154,7 +154,7 @@ pre-push:
   # `check`를 required로 승격했고, 현행 shell 전체 suite는 profile 적용만으로도 cold push
   # 기준을 초과하는 것으로 재측정됐다. 따라서 전체 shell/codex fixture는 required CI의
   # run-all-tests로 이관하고, 로컬 pre-push는 변경과 직접 관련된 3개 glob command와
-# 저장소 밖 상태를 감시하는 always-run 예외 1개(ai-skill-version-stamps)만 남긴다.
+  # 저장소 밖 상태를 감시하는 always-run 예외 1개(ai-skill-version-stamps)만 남긴다.
   # profileless 경로에서는 첫 runtime command가 검증된 profile을 준비한 뒤 다음 command가
   # 재사용하도록 순차 실행해 direct flake-check와의 Nix eval-cache 경합도 막는다. 삭제 파일 등
   # push_files 사각지대는 required CI가 보완한다.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -153,7 +153,8 @@ pre-push:
   # CIR: #1045는 CI가 advisory라 shell 전체 검증을 매 push마다 유지했다. #1090에서 main의
   # `check`를 required로 승격했고, 현행 shell 전체 suite는 profile 적용만으로도 cold push
   # 기준을 초과하는 것으로 재측정됐다. 따라서 전체 shell/codex fixture는 required CI의
-  # run-all-tests로 이관하고, 로컬 pre-push는 변경과 직접 관련된 3개 command만 남긴다.
+  # run-all-tests로 이관하고, 로컬 pre-push는 변경과 직접 관련된 3개 glob command와
+# 저장소 밖 상태를 감시하는 always-run 예외 1개(ai-skill-version-stamps)만 남긴다.
   # profileless 경로에서는 첫 runtime command가 검증된 profile을 준비한 뒤 다음 command가
   # 재사용하도록 순차 실행해 direct flake-check와의 Nix eval-cache 경합도 막는다. 삭제 파일 등
   # push_files 사각지대는 required CI가 보완한다.
@@ -183,5 +184,6 @@ pre-push:
     ai-skill-version-stamps:
       # Claude CLI는 저장소 밖 auto-updater로 갱신되어 staged 신호가 없다 — pre-commit의
       # staged glob 경보를 보완해 push 시점에는 glob 없이 항상 drift를 대조한다 (warn-only,
-      # CLI --version 기동 비용은 push 빈도가 낮아 수용).
-      run: bash ./scripts/ai/warn-skill-version-stamps.sh
+      # CLI --version 기동 비용은 push 빈도가 낮아 수용). --from-head: 검사 대상은 working
+      # tree가 아니라 실제 push되는 HEAD 트리다 (unstaged 수정이 구 스탬프 push를 가리는 것 방지).
+      run: bash ./scripts/ai/warn-skill-version-stamps.sh --from-head

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -180,3 +180,8 @@ pre-push:
         - "scripts/ai/test-runtime-profile.sh"
       # profile의 Bats를 사용하고 비대화형 hook에는 Bats/tput용 기본 TERM을 주입한다.
       run: bash ./scripts/ai/test-runtime-profile.sh run "$PWD" -- env TERM="${TERM:-xterm-256color}" bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
+    ai-skill-version-stamps:
+      # Claude CLI는 저장소 밖 auto-updater로 갱신되어 staged 신호가 없다 — pre-commit의
+      # staged glob 경보를 보완해 push 시점에는 glob 없이 항상 drift를 대조한다 (warn-only,
+      # CLI --version 기동 비용은 push 빈도가 낮아 수용).
+      run: bash ./scripts/ai/warn-skill-version-stamps.sh

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -46,6 +46,18 @@ pre-commit:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-consistency.sh
     ai-skill-stale-identifiers:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-stale-identifiers.sh
+    ai-skill-version-stamps:
+      # 외부 CLI(codex/claude) 의존 스킬의 "확인 버전" 스탬프 drift warn-only 경보 (#1078).
+      # CLI --version 기동 비용이 있어 대상 스킬 문서·codex 핀(버전이 오르는 커밋)·이 스크립트가
+      # staged일 때만 실행한다. glob 변경 시 scripts/ai/check-lefthook-staged-config.sh 의
+      # expected 블록도 함께 갱신한다 (미동기화 시 staged-config guard fail).
+      glob:
+        - "modules/shared/programs/claude/files/skills/using-codex-exec/**"
+        - "modules/shared/programs/claude/files/skills/using-claude-p/**"
+        - ".claude/skills/configuring-codex/**"
+        - "modules/shared/programs/codex/codex-pin.json"
+        - "scripts/ai/warn-skill-version-stamps.sh"
+      run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-version-stamps.sh
     gitleaks:
       run: bash ./scripts/ai/run-gitleaks-staged-policy.sh
     nixfmt:

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -117,6 +117,14 @@ pre-commit:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-consistency.sh
     ai-skill-stale-identifiers:
       run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-stale-identifiers.sh
+    ai-skill-version-stamps:
+      glob:
+        - "modules/shared/programs/claude/files/skills/using-codex-exec/**"
+        - "modules/shared/programs/claude/files/skills/using-claude-p/**"
+        - ".claude/skills/configuring-codex/**"
+        - "modules/shared/programs/codex/codex-pin.json"
+        - "scripts/ai/warn-skill-version-stamps.sh"
+      run: bash ./scripts/ai/run-staged-snapshot.sh -- bash ./scripts/ai/warn-skill-version-stamps.sh
     gitleaks:
       run: bash ./scripts/ai/run-gitleaks-staged-policy.sh
     nixfmt:
@@ -211,6 +219,7 @@ repo_scripts=(
   "scripts/ai/lib/staged-snapshot-cache.sh"
   "scripts/ai/warn-skill-consistency.sh"
   "scripts/ai/warn-skill-stale-identifiers.sh"
+  "scripts/ai/warn-skill-version-stamps.sh"
   "scripts/ai/run-gitleaks-staged-policy.sh"
   "tests/run-eval-tests.sh"
   "tests/test-codex-hook-fixtures.sh"

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -201,6 +201,8 @@ pre-push:
         - "modules/shared/programs/claude/files/scripts/tests/statusline.bats"
         - "scripts/ai/test-runtime-profile.sh"
       run: bash ./scripts/ai/test-runtime-profile.sh run "$PWD" -- env TERM="${TERM:-xterm-256color}" bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
+    ai-skill-version-stamps:
+      run: bash ./scripts/ai/warn-skill-version-stamps.sh
 EOF
 
 if ! diff -u "$expected_prepush" "$normalized_prepush" >&2; then

--- a/scripts/ai/check-lefthook-staged-config.sh
+++ b/scripts/ai/check-lefthook-staged-config.sh
@@ -202,7 +202,7 @@ pre-push:
         - "scripts/ai/test-runtime-profile.sh"
       run: bash ./scripts/ai/test-runtime-profile.sh run "$PWD" -- env TERM="${TERM:-xterm-256color}" bats modules/shared/programs/claude/files/scripts/tests/statusline.bats
     ai-skill-version-stamps:
-      run: bash ./scripts/ai/warn-skill-version-stamps.sh
+      run: bash ./scripts/ai/warn-skill-version-stamps.sh --from-head
 EOF
 
 if ! diff -u "$expected_prepush" "$normalized_prepush" >&2; then

--- a/scripts/ai/warn-skill-version-stamps.sh
+++ b/scripts/ai/warn-skill-version-stamps.sh
@@ -26,7 +26,8 @@ is_true() {
 # 버전 뒤 괄호 텍스트가 붙어도 매칭한다. prefix의 trailing space는 필드 구분자 IFS='|'가
 # whitespace를 포함하지 않아 read에서 보존된다.
 # 대상 skill root를 추가/변경하면 lefthook.yml의 ai-skill-version-stamps glob과
-# scripts/ai/check-lefthook-staged-config.sh의 기대 블록도 함께 갱신한다 (3곳 수동 동기화).
+# scripts/ai/check-lefthook-staged-config.sh의 기대 블록, tests/suites/skill-version-stamps.sh의
+# fixture(대상 경로·스탬프·기대 경고 건수)도 함께 갱신한다 (4곳 수동 동기화).
 TARGETS=(
   "using-codex-exec|modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md|codex|codex-cli "
   "using-claude-p|modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md|claude|Claude Code v"

--- a/scripts/ai/warn-skill-version-stamps.sh
+++ b/scripts/ai/warn-skill-version-stamps.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# warn-skill-version-stamps.sh
+# 목적: 외부 CLI(codex/claude) 의존 스킬 SKILL.md의 "확인 버전" 스탬프와 설치 CLI 버전의
+#       drift를 pre-commit에서 조기 경보 (#1078 — drift 전면 재작성 재발: PR #967, #1036, #1074)
+# 정책:
+# - 항상 warning-only (exit 0) — 버전 상승은 오류가 아니라 "재검증 명령을 실행할 때" 신호
+# - CLI 부재 환경(CI 등)에서는 해당 대상을 조용히 skip (노이즈 금지)
+# - 스탬프 형식의 SSOT는 각 SKILL.md "작성 기준" 절 — 이 체크가 형식에 맞춘다 (역방향 금지)
+# - 우회: SKIP_AI_SKILL_CHECK=1 (또는 true/yes)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+warn() {
+  echo "[WARN] $1" >&2
+}
+
+is_true() {
+  local val="${1:-}"
+  val="${val,,}"
+  [ "$val" = "1" ] || [ "$val" = "true" ] || [ "$val" = "yes" ]
+}
+
+# 대상 선언: <스킬 이름>|<SKILL.md 상대경로>|<CLI 명령>|<스탬프 버전 prefix>
+# 스탬프 라인은 "- 확인 버전: <prefix><버전>[ 부가 설명]" 형식이며, configuring-codex처럼
+# 버전 뒤 괄호 텍스트가 붙어도 매칭한다. prefix의 trailing space는 필드 구분자 IFS='|'가
+# whitespace를 포함하지 않아 read에서 보존된다.
+TARGETS=(
+  "using-codex-exec|modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md|codex|codex-cli "
+  "using-claude-p|modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md|claude|Claude Code v"
+  "configuring-codex|.claude/skills/configuring-codex/SKILL.md|codex|codex-cli "
+)
+
+# CLI --version 출력의 첫 X.Y[.Z...] 토큰 추출
+# (codex: "codex-cli 0.144.6" / claude: "2.1.216 (Claude Code)")
+installed_version() {
+  local cli="$1" output
+  command -v "$cli" >/dev/null 2>&1 || return 1
+  output="$("$cli" --version 2>/dev/null)" || return 1
+  local pattern='([0-9]+(\.[0-9]+)+)'
+  [[ "$output" =~ $pattern ]] || return 1
+  printf '%s\n' "${BASH_REMATCH[1]}"
+}
+
+# SKILL.md "작성 기준" 절의 "- 확인 버전:" 라인에서 prefix 뒤 버전 토큰 추출
+stamp_version() {
+  local file="$1" prefix="$2" line
+  local pattern="^- 확인 버전: ${prefix}([0-9]+(\.[0-9]+)+)"
+  while IFS= read -r line; do
+    if [[ "$line" =~ $pattern ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done < "$file"
+  return 1
+}
+
+# 같은 절의 "- 재검증:" 라인에서 백틱 안 명령 텍스트 추출 (WARN 메시지 병기용)
+recheck_command() {
+  local file="$1" line
+  local pattern='^- 재검증: `([^`]+)`'
+  while IFS= read -r line; do
+    if [[ "$line" =~ $pattern ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done < "$file"
+  return 1
+}
+
+main() {
+  local entry skill rel_path cli prefix file
+  local doc_ver cli_ver recheck warnings=0
+
+  if is_true "${SKIP_AI_SKILL_CHECK:-}"; then
+    return 0
+  fi
+
+  for entry in "${TARGETS[@]}"; do
+    IFS='|' read -r skill rel_path cli prefix <<< "$entry"
+    file="$REPO_ROOT/$rel_path"
+
+    cli_ver="$(installed_version "$cli")" || continue
+
+    if [ ! -f "$file" ]; then
+      warn "$skill: SKILL.md 없음 ($rel_path) — 대상 목록 갱신 필요"
+      warnings=$((warnings + 1))
+      continue
+    fi
+
+    if ! doc_ver="$(stamp_version "$file" "$prefix")"; then
+      warn "$skill: '확인 버전' 스탬프 추출 실패 ($rel_path) — 스탬프 형식 변경 시 이 체크의 추출 규칙도 갱신"
+      warnings=$((warnings + 1))
+      continue
+    fi
+
+    if [ "$doc_ver" != "$cli_ver" ]; then
+      recheck="$(recheck_command "$file")" || recheck="$rel_path '작성 기준' 절의 재검증 명령 참조"
+      warn "$skill: 문서 스탬프 $doc_ver vs 설치 $cli_ver — 재검증: $recheck"
+      warnings=$((warnings + 1))
+    fi
+  done
+
+  if [ "$warnings" -gt 0 ]; then
+    warn "스킬 버전 스탬프 경고 ${warnings}건 (warn-only — 재검증 후 스탬프 갱신)"
+  fi
+}
+
+main "$@" || warn "스킬 버전 스탬프 검사 중 내부 오류 발생 (warn-only)"
+exit 0

--- a/scripts/ai/warn-skill-version-stamps.sh
+++ b/scripts/ai/warn-skill-version-stamps.sh
@@ -13,7 +13,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # --from-head: working tree 대신 HEAD 커밋의 문서를 읽는다. pre-push에서 사용 —
 # unstaged로만 고쳐진 스탬프가 "일치"로 보이면 구 스탬프가 담긴 HEAD가 조용히 push되므로,
-# push 경계에서는 실제 push 대상 트리를 검사한다.
+# push 경계에서는 실제 push 대상 트리를 검사한다. HEAD는 push 대상의 근사다(현재 브랜치
+# push 워크플로우 기준) — 다른 ref를 지정 push하는 경우는 warn-only 도구의 검사 범위 밖.
 FROM_HEAD=false
 [ "${1:-}" = "--from-head" ] && FROM_HEAD=true
 

--- a/scripts/ai/warn-skill-version-stamps.sh
+++ b/scripts/ai/warn-skill-version-stamps.sh
@@ -74,28 +74,32 @@ installed_version() {
 # 절 경계는 확인하지 않는다 — 이 고정 형식 라인은 "작성 기준" 절에만 존재한다는 전제이며,
 # 다른 절에 같은 형식이 생기면 먼저 나오는 쪽이 이긴다.
 stamp_version() {
-  local rel_path="$1" prefix="$2" line
+  local rel_path="$1" prefix="$2" line content
+  # 내용을 변수로 캡처 후 herestring 순회 — process substitution은 매치 시 조기 return이
+  # writer printf에 SIGPIPE(Broken pipe stderr)를 일으킨다 (CI 실측).
+  content="$(doc_content "$rel_path")" || return 1
   local pattern="^- 확인 버전: ${prefix}([0-9]+(\.[0-9]+)+)"
   while IFS= read -r line; do
     if [[ "$line" =~ $pattern ]]; then
       printf '%s\n' "${BASH_REMATCH[1]}"
       return 0
     fi
-  done < <(doc_content "$rel_path")
+  done <<< "$content"
   return 1
 }
 
 # 파일 전체에서 "- 재검증:" 형식의 최초 일치 라인에서 백틱 안 명령 텍스트 추출
 # (WARN 메시지 병기용 — stamp_version과 같은 최초-일치 전제).
 recheck_command() {
-  local rel_path="$1" line
+  local rel_path="$1" line content
+  content="$(doc_content "$rel_path")" || return 1
   local pattern='^- 재검증: `([^`]+)`'
   while IFS= read -r line; do
     if [[ "$line" =~ $pattern ]]; then
       printf '%s\n' "${BASH_REMATCH[1]}"
       return 0
     fi
-  done < <(doc_content "$rel_path")
+  done <<< "$content"
   return 1
 }
 

--- a/scripts/ai/warn-skill-version-stamps.sh
+++ b/scripts/ai/warn-skill-version-stamps.sh
@@ -25,24 +25,28 @@ is_true() {
 # 스탬프 라인은 "- 확인 버전: <prefix><버전>[ 부가 설명]" 형식이며, configuring-codex처럼
 # 버전 뒤 괄호 텍스트가 붙어도 매칭한다. prefix의 trailing space는 필드 구분자 IFS='|'가
 # whitespace를 포함하지 않아 read에서 보존된다.
+# 대상 skill root를 추가/변경하면 lefthook.yml의 ai-skill-version-stamps glob과
+# scripts/ai/check-lefthook-staged-config.sh의 기대 블록도 함께 갱신한다 (3곳 수동 동기화).
 TARGETS=(
   "using-codex-exec|modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md|codex|codex-cli "
   "using-claude-p|modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md|claude|Claude Code v"
   "configuring-codex|.claude/skills/configuring-codex/SKILL.md|codex|codex-cli "
 )
 
-# CLI --version 출력의 첫 X.Y[.Z...] 토큰 추출
-# (codex: "codex-cli 0.144.6" / claude: "2.1.216 (Claude Code)")
+# 설치된 CLI의 --version 출력에서 첫 X.Y[.Z...] 토큰 추출
+# (codex: "codex-cli 0.144.6" / claude: "2.1.216 (Claude Code)").
+# CLI 존재 확인은 호출부 책임 — 여기 실패는 실행·파싱 실패를 뜻한다.
 installed_version() {
   local cli="$1" output
-  command -v "$cli" >/dev/null 2>&1 || return 1
   output="$("$cli" --version 2>/dev/null)" || return 1
   local pattern='([0-9]+(\.[0-9]+)+)'
   [[ "$output" =~ $pattern ]] || return 1
   printf '%s\n' "${BASH_REMATCH[1]}"
 }
 
-# SKILL.md "작성 기준" 절의 "- 확인 버전:" 라인에서 prefix 뒤 버전 토큰 추출
+# 파일 전체에서 "- 확인 버전:" 형식의 최초 일치 라인에서 prefix 뒤 버전 토큰 추출.
+# 절 경계는 확인하지 않는다 — 이 고정 형식 라인은 "작성 기준" 절에만 존재한다는 전제이며,
+# 다른 절에 같은 형식이 생기면 먼저 나오는 쪽이 이긴다.
 stamp_version() {
   local file="$1" prefix="$2" line
   local pattern="^- 확인 버전: ${prefix}([0-9]+(\.[0-9]+)+)"
@@ -55,7 +59,8 @@ stamp_version() {
   return 1
 }
 
-# 같은 절의 "- 재검증:" 라인에서 백틱 안 명령 텍스트 추출 (WARN 메시지 병기용)
+# 파일 전체에서 "- 재검증:" 형식의 최초 일치 라인에서 백틱 안 명령 텍스트 추출
+# (WARN 메시지 병기용 — stamp_version과 같은 최초-일치 전제).
 recheck_command() {
   local file="$1" line
   local pattern='^- 재검증: `([^`]+)`'
@@ -80,7 +85,14 @@ main() {
     IFS='|' read -r skill rel_path cli prefix <<< "$entry"
     file="$REPO_ROOT/$rel_path"
 
-    cli_ver="$(installed_version "$cli")" || continue
+    # CLI 부재만 조용히 skip한다 (정책: 미설치 환경 무소음). 설치된 CLI의
+    # 실행·파싱 실패는 출력 계약 drift 신호이므로 WARN으로 드러낸다.
+    command -v "$cli" >/dev/null 2>&1 || continue
+    if ! cli_ver="$(installed_version "$cli")"; then
+      warn "$skill: $cli --version 실행·버전 파싱 실패 — CLI 출력 형식 변경 시 이 체크의 추출 규칙도 갱신"
+      warnings=$((warnings + 1))
+      continue
+    fi
 
     if [ ! -f "$file" ]; then
       warn "$skill: SKILL.md 없음 ($rel_path) — 대상 목록 갱신 필요"

--- a/scripts/ai/warn-skill-version-stamps.sh
+++ b/scripts/ai/warn-skill-version-stamps.sh
@@ -11,6 +11,30 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# --from-head: working tree 대신 HEAD 커밋의 문서를 읽는다. pre-push에서 사용 —
+# unstaged로만 고쳐진 스탬프가 "일치"로 보이면 구 스탬프가 담긴 HEAD가 조용히 push되므로,
+# push 경계에서는 실제 push 대상 트리를 검사한다.
+FROM_HEAD=false
+[ "${1:-}" = "--from-head" ] && FROM_HEAD=true
+
+# 대상 문서 읽기 — FROM_HEAD면 git 객체에서, 아니면 working tree에서.
+doc_exists() {
+  if $FROM_HEAD; then
+    git -C "$REPO_ROOT" cat-file -e "HEAD:$1" 2>/dev/null
+  else
+    [ -f "$REPO_ROOT/$1" ]
+  fi
+}
+
+doc_content() {
+  if $FROM_HEAD; then
+    git -C "$REPO_ROOT" show "HEAD:$1" 2>/dev/null
+  else
+    # $(<file)은 bash 내장 읽기 — PATH가 최소화된 hook 환경에서 외부 cat 의존을 피한다.
+    printf '%s\n' "$(<"$REPO_ROOT/$1")"
+  fi
+}
+
 warn() {
   echo "[WARN] $1" >&2
 }
@@ -49,33 +73,33 @@ installed_version() {
 # 절 경계는 확인하지 않는다 — 이 고정 형식 라인은 "작성 기준" 절에만 존재한다는 전제이며,
 # 다른 절에 같은 형식이 생기면 먼저 나오는 쪽이 이긴다.
 stamp_version() {
-  local file="$1" prefix="$2" line
+  local rel_path="$1" prefix="$2" line
   local pattern="^- 확인 버전: ${prefix}([0-9]+(\.[0-9]+)+)"
   while IFS= read -r line; do
     if [[ "$line" =~ $pattern ]]; then
       printf '%s\n' "${BASH_REMATCH[1]}"
       return 0
     fi
-  done < "$file"
+  done < <(doc_content "$rel_path")
   return 1
 }
 
 # 파일 전체에서 "- 재검증:" 형식의 최초 일치 라인에서 백틱 안 명령 텍스트 추출
 # (WARN 메시지 병기용 — stamp_version과 같은 최초-일치 전제).
 recheck_command() {
-  local file="$1" line
+  local rel_path="$1" line
   local pattern='^- 재검증: `([^`]+)`'
   while IFS= read -r line; do
     if [[ "$line" =~ $pattern ]]; then
       printf '%s\n' "${BASH_REMATCH[1]}"
       return 0
     fi
-  done < "$file"
+  done < <(doc_content "$rel_path")
   return 1
 }
 
 main() {
-  local entry skill rel_path cli prefix file
+  local entry skill rel_path cli prefix
   local doc_ver cli_ver recheck warnings=0
 
   if is_true "${SKIP_AI_SKILL_CHECK:-}"; then
@@ -84,7 +108,6 @@ main() {
 
   for entry in "${TARGETS[@]}"; do
     IFS='|' read -r skill rel_path cli prefix <<< "$entry"
-    file="$REPO_ROOT/$rel_path"
 
     # CLI 부재만 조용히 skip한다 (정책: 미설치 환경 무소음). 설치된 CLI의
     # 실행·파싱 실패는 출력 계약 drift 신호이므로 WARN으로 드러낸다.
@@ -95,20 +118,20 @@ main() {
       continue
     fi
 
-    if [ ! -f "$file" ]; then
+    if ! doc_exists "$rel_path"; then
       warn "$skill: SKILL.md 없음 ($rel_path) — 대상 목록 갱신 필요"
       warnings=$((warnings + 1))
       continue
     fi
 
-    if ! doc_ver="$(stamp_version "$file" "$prefix")"; then
+    if ! doc_ver="$(stamp_version "$rel_path" "$prefix")"; then
       warn "$skill: '확인 버전' 스탬프 추출 실패 ($rel_path) — 스탬프 형식 변경 시 이 체크의 추출 규칙도 갱신"
       warnings=$((warnings + 1))
       continue
     fi
 
     if [ "$doc_ver" != "$cli_ver" ]; then
-      recheck="$(recheck_command "$file")" || recheck="$rel_path '작성 기준' 절의 재검증 명령 참조"
+      recheck="$(recheck_command "$rel_path")" || recheck="$rel_path '작성 기준' 절의 재검증 명령 참조"
       warn "$skill: 문서 스탬프 $doc_ver vs 설치 $cli_ver — 재검증: $recheck"
       warnings=$((warnings + 1))
     fi

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -170,6 +170,7 @@ run_test "warn-skill-stale-identifiers clean pass stays quiet" test_warn_skill_s
 run_test "warn-skill-version-stamps matching stays quiet" test_warn_skill_version_stamps_matching_stays_quiet
 run_test "warn-skill-version-stamps detects drift" test_warn_skill_version_stamps_detects_drift
 run_test "warn-skill-version-stamps skips when cli absent" test_warn_skill_version_stamps_skips_when_cli_absent
+run_test "warn-skill-version-stamps warns on cli exec failure" test_warn_skill_version_stamps_warns_on_cli_exec_failure
 run_test "warn-skill-version-stamps warns on unparseable stamp" test_warn_skill_version_stamps_warns_on_unparseable_stamp
 run_test "skill-usage-report aggregates sample TSV" test_skill_usage_report_aggregates_sample_tsv
 run_test "skill-usage-report --since filters sample TSV" test_skill_usage_report_since_filters_sample_tsv

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -171,6 +171,7 @@ run_test "warn-skill-version-stamps matching stays quiet" test_warn_skill_versio
 run_test "warn-skill-version-stamps detects drift" test_warn_skill_version_stamps_detects_drift
 run_test "warn-skill-version-stamps skips when cli absent" test_warn_skill_version_stamps_skips_when_cli_absent
 run_test "warn-skill-version-stamps warns on cli exec failure" test_warn_skill_version_stamps_warns_on_cli_exec_failure
+run_test "warn-skill-version-stamps --from-head detects stale HEAD" test_warn_skill_version_stamps_from_head_detects_stale_head
 run_test "warn-skill-version-stamps warns on unparseable stamp" test_warn_skill_version_stamps_warns_on_unparseable_stamp
 run_test "skill-usage-report aggregates sample TSV" test_skill_usage_report_aggregates_sample_tsv
 run_test "skill-usage-report --since filters sample TSV" test_skill_usage_report_since_filters_sample_tsv

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -167,6 +167,10 @@ run_test "check-skill-noise rejects external symlink skill projection" test_chec
 run_test "warn-skill-consistency ignores managed plugin skill projection" test_warn_skill_consistency_ignores_managed_plugin_skill_projection
 run_test "warn-skill-stale-identifiers detects residual skill doc" test_warn_skill_stale_identifiers_detects_residual_skill_doc
 run_test "warn-skill-stale-identifiers clean pass stays quiet" test_warn_skill_stale_identifiers_clean_pass_stays_quiet
+run_test "warn-skill-version-stamps matching stays quiet" test_warn_skill_version_stamps_matching_stays_quiet
+run_test "warn-skill-version-stamps detects drift" test_warn_skill_version_stamps_detects_drift
+run_test "warn-skill-version-stamps skips when cli absent" test_warn_skill_version_stamps_skips_when_cli_absent
+run_test "warn-skill-version-stamps warns on unparseable stamp" test_warn_skill_version_stamps_warns_on_unparseable_stamp
 run_test "skill-usage-report aggregates sample TSV" test_skill_usage_report_aggregates_sample_tsv
 run_test "skill-usage-report --since filters sample TSV" test_skill_usage_report_since_filters_sample_tsv
 run_test "skill-usage-report missing log errors" test_skill_usage_report_missing_log_errors

--- a/tests/suites/skill-version-stamps.sh
+++ b/tests/suites/skill-version-stamps.sh
@@ -106,6 +106,31 @@ test_warn_skill_version_stamps_skips_when_cli_absent() {
   [ -z "$output" ] || fail "expected silent skip when CLIs are absent, got: $output"
 }
 
+test_warn_skill_version_stamps_from_head_detects_stale_head() {
+  local sandbox repo_root bin_dir output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  bin_dir="$sandbox/bin"
+  create_version_stamp_fixture_repo "$repo_root" "0.144.1" "2.1.206"
+  create_version_stamp_cli_stubs "$bin_dir" "0.145.0" "2.1.206"
+  ln -s "$(command -v git)" "$bin_dir/git"
+
+  # HEAD에는 구 스탬프를 커밋하고 working tree만 신 스탬프로 갱신 —
+  # 기본 모드는 일치로 침묵하지만 --from-head는 push 대상 HEAD의 drift를 경고해야 한다.
+  (cd "$repo_root" && \
+    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 git -c init.templateDir= init -q -b main && \
+    git add -A && \
+    git -c user.email=fixture@test -c user.name=fixture commit -qm "stale stamps")
+  create_version_stamp_fixture_repo "$repo_root" "0.145.0" "2.1.206"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1)
+  [ -z "$output" ] || fail "expected working-tree mode to stay quiet after unstaged fix, got: $output"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh --from-head 2>&1) \
+    || fail "expected warn-only exit 0 from --from-head, got exit $?: $output"
+  assert_contains "$output" "문서 스탬프 0.144.1 vs 설치 0.145.0"
+}
+
 test_warn_skill_version_stamps_warns_on_cli_exec_failure() {
   local sandbox repo_root bin_dir output
   sandbox=$(new_sandbox)

--- a/tests/suites/skill-version-stamps.sh
+++ b/tests/suites/skill-version-stamps.sh
@@ -106,6 +106,27 @@ test_warn_skill_version_stamps_skips_when_cli_absent() {
   [ -z "$output" ] || fail "expected silent skip when CLIs are absent, got: $output"
 }
 
+test_warn_skill_version_stamps_warns_on_cli_exec_failure() {
+  local sandbox repo_root bin_dir output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  bin_dir="$sandbox/bin"
+  create_version_stamp_fixture_repo "$repo_root" "0.144.1" "2.1.206"
+  create_version_stamp_cli_stubs "$bin_dir" "0.144.1" "2.1.206"
+  # codex는 설치되어 있으나 --version이 실패 — CLI 부재의 silent skip과 달리
+  # 출력 계약 drift 신호이므로 WARN으로 드러나야 한다.
+  cat > "$bin_dir/codex" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "$bin_dir/codex"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1) \
+    || fail "expected warn-only exit 0 on exec failure, got exit $?: $output"
+  assert_contains "$output" "codex --version 실행·버전 파싱 실패"
+  assert_not_contains "$output" "using-claude-p"
+}
+
 test_warn_skill_version_stamps_warns_on_unparseable_stamp() {
   local sandbox repo_root bin_dir output
   sandbox=$(new_sandbox)

--- a/tests/suites/skill-version-stamps.sh
+++ b/tests/suites/skill-version-stamps.sh
@@ -118,10 +118,12 @@ test_warn_skill_version_stamps_from_head_detects_stale_head() {
 
   # HEAD에는 구 스탬프를 커밋하고 working tree만 신 스탬프로 갱신 —
   # 기본 모드는 일치로 침묵하지만 --from-head는 push 대상 HEAD의 drift를 경고해야 한다.
+  # GIT_CONFIG 격리는 subshell 전체에 export — commit이 호스트 hooksPath·훅을 상속하지 않게 한다.
   (cd "$repo_root" && \
-    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 git -c init.templateDir= init -q -b main && \
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 && \
+    git -c init.templateDir= init -q -b main && \
     git add -A && \
-    git -c user.email=fixture@test -c user.name=fixture commit -qm "stale stamps")
+    git -c user.email=fixture@test -c user.name=fixture -c core.hooksPath= commit -qm "stale stamps")
   create_version_stamp_fixture_repo "$repo_root" "0.145.0" "2.1.206"
 
   output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1)
@@ -151,6 +153,16 @@ EOF
     || fail "expected warn-only exit 0 on exec failure, got exit $?: $output"
   assert_contains "$output" "codex --version 실행·버전 파싱 실패"
   assert_not_contains "$output" "using-claude-p"
+
+  # 정상 종료하지만 버전 토큰이 없는 출력도 동일한 WARN 경로를 타야 한다 (파싱 실패 분기).
+  cat > "$bin_dir/codex" <<'EOF'
+#!/bin/sh
+echo "unknown-format"
+EOF
+  chmod +x "$bin_dir/codex"
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1) \
+    || fail "expected warn-only exit 0 on unparseable output, got exit $?: $output"
+  assert_contains "$output" "codex --version 실행·버전 파싱 실패"
 }
 
 test_warn_skill_version_stamps_warns_on_unparseable_stamp() {

--- a/tests/suites/skill-version-stamps.sh
+++ b/tests/suites/skill-version-stamps.sh
@@ -39,8 +39,9 @@ EOF
 EOF
 }
 
-# PATH 통제용 디렉토리: warn 스크립트의 외부 명령 의존은 dirname뿐(나머지는 bash 내장)이라,
-# dirname만 담은 디렉토리 하나로 PATH를 좁혀 CLI 존재/부재를 결정론적으로 재현한다.
+# PATH 통제용 디렉토리: warn 스크립트의 기본 모드 외부 명령 의존은 dirname뿐(나머지는
+# bash 내장)이라, dirname만 담은 디렉토리 하나로 PATH를 좁혀 CLI 존재/부재를 결정론적으로
+# 재현한다. --from-head 모드는 git이 추가로 필요하므로 해당 테스트가 별도로 링크한다.
 create_version_stamp_path_dir() {
   local bin_dir="$1"
   mkdir -p "$bin_dir"

--- a/tests/suites/skill-version-stamps.sh
+++ b/tests/suites/skill-version-stamps.sh
@@ -1,0 +1,123 @@
+# tests/suites/skill-version-stamps.sh — skill version stamp drift warning fixtures (#1078)
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+# fixture repo 골격 + 스크립트 사본 + 세 대상 SKILL.md (스탬프 버전은 인자로 주입)
+create_version_stamp_fixture_repo() {
+  local repo_root="$1" codex_stamp="$2" claude_stamp="$3"
+
+  mkdir -p \
+    "$repo_root/scripts/ai" \
+    "$repo_root/modules/shared/programs/claude/files/skills/using-codex-exec" \
+    "$repo_root/modules/shared/programs/claude/files/skills/using-claude-p" \
+    "$repo_root/.claude/skills/configuring-codex"
+  cp "$REPO_ROOT/scripts/ai/warn-skill-version-stamps.sh" \
+    "$repo_root/scripts/ai/warn-skill-version-stamps.sh"
+
+  cat > "$repo_root/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md" <<EOF
+## 작성 기준
+
+- 확인 날짜: 2026-07-10
+- 확인 버전: codex-cli $codex_stamp
+- 재검증: \`command codex --version && command codex exec --help\`
+EOF
+  cat > "$repo_root/modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md" <<EOF
+## 작성 기준
+
+- 확인 날짜: 2026-07-10
+- 확인 버전: Claude Code v$claude_stamp
+- 재검증: \`claude --version && claude --help && claude -p --help\`
+EOF
+  # 버전 뒤 괄호 부가 설명이 붙는 형식 (실제 configuring-codex 스탬프와 동일 shape)
+  cat > "$repo_root/.claude/skills/configuring-codex/SKILL.md" <<EOF
+## 작성 기준
+
+- 확인 날짜: 2026-07-11
+- 확인 버전: codex-cli $codex_stamp (codex-pin.json/runtime 일치)
+- 재검증: \`codex --version && codex --help\`
+EOF
+}
+
+# PATH 통제용 디렉토리: warn 스크립트의 외부 명령 의존은 dirname뿐(나머지는 bash 내장)이라,
+# dirname만 담은 디렉토리 하나로 PATH를 좁혀 CLI 존재/부재를 결정론적으로 재현한다.
+create_version_stamp_path_dir() {
+  local bin_dir="$1"
+  mkdir -p "$bin_dir"
+  ln -s "$(command -v dirname)" "$bin_dir/dirname"
+}
+
+# stub CLI 설치. shebang은 /bin/sh — /usr/bin/env가 좁힌 PATH에서 bash를 못 찾는 문제를 피한다.
+create_version_stamp_cli_stubs() {
+  local bin_dir="$1" codex_ver="$2" claude_ver="$3"
+
+  create_version_stamp_path_dir "$bin_dir"
+  cat > "$bin_dir/codex" <<EOF
+#!/bin/sh
+echo "codex-cli $codex_ver"
+EOF
+  cat > "$bin_dir/claude" <<EOF
+#!/bin/sh
+echo "$claude_ver (Claude Code)"
+EOF
+  chmod +x "$bin_dir/codex" "$bin_dir/claude"
+}
+
+test_warn_skill_version_stamps_matching_stays_quiet() {
+  local sandbox repo_root bin_dir output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  bin_dir="$sandbox/bin"
+  create_version_stamp_fixture_repo "$repo_root" "0.144.1" "2.1.206"
+  create_version_stamp_cli_stubs "$bin_dir" "0.144.1" "2.1.206"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1)
+  [ -z "$output" ] || fail "expected matching stamps to stay quiet, got: $output"
+}
+
+test_warn_skill_version_stamps_detects_drift() {
+  local sandbox repo_root bin_dir output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  bin_dir="$sandbox/bin"
+  create_version_stamp_fixture_repo "$repo_root" "0.144.1" "2.1.206"
+  # codex만 상승, claude는 일치 — codex 대상 2건만 WARN 되어야 한다
+  create_version_stamp_cli_stubs "$bin_dir" "0.145.0" "2.1.206"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1) \
+    || fail "expected warn-only exit 0 on drift, got exit $?: $output"
+  assert_contains "$output" "[WARN] using-codex-exec: 문서 스탬프 0.144.1 vs 설치 0.145.0"
+  assert_contains "$output" "재검증: command codex --version && command codex exec --help"
+  assert_contains "$output" "[WARN] configuring-codex: 문서 스탬프 0.144.1 vs 설치 0.145.0"
+  assert_not_contains "$output" "using-claude-p"
+  assert_contains "$output" "스킬 버전 스탬프 경고 2건 (warn-only"
+}
+
+test_warn_skill_version_stamps_skips_when_cli_absent() {
+  local sandbox repo_root bin_dir output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  bin_dir="$sandbox/bin"
+  create_version_stamp_fixture_repo "$repo_root" "0.144.1" "2.1.206"
+  # CLI stub 미설치 — dirname만 있는 PATH 디렉토리로 CLI 부재 환경(CI 등)을 재현한다
+  create_version_stamp_path_dir "$bin_dir"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1)
+  [ -z "$output" ] || fail "expected silent skip when CLIs are absent, got: $output"
+}
+
+test_warn_skill_version_stamps_warns_on_unparseable_stamp() {
+  local sandbox repo_root bin_dir output
+  sandbox=$(new_sandbox)
+  repo_root="$sandbox/repo"
+  bin_dir="$sandbox/bin"
+  create_version_stamp_fixture_repo "$repo_root" "0.144.1" "2.1.206"
+  create_version_stamp_cli_stubs "$bin_dir" "0.144.1" "2.1.206"
+  # 스탬프 형식이 바뀌어 추출 규칙과 어긋난 경우 — 조용히 통과하면 체크가 무력화되므로 WARN
+  printf '## 작성 기준\n\n- 확인 버전: unknown-format\n' \
+    > "$repo_root/modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md"
+
+  output=$(cd "$repo_root" && PATH="$bin_dir" "$BASH" scripts/ai/warn-skill-version-stamps.sh 2>&1) \
+    || fail "expected warn-only exit 0 on unparseable stamp, got exit $?: $output"
+  assert_contains "$output" "[WARN] using-codex-exec: '확인 버전' 스탬프 추출 실패"
+}


### PR DESCRIPTION
## Summary

- 외부 CLI(codex, claude)에 의존하는 스킬 문서의 "확인 버전" 스탬프와 설치 CLI 버전을 대조하는 warn-only pre-commit 경보(`scripts/ai/warn-skill-version-stamps.sh`)를 추가한다.
- drift로 인한 전면 재실측 재작성이 3회 재발(PR #967, #1036, #1074)했고 매번 발견 경로가 수동 감사였던 문제를, 커밋 시점 자동 조기 경보로 전환한다.
- WARN 메시지에는 해당 SKILL.md의 재검증 명령을 병기해 "지금 무엇을 실행해볼 때인지"를 바로 알린다.

Closes #1078

## 기존 문제/배경

외부 CLI에 의존하는 스킬 문서는 "작성 기준" 절에 확인 시점의 CLI 버전 스탬프를 남기지만, 설치 버전이 올라가도 이를 알려주는 장치가 없어 drift 발견이 전적으로 수동 감사에 의존했다.

- using-codex-exec: 0.122.0→0.142.5(#861→PR #967), 0.142.5→0.144.1(PR #1074) — 전면 재실측 재작성 2회
- using-claude-p: v2.1.116→v2.1.202(#1018→PR #1036) — 격차가 약 2.5개월 잠복한 뒤 재작성

자동화 백로그였던 #504(upstream SKILL 자동 sync)·#447(playwright-cli 스킬 자동 갱신)은 백로그 다이어트로 close되며 재개 조건을 "drift로 인한 실사용 오류 재발"로 명시했는데, PR #1074 조사에서 문서 격차가 실전 오판(JSON shape 오해, silent fallback 미인지)으로 이어진 사례가 확인되어 조건이 실측으로 충족됐다.

## CIR (Change Intent Record)

- **이슈 시점** (#1078): 체크 위치 후보로 "기존 `verify-ai-compat.sh` 또는 warn 계열 스크립트 중 적합한 위치"를 열어둔 채 등록. 스코프는 #504가 기각한 전체 sync 자동화의 부활이 아니라 "버전 스탬프 대조 경보"로 한정 (문서 내용 갱신은 여전히 사람+LLM의 실측 작업).
- **이번 변경**: 기존 warn 계열(`warn-skill-consistency.sh`, `warn-skill-stale-identifiers.sh`)과 같은 패턴의 독립 warn 스크립트로 결정 — warn-only 정책과 pre-commit 연결 방식이 동일해 결이 맞는다. CLI `--version` 기동 비용이 있어 모든 커밋 실행 대신 대상 스킬 문서·codex 핀·스크립트 자신이 staged일 때만 실행하는 glob 조건을 채택했다.
- 스탬프 형식의 SSOT는 각 SKILL.md "작성 기준" 절이며, 이 체크가 문서 형식에 맞춘다 (역방향 강제 금지). 형식이 어긋나 추출에 실패하면 조용히 통과하는 대신 WARN을 내 체크의 조용한 무력화를 방지한다.

**trade-off**: glob 조건이라 무관한 커밋에서는 drift가 경보되지 않는다. 대신 대상 문서·codex 핀을 건드리는 커밋(= 스탬프 재검증이 가장 필요한 순간)에 신호를 집중해 노이즈와 실행 비용의 균형을 선택했다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 독립 warn 스크립트 + lefthook glob | 기존 warn 계열 패턴을 따르는 신규 pre-commit 경보, 관련 파일 staged 시에만 실행 | warn-only 정책 일관, CLI 기동 비용 국소화 | 무관 커밋에서는 경보 없음 | ✅ |
| `verify-ai-compat.sh`에 통합 | 기존 호환 검증 스크립트에 체크 추가 | 신규 파일 없음 | fail 계열 게이트와 warn-only 정책의 결 불일치, 실행 시마다 CLI 기동 비용 부과 | ❌ |
| fail 게이트 | 스탬프 불일치 시 커밋 차단 | drift 즉시 강제 수정 | patch 버전 상승마다 커밋이 막혀 노이즈 — 버전 상승은 오류가 아니라 재검증 신호 | ❌ |
| 전체 문서 sync 자동화 | CLI 출력·upstream 문서를 자동 반영 | 수동 재실측 제거 | #504에서 기각된 스코프 — 문서 품질은 실측 작업이 필요 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `scripts/ai/warn-skill-version-stamps.sh` | 신규 | 대상 3스킬(using-codex-exec, using-claude-p, configuring-codex)의 "확인 버전" 스탬프 vs 설치 CLI 버전 대조. 항상 exit 0(warn-only), CLI 부재 환경(CI 등)은 조용히 skip, WARN에 SKILL.md의 재검증 명령 병기 |
| `lefthook.yml` | 수정 | `ai-skill-version-stamps` pre-commit 훅 추가 — 대상 스킬 문서·`codex-pin.json`·스크립트 자신이 staged일 때만 실행하는 glob 조건 |
| `scripts/ai/check-lefthook-staged-config.sh` | 수정 | expected 블록과 `repo_scripts` allowlist에 신규 훅/스크립트 동기화 (미동기화 시 staged-config guard fail) |
| `tests/suites/skill-version-stamps.sh` | 신규 | fixture 4건 — 스탬프 일치 시 무음 / drift 시 대상별 WARN / CLI 부재 시 조용한 skip / 스탬프 형식 파손 시 추출 실패 WARN |
| `tests/shell-script-tests.sh` | 수정 | 신규 스위트의 테스트 4건 등록 |

### 핵심 코드

```bash
# 대상 선언: <스킬 이름>|<SKILL.md 상대경로>|<CLI 명령>|<스탬프 버전 prefix>
TARGETS=(
  "using-codex-exec|modules/shared/programs/claude/files/skills/using-codex-exec/SKILL.md|codex|codex-cli "
  "using-claude-p|modules/shared/programs/claude/files/skills/using-claude-p/SKILL.md|claude|Claude Code v"
  "configuring-codex|.claude/skills/configuring-codex/SKILL.md|codex|codex-cli "
)

# drift 시: 해당 SKILL.md의 재검증 명령을 병기한 WARN (커밋은 차단하지 않음)
if [ "$doc_ver" != "$cli_ver" ]; then
  recheck="$(recheck_command "$file")" || recheck="$rel_path '작성 기준' 절의 재검증 명령 참조"
  warn "$skill: 문서 스탬프 $doc_ver vs 설치 $cli_ver — 재검증: $recheck"
  warnings=$((warnings + 1))
fi
```

## 참고 레퍼런스

- Issue #1078 — 요구사항 원문 (스코프·warn-only 근거·대상 스킬)
- Issue #504, #447 — 자동화 백로그 close 사유와 재개 조건 원문
- PR #967, PR #1036, PR #1074 — drift 전면 재작성 3회의 실례
- `plans/022-using-codex-exec-doc-refresh.md` — "CLI 버전이 오를 때마다 같은 drift가 재발한다" maintenance note
- `scripts/ai/warn-skill-consistency.sh`, `scripts/ai/warn-skill-stale-identifiers.sh` — 이번 스크립트가 따른 기존 warn 계열 패턴

## Human Test Plan

### 정상 동작 검증

1. repo 루트에서 `bash scripts/ai/warn-skill-version-stamps.sh`를 실행한다 (스탬프 일치 상태).
   - **기대**: 출력 없음, exit 0.
   - **실패 시**: `codex --version`/`claude --version` 실측값과 각 SKILL.md "작성 기준" 절의 "확인 버전" 라인을 눈으로 대조한다 — 실제 drift라면 WARN이 정상 동작이다.

2. 대상 SKILL.md 하나의 "확인 버전"을 임의로 낮춘 뒤 다시 실행한다 (확인 후 되돌린다).
   - **기대**: `[WARN] <스킬>: 문서 스탬프 X vs 설치 Y — 재검증: <명령>`과 합계 라인이 stderr로 출력되고 exit 0 (커밋 차단 없음).
   - **실패 시**: 스크립트의 `TARGETS` 선언과 해당 SKILL.md의 스탬프 prefix(`codex-cli `, `Claude Code v`)를 비교한다.

3. `bash tests/shell-script-tests.sh`를 실행한다.
   - **기대**: `warn-skill-version-stamps` 4건을 포함해 전체 통과.
   - **실패 시**: `tests/suites/skill-version-stamps.sh`의 fixture PATH 통제(dirname만 담은 디렉토리) 구성을 확인한다.

### 엣지 케이스

4. CLI 부재 환경(CI 등) — 테스트 케이스 `skips_when_cli_absent`가 PATH를 좁혀 재현한다.
   - **기대**: 출력 없이 조용히 skip (노이즈 금지 정책).
   - **실패 시**: `installed_version`의 `command -v` guard를 확인한다.

5. 스탬프 형식 파손 — 테스트 케이스 `warns_on_unparseable_stamp`.
   - **기대**: "'확인 버전' 스탬프 추출 실패" WARN — 형식 변경 시 체크가 조용히 무력화되지 않는다.
   - **실패 시**: SKILL.md 스탬프 형식과 스크립트의 추출 정규식을 함께 갱신한다.

### Regression

6. 대상 외 파일만 staged인 커밋을 만든다.
   - **기대**: `ai-skill-version-stamps` 훅이 실행되지 않는다 (glob 조건 — CLI 기동 비용 국소화).
   - **실패 시**: `lefthook.yml`의 glob 목록을 확인한다.

7. 대상 스킬 문서를 staged한 커밋에서 pre-commit 훅 전체가 통과하는지 확인한다.
   - **기대**: `check-lefthook-staged-config.sh`의 staged-config guard가 expected 블록 일치로 통과하고, 기존 warn 계열 훅(ai-skill-consistency 등)도 이전과 동일하게 동작한다.
   - **실패 시**: `lefthook.yml`과 `check-lefthook-staged-config.sh` expected 블록의 diff를 대조한다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 커밋/푸시 시 설치된 Codex/Claude CLI 버전과 각 스킬 문서의 “확인 버전” 스탬프를 자동 비교해 warn-only로 경고합니다.
  - staged(pre-commit)와 HEAD 기준(pre-push) 드리프트를 각각 점검합니다.
- **개선 사항**
  - 훅 staged 설정의 허용 커맨드/패턴 검증 범위가 확장되어, 스킬 버전 스탬프 점검이 기대대로 동작하는지 사전에 확인합니다.
- **테스트**
  - 경고/스킵/CLI 실패/버전 파싱 실패/HEAD 모드 동작 관련 테스트 케이스와 전용 스위트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->