### PR TITLE
fix(private-job-runner): schedule 경로 이중 슬래시로 canonical 검증 오탐

### DIFF
--- a/modules/nixos/programs/private-job-runner/sync.sh
+++ b/modules/nixos/programs/private-job-runner/sync.sh
@@ -112,7 +112,10 @@ if [ -d "$JOBS_ROOT" ]; then
         job_error "$slug" "$violation"
         continue
       fi
-      schedule_file="$job_dir/schedule"
+      # job_dir는 glob("$JOBS_ROOT"/*/)에서 와 트레일링 슬래시를 포함한다 — 그대로
+      # 이어 붙이면 "…//schedule"이 되고, realpath 정규화(단일 슬래시)와 달라져
+      # canonical 검증이 정상 경로를 오탐 거부한다 (실기기 발현).
+      schedule_file="${job_dir%/}/schedule"
       # schedule도 실행 계약의 입력이다 — run.sh와 같은 소유·링크·권한 기준을 요구한다.
       violation="$(path_violation_reason "$schedule_file" "schedule" f 022)"
       if [ -n "$violation" ]; then


### PR DESCRIPTION
## Summary
- `sync.sh`의 `schedule_file="$job_dir/schedule"`에서 `job_dir`가 glob 트레일링 슬래시를 포함해 `…//schedule`이 되고, `path_violation_reason`의 canonical 검증(`realpath(path) != path`)이 정상 schedule을 **오탐 거부** — 실기기 sync에서 `schedule resolves outside its declared path`로 전 job 등록 실패
- job directory 검증이 이미 쓰는 `${job_dir%/}` 정규화를 schedule 조립에도 적용

## 재현
```bash
d="/path/jobs/myjob/"           # glob 결과 (트레일링 슬래시)
bad="$d/schedule"               # → /path/jobs/myjob//schedule
[ "$(realpath "$bad")" != "$bad" ]  # true — canonical 불일치 → 오탐
```

## Human Test Plan
1. 실기기: `systemctl --user start private-jobs-sync.service` → `sync ok: N job(s)`, timer 등록 확인
2. `journalctl --user -u private-jobs-sync`에 schedule 오류 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 작업 디렉터리 경로에 불필요한 후행 슬래시가 포함된 경우에도 일정 파일을 올바르게 찾고 검증하도록 개선했습니다.
  * 일정 실행 계약 및 형식 검증이 다양한 경로 형식에서 일관되게 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->