### PR TITLE
feat(mise): 전역 config를 nix 선언 관리로 이관

### DIFF
--- a/.claude/skills/configuring-codex/references/runbook-codex-compat.md
+++ b/.claude/skills/configuring-codex/references/runbook-codex-compat.md
@@ -217,7 +217,9 @@ Codex CLI가 디렉토리 심링크는 공식 지원함을 확인했다.
   codex(nix profile)를 shadow하지 못하게 정리만 한다:
   1. `cleanupLegacyCodexCli` — 과거 GitHub ELF(NixOS)/brew cask(macOS) 잔재 정리
   2. `cleanupMiseCodexShim` — mise npm backend 잔재(`shims/codex`·`installs/npm-openai-codex/`) 멱등 제거.
-     mise 명령을 호출하지 않고 순수 rm (dangling shim의 mise resolve가 fork 폭주원). config.toml entry 제거는 수동.
+     mise 명령을 호출하지 않고 순수 rm (dangling shim의 mise resolve가 fork 폭주원). config.toml의 codex
+     entry는 mise 전역 config가 nix 선언(`modules/shared/programs/mise/config.toml`)으로 이관되며 선언에서
+     제외되는 방식으로 소멸한다.
   3. `cleanupManualNodeCodex` — 수동 `npm install -g @openai/codex` 잔재 제거 (node가 mise에 남아 유효)
 
 ### SoT와 업데이트
@@ -227,8 +229,9 @@ Codex CLI가 디렉토리 심링크는 공식 지원함을 확인했다.
   해시 prefetch → 핀 갱신 → nrs; `--pre`로 alpha 포함). platforms/asset 키는 정적 설정이라 손으로 관리.
 - overlay는 OpenAI 릴리스를 직핀하므로 lag이 사실상 없다(직핀 최신). config 템플릿 feature floor
   (현재 0.124+)는 항상 충족. 갱신 후 `codex-pin.json` 변경을 커밋한다.
-- runtime `~/.config/mise/config.toml`의 `[tools]."npm:@openai/codex"` entry는 nix 비관리 SoT라
-  이관 시 직접 텍스트 편집으로 제거한다(mise 명령 금지). `node`/`gitleaks` entry는 보존.
+- `~/.config/mise/config.toml`은 nix 선언 read-only symlink다 (SoT:
+  `modules/shared/programs/mise/config.toml`; 직접 편집·`mise use -g` 불가). codex entry는
+  선언에 없으므로 배포 시 자동 소멸하고, `node`/`gitleaks`는 선언에 포함되어 보존된다.
 
 ### 운영 주의 (nix overlay)
 

--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -87,7 +87,7 @@ mise는 두 계층으로 활성화된다:
 ## 자주 발생하는 문제
 
 1. SSH 비대화형 세션에서 pnpm not found: `.zshenv`에 mise shims 누락 → 셸 활성화 구조 참조
-2. .nvmrc 인식 안 됨: mise 2025.10.0부터 기본 비활성화 → `idiomatic_version_file_enable_tools` 설정 필요
+2. .nvmrc 인식 안 됨: node는 전역 SoT에 이미 idiomatic 선언돼 있으므로 nrs 배포 상태부터 확인 → 상세·다른 도구 추가는 troubleshooting 참조
 3. NixOS에서 node 빌드 실패: `MISE_NODE_COMPILE=0` 필요 (현재 `nixos.nix`에서 영구 설정됨)
 4. mise.local.toml 미신뢰: `mise trust` 실행 필요 (최초 1회; worktree도 경로가 다르므로 별도 trust)
 5. `mise use -g`/`mise settings add·set·unset` 실패 (read-only config): 의도된 가드 — 전역 변경은 SoT 파일 수정 + nrs, 임시 도구는 `~/.config/mise/conf.d/` (읽기 명령 `mise settings`는 정상 동작)

--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -47,7 +47,8 @@ mise current
 # 프로젝트 버전 설치
 mise install node@20.18
 
