### PR TITLE
docs(anki-study): GUIDE §5 시제 강등 + 철거된 인프라 전제 정정 (plan 026 Part A)

### DIFF
--- a/anki-study/GUIDE.md
+++ b/anki-study/GUIDE.md
@@ -164,7 +164,12 @@ async function submitAnswers() {
 
 타이머/스코어/힌트(잠금-탭 시 -10pt)/자기평가(Again/Hard/Good/Easy +0/+5/+10/+20).
 
-## 5. 호스팅 & 채점 흐름 (현재 운영 방식, Future Ideas는 별도)
+## 5. 호스팅 & 채점 흐름 (⚠️ 중단됨 — server.py 부재, #839 참조)
+
+> **2026-07-05 현행화**: 아래 흐름은 2026-05-10 첫 세션의 기록이다. `server.py`는
+> repo에 없고 minipc의 Anki 인프라는 PR #863로 철거됐다. 학습 세션을 재개하려면
+> 첫 작업으로 서빙 경로 복구 또는 static-only 강등을 선행할 것 (issue #839
+> close 코멘트의 재개 조건).
 
 - LLM이 `/tmp/<workspace>/<card>.html` 작성 → Python http.server로 minipc Tailscale IP에서 서빙
 - 사용자가 답 입력 → POST `/submit` → `<workspace>/answers/ans_<unix_ms>.json` 저장
@@ -174,6 +179,8 @@ async function submitAnswers() {
 ## 6. 무엇을 *하지 않을지* (Future Ideas — 사용자가 명시적으로 요청할 때만)
 
 다음은 awesome-anki 1.0 함정의 재발 위험이 큰 것들. dogfooding 결과 *불편/욕구*가 명확해지기 전에는 손대지 마라:
+
+> ⚠️ AnkiConnect·homeserver 관련 항목은 PR #863(2026-05-30)로 self-host 인프라가 전량 철거되어, 착수 시 모듈·시크릿·vhost 재구축이 전제된다.
 
 - 공통 HTML 셸 + 카드별 JSON 스키마 (템플릿화)
 - 호스팅 영구화 (`homeserver.ankiStudy.*` 모듈, Caddy 리버스 프록시)

--- a/anki-study/GUIDE.md
+++ b/anki-study/GUIDE.md
@@ -180,7 +180,7 @@ async function submitAnswers() {
 
 다음은 awesome-anki 1.0 함정의 재발 위험이 큰 것들. dogfooding 결과 *불편/욕구*가 명확해지기 전에는 손대지 마라:
 
-> ⚠️ AnkiConnect·homeserver 관련 항목은 PR #863(2026-05-30)로 self-host 인프라가 전량 철거되어, 착수 시 모듈·시크릿·vhost 재구축이 전제된다.
+> ⚠️ AnkiConnect·homeserver 관련 항목은 PR #863(2026-05-30)로 self-host 인프라 구성(서비스·모듈·시크릿·vhost)이 제거되어, 착수 시 재구축이 전제된다. 단 minipc `/var/lib/private/anki-sync-server`의 실데이터(203MB)는 처분 보류 상태다 — plans/README.md 026 행의 Part C STOP 기록 참조.
 
 - 공통 HTML 셸 + 카드별 JSON 스키마 (템플릿화)
 - 호스팅 영구화 (`homeserver.ankiStudy.*` 모듈, Caddy 리버스 프록시)

--- a/anki-study/README.md
+++ b/anki-study/README.md
@@ -42,7 +42,7 @@ anki-study/
 
 1. [`GUIDE.md`](GUIDE.md) 를 LLM에게 입력으로 제공
 2. lapses 상위 카드 1-5장을 골라 "이 카드들로 학습 페이지 만들어줘" 라고 부탁
-3. minipc Tailscale 내부에서 호스팅된 페이지로 학습 + AI 채점
+3. (중단됨) minipc Tailscale 내부 호스팅 페이지 학습 + AI 채점 — `server.py` 부재로 이 흐름은 현재 동작하지 않는다 (GUIDE §5의 중단 기록·재개 선행조건 참조)
 
 세션 종료 후:
 

--- a/anki-study/README.md
+++ b/anki-study/README.md
@@ -58,6 +58,15 @@ anki-study/
 
 이걸 깨는 어떤 결정도 1순위 위반.
 
+## 운영 전제 (2026-07-05 기준)
+
+- 데스크톱 Anki 26.5, 프로필 `greenheadHQ` 단일.
+- 동기화: plans/024 이행 **전** = 무동기화(로컬 단독) / 이행·검증 **후** =
+  AnkiWeb. 현재 어느 쪽인지는 `plans/README.md`의 024 status 행이 판정 기준.
+- 백업: Anki 로컬 자동 .colpkg (같은 디스크). AnkiWeb 서버본은 024 완료·검증
+  후에만 존재. 독립 오프사이트 백업은 시점 무관 **없음**.
+- 복습 운영 규칙은 `plans/025-anki-restart-protocol.md` Step 2가 SSOT.
+
 ## 관련 자료
 
 - [issue #711](https://github.com/greenheadHQ/nixos-config/issues/711) — 프로젝트 etcd (1.0 회고 + 2.0 정의 + Future Ideas 박제)
@@ -67,6 +76,8 @@ anki-study/
 ## Future Ideas (현재 결정 X — issue #711 § 8 참조)
 
 dogfooding 결과 *불편/욕구*가 명확해지면 그때 검토:
+
+> ⚠️ AnkiConnect·homeserver 관련 항목은 PR #863(2026-05-30)로 self-host 인프라가 전량 철거되어, 착수 시 모듈·시크릿·vhost 재구축이 전제된다.
 
 - 공통 HTML 셸 + 카드별 JSON 스키마 (템플릿화)
 - 호스팅 영구화 (`homeserver.ankiStudy.*` 모듈)

--- a/plans/README.md
+++ b/plans/README.md
@@ -72,7 +72,7 @@ reconcile 당시 PR [#978](https://github.com/greenheadHQ/nixos-config/pull/978)
 | 023 | worktree-path-guard sibling worktree 오탐 제거 | P2 | S | — | #935 | DONE (PR #968) |
 | 024 | Anki를 AnkiWeb 동기화로 실제 전환 (5/30 결정 이행) | P1 | S | — | #974 | DONE (2026-07-12 이행 — 외부 사본 minipc·해시 일치, 서버는 2025-12-24 스냅샷임을 temp 프로필 실측 확증 후 Upload, prefs syncKey=SET 검증. 감사 "미사용" 결론 정정은 evidence 문서 서두 참조) |
 | 025 | 601장 백로그 재시작 프로토콜 (상한·정렬·2주 게이트) | P1 | S-M | 024 (soft) | #975 | TODO |
-| 026 | Anki 애드온·문서 drift·인프라 잔재 일괄 정리 | P2 | S | 024 (soft) | #976 | TODO |
+| 026 | Anki 애드온·문서 drift·인프라 잔재 일괄 정리 | P2 | S | 024 (soft) | #976 | TODO (Part A 문서 정정 완료 2026-07-21. 잔여: Part B 운영자 GUI, Part C는 STOP — `/var/lib/private/anki-sync-server`에 203MB 실데이터 실측되어 삭제 보류, 처분은 운영자 결정 대기) |
 | 027 | 비대 노트 "걸린 것부터" 점진 분할 절차 수립 | P2 | M | 025 (hard) | #977 | TODO |
 | 028 | 원격 AI 세션 macOS TCC 권한 정책을 DX 우선으로 확정·적용 | P1 | M | — | #1093 | TODO |
 | 029 | 원격 AI 세션 1Password SSH 승인 hang을 DX 우선으로 제거 | P1 | M-L | — | #1094 | TODO |


### PR DESCRIPTION
## Summary

- `anki-study/GUIDE.md` §5가 repo에 없는 `server.py` 흐름을 "현재 운영 방식"으로 안내하던 시제 drift를 강등 표기 + 현행화 blockquote로 정정한다 — GUIDE는 학습 세션 LLM에 그대로 입력되는 문서라 drift가 곧 오작동이다.
- GUIDE §6·README Future Ideas에 PR #863 self-host 인프라 철거 각주를 달아 착수 비용 저평가를 방지하고, README에 "운영 전제 (2026-07-05 기준)" 섹션을 신설한다.
- plan 026의 Part C(minipc 심링크 제거)는 실측 결과 `/var/lib/private/anki-sync-server`에 203MB 실데이터가 존재해 plan의 STOP 조건이 발동, 삭제를 보류하고 `plans/README.md` 026 행에 판정을 박제한다.

Refs #976 (plan 026 Part A만 이행 — Part B 운영자 GUI 작업, Part C는 실데이터 실측으로 STOP 보류. 이슈는 잔여 작업 정리 후 별도 종결)

## 기존 문제/배경

- **GUIDE §5 시제 drift**: `anki-study/GUIDE.md` §5가 2026-05-10 첫 세션의 `server.py` 서빙·채점 흐름을 현재형("현재 운영 방식")으로 기술하고 있었다. 그 `server.py`는 repo에 없고, minipc의 Anki self-host 인프라는 PR #863(2026-05-30)로 전량 철거됐다. GUIDE는 학습 세션 시작 시 LLM에 그대로 입력되는 문서이므로, 존재하지 않는 서버를 전제로 한 안내는 곧 세션 오작동으로 이어진다 (#839 close 조건과도 어긋남).
- **Future Ideas의 착수 비용 저평가**: GUIDE §6과 README의 Future Ideas가 AnkiConnect·homeserver 항목을 인프라 존재 전제로 기술 — 실제로는 모듈·시크릿·vhost 재구축이 선행돼야 한다.
- **운영 전제 미기록**: README에 현재 Anki 운영 상태(버전, 프로필, 동기화·백업 현황)를 판정할 기준 단락이 없었다.
- **Part C 전제 불일치**: 이슈 #976은 감사 evidence(2026-07-05)의 "빈 심링크" 실측을 근거로 minipc `/var/lib/anki-sync-server` 제거를 제안했으나, 이번 세션 재실측에서 `/var/lib/private/anki-sync-server`에 203MB 실데이터가 확인됐다.

## CIR (Change Intent Record)

- **v1** (issue #976, plan 026): 감사 evidence 문서의 "빈 심링크" 실측을 근거로 Part A(문서 정정)·Part B(운영자 GUI)·Part C(minipc 잔재 제거) 3부 구성 수립.
- **v2** (이번 변경): Part A를 이행. Part C 착수 전 재실측에서 `/var/lib/private/anki-sync-server`에 203MB 실데이터가 발견돼 감사 전제("빈 심링크")와 불일치 — plan 026이 정의한 STOP 조건 발동으로 삭제를 보류하고, 처분(백업 후 삭제 vs 보존)은 운영자 결정 대기로 `plans/README.md` 026 행에 기록. Part B(애드온 비활성화·suspend 일관화)는 Anki 앱 GUI 작업이라 처음부터 운영자 소관.

**trade-off**: `Closes #976`로 이슈를 닫으면 Part B·C가 미이행 상태로 남지만, 잔여 작업의 소재와 판정 근거를 `plans/README.md` 026 행(status 열)에 박제해 유실을 방지했다. 코드로 해결할 수 있는 범위(문서 정정)는 이 PR로 완결된다.

**제거·되돌림 근거**: GUIDE §5의 "현재 운영 방식" 표기는 2026-05-10 첫 학습 세션 시점에는 사실이었다 — 틀린 기술이 아니라 시효가 만료된 기술이므로, 내용 삭제가 아닌 시제 강등(제목 중단 표기 + 현행화 blockquote)으로 처리했다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| GUIDE §5 전체 삭제 | drift 섹션을 통째로 제거 | drift 원천 제거 | 재개 시 참조할 첫 세션 흐름 기록 소실, #839 재개 조건 맥락 유실 | ❌ |
| §5 시제 강등 + 현행화 blockquote | 제목에 중단 표기, 서두에 현행화 시점·재개 조건 명시 | 기록 보존 + LLM 오독 방지 양립 | 섹션이 다소 길어짐 | ✅ |
| Part C 즉시 삭제 (이슈 원안) | minipc 심링크·데이터 제거 | 이슈 체크리스트 완결 | 감사 전제(빈 심링크)와 실측(203MB 실데이터) 불일치, 비가역 데이터 손실 위험 | ❌ |
| Part C STOP — 운영자 결정 대기 | plan 026의 STOP 조건 준수, 판정을 plans/README.md에 박제 | 비가역 조작 회피, 판단 근거 보존 | 이슈가 부분 이행으로 닫힘 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `anki-study/GUIDE.md` | 수정 | §5 제목 중단 표기 + 현행화 blockquote, §6 Future Ideas에 PR #863 철거 각주 |
| `anki-study/README.md` | 수정 | "운영 전제 (2026-07-05 기준)" 섹션 신설, Future Ideas에 동일 철거 각주 |
| `plans/README.md` | 수정 | 026 행 status 갱신 — Part A 완료, Part B 잔여, Part C STOP 판정 기록 |

### 핵심 변경

```markdown
# BEFORE
## 5. 호스팅 & 채점 흐름 (현재 운영 방식, Future Ideas는 별도)

# AFTER
## 5. 호스팅 & 채점 흐름 (⚠️ 중단됨 — server.py 부재, #839 참조)

> **2026-07-05 현행화**: 아래 흐름은 2026-05-10 첫 세션의 기록이다. `server.py`는
> repo에 없고 minipc의 Anki 인프라는 PR #863로 철거됐다. 학습 세션을 재개하려면
> 첫 작업으로 서빙 경로 복구 또는 static-only 강등을 선행할 것 (issue #839
> close 코멘트의 재개 조건).
```

## 참고 레퍼런스

- Issue #976 — plan 026 실행 이슈 (이 PR로 close, Part B·C 잔여는 `plans/README.md` 026 행 참조)
- Issue #839 — 학습 서버 계약 복구 이슈, "재개 시 복구 or static-only 강등 선행" 재개 조건의 출처
- PR #863 — minipc Anki self-host 인프라 철거 (Future Ideas 각주의 근거)
- Issue #711 — anki-study 프로젝트 1.0 회고 + 2.0 정의 + Future Ideas 박제
- `plans/026-anki-cleanup-addons-docs-residue.md` — 실행 절차·STOP 조건 SSOT
- `plans/anki-audit-evidence/2026-07-05-audit.md` — 애드온 meta.json·minipc 실측 evidence

## Human Test Plan

### 정상 동작 검증

1. `anki-study/GUIDE.md` §5 제목과 서두를 확인한다.
   - **기대**: 제목에 "⚠️ 중단됨 — server.py 부재, #839 참조" 표기, 바로 아래 2026-07-05 현행화 blockquote(재개 조건 포함)가 있다.
   - **실패 시**: `git log --oneline -- anki-study/GUIDE.md`로 이 브랜치 커밋이 반영됐는지 확인한다.

2. `anki-study/GUIDE.md` §6과 `anki-study/README.md` Future Ideas 섹션을 확인한다.
   - **기대**: 두 곳 모두 목록 서두에 PR #863 철거 전제 각주(blockquote)가 있다.
   - **실패 시**: 두 파일의 Future Ideas 섹션 diff를 대조한다.

3. `anki-study/README.md`에서 "운영 전제 (2026-07-05 기준)" 섹션을 확인한다.
   - **기대**: Anki 버전·프로필, 동기화 판정 기준(plans/README.md 024 status 행), 백업 현황, 복습 규칙 SSOT(plans/025 Step 2)가 명시돼 있다.
   - **실패 시**: README의 섹션 순서("설계 원칙" 뒤, "관련 자료" 앞)를 확인한다.

4. `plans/README.md` 026 행을 확인한다.
   - **기대**: status가 Part A 완료(2026-07-21)·Part B 잔여·Part C STOP(203MB 실데이터, 운영자 결정 대기)을 담고 있다.
   - **실패 시**: 테이블 파이프 구분이 깨지지 않았는지 렌더링을 확인한다.

### Negative 검증

5. GUIDE에서 옛 현재형 표기의 부재를 확인한다: `grep -n "현재 운영 방식" anki-study/GUIDE.md`
   - **기대**: 매치 없음 (0건).
   - **실패 시**: §5 제목 치환이 누락된 위치를 수정한다.

### Regression 검증

6. 변경 범위가 문서에 한정됐는지 확인한다: `git diff main...HEAD --stat`
   - **기대**: `.md` 3파일만 변경 — Nix 모듈·스크립트·minipc 상태 변경 없음 (Part C STOP 판정과 일관).
   - **실패 시**: 의도치 않은 파일이 섞였는지 diff를 전수 확인한다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * Anki 학습 서비스의 호스팅·채점 흐름이 현재 중단된 상태임을 명확히 안내하고, 2026년 기준 운영 전제를 최신화했습니다.
  * 학습 세션 재개를 위한 선행 조건(호스팅 경로 복구 또는 static-only 전환)을 정리했습니다.
  * self-host 관련 구성 요소가 철거된 이후 재개 시 재구축이 필요하다는 경고를 추가했습니다.
  * 동기화·백업·복습 운영 규칙과 026번 계획의 진행 상태/데이터 삭제 보류 조건을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->