### PR TITLE
docs(skills): service runbook drift를 pinned config와 정렬

### DIFF
--- a/.claude/skills/hosting-copyparty/SKILL.md
+++ b/.claude/skills/hosting-copyparty/SKILL.md
@@ -66,18 +66,21 @@ sudo copyparty-update --dry-run   # 수행 예정 작업 확인
 sudo copyparty-update             # 실제 업데이트 (pull → digest 비교 → 재시작 → 헬스체크)
 ```
 
-- 이미지에 버전 레이블이 없으므로 GitHub latest 추적 + 이미지 digest 비교 방식
+- pinned tag 기준: 설정된 이미지를 pull → digest 비교 (같은 태그의 재빌드만 반영). GitHub latest는 알림/안내용
+- 새 버전 반영은 `modules/nixos/programs/docker/copyparty.nix`의 image 태그 수정 후 `nrs`
 - 백업 불필요 (설정은 Nix 관리, 데이터는 HDD 볼륨)
 - ERR trap에서 컨테이너 자동 복구
 - 통합 업데이트 시스템 상세: `running-containers` 스킬의 [service-update-system.md](../running-containers/references/service-update-system.md) 참조
 
 ### ACL 구조
 
-현재 단일 루트 볼륨으로 HDD 전체를 rwda(읽기/쓰기/삭제/관리) 권한으로 제공합니다.
+현재 단일 루트 볼륨으로 HDD 전체를 rwmda(읽기/쓰기/이동/삭제/관리) 권한으로 제공합니다.
+`m`(move)이 빠지면 웹 UI에서 파일 이름 변경/이동이 조용히 사라지므로, config 재작성 시 누락 금지.
+정본: `modules/nixos/programs/docker/copyparty.nix`의 `accs:` 블록.
 
 | Copyparty 경로 | 호스트 경로 | 권한 |
 |----------------|------------|------|
-| `/` | `/mnt/data` | 읽기/쓰기/삭제/관리 |
+| `/` | `/mnt/data` | 읽기/쓰기/이동/삭제/관리 |
 
 > 주의: Immich 사진(`/immich/`)을 Copyparty에서 삭제하지 않도록 주의.
 > Copyparty에서 Immich 파일 삭제 시 Immich DB와 불일치 발생.
@@ -140,7 +143,8 @@ localhost 바인딩 (Caddy 연동)
 - `th-maxsize` 옵션은 존재하지 않음 (사용 금지)
 
 이미지 태그
-- `copyparty/ac:latest` 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
+- `copyparty/ac` variant를 pinned tag로 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
+- 실제 태그 정본: `modules/nixos/programs/docker/copyparty.nix` (재검증: `rg -n 'image = ' modules/nixos/programs/docker/copyparty.nix`)
 - 기본 `copyparty/copyparty` 이미지는 썸네일 미지원
 
 세션 데이터 영속성

--- a/.claude/skills/hosting-copyparty/references/setup.md
+++ b/.claude/skills/hosting-copyparty/references/setup.md
@@ -42,7 +42,7 @@ copyparty = {
 
 핵심 구성요소:
 - copyparty-config oneshot 서비스: agenix 시크릿에서 비밀번호 추출 → INI 설정 파일 생성
-- copyparty Podman 컨테이너: `copyparty/ac:latest` 이미지
+- copyparty Podman 컨테이너: `copyparty/ac` 이미지 (pinned tag — 정본은 이 파일의 `image =` 줄)
 - `--entrypoint=python3`: 이미지 기본 ENTRYPOINT 오버라이드 (initcfg 볼륨 충돌 방지)
 - cmd: `["-m" "copyparty" "-c" "/cfg/config.conf"]`
 - ConditionPathExists: 설정 파일 없으면 시작 방지
@@ -73,17 +73,17 @@ INI 스타일, 섹션별 구성:
 [/]                       # 가상 경로 (루트)
   /data                   # 컨테이너 내 실제 파일시스템 경로
   accs:
-    rwda: greenhead       # 읽기/쓰기/삭제/관리
+    rwmda: greenhead      # 읽기/쓰기/이동/삭제/관리
 ```
 
 주의사항:
 - 루트 `[/]` -> `/data` 볼륨 하나만 사용 (하위 경로 별도 마운트 시 충돌)
