### PR TITLE
feat(wt): worktree bootstrap에 mise config 자동 trust 추가

### DIFF
--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -39,7 +39,23 @@ _bootstrap_worktree() {
   fi
 
   _wt_trust_codex_project "$wt_path"
+  _wt_trust_mise_configs "$wt_path"
   _wt_inherit_claude_local_plugins "$wt_path" "$git_root"
+}
+
+# mise trust는 config 파일 경로 기준이라 원본 repo에서 한 trust가 worktree로
+# 승계되지 않는다. 미신뢰로 두면 worktree의 mise 도구 호출이 막혀, 세션들이
+# 명령마다 `mise trust`를 방어적으로 앞세우는 낭비가 반복 관측됐다 (2026-07
+# 전수조사). mise 부재·trust 실패는 non-fatal — worktree 생성을 막지 않는다.
+_wt_trust_mise_configs() {
+  local wt_path="$1"
+  command -v mise > /dev/null 2>&1 || return 0
+  local cfg
+  for cfg in mise.toml .mise.toml mise.local.toml .mise.local.toml; do
+    [[ -f "$wt_path/$cfg" ]] || continue
+    mise trust "$wt_path/$cfg" > /dev/null 2>&1 \
+      || _warn "mise trust 실패: $cfg — 필요 시 worktree에서 수동 mise trust"
+  done
 }
 
 _wt_prepare_claude_settings() {

--- a/modules/shared/scripts/lib/wt/bootstrap.sh
+++ b/modules/shared/scripts/lib/wt/bootstrap.sh
@@ -43,19 +43,45 @@ _bootstrap_worktree() {
   _wt_inherit_claude_local_plugins "$wt_path" "$git_root"
 }
 
-# mise trust는 config 파일 경로 기준이라 원본 repo에서 한 trust가 worktree로
-# 승계되지 않는다. 미신뢰로 두면 worktree의 mise 도구 호출이 막혀, 세션들이
-# 명령마다 `mise trust`를 방어적으로 앞세우는 낭비가 반복 관측됐다 (2026-07
-# 전수조사). mise 부재·trust 실패는 non-fatal — worktree 생성을 막지 않는다.
+# mise trust는 경로 기준이라 원본 repo에서 한 trust가 worktree로 승계되지 않는다
+# (구버전 기준; 2026.x는 일반 모드에서 worktree 공유하나 paranoid·구버전은 비공유).
+# 미신뢰로 두면 worktree의 mise 도구 호출이 막혀, 세션들이 명령마다 `mise trust`를
+# 방어적으로 앞세우는 낭비가 반복 관측됐다 (2026-07 전수조사).
+# mise 부재·trust 실패는 non-fatal — worktree 생성을 막지 않는다.
 _wt_trust_mise_configs() {
   local wt_path="$1"
   command -v mise > /dev/null 2>&1 || return 0
-  local cfg
-  for cfg in mise.toml .mise.toml mise.local.toml .mise.local.toml; do
-    [[ -f "$wt_path/$cfg" ]] || continue
-    mise trust "$wt_path/$cfg" > /dev/null 2>&1 \
-      || _warn "mise trust 실패: $cfg — 필요 시 worktree에서 수동 mise trust"
+
+  # paranoid 모드는 config 내용 변경마다 수동 재승인이 설계 의도다 — 자동 trust로
+  # 그 보안 경계를 우회하지 않는다 (https://mise.jdx.dev/paranoid.html).
+  if [[ "${MISE_PARANOID:-0}" == "1" ]] \
+    || [[ "$(mise settings get paranoid 2> /dev/null)" == "true" ]]; then
+    _warn "mise paranoid mode 감지 — 자동 trust 생략 (필요 시 worktree에서 수동 mise trust)"
+    return 0
+  fi
+
+  # mise가 탐색하는 config 후보를 훑어 (1) 존재 여부 (2) symlink 여부를 본다.
+  # symlink config는 worktree 밖 파일을 trust/파싱 대상으로 끌어들일 수 있으므로
+  # (.codex 복사의 symlink 거부와 동일 원칙) 자동 trust를 생략한다.
+  local cfg found=0
+  for cfg in "$wt_path"/mise*.toml "$wt_path"/.mise*.toml \
+    "$wt_path"/mise/config.toml "$wt_path"/.mise/config.toml \
+    "$wt_path"/.config/mise.toml "$wt_path"/.config/mise/config*.toml \
+    "$wt_path"/.config/mise/conf.d/*.toml; do
+    [[ -e "$cfg" || -L "$cfg" ]] || continue
+    if [[ -L "$cfg" ]]; then
+      _warn "worktree mise config가 symlink라 자동 trust를 생략합니다: ${cfg#"$wt_path"/}"
+      return 0
+    fi
+    found=1
   done
+  [[ "$found" == "1" ]] || return 0
+
+  # 인자 없는 `mise trust`는 디렉토리 단위 trust다 — mise가 지원하는 모든 config 경로
+  # (mise.toml, .config/mise/config.toml, conf.d/*.toml, local 변형)를 한 번에 커버한다
+  # (실측: trust 후 `mise config ls`가 전부 파싱됨). `--all`과 달리 parents는 trust하지 않는다.
+  (cd "$wt_path" && mise trust > /dev/null 2>&1) \
+    || _warn "mise trust 실패 — 필요 시 worktree에서 수동 mise trust"
 }
 
 _wt_prepare_claude_settings() {

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -61,6 +61,9 @@ run_test "wt create supports valid Codex projects shapes" test_wt_create_support
 run_test "wt create preserves unmergeable Codex config" test_wt_create_preserves_unmergeable_codex_config
 run_test "wt create trusts worktree mise configs" test_wt_create_trusts_mise_configs
 run_test "wt create survives mise trust failure" test_wt_create_mise_trust_failure_is_nonfatal
+run_test "wt create skips mise trust in paranoid env" test_wt_create_mise_paranoid_skips_auto_trust
+run_test "wt create skips mise trust with paranoid setting" test_wt_create_mise_paranoid_setting_skips_auto_trust
+run_test "wt create skips mise trust for symlinked config" test_wt_create_mise_symlink_config_skips_auto_trust
 run_test "wt create inherits Claude local plugin manifest" test_wt_create_inherits_claude_local_plugin_manifest
 run_test "wt create ignores branch-tracked plugin settings" test_wt_create_ignores_branch_tracked_plugin_settings
 run_test "wt plugin manifest ignores noncanonical adjacent lock directory" test_wt_plugin_manifest_ignores_noncanonical_adjacent_lock_directory

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -59,6 +59,8 @@ run_test "wt create trusts Codex project config" test_wt_create_trusts_codex_pro
 run_test "wt create skips unsafe Codex config path" test_wt_create_skips_unsafe_codex_config
 run_test "wt create supports valid Codex projects shapes" test_wt_create_supports_valid_projects_shapes
 run_test "wt create preserves unmergeable Codex config" test_wt_create_preserves_unmergeable_codex_config
+run_test "wt create trusts worktree mise configs" test_wt_create_trusts_mise_configs
+run_test "wt create survives mise trust failure" test_wt_create_mise_trust_failure_is_nonfatal
 run_test "wt create inherits Claude local plugin manifest" test_wt_create_inherits_claude_local_plugin_manifest
 run_test "wt create ignores branch-tracked plugin settings" test_wt_create_ignores_branch_tracked_plugin_settings
 run_test "wt plugin manifest ignores noncanonical adjacent lock directory" test_wt_plugin_manifest_ignores_noncanonical_adjacent_lock_directory

--- a/tests/suites/wt-create-mise.sh
+++ b/tests/suites/wt-create-mise.sh
@@ -1,0 +1,107 @@
+# tests/suites/wt-create-mise.sh — 도메인 테스트 정의 (sourced; aggregator가 lib/test-common.sh 후 source)
+# shellcheck shell=bash
+# SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
+# shellcheck disable=SC2154,SC2164
+
+# fixture repo에 파일을 추가 커밋한다 (create_git_fixture_repo와 동일한 격리 가드).
+_mise_fixture_commit() {
+  local repo_root="$1" home_dir="$2"
+  shift 2
+  HOME="$home_dir" \
+    XDG_CONFIG_HOME="$home_dir/.config" \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_NOSYSTEM=1 \
+    git -C "$repo_root" \
+    -c core.hooksPath=/dev/null \
+    -c commit.gpgSign=false \
+    "$@"
+}
+
+# stub mise를 설치한다: trust 호출을 marker에 기록하고 MISE_STUB_EXIT로 종료.
+_install_mise_stub() {
+  local stub_dir="$1"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/mise" << 'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "trust" ]]; then
+  printf 'trust:%s\n' "${2:-}" >> "${MISE_TRUST_MARKER:?}"
+fi
+exit "${MISE_STUB_EXIT:-0}"
+EOF
+  chmod +x "$stub_dir/mise"
+}
+
+test_wt_create_trusts_mise_configs() {
+  local sandbox home_dir repo_root stub_dir marker_file output new_worktree
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stub-bin"
+  marker_file="$sandbox/mise-trust-marker"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  _install_mise_stub "$stub_dir"
+
+  printf '[tools]\nnode = "22"\n' > "$repo_root/mise.toml"
+  _mise_fixture_commit "$repo_root" "$home_dir" add mise.toml
+  _mise_fixture_commit "$repo_root" "$home_dir" commit -m "add mise.toml" > /dev/null 2>&1
+
+  output=$(
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
+      MISE_TRUST_MARKER="$marker_file" \
+      WT_NONINTERACTIVE=1 \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" feature-mise-trust
+      ' 2>&1
+  )
+
+  new_worktree="$repo_root/.claude/worktrees/feature-mise-trust"
+  [[ -d "$new_worktree" ]] || fail "expected worktree directory to exist: $new_worktree"
+  assert_contains "$output" "$new_worktree"
+  [[ -f "$marker_file" ]] || fail "expected mise trust to be called for worktree mise.toml"
+  assert_contains "$(cat "$marker_file")" "trust:$new_worktree/mise.toml"
+}
+
+test_wt_create_mise_trust_failure_is_nonfatal() {
+  local sandbox home_dir repo_root stub_dir marker_file output new_worktree
+  sandbox=$(new_sandbox)
+  home_dir="$sandbox/home"
+  repo_root="$sandbox/repo"
+  stub_dir="$sandbox/stub-bin"
+  marker_file="$sandbox/mise-trust-marker"
+
+  create_git_fixture_repo "$repo_root"
+  repo_root="$(cd "$repo_root" && pwd -P)"
+  install_deployed_layout "$sandbox" "$repo_root"
+  _install_mise_stub "$stub_dir"
+
+  printf '[tools]\nnode = "22"\n' > "$repo_root/mise.toml"
+  _mise_fixture_commit "$repo_root" "$home_dir" add mise.toml
+  _mise_fixture_commit "$repo_root" "$home_dir" commit -m "add mise.toml" > /dev/null 2>&1
+
+  output=$(
+    env -u TMUX \
+      HOME="$home_dir" \
+      PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
+      MISE_TRUST_MARKER="$marker_file" \
+      MISE_STUB_EXIT=1 \
+      WT_NONINTERACTIVE=1 \
+      bash -c '
+        set -euo pipefail
+        cd "'"$repo_root"'"
+        "'"$home_dir/.local/bin/wt"'" feature-mise-fail
+      ' 2>&1
+  )
+
+  new_worktree="$repo_root/.claude/worktrees/feature-mise-fail"
+  [[ -d "$new_worktree" ]] || fail "worktree creation must survive mise trust failure: $new_worktree"
+  assert_contains "$output" "$new_worktree"
+  assert_contains "$output" "mise trust 실패"
+}

--- a/tests/suites/wt-create-mise.sh
+++ b/tests/suites/wt-create-mise.sh
@@ -3,8 +3,8 @@
 # SC2154: 공통 변수는 aggregator/test-common이 정의. SC2164: set -euo pipefail 런타임 상속.
 # shellcheck disable=SC2154,SC2164
 
-# fixture repo에 파일을 추가 커밋한다 (create_git_fixture_repo와 동일한 격리 가드).
-_mise_fixture_commit() {
+# 격리된 환경(fixture HOME, 전역 git config 차단)에서 fixture repo의 Git 명령을 실행한다.
+_mise_fixture_git() {
   local repo_root="$1" home_dir="$2"
   shift 2
   HOME="$home_dir" \
@@ -17,28 +17,40 @@ _mise_fixture_commit() {
     "$@"
 }
 
-# stub mise를 설치한다: trust 호출을 marker에 기록하고 MISE_STUB_EXIT로 종료.
+# stub mise: trust 호출(인자 없는 디렉토리 trust — cwd 기록)을 marker에 남기고
+# MISE_STUB_EXIT로 종료. settings get paranoid는 MISE_STUB_PARANOID를 반환.
 _install_mise_stub() {
   local stub_dir="$1"
   mkdir -p "$stub_dir"
   cat > "$stub_dir/mise" << 'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "trust" ]]; then
-  printf 'trust:%s\n' "${2:-}" >> "${MISE_TRUST_MARKER:?}"
-fi
-exit "${MISE_STUB_EXIT:-0}"
+case "${1:-}" in
+  trust)
+    printf 'trust:%s\n' "$PWD" >> "${MISE_TRUST_MARKER:?}"
+    exit "${MISE_STUB_EXIT:-0}"
+    ;;
+  settings)
+    echo "${MISE_STUB_PARANOID:-false}"
+    ;;
+esac
+exit 0
 EOF
   chmod +x "$stub_dir/mise"
 }
 
-test_wt_create_trusts_mise_configs() {
-  local sandbox home_dir repo_root stub_dir marker_file output new_worktree
+# 공통 준비: sandbox + fixture repo(+mise.toml 커밋) + stub 설치 후 wt create 실행.
+# 인자: <branch> [extra env KEY=VALUE ...]. 전역 출력 변수:
+#   _MISE_WT_OUTPUT(실행 출력), _MISE_WT_PATH(생성 worktree 경로), _MISE_WT_MARKER(marker 파일).
+_run_wt_create_with_mise_stub() {
+  local branch="$1"
+  shift
+  local sandbox home_dir repo_root stub_dir
   sandbox=$(new_sandbox)
   home_dir="$sandbox/home"
   repo_root="$sandbox/repo"
   stub_dir="$sandbox/stub-bin"
-  marker_file="$sandbox/mise-trust-marker"
+  _MISE_WT_MARKER="$sandbox/mise-trust-marker"
 
   create_git_fixture_repo "$repo_root"
   repo_root="$(cd "$repo_root" && pwd -P)"
@@ -46,62 +58,97 @@ test_wt_create_trusts_mise_configs() {
   _install_mise_stub "$stub_dir"
 
   printf '[tools]\nnode = "22"\n' > "$repo_root/mise.toml"
-  _mise_fixture_commit "$repo_root" "$home_dir" add mise.toml
-  _mise_fixture_commit "$repo_root" "$home_dir" commit -m "add mise.toml" > /dev/null 2>&1
+  _mise_fixture_git "$repo_root" "$home_dir" add mise.toml
+  _mise_fixture_git "$repo_root" "$home_dir" commit -m "add mise.toml" > /dev/null 2>&1
 
-  output=$(
+  _MISE_WT_OUTPUT=$(
     env -u TMUX \
       HOME="$home_dir" \
       PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
-      MISE_TRUST_MARKER="$marker_file" \
+      MISE_TRUST_MARKER="$_MISE_WT_MARKER" \
       WT_NONINTERACTIVE=1 \
+      "$@" \
       bash -c '
         set -euo pipefail
         cd "'"$repo_root"'"
-        "'"$home_dir/.local/bin/wt"'" feature-mise-trust
+        "'"$home_dir/.local/bin/wt"'" "'"$branch"'"
       ' 2>&1
   )
+  _MISE_WT_PATH="$repo_root/.claude/worktrees/$branch"
+}
 
-  new_worktree="$repo_root/.claude/worktrees/feature-mise-trust"
-  [[ -d "$new_worktree" ]] || fail "expected worktree directory to exist: $new_worktree"
-  assert_contains "$output" "$new_worktree"
-  [[ -f "$marker_file" ]] || fail "expected mise trust to be called for worktree mise.toml"
-  assert_contains "$(cat "$marker_file")" "trust:$new_worktree/mise.toml"
+test_wt_create_trusts_mise_configs() {
+  local _MISE_WT_OUTPUT _MISE_WT_PATH _MISE_WT_MARKER
+  _run_wt_create_with_mise_stub feature-mise-trust
+
+  [[ -d "$_MISE_WT_PATH" ]] || fail "expected worktree directory to exist: $_MISE_WT_PATH"
+  assert_contains "$_MISE_WT_OUTPUT" "$_MISE_WT_PATH"
+  [[ -f "$_MISE_WT_MARKER" ]] || fail "expected directory-level mise trust to run in the worktree"
+  assert_contains "$(cat "$_MISE_WT_MARKER")" "trust:$_MISE_WT_PATH"
 }
 
 test_wt_create_mise_trust_failure_is_nonfatal() {
-  local sandbox home_dir repo_root stub_dir marker_file output new_worktree
+  local _MISE_WT_OUTPUT _MISE_WT_PATH _MISE_WT_MARKER
+  _run_wt_create_with_mise_stub feature-mise-fail MISE_STUB_EXIT=1
+
+  [[ -d "$_MISE_WT_PATH" ]] || fail "worktree creation must survive mise trust failure: $_MISE_WT_PATH"
+  assert_contains "$_MISE_WT_OUTPUT" "$_MISE_WT_PATH"
+  assert_contains "$_MISE_WT_OUTPUT" "mise trust 실패"
+}
+
+test_wt_create_mise_paranoid_skips_auto_trust() {
+  local _MISE_WT_OUTPUT _MISE_WT_PATH _MISE_WT_MARKER
+  _run_wt_create_with_mise_stub feature-mise-paranoid MISE_PARANOID=1
+
+  [[ -d "$_MISE_WT_PATH" ]] || fail "worktree creation must succeed in paranoid mode: $_MISE_WT_PATH"
+  assert_contains "$_MISE_WT_OUTPUT" "paranoid"
+  [[ ! -f "$_MISE_WT_MARKER" ]] || fail "paranoid mode must not auto-trust: $(cat "$_MISE_WT_MARKER")"
+}
+
+test_wt_create_mise_paranoid_setting_skips_auto_trust() {
+  local _MISE_WT_OUTPUT _MISE_WT_PATH _MISE_WT_MARKER
+  _run_wt_create_with_mise_stub feature-mise-paranoid-set MISE_STUB_PARANOID=true
+
+  [[ -d "$_MISE_WT_PATH" ]] || fail "worktree creation must succeed with paranoid=true: $_MISE_WT_PATH"
+  assert_contains "$_MISE_WT_OUTPUT" "paranoid"
+  [[ ! -f "$_MISE_WT_MARKER" ]] || fail "paranoid setting must not auto-trust: $(cat "$_MISE_WT_MARKER")"
+}
+
+test_wt_create_mise_symlink_config_skips_auto_trust() {
+  local _MISE_WT_OUTPUT _MISE_WT_PATH _MISE_WT_MARKER
+  local sandbox home_dir repo_root stub_dir outside
   sandbox=$(new_sandbox)
   home_dir="$sandbox/home"
   repo_root="$sandbox/repo"
   stub_dir="$sandbox/stub-bin"
-  marker_file="$sandbox/mise-trust-marker"
+  outside="$sandbox/outside.toml"
+  _MISE_WT_MARKER="$sandbox/mise-trust-marker"
 
   create_git_fixture_repo "$repo_root"
   repo_root="$(cd "$repo_root" && pwd -P)"
   install_deployed_layout "$sandbox" "$repo_root"
   _install_mise_stub "$stub_dir"
 
-  printf '[tools]\nnode = "22"\n' > "$repo_root/mise.toml"
-  _mise_fixture_commit "$repo_root" "$home_dir" add mise.toml
-  _mise_fixture_commit "$repo_root" "$home_dir" commit -m "add mise.toml" > /dev/null 2>&1
+  printf '[env]\nEVIL = "1"\n' > "$outside"
+  ln -s "$outside" "$repo_root/mise.toml"
+  _mise_fixture_git "$repo_root" "$home_dir" add mise.toml
+  _mise_fixture_git "$repo_root" "$home_dir" commit -m "add symlinked mise.toml" > /dev/null 2>&1
 
-  output=$(
+  _MISE_WT_OUTPUT=$(
     env -u TMUX \
       HOME="$home_dir" \
       PATH="$stub_dir:$FIXTURE_DIR/bin:$PATH" \
-      MISE_TRUST_MARKER="$marker_file" \
-      MISE_STUB_EXIT=1 \
+      MISE_TRUST_MARKER="$_MISE_WT_MARKER" \
       WT_NONINTERACTIVE=1 \
       bash -c '
         set -euo pipefail
         cd "'"$repo_root"'"
-        "'"$home_dir/.local/bin/wt"'" feature-mise-fail
+        "'"$home_dir/.local/bin/wt"'" feature-mise-symlink
       ' 2>&1
   )
+  _MISE_WT_PATH="$repo_root/.claude/worktrees/feature-mise-symlink"
 
-  new_worktree="$repo_root/.claude/worktrees/feature-mise-fail"
-  [[ -d "$new_worktree" ]] || fail "worktree creation must survive mise trust failure: $new_worktree"
-  assert_contains "$output" "$new_worktree"
-  assert_contains "$output" "mise trust 실패"
+  [[ -d "$_MISE_WT_PATH" ]] || fail "worktree creation must succeed with symlinked config: $_MISE_WT_PATH"
+  assert_contains "$_MISE_WT_OUTPUT" "symlink"
+  [[ ! -f "$_MISE_WT_MARKER" ]] || fail "symlinked config must not be auto-trusted: $(cat "$_MISE_WT_MARKER")"
 }


### PR DESCRIPTION
## Summary

- `wt` worktree 생성/재생성 bootstrap에 worktree 내 mise config(`mise.toml`/`.mise.toml`/`mise.local.toml`/`.mise.local.toml`) 자동 `mise trust` 단계를 추가한다.
- 세션 로그 전수조사에서 관측된 "worktree마다 명령 앞에 방어적 `mise trust`를 반복하는" 낭비(관련 흔적 360회)를 생성 시점 1회 처리로 종결한다.

## 기존 문제/배경

mise의 trust는 config 파일 경로 기준이라, 원본 repo에서 한 trust가 worktree 경로의 동일 파일로 승계되지 않는다. 그 결과:

- worktree에서 mise 도구(node/pnpm 등) 첫 호출이 미신뢰 config로 막히고, 비대화형(LLM) 셸에서는 trust 프롬프트도 불가능해 에러로만 나타난다.
- 세션 로그 전수조사(이번 세션)에서, mise.toml을 쓰는 프로젝트의 세션들이 사실상 모든 명령 앞에 `mise trust 2>&1 | tail -1 && <실제 명령>` 형태의 방어 코드를 붙이는 패턴이 반복 확인됐다.
- `wt` bootstrap은 이미 Codex 전역 config에 worktree project trust를 등록하고 있어(#1073 계열), mise trust는 같은 자리의 자연스러운 확장이다.

## CIR (Change Intent Record)

- 전수조사 결론(이번 세션)에서 worktree cwd가 mise 마찰 4대 경계면 중 하나로 확인됨 — 프로젝트 config 미신뢰/미활성으로 도구가 비결정적으로 실패하고, 대화형 성공 경험이 진단을 지연시킨다.
- 처리 위치는 wt bootstrap으로 결정 — trust가 필요한 시점이 정확히 worktree 생성 직후이고, Codex trust 등록이라는 동형 선례가 같은 함수에 있다.

**trade-off**: bootstrap이 mise 명령을 1회 호출하게 된다. #814→#890의 "activation에서 mise 실행 금지" 교훈과 구분되는 점 — 여기는 home-manager activation의 제한 PATH가 아니라 사용자 셸 PATH를 상속한 wt 실행 컨텍스트이고, `trust`는 버전 resolve 없이 파일 등록만 하는 경량 서브커맨드다. 그래도 mise 부재·실패는 non-fatal로 감싸 worktree 생성을 절대 막지 않는다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| wt bootstrap에서 자동 trust | 생성 시점 1회 처리 | 마찰 원천 제거, Codex trust와 동형 | bootstrap이 mise 1회 호출 | ✅ |
| 문서/규약으로만 안내 | "worktree에서는 mise trust 먼저" | 코드 변경 0 | 세션마다 재발견 비용, 이미 실패가 실증된 상태 유지 | ❌ |
| `mise settings trusted_config_paths`에 worktree 루트 등록 | 경로 전체 신뢰 | 파일별 trust 불필요 | 전역 config는 nix 선언(read-only, #1159)이라 동적 등록 불가 + 과잉 신뢰 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/scripts/lib/wt/bootstrap.sh` | `_wt_trust_mise_configs` 신설 — worktree의 mise config 4종을 파일별 `mise trust`, mise 부재 시 skip, 실패 시 warn 후 계속 |
| `tests/suites/wt-create-mise.sh` | 신규 suite — stub mise + marker 파일로 (1) worktree mise.toml trust 호출 검증 (2) trust 실패 시 worktree 생성 생존 검증 |
| `tests/shell-script-tests.sh` | 신규 테스트 2건 등록 |

## 참고 레퍼런스

- #1159 — mise 전역 config nix 선언화 (같은 전수조사에서 파생된 자매 PR; trusted_config_paths 대안 기각 근거)
- #1160 — LLM용 mise 규약 명문화 (스킬 문서의 "worktree cwd 경계면" 행이 본 PR의 자동화를 전제)
- #814 / #890 — activation 컨텍스트에서의 mise 실행 금지 교훈 (본 PR의 실행 컨텍스트 구분 근거)

## Human Test Plan

1. `wt <임의-브랜치>`로 worktree 생성 (이 repo는 mise.toml이 없으므로 no-op — 에러 없이 생성되는지만 확인).
2. mise.toml이 있는 프로젝트에서 `wt <브랜치>` 생성 후, worktree에서 `mise current` 실행 → trust 프롬프트/에러 없이 즉시 버전이 출력되는지 확인.
3. `mise trust --show`(worktree cwd에서) → worktree의 mise.toml이 trusted로 표시되는지 확인.
4. 회귀 확인: `bash tests/run-shell-script-tests.sh` → 전체 통과 (이번 세션 실측: 220 통과 / 0 실패).
5. 실패 시 진단: trust가 안 됐다면 wt 출력에서 "mise trust 실패" warn 여부 확인 — warn이 있으면 mise 버전의 trust CLI 계약 변화(`mise trust --help`) 확인.
