### PR TITLE
fix(claudex): stat 특수비트 mode 오거부 방어 + layout drift 항목 덤프

### DIFF
--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -122,7 +122,7 @@ _claudex_assert_default_state_ancestors() {
 # directory prints 2700), which the exact "700"/"600" comparisons at the call sites would
 # wrongly reject. Return only the trailing owner/group/other triplet: with group/other bits
 # forced to zero by those comparisons, special bits grant no additional access.
-_claudex_file_mode() {
+_claudex_permission_triplet() {
   local mode
   mode="$("$CLAUDEX_STAT" -c '%a' "$1" 2>/dev/null)" || return 1
   printf '%s\n' "${mode: -3}"
@@ -139,7 +139,7 @@ _claudex_assert_private_dir() {
     _claudex_error "expected a real private directory: $path"
     return 1
   fi
-  if [ "$(_claudex_file_mode "$path")" != "700" ]; then
+  if [ "$(_claudex_permission_triplet "$path")" != "700" ]; then
     _claudex_error "directory mode must be 0700: $path"
     return 1
   fi
@@ -173,7 +173,7 @@ _claudex_assert_private_file() {
     _claudex_error "expected a real private file: $path"
     return 1
   fi
-  if [ "$(_claudex_file_mode "$path")" != "600" ]; then
+  if [ "$(_claudex_permission_triplet "$path")" != "600" ]; then
     _claudex_error "file mode must be 0600: $path"
     return 1
   fi
@@ -459,7 +459,7 @@ _claudex_credential_path_of_type() (
 # flock). -x is stated explicitly so the exclusive contract does not rest on flock's default.
 # Tests may inject CLAUDEX_FLOCK.
 with_state_lock() (
-  local lock_mode
+  local lock_triplet
   umask 077
   _claudex_assert_default_state_ancestors || exit 1
   _claudex_ensure_private_dir "$CLAUDEX_STATE_DIR" || exit 1
@@ -469,8 +469,8 @@ with_state_lock() (
   fi
   : >> "$CLAUDEX_STATE_LOCK" || exit 1
   "$CLAUDEX_CHMOD" 600 -- "$CLAUDEX_STATE_LOCK" || exit 1
-  lock_mode="$(_claudex_file_mode "$CLAUDEX_STATE_LOCK")"
-  if [ "$lock_mode" != "600" ]; then
+  lock_triplet="$(_claudex_permission_triplet "$CLAUDEX_STATE_LOCK")"
+  if [ "$lock_triplet" != "600" ]; then
     _claudex_error "state lock mode must be 0600"
     exit 1
   fi

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -118,8 +118,14 @@ _claudex_assert_default_state_ancestors() {
   done
 }
 
+# GNU stat %a prefixes a special-bit digit when setuid/setgid/sticky is set (a setgid 0700
+# directory prints 2700), which the exact "700"/"600" comparisons at the call sites would
+# wrongly reject. Return only the trailing owner/group/other triplet: with group/other bits
+# forced to zero by those comparisons, special bits grant no additional access.
 _claudex_file_mode() {
-  "$CLAUDEX_STAT" -c '%a' "$1" 2>/dev/null
+  local mode
+  mode="$("$CLAUDEX_STAT" -c '%a' "$1" 2>/dev/null)" || return 1
+  printf '%s\n' "${mode: -3}"
 }
 
 _claudex_file_owner() {

--- a/modules/shared/programs/claudex/files/verify-release-layout.sh
+++ b/modules/shared/programs/claudex/files/verify-release-layout.sh
@@ -8,16 +8,18 @@ if [ "$#" -ne 1 ] || [ ! -d "$1" ] || [ -L "$1" ]; then
 fi
 
 shopt -s dotglob nullglob
+# 기대 항목의 단일 진실 원천 — 개수 검사·오류 메시지·항목 순회가 모두 이 배열에서 파생된다.
+expected_entries=(LICENSE README.md README_CN.md cli-proxy-api config.example.yaml)
 entries=("$1"/*)
-if [ "${#entries[@]}" -ne 5 ]; then
-  echo "cli-proxy-api: upstream release layout changed (expected 5 entries, found ${#entries[@]}):" >&2
+if [ "${#entries[@]}" -ne "${#expected_entries[@]}" ]; then
+  echo "cli-proxy-api: upstream release layout changed (expected ${#expected_entries[@]} entries, found ${#entries[@]}):" >&2
   for entry in "${entries[@]}"; do
     echo "  ${entry##*/}" >&2
   done
   exit 1
 fi
 
-for expected in LICENSE README.md README_CN.md cli-proxy-api config.example.yaml; do
+for expected in "${expected_entries[@]}"; do
   path="$1/$expected"
   if [ -L "$path" ] || [ ! -f "$path" ]; then
     echo "cli-proxy-api: expected a regular release entry: $expected" >&2

--- a/modules/shared/programs/claudex/files/verify-release-layout.sh
+++ b/modules/shared/programs/claudex/files/verify-release-layout.sh
@@ -14,7 +14,8 @@ entries=("$1"/*)
 if [ "${#entries[@]}" -ne "${#expected_entries[@]}" ]; then
   echo "cli-proxy-api: upstream release layout changed (expected ${#expected_entries[@]} entries, found ${#entries[@]}):" >&2
   for entry in "${entries[@]}"; do
-    echo "  ${entry##*/}" >&2
+    # 외부 아카이브 유래 파일명 — 개행·ESC 등 제어문자를 %q로 중화해 로그 위조를 막는다.
+    printf '  %q\n' "${entry##*/}" >&2
   done
   exit 1
 fi

--- a/modules/shared/programs/claudex/files/verify-release-layout.sh
+++ b/modules/shared/programs/claudex/files/verify-release-layout.sh
@@ -10,7 +10,10 @@ fi
 shopt -s dotglob nullglob
 entries=("$1"/*)
 if [ "${#entries[@]}" -ne 5 ]; then
-  echo "cli-proxy-api: upstream release layout changed" >&2
+  echo "cli-proxy-api: upstream release layout changed (expected 5 entries, found ${#entries[@]}):" >&2
+  for entry in "${entries[@]}"; do
+    echo "  ${entry##*/}" >&2
+  done
   exit 1
 fi
 

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -376,6 +376,20 @@ test_claudex_runtime_api_and_private_state() {
      and .["usage-statistics-enabled"] == false' \
     "$state/config.yaml" >/dev/null || fail "rendered claudex config violates its contract"
 
+  # GNU stat %a prefixes a special-bit digit (setgid 0700 -> "2700") and GNU chmod 700
+  # does not clear a directory's setgid bit, so the runtime cannot self-heal from one:
+  # the mode check must accept special bits over a private triplet while still rejecting
+  # any group/other access.
+  chmod g+s "$state/auth"
+  _claudex_prepare_fixture_state "$sandbox" \
+    || fail "prepare_state rejected a setgid auth dir with a 700 triplet"
+  chmod g-s "$state/auth"
+  chmod 750 "$state/work"
+  if _claudex_prepare_fixture_state "$sandbox" >/dev/null 2>&1; then
+    fail "prepare_state accepted a group-readable work dir"
+  fi
+  chmod 700 "$state/work"
+
   key_before="$(<"$state/client-api-key")"
   config_inode_before="$(_claudex_file_inode "$state/config.yaml")"
   _claudex_prepare_fixture_state "$sandbox"
@@ -1237,7 +1251,7 @@ test_claudex_nix_generated_command_outputs_are_pinned() {
 }
 
 test_claudex_release_layout_verifier() {
-  local sandbox verifier exact entry
+  local sandbox verifier exact entry output
   sandbox="$(new_sandbox)"
   verifier="$REPO_ROOT/modules/shared/programs/claudex/files/verify-release-layout.sh"
   exact="$sandbox/exact"
@@ -1266,6 +1280,17 @@ test_claudex_release_layout_verifier() {
       fail "CLIProxyAPI release verifier accepted $entry layout drift"
     fi
   done
+
+  # A count mismatch must dump the actual entries so an upstream version bump is
+  # diagnosable from the failure output alone.
+  rm -rf "$sandbox/candidate"
+  cp -R "$exact" "$sandbox/candidate"
+  : > "$sandbox/candidate/EXTRA"
+  if output="$(bash "$verifier" "$sandbox/candidate" 2>&1)"; then
+    fail "CLIProxyAPI release verifier accepted an extra release entry"
+  fi
+  assert_contains "$output" "expected 5 entries, found 6"
+  assert_contains "$output" "EXTRA"
 }
 
 test_claudex_disabled_home_excludes_enabled_closure() {

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -1291,6 +1291,18 @@ test_claudex_release_layout_verifier() {
   fi
   assert_contains "$output" "expected 5 entries, found 6"
   assert_contains "$output" "EXTRA"
+
+  # Upstream 유래 파일명의 제어문자(개행·ESC)는 %q로 중화되어 로그를 위조할 수 없어야 한다.
+  rm -rf "$sandbox/candidate"
+  cp -R "$exact" "$sandbox/candidate"
+  : > "$sandbox/candidate/$(printf 'EVIL\nFORGED')"
+  if output="$(bash "$verifier" "$sandbox/candidate" 2>&1)"; then
+    fail "CLIProxyAPI release verifier accepted a control-character entry"
+  fi
+  assert_contains "$output" "EVIL"
+  if printf '%s\n' "$output" | grep -q '^FORGED'; then
+    fail "control-character entry forged an independent log line"
+  fi
 }
 
 test_claudex_disabled_home_excludes_enabled_closure() {

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -1261,12 +1261,12 @@ test_claudex_release_layout_verifier() {
   done
   bash "$verifier" "$exact" || fail "exact CLIProxyAPI release layout was rejected"
 
-  for entry in missing extra symlink directory; do
+  # extra(초과 항목) 케이스는 아래 진단 출력 테스트가 거부·메시지 계약을 함께 검증한다.
+  for entry in missing symlink directory; do
     rm -rf "$sandbox/candidate"
     cp -R "$exact" "$sandbox/candidate"
     case "$entry" in
       missing) rm "$sandbox/candidate/LICENSE" ;;
-      extra) : > "$sandbox/candidate/EXTRA" ;;
       symlink)
         rm "$sandbox/candidate/LICENSE"
         ln -s README.md "$sandbox/candidate/LICENSE"


### PR DESCRIPTION
## Summary

- claudex runtime의 `_claudex_file_mode`가 GNU `stat %a`의 특수비트 접두 자릿수(setgid 0700 → `"2700"`)를 그대로 반환해 정상 private 권한 디렉토리가 `"700"` 정확 일치 비교에서 오거부되던 것을, 뒤 3자리 owner/group/other triplet만 반환하도록 방어한다.
- `verify-release-layout.sh`의 항목 개수 불일치 메시지에 기대/실측 개수와 실제 항목 목록을 덤프해, upstream 버전 갱신 시 실패 출력만으로 원인을 진단할 수 있게 한다.
- 두 변경에 대응하는 `tests/suites/claudex.sh` 케이스를 추가한다.

Closes #1109

## 기존 문제/배경

두 건 모두 PR #1107 리뷰에서 발견된 저위험 개선으로, 안정 상태인 claudex 본체 변경과 분리해 이슈 #1109로 트래킹했다.

**1) stat 특수비트 오거부** — `_claudex_file_mode`는 GNU `stat -c '%a'` 출력을 그대로 반환하고, 호출부는 `"700"`/`"600"` 정확 일치로 비교한다. setuid/setgid/sticky 비트가 붙으면 GNU stat은 특수비트 자릿수를 앞에 붙여 4자리(예: setgid 0700 → `2700`)를 출력하므로, 실질 권한이 private인 디렉토리도 거부된다. 특히 GNU `chmod 700`은 디렉토리의 setgid 비트를 지우지 않으므로(실측), 한번 setgid가 붙은 디렉토리는 runtime의 권한 재적용 경로로도 벗어날 수 없는 영구 오거부 상태가 된다.

**2) layout drift 진단 부족** — `verify-release-layout.sh`는 릴리스 항목 개수가 기대(5개)와 다르면 "layout changed" 한 줄만 출력했다. upstream 버전 갱신으로 항목이 늘거나 줄었을 때 어떤 항목이 달라졌는지 실패 출력만으로 알 수 없었다.

## CIR (Change Intent Record)

- 이슈 #1109는 "현재의 엄격 비교가 의도적 fail-safe일 수 있다"는 관점을 함께 검토하도록 요구했다. 검토 결과: 호출부 비교가 group/other 비트를 0으로 강제하는 한 특수비트는 추가 접근 권한을 부여하지 않는다 — setgid는 하위 파일의 그룹 상속, sticky는 삭제 제한 성격이며 group/other가 0이면 외부 주체의 접근 경로 자체가 없다. 반면 엄격 비교를 유지하는 쪽은 GNU chmod 700이 디렉토리 setgid를 지우지 않아 자가 복구가 불가(실측 확인)하다는 실질 비용이 있어, 뒤 3자리 비교를 채택했다.
- 방어 위치는 호출부(허용 mode 값 열거)가 아니라 `_claudex_file_mode` 함수 한 곳으로 정했다 — 호출부가 늘어나도 동일한 방어가 자동 적용된다.
- stat 실패 시에는 빈 문자열에 substring을 적용하지 않도록 `|| return 1`로 조기 반환한다.

**trade-off**: mode 검사에서 특수비트의 존재 자체는 더 이상 신호로 잡지 않는다. group/other 접근 차단이 유지되는 한 보안 경계에 영향이 없다고 판단했다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 함수에서 뒤 3자리 triplet 반환 | `_claudex_file_mode`가 특수비트 자릿수를 제거해 반환 | 방어 지점 1곳, 호출부 무변경 | 특수비트 존재 자체는 검사 대상에서 제외 | ✅ |
| 호출부에서 허용 mode 열거 | 비교 값을 `700`, `2700` 등으로 확장 | 함수 계약 유지 | 특수비트 조합(1xxx/2xxx/…/7xxx)마다 열거 필요, 호출부마다 반복 | ❌ |
| 현상 유지 (엄격 비교 = fail-safe) | 변경 없음 | 가장 보수적 | 특수비트는 추가 접근을 부여하지 않는데도 영구 오거부, chmod 700로 자가 복구 불가 | ❌ |

layout drift 메시지는 실질 대안이 진단 정보 추가 1개뿐이라 비교 테이블을 생략한다.

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/claudex/files/claudex-runtime.sh` | 수정 | `_claudex_file_mode`: stat 실패 시 조기 반환, 성공 시 뒤 3자리 triplet만 반환 + 근거 주석 |
| `modules/shared/programs/claudex/files/verify-release-layout.sh` | 수정 | 개수 불일치 시 기대/실측 개수와 항목 목록을 stderr로 덤프 |
| `tests/suites/claudex.sh` | 수정 | setgid 0700 수용, group 접근(750) 거부, drift 시 항목 목록 출력 검증 케이스 추가 |

### 핵심 코드

```bash
# BEFORE: GNU stat %a 출력을 그대로 반환 → setgid 0700 디렉토리는 "2700"이 되어
# 호출부의 "700" 정확 일치 비교에서 오거부
_claudex_file_mode() {
  "$CLAUDEX_STAT" -c '%a' "$1" 2>/dev/null
}

# AFTER: 뒤 3자리 owner/group/other triplet만 반환 — group/other가 0으로 강제되는 한
# 특수비트는 추가 접근을 부여하지 않는다
_claudex_file_mode() {
  local mode
  mode="$("$CLAUDEX_STAT" -c '%a' "$1" 2>/dev/null)" || return 1
  printf '%s\n' "${mode: -3}"
}
```

```bash
# verify-release-layout.sh — 개수 불일치 시 실제 항목을 덤프
echo "cli-proxy-api: upstream release layout changed (expected 5 entries, found ${#entries[@]}):" >&2
for entry in "${entries[@]}"; do
  echo "  ${entry##*/}" >&2
done
```

## 참고 레퍼런스

- Issue #1109 — 본 변경의 요구사항 정의 (엄격 비교 fail-safe 관점 검토 요구 포함)
- PR #1107 — 발견 경위가 된 claudex 리뷰 (안정성 영향이 작아 본 변경으로 분리)
- [GNU coreutils stat 문서](https://www.gnu.org/software/coreutils/manual/html_node/stat-invocation.html) — `%a` 8진수 mode 출력 형식

## Human Test Plan

### 정상 동작 검증

1. repo 루트에서 `bash tests/run-shell-script-tests.sh`를 실행한다.
   - **기대**: 전체 통과. 특히 "claudex runtime API and private state"(setgid 수용/750 거부 케이스 포함)와 "claudex release layout verifier"(drift 덤프 케이스 포함)가 통과한다.
   - **실패 시**: 실패한 테스트 이름으로 `tests/suites/claudex.sh`의 해당 케이스를 열어 fixture 권한 상태를 확인한다.

2. 특수비트 방어를 수동 확인한다: 임시 디렉토리에 `chmod 700` 후 `chmod g+s`를 적용하고 GNU `stat -c '%a'` 출력이 `2700`임을 확인한 뒤, claudex state 디렉토리에 같은 상태를 재현해 claudex가 정상 기동하는지 본다.
   - **기대**: mode 검사를 통과해 정상 기동한다 (기존에는 영구 오거부).
   - **실패 시**: `_claudex_file_mode` 반환값이 3자리인지 확인한다 (`${mode: -3}` 적용 여부).

### Negative 검증

3. state 하위 디렉토리 하나를 `chmod 750`(group 읽기 허용)으로 바꾸고 claudex 기동을 시도한다.
   - **기대**: 여전히 거부된다 — 이번 변경은 특수비트만 수용하고 group/other 접근 차단은 유지한다.
   - **실패 시**: 호출부의 `"700"`/`"600"` 비교 로직이 유지되는지 확인한다.

4. 릴리스 디렉토리 사본에 더미 항목을 추가하고 `bash modules/shared/programs/claudex/files/verify-release-layout.sh <사본 경로>`를 실행한다.
   - **기대**: exit 1과 함께 `expected 5 entries, found 6` 및 더미 항목 이름이 stderr에 출력된다.
   - **실패 시**: 스크립트의 `dotglob`/`nullglob` 설정과 entries glob 결과를 확인한다.

### Regression

5. 특수비트 없는 정상 상태(디렉토리 700, 파일 600)에서 claudex를 기동한다.
   - **기대**: 기존과 동일하게 정상 동작한다 — 3자리 출력은 `${mode: -3}` 적용 전후가 동일하다.
   - **실패 시**: stat 바이너리(`CLAUDEX_STAT`)가 GNU stat인지 확인한다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - setuid/setgid/sticky 등 특수 권한 비트가 설정된 환경에서도 개인 디렉터리·파일 및 상태 잠금 파일의 권한을 더 엄격히 검증합니다.
- **개선**
  - 릴리스 레이아웃 검증 실패 시 예상 항목 수와 실제 항목 수를 함께 표시하고, 발견된 항목까지 자세히 출력해 원인 파악이 쉬워졌습니다.
  - 제어 문자(예: 개행/ESC) 조작 및 로그 위조 시나리오를 거부하도록 보안 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->