-# 프로젝트 설정 신뢰
+# 프로젝트 설정 신뢰 — config의 env·template 등 실행성 내용을 검토한 뒤,
+# 사용자 소유이거나 신뢰가 명시된 저장소에서만 실행한다
 mise trust
 ```
 
@@ -89,7 +90,7 @@ mise는 두 계층으로 활성화된다:
 1. SSH 비대화형 세션에서 pnpm not found: `.zshenv`에 mise shims 누락 → 셸 활성화 구조 참조
 2. .nvmrc 인식 안 됨: node는 전역 SoT에 이미 idiomatic 선언돼 있으므로 nrs 배포 상태부터 확인 → 상세·다른 도구 추가는 troubleshooting 참조
 3. NixOS에서 node 빌드 실패: `MISE_NODE_COMPILE=0` 필요 (현재 `nixos.nix`에서 영구 설정됨)
-4. mise.local.toml 미신뢰: `mise trust` 실행 필요 (최초 1회; worktree도 경로가 다르므로 별도 trust)
+4. mise.local.toml 미신뢰: config 내용 검토 후 신뢰하는 저장소에서만 `mise trust` 실행 (최초 1회; worktree도 경로가 다르므로 별도 trust)
 5. `mise use -g`/`mise settings add·set·unset` 실패 (read-only config): 의도된 가드 — 전역 변경은 SoT 파일 수정 + nrs, 임시 도구는 `~/.config/mise/conf.d/` (읽기 명령 `mise settings`는 정상 동작)
 
 ## 레퍼런스

--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -42,7 +42,7 @@ macOS·NixOS 모두 `pkgs.mise`(nix, `libraries/packages.nix`의 shared)로 설�
 mise current
 
 # 전역 버전 변경: modules/shared/programs/mise/config.toml 수정 후 nrs
-# (`mise use -g`·`mise settings`는 read-only config라 의도적으로 실패 — drift 가드)
+# (`mise use -g`·`mise settings add/set/unset` 같은 전역 쓰기 명령은 read-only config라 의도적으로 실패 — drift 가드)
 
 # 프로젝트 버전 설치
 mise install node@20.18
@@ -90,7 +90,7 @@ mise는 두 계층으로 활성화된다:
 2. .nvmrc 인식 안 됨: mise 2025.10.0부터 기본 비활성화 → `idiomatic_version_file_enable_tools` 설정 필요
 3. NixOS에서 node 빌드 실패: `MISE_NODE_COMPILE=0` 필요 (현재 `nixos.nix`에서 영구 설정됨)
 4. mise.local.toml 미신뢰: `mise trust` 실행 필요 (최초 1회; worktree도 경로가 다르므로 별도 trust)
-5. `mise use -g`/`mise settings` 실패 (read-only config): 의도된 가드 — 전역 변경은 SoT 파일 수정 + nrs, 임시 도구는 `~/.config/mise/conf.d/`
+5. `mise use -g`/`mise settings add·set·unset` 실패 (read-only config): 의도된 가드 — 전역 변경은 SoT 파일 수정 + nrs, 임시 도구는 `~/.config/mise/conf.d/` (읽기 명령 `mise settings`는 정상 동작)
 
 ## 레퍼런스
 

--- a/.claude/skills/managing-mise/SKILL.md
+++ b/.claude/skills/managing-mise/SKILL.md
@@ -29,7 +29,8 @@ macOS·NixOS 모두 `pkgs.mise`(nix, `libraries/packages.nix`의 shared)로 설�
 
 | 파일 | 용도 |
 |------|------|
-| `~/.config/mise/config.toml` | 전역 설정 |
+| `~/.config/mise/config.toml` | 전역 설정 — nix 선언 read-only symlink. SoT: `modules/shared/programs/mise/config.toml` |
+| `~/.config/mise/conf.d/*.toml` | 머신 로컬/임시 전역 도구 (nix 비관리 — config.toml과 병합 로드) |
 | `mise.toml` / `.mise.toml` | 프로젝트별 설정 |
 | `mise.local.toml` | 프로젝트 로컬 (gitignore됨) |
 | `.nvmrc`, `.node-version` | Node.js 버전 (idiomatic files) |
@@ -40,8 +41,8 @@ macOS·NixOS 모두 `pkgs.mise`(nix, `libraries/packages.nix`의 shared)로 설�
 # 현재 버전 확인
 mise current
 
-# 전역 버전 설정
-mise use -g node@lts
+# 전역 버전 변경: modules/shared/programs/mise/config.toml 수정 후 nrs
+# (`mise use -g`·`mise settings`는 read-only config라 의도적으로 실패 — drift 가드)
 
 # 프로젝트 버전 설치
 mise install node@20.18
@@ -54,6 +55,7 @@ mise trust
 
 | 파일 | 용도 |
 |------|------|
+| `modules/shared/programs/mise/config.toml` | 전역 config SoT (`~/.config/mise/config.toml`로 심링크 배포) |
 | `modules/shared/programs/shell/default.nix` | zsh mise 활성화 (shims + activate) |
 | `modules/shared/programs/shell/nixos.nix` | NixOS 환경변수 (`MISE_ALL_COMPILE=0`, `MISE_NODE_COMPILE=0`) |
 | `libraries/packages.nix` | `pkgs.mise` 패키지 설치 (shared — macOS+NixOS 공통) |
@@ -77,9 +79,9 @@ mise는 두 계층으로 활성화된다:
 ## 핵심 절차
 
 1. `mise current`로 현재 선택된 런타임을 확인한다.
-2. 전역 버전이 필요하면 `mise use -g node@lts`로 고정한다.
+2. 전역 버전 변경은 `modules/shared/programs/mise/config.toml` 수정 후 `nrs`로 배포한다.
 3. 프로젝트별 버전은 `mise.toml` 또는 `.nvmrc` 기준으로 `mise install`을 실행한다.
-4. `.nvmrc` 인식이 필요하면 `mise settings add idiomatic_version_file_enable_tools node`를 실행한다.
+4. `.nvmrc` 인식(`idiomatic_version_file_enable_tools`)은 전역 config에 선언돼 있다 — 별도 실행 불필요.
 5. 비대화형 셸 문제는 `~/.zshenv`의 shims 경로와 `mise activate` 적용 여부를 점검한다.
 
 ## 자주 발생하는 문제
@@ -87,7 +89,8 @@ mise는 두 계층으로 활성화된다:
 1. SSH 비대화형 세션에서 pnpm not found: `.zshenv`에 mise shims 누락 → 셸 활성화 구조 참조
 2. .nvmrc 인식 안 됨: mise 2025.10.0부터 기본 비활성화 → `idiomatic_version_file_enable_tools` 설정 필요
 3. NixOS에서 node 빌드 실패: `MISE_NODE_COMPILE=0` 필요 (현재 `nixos.nix`에서 영구 설정됨)
-4. mise.local.toml 미신뢰: `mise trust` 실행 필요 (최초 1회)
+4. mise.local.toml 미신뢰: `mise trust` 실행 필요 (최초 1회; worktree도 경로가 다르므로 별도 trust)
+5. `mise use -g`/`mise settings` 실패 (read-only config): 의도된 가드 — 전역 변경은 SoT 파일 수정 + nrs, 임시 도구는 `~/.config/mise/conf.d/`
 
 ## 레퍼런스
 

--- a/.claude/skills/managing-mise/references/troubleshooting.md
+++ b/.claude/skills/managing-mise/references/troubleshooting.md
@@ -159,7 +159,7 @@ node = "20.18"
 pnpm = "latest"
 EOF
 
-# trust 실행 (최초 1회)
+# trust 실행 (최초 1회 — config의 env·template 검토 후, 신뢰하는 저장소에서만)
 $ mise trust
 ```
 

--- a/.claude/skills/managing-mise/references/troubleshooting.md
+++ b/.claude/skills/managing-mise/references/troubleshooting.md
@@ -123,16 +123,12 @@ pnpm 10.28.0
 
 해결: `idiomatic_version_file_enable_tools` 설정 추가.
 
-```bash
-# CLI로 설정
-$ mise settings add idiomatic_version_file_enable_tools node
-```
-
-또는 `~/.config/mise/config.toml`에 직접 추가:
+현재는 전역 config가 nix 선언(`modules/shared/programs/mise/config.toml`)이고 이 설정이 이미 포함돼 있어 별도 조치가 불필요하다. 새 도구를 idiomatic file 인식 대상에 추가하려면 SoT 파일을 수정 후 `nrs`한다 (`mise settings add`는 read-only config라 실패한다):
 
 ```toml
+# modules/shared/programs/mise/config.toml
 [settings]
-idiomatic_version_file_enable_tools = ['node']
+idiomatic_version_file_enable_tools = ["node"]
 
 [tools]
 node = "lts"      # 전역 기본값
@@ -182,7 +178,7 @@ $ mise trust
 증상: mise로 node 설치 시 빌드 실패.
 
 ```bash
-$ mise use -g node@lts
+$ mise install node@lts
 ./configure: line 8: exec: python: not found
 ```
 
@@ -192,12 +188,10 @@ $ mise use -g node@lts
 
 ```bash
 # 환경변수로 컴파일 비활성화
-$ MISE_NODE_COMPILE=0 mise use -g node@lts
-
-# 또는 영구 설정 (~/.config/mise/config.toml)
-[settings]
-node_compile = false
+$ MISE_NODE_COMPILE=0 mise install node@lts
 ```
+
+현재는 `modules/shared/programs/shell/nixos.nix`가 `MISE_NODE_COMPILE=0`·`MISE_ALL_COMPILE=0`을 영구 설정하므로 평상시엔 재발하지 않는다.
 
 확인:
 

--- a/.claude/skills/managing-mise/references/troubleshooting.md
+++ b/.claude/skills/managing-mise/references/troubleshooting.md
@@ -121,18 +121,14 @@ pnpm 10.28.0
 - [Discussion #4345: idiomatic versions default disabled](https://github.com/jdx/mise/discussions/4345)
 - [mise 공식 설정 문서](https://mise.jdx.dev/configuration.html)
 
-해결: `idiomatic_version_file_enable_tools` 설정 추가.
+현재 상태: 전역 config SoT(`modules/shared/programs/mise/config.toml`)에 `idiomatic_version_file_enable_tools = ["node"]`가 이미 선언돼 있어 node의 `.nvmrc` 인식에는 별도 조치가 불필요하다.
 
-현재는 전역 config가 nix 선언(`modules/shared/programs/mise/config.toml`)이고 이 설정이 이미 포함돼 있어 별도 조치가 불필요하다. 새 도구를 idiomatic file 인식 대상에 추가하려면 SoT 파일을 수정 후 `nrs`한다 (`mise settings add`는 read-only config라 실패한다):
+다른 도구를 idiomatic file 인식 대상에 추가하려면 SoT 파일의 해당 배열에 도구명을 추가하고 `nrs`한다 (`mise settings add`는 read-only config라 실패한다):
 
 ```toml
-# modules/shared/programs/mise/config.toml
+# modules/shared/programs/mise/config.toml — 최소 변경 예시 (전체 내용은 SoT 파일 참조)
 [settings]
-idiomatic_version_file_enable_tools = ["node"]
-
-[tools]
-node = "lts"      # 전역 기본값
-pnpm = "latest"
+idiomatic_version_file_enable_tools = ["node", "<추가할-도구>"]
 ```
 
 프로젝트별 버전 설치:

--- a/modules/darwin/home.nix
+++ b/modules/darwin/home.nix
@@ -95,6 +95,7 @@ in
         ../shared/programs/direnv # 디렉토리별 개발 환경 자동 활성화
         ../shared/programs/git
         ../shared/programs/lazygit
+        ../shared/programs/mise # mise 전역 config 선언 관리
         ../shared/programs/shell # 공통 shell 설정
         ../shared/programs/shell/darwin.nix # macOS 전용 shell 추가
         ../shared/programs/tmux

--- a/modules/nixos/home.nix
+++ b/modules/nixos/home.nix
@@ -33,6 +33,7 @@ in
     ../shared/programs/direnv # 디렉토리별 개발 환경 자동 활성화
     ../shared/programs/git
     ../shared/programs/lazygit
+    ../shared/programs/mise # mise 전역 config 선언 관리
     ../shared/programs/shell # 공통 shell 설정
     ../shared/programs/shell/nixos.nix # Linux 전용 추가
     ../shared/programs/tmux

--- a/modules/shared/programs/codex/default.nix
+++ b/modules/shared/programs/codex/default.nix
@@ -172,8 +172,8 @@ in
   #   shadow한다. 게다가 config(~/.config/mise/config.toml) 미등록 dangling shim 호출은
   #   mise version resolve(fork 폭주, os error 35)를 재유발한다 — 본 이관이 탈출하려는 실패 모드.
   #   따라서 mise 명령을 일절 호출하지 않고 순수 rm만 한다(mise resolve 자체가 폭주원이므로).
-  #   config.toml의 [tools]."npm:@openai/codex" entry 제거는 nix 비관리 runtime SoT라 마이그레이션
-  #   수동 단계로 둔다(activation이 사용자 mise config를 편집하지 않음). 설치본 trail
+  #   config.toml의 [tools]."npm:@openai/codex" entry는 mise 전역 config의 nix 선언 이관
+  #   (modules/shared/programs/mise/config.toml — codex entry 미포함)으로 배포 시 소멸한다. 설치본 trail
   #   (MISE_DATA_DIR 커스텀 환경은 경로가 다를 수 있으나 이 프로젝트 범위 밖):
   #     ~/.local/share/mise/shims/codex                  (shim — PATH shadow의 직접 원인)
   #     ~/.local/share/mise/installs/npm-openai-codex/    (backend 설치 트리)

--- a/modules/shared/programs/mise/config.toml
+++ b/modules/shared/programs/mise/config.toml
@@ -1,0 +1,21 @@
+# mise 전역 설정 — nix 선언 관리 (SoT: 이 파일. ~/.config/mise/config.toml은 read-only symlink)
+#
+# 전역 도구 추가/변경: 이 파일 수정 후 nrs.
+# 머신 로컬/임시 도구: ~/.config/mise/conf.d/*.toml (nix 비관리 — mise가 config.toml과 병합 로드).
+# 프로젝트별 버전: 각 프로젝트의 mise.toml / .nvmrc (idiomatic file, 아래 settings 참조).
+#
+# 배경: 전역 config가 runtime mutation(mise use -g)으로 관리되던 시절 두 머신이
+# drift했고(Mac: node latest+yarn / MiniPC: node lts+pnpm+죽은 codex entry),
+# 오타(cocodpods)·deprecated 설정(legacy_version_file)이 잔존해 선언 관리로 이관했다.
+# mise use -g / mise settings 같은 전역 쓰기 명령은 이제 의도적으로 실패한다 (drift 가드).
+
+[settings]
+# .nvmrc / .node-version 인식 (mise 2025.10.0부터 기본 비활성 — idiomatic version file)
+idiomatic_version_file_enable_tools = ["node"]
+
+[tools]
+# 전역은 fallback일 뿐 — 프로젝트별 버전은 .nvmrc/mise.toml이 우선한다.
+node = "lts"
+pnpm = "latest"
+yarn = "1.22.22" # yarn classic 고정 (v1 계열을 쓰는 외부 프로젝트용)
+gitleaks = "8.30.0" # NOTE: nix devShell(flake.nix)과 이중 관리 — 정리 별도 검토 (#890 비목표)

--- a/modules/shared/programs/mise/config.toml
+++ b/modules/shared/programs/mise/config.toml
@@ -7,7 +7,8 @@
 # 배경: 전역 config가 runtime mutation(mise use -g)으로 관리되던 시절 두 머신이
 # drift했고(Mac: node latest+yarn / MiniPC: node lts+pnpm+죽은 codex entry),
 # 오타(cocodpods)·deprecated 설정(legacy_version_file)이 잔존해 선언 관리로 이관했다.
-# mise use -g / mise settings 같은 전역 쓰기 명령은 이제 의도적으로 실패한다 (drift 가드).
+# mise use -g / mise settings add·set·unset 같은 전역 쓰기 명령은 이제 의도적으로
+# 실패한다 (drift 가드). 읽기 조회(인자 없는 mise settings)는 정상 동작한다.
 
 [settings]
 # .nvmrc / .node-version 인식 (mise 2025.10.0부터 기본 비활성 — idiomatic version file)

--- a/modules/shared/programs/mise/config.toml
+++ b/modules/shared/programs/mise/config.toml
@@ -18,4 +18,7 @@ idiomatic_version_file_enable_tools = ["node"]
 node = "lts"
 pnpm = "latest"
 yarn = "1.22.22" # yarn classic 고정 (v1 계열을 쓰는 외부 프로젝트용)
-gitleaks = "8.30.0" # NOTE: nix devShell(flake.nix)과 이중 관리 — 정리 별도 검토 (#890 비목표)
+# gitleaks 이중 선언의 역할 분리: flake.nix devShell은 이 repo 진입 시(direnv) 제공하고,
+# 아래 mise 전역은 devShell 밖 컨텍스트(비대화형 훅·타 프로젝트 — #826 계열)의 fallback이다.
+# 단일 SoT로 합치려면 devShell 밖 훅의 gitleaks 해석 경로를 먼저 재설계해야 한다 (착수 시 이슈로 승격).
+gitleaks = "8.30.0"

--- a/modules/shared/programs/mise/default.nix
+++ b/modules/shared/programs/mise/default.nix
@@ -1,0 +1,16 @@
+# mise 전역 config 선언 관리 (macOS + NixOS 공통)
+#
+# 범위: ~/.config/mise/config.toml 하나만 선언한다.
+#   - 바이너리 설치는 libraries/packages.nix(pkgs.mise), 셸 활성화는 shell/default.nix,
+#     NixOS 컴파일 차단 환경변수는 shell/nixos.nix가 각각 담당 (기존 구조 유지).
+#   - 도구 설치본(~/.local/share/mise/installs)은 선언하지 않는다 — activation에서
+#     mise를 실행하는 순간 제한 PATH·reshim fragility로 회귀한다는 것이 #814→#890의
+#     교훈이므로, 미설치 도구는 대화형 셸에서 `mise install`로 해결한다.
+#
+# 마이그레이션: 기존 ~/.config/mise/config.toml이 regular file이면 첫 nrs가 충돌한다.
+#   macOS는 home-manager backupCommand가 처리하고, NixOS는 백업 정책이 없으므로
+#   `mv ~/.config/mise/config.toml{,.bak}` 후 nrs한다.
+{ ... }:
+{
+  xdg.configFile."mise/config.toml".source = ./config.toml;
+}

--- a/modules/shared/programs/mise/default.nix
+++ b/modules/shared/programs/mise/default.nix
@@ -7,9 +7,11 @@
 #     mise를 실행하는 순간 제한 PATH·reshim fragility로 회귀한다는 것이 #814→#890의
 #     교훈이므로, 미설치 도구는 대화형 셸에서 `mise install`로 해결한다.
 #
-# 마이그레이션: 기존 ~/.config/mise/config.toml이 regular file이면 첫 nrs가 충돌한다.
-#   macOS는 home-manager backupCommand가 처리하고, NixOS는 백업 정책이 없으므로
-#   `mv ~/.config/mise/config.toml{,.bak}` 후 nrs한다.
+# 마이그레이션: 기존 ~/.config/mise/config.toml이 regular file이면 첫 nrs에서
+#   home-manager 백업 정책이 처리한다 — macOS는 backupCommand(darwin/home.nix),
+#   NixOS는 backupFileExtension = "backup"(flake.nix)으로 자동 백업된다.
+#   단 NixOS에서 같은 이름의 .backup 파일이 이미 있으면 activation이 중단되므로
+#   그 경우에만 기존 .backup을 먼저 정리한다.
 { ... }:
 {
   xdg.configFile."mise/config.toml".source = ./config.toml;


### PR DESCRIPTION
## Summary

- runtime mutation(`mise use -g`)으로 관리되던 mise 전역 config(`~/.config/mise/config.toml`)를 nix 선언 관리(`modules/shared/programs/mise/config.toml` SoT)로 이관한다.
- 두 머신 config drift(Mac: node latest+yarn / MiniPC: node lts+pnpm+죽은 `npm:@openai/codex` entry)와 잔존 결함(오타 `cocodpods`, deprecated `legacy_version_file`)을 선언 통일로 종결한다.


Closes #1166
## 기존 문제/배경

전체 세션 로그·GitHub 히스토리 전수조사(이번 세션)에서 mise 전역 config가 nix 밖 runtime SoT로 남아 다음이 실증됐다:

- **머신 간 drift**: Mac은 `node = "latest"` + yarn, MiniPC는 `node = "lts"` + pnpm — "선언적 관리" 목표와 달리 전역 런타임 구성이 머신마다 다르게 표류.
- **죽은 entry 잔존**: MiniPC에 `"npm:@openai/codex" = "latest"`가 남아 backend 설치본 0.144.6이 재생성되고 있었다. dangling shim resolve의 fork 폭주(`os error 35`, 2026-06-06 시스템 마비)를 유발했던 바로 그 계열의 잔재다 (#890).
- **잔존 결함**: Mac config의 `idiomatic_version_file_enable_tools = ["node", "cocodpods", "pod"]` 오타, MiniPC의 deprecated `legacy_version_file = true`.

## CIR (Change Intent Record)

- **v1** (#814 ADR): "mise config.toml을 nix 생성" 대안이 검토됐으나 "수동 config 워크플로 상실, scope 확대"로 기각 — 당시엔 drift가 실증되지 않았다.
- **v2** (#890/#893): codex를 mise npm backend에서 nix overlay로 이관하며 config entry 제거를 "nix 비관리 runtime SoT라 수동 단계"로 남김 → MiniPC에서 그 수동 단계가 누락된 채 잔존함이 이번 조사에서 확인됐다.
- **v3** (이번 변경): drift·잔존 entry가 실증되어 v1의 기각 근거를 재평가, 전역 config를 선언 관리로 이관. 수동 워크플로 상실은 `~/.config/mise/conf.d/*.toml`(mise 표준 병합 로드, nix 비관리)을 탈출구로 보전한다.

**trade-off**: `mise use -g`·`mise settings` 같은 전역 쓰기 명령이 read-only symlink에 막혀 실패하게 된다. 이는 의도된 drift 가드이며, 전역 변경은 SoT 파일 수정 + `nrs`, 임시/머신 로컬 도구는 `conf.d/`로 흡수한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `xdg.configFile` 정적 선언 | config.toml을 read-only symlink로 배포 | 단순, drift 원천 차단, mise 표준 `conf.d/`가 탈출구 제공 | 전역 쓰기 명령 실패 (의도된 가드) | ✅ |
| activation merge (codex `syncCodexConfig` 방식) | template wins + 밖은 preserve | 수동 `mise use -g` 워크플로 보존 | merge 로직 복잡도, drift를 "허용하며 관리"하는 어중간한 SoT | ❌ |
| 현상 유지 + 문서화 | 수동 정리 절차만 문서화 | 변경 0 | drift 재발 구조 그대로 (#890 수동 단계 누락이 재발 사례) | ❌ |
| 도구 설치본까지 activation으로 보장 | `mise install`을 activation에서 실행 | 완전 선언 | activation 제한 PATH에서 mise 실행은 #814→#890에서 실증된 회귀 경로 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/mise/config.toml` | 신규 — 전역 config SoT (node lts / pnpm latest / yarn 1.22.22 / gitleaks 8.30.0, idiomatic node) |
| `modules/shared/programs/mise/default.nix` | 신규 — `xdg.configFile."mise/config.toml"` 선언 + 범위·마이그레이션 주석 |
| `modules/darwin/home.nix`, `modules/nixos/home.nix` | `../shared/programs/mise` import 배선 |
| `.claude/skills/managing-mise/SKILL.md` | 설정 위치 표·명령어·핵심 절차를 SoT 수정 + nrs 기준으로 정합화, read-only 가드 FAQ 추가 |
| `.claude/skills/managing-mise/references/troubleshooting.md` | `mise settings add`/`mise use -g` 절차를 선언 관리 기준으로 갱신 |

통일 내용 결정 근거: `node = "lts"`(전역은 fallback — 프로젝트별은 `.nvmrc`/`mise.toml` 우선, latest는 비-LTS 홀수 버전까지 추적해 기각), `yarn 1.22.22`(yarn classic v1 계열을 쓰는 외부 프로젝트 고정), `gitleaks 8.30.0`(양 머신 기존값 유지 — nix devShell과의 이중 관리 정리는 #890 비목표대로 별도 검토).

## 참고 레퍼런스

- #814 — codex mise npm backend 전환 (config nix 생성 대안 기각 이력)
- #890 / #893 — codex nix overlay 이관 (config entry 제거를 수동 단계로 남김)
- #145 — NixOS mise prebuilt 강제 (`MISE_NODE_COMPILE=0`)

## Human Test Plan

**Mac (이번 세션에서 검증 완료)**
1. `nrs` → 성공 (99s). 기존 regular file은 home-manager backup 정책이 처리.
2. `ls -la ~/.config/mise/config.toml` → nix store symlink 확인됨.
3. `mise current` → `node 24.15.0 / pnpm 10.30.3 / yarn 1.22.22 / gitleaks 8.30.0`, `node --version` 정상.
4. drift 가드: `mise use -g biome@latest` → `Permission denied (os error 13)`로 실패 확인됨 (의도된 동작).

**MiniPC (머지 후 배포 시)**
1. `git pull` 후 `nrs` → 성공 확인. 기존 regular file은 `backupFileExtension = "backup"`(flake.nix)이 `config.toml.backup`으로 자동 백업한다 — 수동 조치 불필요.
2. `mise current` → codex entry 소멸, node lts/pnpm/yarn/gitleaks만 노출.
3. 다음 activation에서 `cleanupMiseCodexShim`이 잔존 설치본(`~/.local/share/mise/installs/npm-openai-codex/`)을 제거하는지 확인 (nrs 로그에 "Removing stale mise codex backend install" 라인).
4. 실패 시 진단: activation이 기존 `config.toml.backup` 존재로 중단되면 그 백업 파일을 정리 후 재실행.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - macOS/ NixOS Home Manager에서 mise 전역 설정을 단일 소스(Sot)로 관리하고, 전역 설정 직접 변경은 제한됩니다.
  - 전역 기본 도구 버전(Node LTS, pnpm latest, Yarn Classic, gitleaks)을 제공합니다.
  - `.nvmrc`/`.node-version` 같은 idiomatic 버전 파일을 node에 대해 자동 인식합니다.
- **문서**
  - 전역/프로젝트 버전 변경 및 `trust`(최초 1회, worktree별 추가) 절차를 갱신했습니다.
  - NixOS node 설치/빌드 실패 대응 커맨드와 설정 근거를 수정했습니다.
  - Codex shim 정리 및 설정/배포 시 소멸 범위 설명을 정정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