-- `r:` = 읽기 전용, `rwda:` = 전체 권한
+- `r:` = 읽기 전용, `rwmda:` = 전체 권한 (`m` = move — 빠지면 파일 이름 변경/이동 불가)
 - 들여쓰기는 2칸 스페이스 (탭 불가)
 
 ## Docker 이미지 정보
 
-- 이미지: `copyparty/ac:latest` (thumbnailer for audio/video/images + transcoding)
+- 이미지: `copyparty/ac` pinned tag (thumbnailer for audio/video/images + transcoding). 실제 태그: `rg -n 'image = ' modules/nixos/programs/docker/copyparty.nix`
 - 기본 포트: 3923
 - 기본 ENTRYPOINT: `python3 -m copyparty -c /z/initcfg` ← 오버라이드 필수
 - 우리 설정: `--entrypoint=python3`, cmd: `-m copyparty -c /cfg/config.conf`

--- a/.claude/skills/hosting-copyparty/references/troubleshooting.md
+++ b/.claude/skills/hosting-copyparty/references/troubleshooting.md
@@ -92,7 +92,7 @@ sudo cat /var/lib/docker-data/copyparty/config/copyparty.conf | cat -A
 [/]
   /data
   accs:
-    rwda: greenhead
+    rwmda: greenhead
 ```
 
 ## 6. "multiple filesystem-paths" 에러
@@ -111,7 +111,7 @@ Copyparty 설정에서 루트 볼륨 `[/]` -> `/data`와 서브경로 볼륨 `[/
 
 해결:
 - 경로별 읽기 전용 ACL 분리 불가 - Copyparty 구조적 제약
-- 단일 루트 볼륨 `[/]` -> `/data`만 사용 (rwda 권한)
+- 단일 루트 볼륨 `[/]` -> `/data`만 사용 (rwmda 권한)
 - Immich/백업 데이터 보호는 사용자 주의에 의존
 
 교훈:

--- a/.claude/skills/hosting-karakeep/SKILL.md
+++ b/.claude/skills/hosting-karakeep/SKILL.md
@@ -33,9 +33,12 @@ Karakeep 웹 아카이버/북마크 관리 서비스 운영 스킬.
 
 | 컨테이너 | 이미지 | 역할 | 리소스 |
 |-----------|--------|------|--------|
-| `karakeep` | `ghcr.io/karakeep-app/karakeep:release` | Next.js 앱 (포트 3000) | 2GB / 1 CPU |
-| `karakeep-chrome` | `gcr.io/zenika-hub/alpine-chrome:124` | 헤드리스 Chrome (스크린샷) | 2GB / 1 CPU |
-| `karakeep-meilisearch` | `getmeili/meilisearch:v1.13.3` | 전문 검색 | 1GB / 0.5 CPU |
+| `karakeep` | `ghcr.io/karakeep-app/karakeep` | Next.js 앱 (포트 3000) | 2GB / 1 CPU |
+| `karakeep-chrome` | `gcr.io/zenika-hub/alpine-chrome` | 헤드리스 Chrome (스크린샷) | 2GB / 1 CPU |
+| `karakeep-meilisearch` | `getmeili/meilisearch` | 전문 검색 | 1GB / 0.5 CPU |
+
+세 이미지 모두 pinned tag 사용 (rolling `:release`/`:latest` 아님). 실제 태그 정본:
+`rg -n 'image = ' modules/nixos/programs/docker/karakeep.nix`. 새 버전 반영은 태그 수정 후 `nrs`.
 
 ### Data Path
 

--- a/.claude/skills/hosting-karakeep/references/update-guide.md
+++ b/.claude/skills/hosting-karakeep/references/update-guide.md
@@ -12,7 +12,7 @@ Karakeep 버전 업데이트 후 반드시 아래 패턴이 유효한지 확인�
 
 검증이 누락되면 OOM/크롤 실패 시 Pushover 알림이 발송되지 않아, 크래시 루프를 사용자가 인지하지 못할 수 있다.
 
-의존 패턴 목록 (현재 기준: `ghcr.io/karakeep-app/karakeep:release`):
+의존 패턴 목록 (기준: `ghcr.io/karakeep-app/karakeep`의 pinned tag — 실제 태그는 `rg -n 'image = ' modules/nixos/programs/docker/karakeep.nix`로 확인):
 
 | 패턴 | 용도 | 변경 가능성 |
 |------|------|-----------|

--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -44,18 +44,20 @@ darwinOnly = [ ... pkgs.패키지명 ];
 |------|------|------|
 | Dock | `configuration.nix` | 자동 숨김, 크기, 최근 앱 |
 | Finder | `configuration.nix` | 숨김 파일, 확장자, 네트워크 .DS_Store 방지 |
-| 키보드 | `configuration.nix` | 키 반복 속도 |
-| 트랙패드 | `configuration.nix` | 탭 클릭, 자연스러운 스크롤 |
+| 키보드 | `configuration.nix` | 키 반복 속도, F1-F12 표준 기능키 |
+| 마우스/스크롤 | `configuration.nix` | 자연스러운 스크롤 비활성화 (트랙패드 탭 클릭 설정은 없음) |
 
 ### Homebrew 관리
 
-`modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다 (personal 호스트만 적용).
+`modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다.
+공통(모든 darwin 호스트: `ghostty` cask, `playwright-cli` formula)과 personal 전용(`hostType == "personal"` 가드)으로 분리되어 있습니다.
 
 ```nix
 # cleanup = "none" — 선언되지 않은 앱을 삭제하지 않음 (수동 설치 cask 보호)
 # upgrade = true + greedyCasks = false — 자체 업데이터 cask는 brew upgrade 강제 대상에서 제외
+# personal 전용 예:
 homebrew.casks = [
-  "ghostty" "raycast" "rectangle"
+  "raycast" "rectangle"
   "hammerspoon" "homerow"
   "fork" "monitorcontrol" "1password" "1password-cli"
 ];

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -322,7 +322,8 @@ fc-list | grep -i "D2Coding"
 
 `modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다.
 
-- hostType 제한: `lib.mkIf (hostType == "personal")` — personal 호스트만 적용
+- 공통 + personal 분리: 공통 블록(모든 darwin 호스트 — `ghostty` cask, `playwright-cli` formula)과
+  `lib.mkIf (hostType == "personal")` 가드의 personal 전용 블록(아래 Cask 목록)으로 구성
 - cleanup = "none": 선언되지 않은 앱을 자동 삭제하지 않음 (수동 설치 cask 보호)
 
 ### 서드파티 Tap Formula 주의사항

--- a/.claude/skills/running-containers/SKILL.md
+++ b/.claude/skills/running-containers/SKILL.md
@@ -111,6 +111,7 @@ systemctl status podman-<container-name>  # systemd 서비스 상태
 
 | 서비스 | systemd 서비스 | 타이머 | 백업 위치 |
 |--------|---------------|--------|-----------|
+| Immich 원본 미러 | `immich-originals-mirror` | 04:30 | HDD (`/mnt/data/backups/immich-originals`, SSD upload-cache rsync 미러) |
 | Karakeep | `karakeep-backup` | 05:00 | HDD (`/mnt/data/backups/karakeep`) |
 | Immich DB | `immich-db-backup` | 05:30 | HDD (`/mnt/data/backups/immich`) |
 
@@ -122,10 +123,21 @@ Immich: API 버전 조회 가능 → "현재 v2.5.5 → 최신 v2.6.0" 형태 �
 
 Immich DB 백업: `immich-db-backup` 서비스가 매일 05:30에 `podman exec immich-postgres pg_dump -Fc`로 커스텀 포맷 백업 생성. 디스크 공간 검사, pg_restore --list 무결성 검증, 원자적 파일 이동, 30일 보관. 실패 시 Pushover 알림 (`pushover-immich` 재사용). `sudo systemctl start immich-db-backup`으로 수동 실행.
 
-Uptime Kuma/Copyparty/Karakeep: 이미지에 버전 레이블 없음 → GitHub latest 추적 + 이미지 digest 비교 방식. 상세: [references/service-update-system.md](references/service-update-system.md)
+Uptime Kuma/Copyparty/Karakeep: pinned tag 기준 — 설정된 이미지를 pull → digest 비교 (같은 태그의 재빌드만 반영). GitHub latest는 새 버전 알림/안내용이며, 실제 버전 반영은 해당 서비스 모듈(`modules/nixos/programs/docker/*.nix`)의 image 태그 수정 후 `nrs`. 상세: [references/service-update-system.md](references/service-update-system.md)
 Karakeep 수동 업데이트는 `--ack-bridge-risk` 플래그가 필수다 (브릿지/로그 의존성 인지 강제).
 
 Karakeep 이벤트 알림: `karakeep-notify`가 웹훅→Pushover 브리지(socat)로 아카이빙 성공/실패 알림을 전송한다.
+
+### 런타임 스모크 테스트
+
+`homeserver.smokeTest.enable = true` (`modules/nixos/programs/smoke-test.nix`). 매일 06:00에
+활성 서비스의 HTTPS 엔드포인트 헬스체크 + 백업 신선도(기본 상한 초과 여부)를 검사하고,
+실패 시 Pushover 알림 (`pushover-system-monitor` 공유). 수동 실행:
+
+```bash
+sudo systemctl start homeserver-smoke-test
+journalctl -u homeserver-smoke-test --no-pager -n 30
+```
 
 ### FolderAction 자동 업로드
 

--- a/.claude/skills/running-containers/references/immich-setup.md
+++ b/.claude/skills/running-containers/references/immich-setup.md
@@ -69,10 +69,13 @@ MiniPC(greenhead-minipc)에서 NixOS `virtualisation.oci-containers` (Podman 백
 
 | 컨테이너 | 이미지 | 역할 | 리소스 제한 |
 |----------|--------|------|------------|
-| `immich-server` | `ghcr.io/immich-app/immich-server:release` | 웹 서버 + API | `constants.containers.immich.server` |
-| `immich-postgres` | `tensorchord/pgvecto-rs:pg16-v0.2.0` | DB (pgvecto-rs) | `constants.containers.immich.postgres` |
-| `immich-redis` | `redis:7-alpine` | Job Queue / 캐싱 | `constants.containers.immich.redis` |
-| `immich-ml` | `ghcr.io/immich-app/immich-machine-learning:release` | ML (CPU 버전) | `constants.containers.immich.ml` |
+| `immich-server` | `ghcr.io/immich-app/immich-server` | 웹 서버 + API | `constants.containers.immich.server` |
+| `immich-postgres` | `ghcr.io/immich-app/postgres` | DB (VectorChord) | `constants.containers.immich.postgres` |
+| `immich-redis` | `redis` | Job Queue / 캐싱 | `constants.containers.immich.redis` |
+| `immich-ml` | `ghcr.io/immich-app/immich-machine-learning` | ML (CPU 버전) | `constants.containers.immich.ml` |
+
+모든 이미지는 pinned tag 사용 (rolling `:release` 아님). 실제 태그 정본:
+`rg -n 'image = ' modules/nixos/programs/docker/immich.nix`. 새 버전 반영은 태그 수정 후 `nrs`.
 
 ### 주요 설정 항목
 

--- a/.claude/skills/running-containers/references/immich-update.md
+++ b/.claude/skills/running-containers/references/immich-update.md
@@ -59,7 +59,7 @@ Immich 서버가 `127.0.0.1`에만 바인딩되어 있으므로, Tailscale IP로
     ↓
 [무결성 검증] gzip -t + 최소 크기(1KB) 확인
     ↓
-[이미지 Pull] immich-server:release + immich-ml:release
+[이미지 Pull] immich-server + immich-ml (설정된 pinned tag)
     ↓
 [재시작] stop server → stop ml → start ml → start server
     ↓

--- a/.claude/skills/running-containers/references/service-update-system.md
+++ b/.claude/skills/running-containers/references/service-update-system.md
@@ -6,6 +6,9 @@ Immich, Uptime Kuma, Copyparty, Karakeep 4개 컨테이너 서비스가 `service
 
 - 버전 체크 (자동): 매일 GitHub Releases API로 최신 버전 확인 → Pushover 알림
 - 업데이트 (수동): `sudo <서비스>-update` 명령으로 안전한 업데이트
+- 모든 컨테이너 이미지는 pinned tag (rolling `:latest`/`:release` 아님). update 스크립트는 설정된
+  pinned 이미지를 pull → digest 비교하므로 같은 태그의 재빌드만 반영한다. 새 버전 반영은
+  해당 서비스 모듈(`modules/nixos/programs/docker/*.nix`)의 image 태그 수정 후 `nrs`.
 
 ## 아키텍처
 
@@ -73,26 +76,26 @@ Immich는 Immich API로 현재 버전을 확인하는 고유 로직이 있어 �
 
 ### Uptime Kuma
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 현재 버전 확인: pinned image tag 기준 (update 스크립트가 태그에서 추출). GitHub latest는 알림용
 - 알림 형태: "v2.1.0 출시됨" (현재 버전 미표시)
-- 메이저 불일치 감지: 이미지 태그 `:1`은 1.x만, GitHub latest가 2.x → 추가 안내 포함
-- 업데이트: 이미지 pull → digest 비교 → stop → SQLite 백업(`kuma.db` gzip) → start → HTTP 헬스체크
+- 메이저 불일치 감지 (`DETECT_MAJOR_MISMATCH`): pinned tag 메이저 ≠ GitHub latest 메이저 → 추가 안내 포함
+- 업데이트: pinned 이미지 pull → digest 비교 → stop → SQLite 백업(`kuma.db` gzip) → start → HTTP 헬스체크
 - ERR trap 복구: 실패 시 컨테이너 자동 재시작 (모니터링 서비스 가용성 보장)
 - Tailscale 불필요: localhost + 인터넷만 사용
 
 ### Copyparty
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 현재 버전 확인: pinned image tag 기준 (update 스크립트가 태그에서 추출). GitHub latest는 알림용
 - 알림 형태: "v1.20.6 출시됨"
-- 업데이트: 이미지 pull → digest 비교 → 재시작 → HTTP 헬스체크 (백업 없음)
+- 업데이트: pinned 이미지 pull → digest 비교 → 재시작 → HTTP 헬스체크 (백업 없음)
 - ERR trap 복구: 실패 시 컨테이너 자동 재시작
 - Tailscale 불필요: localhost + 인터넷만 사용
 
 ### Karakeep
 
-- 현재 버전 확인: 이미지에 버전 레이블 없음 → GitHub latest만 추적
+- 현재 버전 확인: pinned image tag 기준 (update 스크립트가 태그에서 추출). GitHub latest는 알림용
 - 알림 형태: "v0.x.y 출시됨"
-- 업데이트: 이미지 pull → digest 비교 → 재시작 → HTTP 헬스체크 (백업 없음)
+- 업데이트: pinned 이미지 pull → digest 비교 → 재시작 → HTTP 헬스체크 (백업 없음)
 - 실행 명령: `sudo karakeep-update --ack-bridge-risk` (`--ack-bridge-risk` 없이 실행 불가)
 - ERR trap 복구: 실패 시 컨테이너 자동 재시작
 - Tailscale 불필요: localhost + 인터넷만 사용

--- a/.claude/skills/running-containers/references/troubleshooting.md
+++ b/.claude/skills/running-containers/references/troubleshooting.md
@@ -33,7 +33,7 @@ sudo systemctl stop podman-immich-server podman-immich-ml podman-immich-postgres
 sudo systemctl restart tailscaled
 ```
 
-2. 영구 해결 - OpenVINO 대신 일반 이미지 사용:
+2. 영구 해결 - OpenVINO 대신 일반 이미지 사용 (당시 config — 이후 rolling `:release`에서 pinned tag로 전환됨, 현재 태그는 `immich.nix` 참조):
 ```nix
 # modules/nixos/programs/docker/immich.nix
 virtualisation.oci-containers.containers.immich-ml = {


### PR DESCRIPTION
## Summary

- 서비스 runbook 스킬(hosting-copyparty, hosting-karakeep, running-containers, managing-macos)이 rolling tag 세계관(`:latest`/`:release`)과 낡은 설정 서술을 유지해 실제 pinned config와 충돌하던 drift를 정리한다.
- 문서 하드코딩 태그를 "실제 값은 해당 `.nix` 참조" 정본 포인터 + 재검증 명령 방식으로 전환해 동일 drift 재발을 구조적으로 방지한다.
- 문서를 따라 config를 재작성하면 기능이 조용히 사라지는 회귀 위험(Copyparty ACL `rwda` vs 실제 `rwmda`)과 커버리지 공백(백업 타이머 표, homeserver-smoke-test)을 함께 정리한다.

Closes #838

## 기존 문제/배경

서비스 runbook은 운영 중 agent가 실제 NixOS 구성을 이해하는 진입점인데, 실제 컨테이너 이미지가 pinned tag로 전환된 뒤에도 문서는 rolling tag 시절 서술을 유지하고 있었다.

- `hosting-copyparty`: `copyparty/ac:latest` 서술 (실제는 pinned tag — `modules/nixos/programs/docker/copyparty.nix`), 업데이트 방식도 "GitHub latest 추적" 중심으로 서술.
- `hosting-karakeep`: `ghcr.io/karakeep-app/karakeep:release` 서술 (실제는 pinned tag — `modules/nixos/programs/docker/karakeep.nix`).
- `running-containers`: immich 이미지 표 3건 낡음 (postgres는 repo 자체가 `tensorchord/pgvecto-rs` → `ghcr.io/immich-app/postgres`로 교체됨), service-update-system 문서 전반이 rolling 세계관, 백업 타이머 표에 `immich-originals-mirror` 누락, `homeserver-smoke-test`가 '서비스 상태'/'헬스체크' 트리거를 가진 스킬 어디에도 없음.
- `managing-macos`: 존재하지 않는 트랙패드 탭 클릭 설정을 서술, Homebrew 적용 범위를 "personal 호스트만"으로 서술 (실제는 공통 블록 + personal 가드 분리 구조).
- **회귀 위험 최상**: Copyparty ACL을 `rwda`로 서술 — 실제는 `rwmda`(move 권한 포함). 문서를 따라 config를 재작성하면 웹 UI의 파일 이름 변경/이동 기능이 조용히 사라진다.

잘못된 runbook은 잘못된 업데이트 판단(rolling pull로 새 버전이 반영된다고 오판)이나 존재하지 않는 설정 점검으로 이어진다.

## CIR (Change Intent Record)

- **v1** (Issue #838): 백로그 전수조사에서 서비스 runbook drift 목록 최초 제기 — Anki/Vaultwarden 항목 포함.
- **v2** (PR #863, PR #880): Anki 셀프호스팅 전면 제거·Vaultwarden EOL로 해당 drift 항목이 소멸 — 이슈 코멘트로 범위 축소.
- **v3** (Issue #838 코멘트): 스킬 문서 전수 점검(문서↔코드 실측)에서 잔여 drift가 구체 라인 단위로 재확인되고, ACL `rwmda` 회귀 위험과 smoke-test 커버리지 공백이 추가 발견됨. 하드코딩 지점과 drift 지점이 정확히 일치함을 확인.
- **v4** (이번 변경): 태그를 현재 값으로 다시 하드코딩하는 대신 정본 포인터 + 재검증 명령 방식으로 전환. CLAUDE.md의 버전 스탬프 규칙("재검증 명령을 함께 병기, 갱신할 수 없는 스탬프는 제거")과 같은 원칙을 적용.

**trade-off**: 문서만 읽어서는 현재 태그를 즉시 알 수 없고 `rg` 한 번이 더 필요하지만, 이번 점검에서 하드코딩 지점 = drift 지점이 정확히 일치했으므로 하드코딩 제거가 재발 방지의 본질이다.

**범위 노트**: 이슈의 understanding-nix host-network 항목은 main에서 이미 정리되어 (문서가 "uptime-kuma만" 확정 서술을 하지 않고 경계 개념만 언급) `tests/eval-tests.nix` allowlist와 충돌하지 않음을 실측 확인했다 — 이번 변경에 포함되지 않는다. Anki/Vaultwarden stale 문구도 rg 스캔 0건으로 이미 소멸 상태다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 하드코딩 태그를 현재 값으로 갱신 | 문서에 현재 pinned tag를 직접 기입 | 문서만으로 즉시 확인 가능 | 다음 태그 bump마다 동일 drift 재발 (이번 점검에서 하드코딩 지점=drift 지점 일치 확인) | ❌ |
| 정본 포인터 + 재검증 명령 병기 | "실제 태그는 해당 `.nix` 참조" + `rg` 명령 병기 | drift 구조적 재발 방지, CLAUDE.md 버전 스탬프 규칙과 일관 | 확인에 `rg` 1회 필요 | ✅ |
| 문서 자동 생성 | `.nix`에서 runbook 표를 생성하는 파이프라인 | 완전 동기화 | 문서 12개 파일 정렬에 파이프라인 인프라는 과잉 (YAGNI) | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `.claude/skills/hosting-copyparty/SKILL.md` | 수정 | ACL `rwda`→`rwmda` (move 권한 누락 금지 경고 추가), `ac:latest`→pinned tag 포인터, 업데이트 흐름을 pinned pull→digest 비교로 정정 |
| `.claude/skills/hosting-copyparty/references/setup.md` | 수정 | ACL `rwmda` 정정 + `m` 권한 의미 명시, 이미지 서술 pinned 포인터화 |
| `.claude/skills/hosting-copyparty/references/troubleshooting.md` | 수정 | ACL 예시/해결책의 `rwda`→`rwmda` 정정 |
| `.claude/skills/hosting-karakeep/SKILL.md` | 수정 | 컨테이너 표 태그 하드코딩 제거, pinned tag 정본 포인터 + 재검증 명령 병기 |
| `.claude/skills/hosting-karakeep/references/update-guide.md` | 수정 | `:release` 기준 서술을 pinned tag 포인터로 정정 |
| `.claude/skills/running-containers/SKILL.md` | 수정 | 백업 타이머 표에 `immich-originals-mirror`(04:30) 추가, 런타임 스모크 테스트 섹션 신설, 업데이트 서술 pinned 세계관 정정 |
| `.claude/skills/running-containers/references/immich-setup.md` | 수정 | 이미지 표 3건 갱신 (postgres repo 교체 반영: `ghcr.io/immich-app/postgres`/VectorChord), pinned 포인터 추가 |
| `.claude/skills/running-containers/references/immich-update.md` | 수정 | 이미지 pull 단계의 `:release` 서술 정정 |
| `.claude/skills/running-containers/references/service-update-system.md` | 수정 | Uptime Kuma/Copyparty/Karakeep 버전 확인·업데이트 서술을 pinned tag 기준으로 전면 정정, 메이저 불일치 감지 서술 정정 |
| `.claude/skills/running-containers/references/troubleshooting.md` | 수정 | OOM 사건 스니펫에 historical note 부기 (당시 rolling config임을 명시) |
| `.claude/skills/managing-macos/SKILL.md` | 수정 | 트랙패드 탭 클릭(미존재 설정) 서술을 실제 설정 기준으로 정정, Homebrew 공통+personal 분리 구조 반영 |
| `.claude/skills/managing-macos/references/features.md` | 수정 | Homebrew hostType 서술을 공통 블록 + personal 가드 구조로 정정 |

### 핵심 변경

```markdown
# BEFORE: rolling 세계관 하드코딩 (drift 재발 지점)
- `copyparty/ac:latest` 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)

# AFTER: 정본 포인터 + 재검증 명령
- `copyparty/ac` variant를 pinned tag로 사용 (audio/video/image 썸네일 + 트랜스코딩 포함)
- 실제 태그 정본: `modules/nixos/programs/docker/copyparty.nix` (재검증: `rg -n 'image = ' modules/nixos/programs/docker/copyparty.nix`)
```

```markdown
# BEFORE: 문서대로 재작성 시 move 권한이 조용히 사라짐
    rwda: greenhead       # 읽기/쓰기/삭제/관리

# AFTER: 실제 config와 일치 + 누락 시 증상 명시
    rwmda: greenhead      # 읽기/쓰기/이동/삭제/관리
- `r:` = 읽기 전용, `rwmda:` = 전체 권한 (`m` = move — 빠지면 파일 이름 변경/이동 불가)
```

## 참고 레퍼런스

- Issue #838 — 서비스 runbook drift 정리 (본 PR 대상), 잔여 drift 실측 근거는 이슈 코멘트 참조
- Issue #834 — 상위 이슈 (스킬 문서 drift 전수 정리)
- PR #863 — awesome-anki 셀프호스팅 전면 제거 (이슈의 Anki 항목 무효화 근거)
- PR #880 — Vaultwarden EOL 제거 (이슈의 Vaultwarden 항목 무효화 근거)
- `modules/nixos/programs/docker/copyparty.nix`, `karakeep.nix`, `immich.nix` — pinned tag 정본
- `modules/nixos/programs/smoke-test.nix` — 신설 문서 섹션의 대상 모듈

## Human Test Plan

### 정상 동작 검증

1. stale 참조 스캔: `rg -n "karakeep:release|copyparty/ac:latest|Vaultwarden|awesome-anki|awesomeAnki|anki\.greenhead" .claude/skills modules`
   - **기대**: 0건.
   - **실패 시**: 검출된 파일이 이번 변경 범위(12개 파일) 밖의 신규 유입인지 확인 후 동일 포인터 방식으로 정정.
2. 문서 재검증 명령 실효성: `rg -n 'image = ' modules/nixos/programs/docker/copyparty.nix` 및 `karakeep.nix` 실행.
   - **기대**: pinned tag(`x.y.z` 형태)가 출력되고 rolling tag(`:latest`/`:release`)가 아님.
   - **실패 시**: 모듈의 image 라인 표기가 바뀐 것이므로 문서의 재검증 명령을 함께 갱신.
3. ACL 문서↔코드 일치: `rg -n "rwmda|rwda" .claude/skills/hosting-copyparty modules/nixos/programs/docker/copyparty.nix`
   - **기대**: 문서와 `copyparty.nix`의 `accs:` 블록 모두 `rwmda`로 일치, `rwda` 단독 표기 0건.
   - **실패 시**: 문서 잔존 `rwda`를 정정 (move 권한 조용한 소실 회귀 방지가 목적).
4. 스킬 문서 구조 검증: `./scripts/ai/verify-ai-compat.sh`
   - **기대**: 통과.
   - **실패 시**: 출력이 지목하는 스킬 문서의 구조 규칙 위반을 수정.
5. eval 테스트: `bash tests/run-eval-tests.sh`
   - **기대**: 통과 (host-network 관련 테스트 포함).
   - **실패 시**: 실패 테스트가 이번 변경(문서만)과 무관한지 확인 — 본 PR은 `.nix` 코드를 변경하지 않는다.

### 엣지 케이스 / Negative 검증

6. 새 스모크 테스트 섹션의 명령 실효성 (MiniPC에서): `sudo systemctl start homeserver-smoke-test && journalctl -u homeserver-smoke-test --no-pager -n 30`
   - **기대**: 서비스가 존재하고 헬스체크 로그가 출력됨.
   - **실패 시**: `homeserver.smokeTest.enable` 설정과 `modules/nixos/programs/smoke-test.nix`를 대조.
7. 이번 범위 밖 항목의 현상 유지 확인: `.claude/skills/understanding-nix/references/features.md`의 host-network 서술.
   - **기대**: "uptime-kuma만"류 확정 서술 없이 경계 개념만 언급 — `tests/eval-tests.nix` allowlist와 충돌 없음 (이미 main에서 정리된 상태 그대로).
   - **실패 시**: main과의 diff에 understanding-nix가 포함되지 않았는지 확인 — 본 PR은 해당 파일을 건드리지 않는다.

https://claude.ai/code/session_01BUJUfcjwhcKJC9MJxLYwJS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 컨테이너 이미지 업데이트를 pinned tag pull 후 digest 비교 방식으로 안내를 정비하고, 서비스별 업데이트 흐름을 명확히 했습니다.
  * Copyparty/Karakeep/Immich의 실제 태그 확인 기준과 수동 업데이트 관련 주의사항을 보완했습니다.
  * Copyparty 권한(루트 볼륨)과 웹 UI에서의 동작 관련 누락 리스크를 업데이트했으며, ACL 표기도 함께 수정했습니다.
* **New Features (문서 반영)**
  * 컨테이너 백업 타이머(Immich 원본 미러)와 일일 런타임 스모크 테스트 점검 절차를 추가했습니다.
  * macOS(Homebrew) 공통/개인 분리 및 OOM 트러블슈팅 단계 구성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->