### PR TITLE
perf(nixos): 셸 startup 최적화 — 이중 compinit + 사문 promptinit 제거

### DIFF
--- a/modules/nixos/configuration.nix
+++ b/modules/nixos/configuration.nix
@@ -82,6 +82,28 @@
   # Zsh 활성화
   programs.zsh.enable = true;
 
+  # 셸 startup 최적화 — NixOS /etc/zshrc가 매 인터랙티브 셸에 emit하는 중복/사문 작업 제거.
+  # darwin(modules/darwin/configuration.nix)과 같은 병리를 이 호스트에서도 실측 확인해 이식했다.
+  # === Change Intent Record ===
+  # 실측(NixOS 호스트):
+  #   (1) 이중 compinit: 시스템 /etc/zshrc:42의 `autoload -U compinit && compinit`과
+  #       사용자 ~/.zshrc:53(home-manager)의 compinit이 셸당 둘 다 실행된다. 두 compinit이
+  #       같은 ~/.zcompdump를 두고 콜드 재빌드(fpath 전수 감사)를 반복한다.
+  #   (2) prompt suse: /etc/zshrc:66의 `promptinit && prompt suse`가 로드되지만 Starship이
+  #       PROMPT/precmd를 전부 덮어써 100% 사문(dead work)이다.
+  # enableGlobalCompInit=false: 시스템 compinit을 제거해 사용자 compinit을 단일 정본으로 만든다.
+  #   단일 compinit은 ~/.zcompdump가 신선하면 로드만 하고, fpath 변경 시 자동 재빌드하며
+  #   compaudit(보안 감사)도 유지한다.
+  # promptInit="": Starship이 덮어쓰는 prompt suse 로드를 제거(프롬프트 동작 불변).
+  # Trade-off (darwin과 다른 점 — 이 호스트 실측 기준): 시스템 compinit 제거는 사용자 ~/.zshrc를
+  #   source하지 않는 zsh 셸에서 compinit 0회를 뜻한다. darwin에서는 root의 zsh 사용 가능성을
+  #   우려했으나, 이 호스트는 root 로그인 셸이 bash이고 /root/.zshrc도 없어 해당 셸이 존재하지
+  #   않는다. 로그인 가능한 일반 사용자도 1명(zsh)뿐이며 그 세션은 home-manager compinit을 탄다.
+  #   enableBashCompletion은 정상 세션의 bash `complete` 기반 completion 호환을 위해 유지한다.
+  #   root가 zsh를 쓰게 되거나 zsh 사용자가 추가되면 이 전제를 재확인한다.
+  programs.zsh.enableGlobalCompInit = false;
+  programs.zsh.promptInit = "";
+
   # 로그 용량 제한 (컨테이너 포함 전체 시스템 로그)
   services.journald.extraConfig = ''
     SystemMaxUse=2G

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -1022,9 +1022,16 @@ let
         # builtins.match는 전체-문자열 앵커(부분 매치 아님)라 .* 래핑이 필요하고, POSIX ERE의 `.`은
         # newline을 매치하지 않아 completionInit이 멀티라인이면 전체 매치가 실패하므로 newline을
         # 공백으로 평탄화한다(현 HM 기본값은 단일 라인이라 평탄화는 방어적 no-op).
+        #
+        # `compinit` 부분 문자열이 아니라 초기화 시퀀스 전체를 요구한다. 부분 문자열만 보면
+        # `# compinit은 나중에` 같은 주석이나 compinit을 실제로 호출하지 않는 값도 통과해,
+        # "사용자 compinit이 단일 정본으로 살아있다"는 이 테스트의 불변식이 헐거워진다.
+        # 현 HM 기본값(실측: `autoload -U compinit && compinit`)과 정확히 대응하며, 업스트림이
+        # 이 시퀀스를 바꾸면 의도대로 여기서 먼저 깨져 재검토를 강제한다.
         &&
-          builtins.match ".*compinit.*" (builtins.replaceStrings [ "\n" ] [ " " ] hmZsh.completionInit)
-          != null;
+          builtins.match ".*autoload -U compinit && compinit.*" (
+            builtins.replaceStrings [ "\n" ] [ " " ] hmZsh.completionInit
+          ) != null;
     }
   ]
   ++ [

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -990,6 +990,42 @@ let
       name = "Test 7a: Tailscale useRoutingFeatures가 server이어야 함 (exit node 방지)";
       cond = nixosCfg.services.tailscale.useRoutingFeatures == "server";
     }
+    # 셸 startup 최적화 회귀 lock — modules/nixos/configuration.nix.
+    # darwin D10-D12와 같은 불변식 쌍을 NixOS에도 잠근다. 타이밍이 아닌 config-level만 검증
+    # (결정론적, 부하 무관). 이 호스트 실측으로 동일 병리를 확인했다: /etc/zshrc의 compinit이
+    # home-manager 사용자 compinit과 중복 실행되고, prompt suse는 Starship이 덮어써 사문이다.
+    {
+      name = "Test 8a: NixOS 시스템 compinit 중복 제거 — enableGlobalCompInit이 false여야 함";
+      cond = nixosCfg.programs.zsh.enableGlobalCompInit == false;
+    }
+    {
+      name = "Test 8b: NixOS 사문 promptinit 제거 — promptInit이 빈 문자열이어야 함 (Starship이 프롬프트를 덮어씀)";
+      cond = nixosCfg.programs.zsh.promptInit == "";
+    }
+    {
+      # 8a가 시스템 compinit을 제거하므로 사용자 compinit이 유일 정본이 되어야 한다.
+      # 부정 불변식(8a)과 긍정 불변식(이 테스트)을 한 쌍으로 잠가 단일-정본 추상화를 보호한다.
+      # 검증 대상 enableCompletion/completionInit은 이 repo가 명시 설정하지 않고 home-manager
+      # 업스트림 기본값에 의존한다 — repo를 grep해도 설정이 안 나오는 이유다. 깨지면
+      # (enableCompletion=false / oh-my-zsh·prezto 도입 / 업스트림 변경) 이 호스트의 셸 completion이
+      # 전면 사망하므로 framework 기본값을 의도적으로 잠근다.
+      name = "Test 8c: NixOS 시스템 compinit 제거의 짝 — 사용자(home-manager) compinit이 단일 정본으로 존재해야 함";
+      cond =
+        let
+          # NixOS에는 darwin의 system.primaryUser 옵션이 없으므로 home-manager.users의 실제 키를
+          # 사용한다(이 호스트는 사용자 1명 — 늘어나면 이 단언이 먼저 깨져 재검토를 강제한다).
+          hmUsers = builtins.attrNames nixosCfg.home-manager.users;
+          hmZsh = nixosCfg.home-manager.users.${builtins.head hmUsers}.programs.zsh;
+        in
+        builtins.length hmUsers == 1
+        && hmZsh.enableCompletion
+        # builtins.match는 전체-문자열 앵커(부분 매치 아님)라 .* 래핑이 필요하고, POSIX ERE의 `.`은
+        # newline을 매치하지 않아 completionInit이 멀티라인이면 전체 매치가 실패하므로 newline을
+        # 공백으로 평탄화한다(현 HM 기본값은 단일 라인이라 평탄화는 방어적 no-op).
+        &&
+          builtins.match ".*compinit.*" (builtins.replaceStrings [ "\n" ] [ " " ] hmZsh.completionInit)
+          != null;
+    }
   ]
   ++ [
     {


### PR DESCRIPTION
## Summary

- NixOS에서도 이중 `compinit`과 사문 `promptinit`을 제거해 매 인터랙티브 셸의 중복/사문 작업을 없앤다 (darwin에 이미 적용된 최적화의 이식).
- 이슈가 요구한 실측을 수행해 **동일 병리를 확인**했고, NixOS 특유의 multi-user trade-off도 실측으로 판정했다.
- 회귀 lock으로 eval-test 3건(부정/긍정 짝)을 추가한다.

Closes #896

## 기존 문제/배경

이 저장소는 darwin에서 `programs.zsh.enableGlobalCompInit = false` / `promptInit = ""`를 적용하고 회귀 테스트(D10-D12)로 잠갔지만, NixOS 쪽에는 같은 설정도 테스트도 없었다. 이슈는 "NixOS도 같은 문제를 겪는지 미확인"을 명시하며 실측을 선행 조건으로 걸었다.

### 실측 결과 (이슈 Remaining work 1)

| 항목 | 관측 |
|---|---|
| 시스템 compinit | `/etc/zshrc:42` — `autoload -U compinit && compinit` |
| 사용자 compinit | `~/.zshrc:53` — home-manager가 생성한 동일 호출 |
| 사문 prompt | `/etc/zshrc:66` — `autoload -U promptinit && promptinit && prompt suse && setopt prompt_sp` |

두 compinit이 같은 `~/.zcompdump`를 두고 셸당 콜드 재빌드(fpath 전수 감사)를 반복하며, `prompt suse`는 Starship이 PROMPT/precmd를 전부 덮어써 100% dead work다. **darwin과 동일 병리 확정.**

## CIR (Change Intent Record)

- 이슈는 "실측 결과가 darwin과 다르면 적용하지 말고 결과만 기록"을 명시했다. 실측 결과가 **동일**했으므로 적용 경로로 진행했다.
- 이슈 Remaining work 3(`enableBashCompletion` 유지 여부를 실측으로 판단)은 NixOS의 multi-user 노출이 darwin보다 클 수 있다는 우려에서 나왔다. 실측으로 **그 반대**임을 확인했다:

| 확인 항목 | 결과 | 함의 |
|---|---|---|
| root 로그인 셸 | `bash` | zsh 경로 자체가 아님 |
| `/root/.zshrc` | 없음 | "사용자 rc를 안 타는 zsh 셸"이 존재하지 않음 |
| 로그인 가능 일반 사용자 | 1명 (zsh) | 그 세션은 home-manager compinit을 탐 |

darwin에서 우려했던 "시스템 compinit 제거 → 특정 셸에서 compinit 0회" 시나리오가 이 호스트에는 실현 대상이 없다. 따라서 `enableBashCompletion`은 darwin과 같은 이유(정상 세션의 bash `complete` 기반 completion 호환)로 유지한다.

**trade-off**: 미래에 root가 zsh를 쓰게 되거나 zsh 사용자가 추가되면 전제가 깨진다. 그래서 Test 8c가 `home-manager.users` 키 개수 1명을 함께 단언한다 — 사용자가 늘면 이 테스트가 먼저 실패해 재검토를 강제한다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| darwin 설정 이식 + 회귀 lock | `enableGlobalCompInit=false` / `promptInit=""` + eval-test 3건 | 병리 제거, 두 호스트 정책 일치, 회귀 검출 | 사용자 rc 미경유 zsh 셸에서 compinit 0회 (이 호스트엔 해당 셸 부재) | ✅ |
| 사용자 compinit을 끄고 시스템 것만 유지 | home-manager 쪽 비활성화 | root 셸도 커버 | home-manager 기본값 역행, fpath 커스터마이징 손실, darwin과 정책 분기 | ❌ |
| `enableBashCompletion`도 함께 비활성화 | 시스템 completion 전면 제거 | 잔여 불일치 제거 | 정상 세션의 nvm/bun 등 bash completion 호환 상실 | ❌ |
| 현상 유지 | 변경 없음 | 리스크 0 | 매 셸 중복 재빌드 + dead work 지속, darwin과 정책 분기 유지 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/nixos/configuration.nix` | `enableGlobalCompInit = false` / `promptInit = ""` + 실측 근거·trade-off를 담은 Change Intent Record 주석 |
| `tests/eval-tests.nix` | Test 8a(시스템 compinit 제거) / 8b(promptInit 빈 문자열) / 8c(사용자 compinit 단일 정본 + 사용자 1명 전제) 추가 |

Test 8c는 darwin D12와 달리 `system.primaryUser` 옵션이 NixOS에 없으므로 `home-manager.users`의 실제 키를 뽑아 쓴다. 하드코딩보다 견고하고, 사용자 증가를 자동 감지한다.

## 참고 레퍼런스

- `modules/darwin/configuration.nix` — 이식 원본 설정과 Change Intent Record (동일 병리·동일 처방의 선행 사례)
- `tests/eval-tests.nix`의 Darwin D10-D12 — 부정/긍정 짝 패턴의 원본
- [nix-darwin `programs.zsh.enableGlobalCompInit` 옵션 문서](https://daiderd.com/nix-darwin/manual/index.html) — "custom fpath + custom compinit을 두면 끄라"는 공식 안내 (darwin 주석이 인용, 같은 논리가 NixOS 모듈에도 적용)

## Human Test Plan

1. `bash tests/run-eval-tests.sh` → 전체 통과 (이번 작업 실측 완료: 신규 8a-8c 포함 통과).
2. 검출력 역검증 — `enableGlobalCompInit = true`로 일시 변경 후 실행하면 **Test 8a가 정확히 실패**해야 한다 (이번 작업에서 확인 후 원복 완료).
3. 배포 후 NixOS 호스트에서 `grep -n 'compinit\|prompt ' /etc/zshrc` → 시스템 compinit과 `prompt suse` 라인이 사라졌는지 확인.
4. 배포 후 `zsh -ic exit`를 연속 실행하며 `~/.zcompdump` mtime이 매번 갱신되지 않는지 확인 (콜드 재빌드 반복 해소).
5. `compaudit` 및 대표 completion(예: `git <TAB>`) 정상 동작 수동 확인.
6. 실패 시 진단: completion이 전면 작동하지 않으면 home-manager `enableCompletion` 기본값이 바뀐 것이므로 Test 8c가 함께 실패한다 — 그 경우 시스템 compinit 복원이 아니라 home-manager 쪽 설정을 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Zsh 초기화 설정을 조정해 전역 `compinit` 중복 초기화와 프롬프트 덮어쓰기 충돌을 방지했습니다.
  * Starship 개입으로 인한 프롬프트 초기화 동작을 제거해 셸 시작 시 동작을 더 안정적으로 유지합니다.

* **테스트**
  * NixOS 평가 테스트에 Zsh 초기화 회귀 불변식을 추가했습니다.
  * 자동 완성/프롬프트 관련 설정 및 `compinit` 초기화 시퀀스 존재 여부를 검증하도록 테스트를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->