### PR TITLE
fix(macos): Shottr activation의 TCC 대기와 크레덴셜 노출 제거 (#1133 분할 2/3)

### DIFF
--- a/.claude/skills/managing-secrets/SKILL.md
+++ b/.claude/skills/managing-secrets/SKILL.md
@@ -117,7 +117,8 @@ agenix `.age` 18개(디스크 실측) + 1Password 항목(github-pat, SSH device 
 
 ### Shottr 라이센스 pre-fill (agenix)
 
-Shottr 라이센스 키를 agenix로 암호화하여 `nrs` 실행 시 `defaults write`로 pre-fill합니다.
+Shottr 라이센스 키를 agenix로 암호화하여 `nrs` 실행 시 전용 CFPreferences writer의 stdin으로
+pre-fill합니다.
 
 Secret 파일 형식:
 ```
@@ -127,19 +128,25 @@ KC_VAULT=<base64 encoded vault>
 
 `.age` 파일 생성/갱신:
 ```bash
-printf 'KC_LICENSE=%s\nKC_VAULT=%s\n' \
-  "$(defaults read cc.ffitch.shottr kc-license)" \
-  "$(defaults read cc.ffitch.shottr kc-vault)" | \
+./scripts/secrets/refresh-shottr-license.sh secrets/shottr-license.age \
   nix shell nixpkgs#age -c age \
-    -r "ssh-ed25519 <macbook-pubkey>" \
-    -r "ssh-ed25519 <minipc-pubkey>" \
-    -o secrets/shottr-license.age
+  -r "ssh-ed25519 <macbook-pubkey>" \
+  -r "ssh-ed25519 <minipc-pubkey>"
 ```
 
-HM activation이 `~/.config/shottr/license`에서 값을 읽어 `defaults write cc.ffitch.shottr kc-license -string ...`로 주입합니다.
+두 read 중 하나라도 실패하거나 30초 deadline을 넘으면 age 출력을 시작하지 않는 fail-closed
+절차다. tracked refresh helper는 첫 명령에서 inherited `xtrace`를 끄고, inherited `allexport`와
+기존 export 속성을 제거하므로 평문은 터미널 trace나 timeout/helper/age의 child environment로
+전달되지 않는다. atomic helper는 stdin을 age에 전달하고 같은 디렉터리의 mode `0600` 임시 파일에
+성공한 뒤에만 원자적으로 교체하므로 실패 시 기존
+암호문을 보존한다. 실제 값은 터미널에 출력하지 않는다. HM activation은 `~/.config/shottr/license`에서 값을
+읽고, 전용 CFPreferences writer의 stdin으로만 전달한다. 라이센스 값은 activation 프로세스의
+명령행 인자나 timeout/writer child environment에 포함되지 않는다. AppData prompt로 timeout되면
+후속 Shottr write만 생략하고 나머지 activation을 계속한다.
 새 맥북에서 Shottr 실행 후 Activate 버튼 1회 클릭으로 활성화됩니다.
 
-> Shottr 크레덴셜 구조 상세는 managing-macos 스킬의 "Shottr 크레덴셜 관리 (상세)" 섹션 참조.
+> Shottr 크레덴셜 구조, deadline, action-time 앱 종료 규칙은
+> [managing-macos의 Shottr 상세 runbook](../managing-macos/references/shottr-credentials.md)을 따른다.
 
 ## 자주 발생하는 문제
 

--- a/libraries/constants.nix
+++ b/libraries/constants.nix
@@ -162,6 +162,8 @@
     paths = {
       # Shottr/FolderActions 공통 저장 경로 (HOME 상대경로)
       shottrDefaultFolderRelative = "FolderActions/upload-immich";
+      # Shottr sandbox container의 CFPreferences target (HOME 상대경로, .plist 확장자 제외)
+      shottrPreferencesTargetRelative = "Library/Containers/cc.ffitch.shottr/Data/Library/Preferences/cc.ffitch.shottr";
     };
   };
 

--- a/modules/darwin/programs/shottr/cfpreferences-writer-package.nix
+++ b/modules/darwin/programs/shottr/cfpreferences-writer-package.nix
@@ -1,0 +1,22 @@
+{ pkgs }:
+pkgs.stdenv.mkDerivation {
+  pname = "shottr-cfpreferences-writer";
+  version = "1";
+  src = ./cfpreferences-writer.c;
+  dontUnpack = true;
+  strictDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+    $CC -std=c11 -O2 -Wall -Wextra -Werror \
+      "$src" -framework CoreFoundation -o shottr-cfpreferences-writer
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -D -m 0755 shottr-cfpreferences-writer \
+      "$out/bin/shottr-cfpreferences-writer"
+    runHook postInstall
+  '';
+}

--- a/modules/darwin/programs/shottr/cfpreferences-writer.c
+++ b/modules/darwin/programs/shottr/cfpreferences-writer.c
@@ -1,0 +1,116 @@
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define MAX_INPUT_BYTES (64U * 1024U)
+
+static void secure_zero(void *buffer, size_t length) {
+    volatile unsigned char *cursor = buffer;
+
+    while (length > 0U) {
+        *cursor++ = 0U;
+        length--;
+    }
+}
+
+static int read_stdin(unsigned char **buffer_out, size_t *length_out) {
+    unsigned char *buffer;
+    size_t length = 0;
+
+    buffer = malloc(MAX_INPUT_BYTES + 1U);
+    if (buffer == NULL) {
+        return -1;
+    }
+
+    for (;;) {
+        ssize_t count = read(STDIN_FILENO, buffer + length,
+                             (MAX_INPUT_BYTES + 1U) - length);
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            secure_zero(buffer, length);
+            free(buffer);
+            return -1;
+        }
+        if (count == 0) {
+            break;
+        }
+        length += (size_t)count;
+        if (length > MAX_INPUT_BYTES) {
+            secure_zero(buffer, length);
+            free(buffer);
+            return -1;
+        }
+    }
+
+    if (length == 0) {
+        free(buffer);
+        return -1;
+    }
+    *buffer_out = buffer;
+    *length_out = length;
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    unsigned char *input = NULL;
+    size_t input_length = 0;
+    CFStringRef target = NULL;
+    CFStringRef key = NULL;
+    CFStringRef value = NULL;
+    bool synchronized = false;
+    int status = 1;
+
+    if (argc != 3 || argv[1][0] != '/' || argv[2][0] == '\0') {
+        fprintf(stderr,
+                "usage: shottr-cfpreferences-writer ABSOLUTE_PREFERENCES_BASENAME KEY\n");
+        return 2;
+    }
+    if (read_stdin(&input, &input_length) != 0) {
+        fprintf(stderr, "invalid preference value input\n");
+        return 1;
+    }
+
+    target = CFStringCreateWithFileSystemRepresentation(kCFAllocatorDefault,
+                                                         argv[1]);
+    key = CFStringCreateWithCString(kCFAllocatorDefault, argv[2],
+                                    kCFStringEncodingUTF8);
+    value = CFStringCreateWithBytes(kCFAllocatorDefault, input, input_length,
+                                    kCFStringEncodingUTF8, false);
+    if (target == NULL || key == NULL || value == NULL) {
+        fprintf(stderr, "invalid preference target, key, or UTF-8 value\n");
+        goto cleanup;
+    }
+
+    CFPreferencesSetValue(key, value, target, kCFPreferencesCurrentUser,
+                          kCFPreferencesAnyHost);
+    synchronized = CFPreferencesSynchronize(target, kCFPreferencesCurrentUser,
+                                            kCFPreferencesAnyHost);
+    if (!synchronized) {
+        fprintf(stderr, "preference synchronization failed\n");
+        goto cleanup;
+    }
+    status = 0;
+
+cleanup:
+    if (value != NULL) {
+        CFRelease(value);
+    }
+    if (key != NULL) {
+        CFRelease(key);
+    }
+    if (target != NULL) {
+        CFRelease(target);
+    }
+    if (input != NULL) {
+        secure_zero(input, input_length);
+        free(input);
+    }
+    return status;
+}

--- a/modules/darwin/programs/shottr/default.nix
+++ b/modules/darwin/programs/shottr/default.nix
@@ -12,6 +12,7 @@
 {
   config,
   lib,
+  pkgs,
   constants,
   ...
 }:
@@ -20,14 +21,17 @@ let
   homeDir = config.home.homeDirectory;
   shottrDomain = "cc.ffitch.shottr";
   shottrDefaultFolder = "${homeDir}/${constants.macos.paths.shottrDefaultFolderRelative}";
+  shottrPreferencesTarget = "${homeDir}/${constants.macos.paths.shottrPreferencesTargetRelative}";
   shottrLicensePath = "${config.xdg.configHome}/shottr/license";
-  shottrDefaultsWriteHelper = ''
-    _shottr_defaults_write() {
-      if ! /usr/bin/defaults write "$@" 2>/dev/null; then
-        echo "Warning: defaults write $2 failed (sandbox restriction?). Skipping."
-      fi
-    }
+  # `defaults`가 sandbox app container를 읽고 쓸 때 responsible app의 AppData TCC prompt가
+  # 발생할 수 있다. 원격 nrs가 GUI 응답을 기다리며 멈추지 않도록 각 호출을 bounded하게 하고,
+  # 한 번 timeout되면 같은 activation의 나머지 Shottr write를 건너뛴다.
+  shottrDefaultsTimeoutBin = "${pkgs.coreutils}/bin/timeout";
+  shottrDefaultsHelper = ''
+    ${builtins.readFile ../../../../scripts/secrets/shottr-deadlines.sh}
+    ${builtins.readFile ./defaults-helper.sh}
   '';
+  shottrCfPreferencesWriter = import ./cfpreferences-writer-package.nix { inherit pkgs; };
 in
 {
   # 경로 가드: 폴더/북마크 이슈를 조기에 알림
@@ -37,7 +41,10 @@ in
       echo "FolderActions activation should create this path."
     fi
 
-    current_folder="$(/usr/bin/defaults read "${shottrDomain}" defaultFolder 2>/dev/null || true)"
+    ${shottrDefaultsHelper}
+    SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+    shottr_defaults_read current_folder \
+      "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" defaultFolder
     if [ -n "$current_folder" ] && [ "$current_folder" != "${shottrDefaultFolder}" ]; then
       echo "Warning: Shottr current folder differs from declared folder."
       echo "  current: $current_folder"
@@ -54,23 +61,23 @@ in
   # Carbon key codes:
   #   1=18(0x12) 2=19(0x13) 3=20(0x14) O=31(0x1F)
   home.activation.applyShottrCoreSettings = lib.hm.dag.entryAfter [ "checkShottrFolderAndWarn" ] ''
-    ${shottrDefaultsWriteHelper}
-    _shottr_defaults_write "${shottrDomain}" defaultFolder "${shottrDefaultFolder}"
-    _shottr_defaults_write "${shottrDomain}" saveFormat "Auto"
-    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_fullscreen -string '{"carbonModifiers":768,"carbonKeyCode":18}'   # ⇧⌘1
-    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_area -string '{"carbonKeyCode":20,"carbonModifiers":768}'          # ⇧⌘3
-    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_scrolling -string '{"carbonModifiers":768,"carbonKeyCode":19}'     # ⇧⌘2
-    _shottr_defaults_write "${shottrDomain}" KeyboardShortcuts_ocr -string '{"carbonModifiers":6400,"carbonKeyCode":31}'          # ⌃⌥⌘O
+    ${shottrDefaultsHelper}
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" defaultFolder "${shottrDefaultFolder}"
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" saveFormat "Auto"
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" KeyboardShortcuts_fullscreen -string '{"carbonModifiers":768,"carbonKeyCode":18}'   # ⇧⌘1
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" KeyboardShortcuts_area -string '{"carbonKeyCode":20,"carbonModifiers":768}'          # ⇧⌘3
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" KeyboardShortcuts_scrolling -string '{"carbonModifiers":768,"carbonKeyCode":19}'     # ⇧⌘2
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" KeyboardShortcuts_ocr -string '{"carbonModifiers":6400,"carbonKeyCode":31}'          # ⌃⌥⌘O
 
     # Manual Scrolling Capture 활성화
     # Auto Scroll Capture는 Terminal, VS Code 등 비표준 스크롤 앱에서 화면이 짤림.
     # Manual 모드는 사용자가 직접 스크롤하며 캡처하므로 이런 앱에서도 정상 동작.
     # ref: https://shottr.cc/kb/faq
     # ref: https://hurricane-flower-fdf.notion.site/Manual-Scrolling-Capture-120d943b739b80bf868dd1009eeadc17
-    _shottr_defaults_write "${shottrDomain}" scrollingManualEnabled -bool true
+    shottr_defaults_write "${shottrDefaultsTimeoutBin}" /usr/bin/defaults "${shottrDomain}" scrollingManualEnabled -bool true
   '';
 
-  # 라이센스 pre-fill (agenix secret → defaults write)
+  # 라이센스 pre-fill (agenix secret → container CFPreferences)
   # Keychain 없는 새 맥북에서 Activate 버튼 1회 클릭만으로 활성화 가능
   #
   # macOS에서 agenix는 launchd agent(activate-agenix, RunAtLoad)로 시크릿을 복호화한다.
@@ -79,7 +86,7 @@ in
   home.activation.applyShottrLicenseFromSecret =
     lib.hm.dag.entryAfter [ "applyShottrCoreSettings" "setupLaunchAgents" ]
       ''
-        ${shottrDefaultsWriteHelper}
+        ${shottrDefaultsHelper}
         _waited=0
         while [ ! -f "${shottrLicensePath}" ] && [ "$_waited" -lt 5 ]; do
           sleep 1
@@ -89,15 +96,36 @@ in
         if [ ! -f "${shottrLicensePath}" ]; then
           echo "Note: Shottr license secret not yet available. License pre-fill skipped."
         else
-          kc_license="$(sed -n 's/^KC_LICENSE=//p' "${shottrLicensePath}" | tail -n 1 | tr -d '\r')"
-          kc_vault="$(sed -n 's/^KC_VAULT=//p' "${shottrLicensePath}" | tail -n 1 | tr -d '\r')"
+          # Hostile/inherited activation environments may enable allexport or
+          # pre-export either spelling. Scrub the parent first, then keep the
+          # entire secret read/write interval in a subshell with allexport off.
+          unset kc_license kc_vault KC_LICENSE KC_VAULT
+          (
+            set +x
+            set +a
+            unset kc_license kc_vault KC_LICENSE KC_VAULT
+            kc_license="$(sed -n 's/^KC_LICENSE=//p' "${shottrLicensePath}" | tail -n 1 | tr -d '\r')"
+            kc_vault="$(sed -n 's/^KC_VAULT=//p' "${shottrLicensePath}" | tail -n 1 | tr -d '\r')"
+            export -n kc_license kc_vault
 
-          if [ -n "$kc_license" ]; then
-            _shottr_defaults_write "${shottrDomain}" kc-license -string "$kc_license"
-          fi
-          if [ -n "$kc_vault" ]; then
-            _shottr_defaults_write "${shottrDomain}" kc-vault -string "$kc_vault"
-          fi
+            if [ -n "$kc_license" ]; then
+              shottr_defaults_write_stdin \
+                "${shottrDefaultsTimeoutBin}" \
+                "${shottrCfPreferencesWriter}/bin/shottr-cfpreferences-writer" \
+                "${shottrPreferencesTarget}" \
+                kc-license \
+                < <(builtin printf '%s' "$kc_license")
+            fi
+            if [ -n "$kc_vault" ]; then
+              shottr_defaults_write_stdin \
+                "${shottrDefaultsTimeoutBin}" \
+                "${shottrCfPreferencesWriter}/bin/shottr-cfpreferences-writer" \
+                "${shottrPreferencesTarget}" \
+                kc-vault \
+                < <(builtin printf '%s' "$kc_vault")
+            fi
+            unset kc_license kc_vault KC_LICENSE KC_VAULT
+          )
         fi
       '';
 

--- a/modules/darwin/programs/shottr/defaults-helper.sh
+++ b/modules/darwin/programs/shottr/defaults-helper.sh
@@ -1,0 +1,96 @@
+# Shottr defaults access helpers. This file is sourced into Home Manager
+# activation entries and is also exercised directly by shell fixtures.
+# shellcheck shell=bash
+
+# Direct shell fixtures source this helper from the repository. Home Manager
+# activation entries inline the same shared file immediately before this body.
+shottr_defaults_helper_source="${BASH_SOURCE[0]:-}"
+if [ -n "$shottr_defaults_helper_source" ]; then
+    shottr_defaults_helper_dir=$(cd -- "$(dirname -- "$shottr_defaults_helper_source")" && pwd -P)
+    shottr_defaults_deadlines_file="$shottr_defaults_helper_dir/../../../../scripts/secrets/shottr-deadlines.sh"
+    if [ -r "$shottr_defaults_deadlines_file" ]; then
+        # shellcheck disable=SC1090 # Repository-relative path is computed above.
+        . "$shottr_defaults_deadlines_file"
+    fi
+fi
+unset shottr_defaults_helper_source shottr_defaults_helper_dir shottr_defaults_deadlines_file
+: "${SHOTTR_DEFAULTS_KILL_AFTER:?Shottr defaults kill-after bound is unavailable}"
+: "${SHOTTR_DEFAULTS_DEADLINE:?Shottr defaults deadline is unavailable}"
+
+shottr_defaults_is_timeout() {
+    [ "$1" -eq 124 ] || [ "$1" -eq 137 ]
+}
+
+shottr_defaults_record_failure() {
+    local operation="$1" key="$2" status="$3"
+    if shottr_defaults_is_timeout "$status"; then
+        SHOTTR_DEFAULTS_WRITES_BLOCKED=1
+        echo "Warning: defaults $operation $key timed out (possible AppData TCC prompt)."
+        if [ "$operation" = "read" ]; then
+            echo "Skipping Shottr defaults writes for this activation."
+        else
+            echo "Skipping remaining Shottr defaults writes for this activation."
+        fi
+    elif [ "$operation" = "write" ]; then
+        echo "Warning: defaults write $key failed (sandbox restriction?). Skipping."
+    fi
+}
+
+shottr_defaults_write() {
+    local timeout_bin="$1" defaults_bin="$2" domain="$3" key="$4"
+    local status
+    shift 4
+
+    if [ "${SHOTTR_DEFAULTS_WRITES_BLOCKED:-0}" = "1" ]; then
+        return 0
+    fi
+
+    if "$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_DEADLINE" \
+        "$defaults_bin" write "$domain" "$key" "$@" 2>/dev/null; then
+        return 0
+    else
+        status=$?
+    fi
+
+    shottr_defaults_record_failure write "$key" "$status"
+}
+
+shottr_defaults_write_stdin() {
+    local timeout_bin="$1" writer_bin="$2" preferences_target="$3" key="$4"
+    local status
+
+    if [ "${SHOTTR_DEFAULTS_WRITES_BLOCKED:-0}" = "1" ]; then
+        return 0
+    fi
+
+    if (
+        # Do not let hostile/inherited activation exports duplicate the secret
+        # into the timeout/writer environment. The value reaches the writer
+        # only through this subshell's inherited stdin.
+        unset kc_license kc_vault KC_LICENSE KC_VAULT
+        "$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_DEADLINE" \
+            "$writer_bin" "$preferences_target" "$key" 2>/dev/null
+    ); then
+        return 0
+    else
+        status=$?
+    fi
+
+    shottr_defaults_record_failure write "$key" "$status"
+}
+
+shottr_defaults_read() {
+    local result_var="$1" timeout_bin="$2" defaults_bin="$3" domain="$4" key="$5"
+    local value status
+
+    if value=$("$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_DEADLINE" \
+        "$defaults_bin" read "$domain" "$key" 2>/dev/null); then
+        printf -v "$result_var" '%s' "$value"
+        return 0
+    else
+        status=$?
+    fi
+
+    printf -v "$result_var" '%s' ""
+    shottr_defaults_record_failure read "$key" "$status"
+}

--- a/scripts/secrets/age-encrypt-atomic.sh
+++ b/scripts/secrets/age-encrypt-atomic.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Encrypt stdin to a same-directory temporary file and atomically replace OUTPUT.
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    printf 'usage: %s OUTPUT AGE_COMMAND [ARG...]\n' "${0##*/}" >&2
+    exit 64
+fi
+
+requested_output="$1"
+shift
+requested_output_dir="${requested_output%/*}"
+requested_output_name="${requested_output##*/}"
+[ "$requested_output_dir" != "$requested_output" ] || requested_output_dir="."
+case "$requested_output_name" in
+    ''|.|..) printf 'invalid output path: %s\n' "$requested_output" >&2; exit 64 ;;
+esac
+[ -d "$requested_output_dir" ] || {
+    printf 'output directory does not exist: %s\n' "$requested_output_dir" >&2
+    exit 66
+}
+
+resolve_output_target() {
+    local current="$1" link current_dir current_name hops=0
+    while [ -L "$current" ]; do
+        [ "$hops" -lt 40 ] || {
+            printf 'too many output symlink hops: %s\n' "$requested_output" >&2
+            return 74
+        }
+        link=$(readlink "$current") || return 74
+        case "$link" in
+            /*) current="$link" ;;
+            *)
+                current_dir="${current%/*}"
+                [ "$current_dir" != "$current" ] || current_dir="."
+                current="$current_dir/$link"
+                ;;
+        esac
+        current_dir="${current%/*}"
+        current_name="${current##*/}"
+        [ "$current_dir" != "$current" ] || current_dir="."
+        current_dir=$(cd -- "$current_dir" 2>/dev/null && pwd -P) || return 66
+        current="$current_dir/$current_name"
+        hops=$((hops + 1))
+    done
+    printf '%s\n' "$current"
+}
+
+file_mode() {
+    stat -c '%a' "$1" 2>/dev/null || /usr/bin/stat -f '%Lp' "$1" 2>/dev/null
+}
+
+file_uid() {
+    stat -c '%u' "$1" 2>/dev/null || /usr/bin/stat -f '%u' "$1" 2>/dev/null
+}
+
+file_gid() {
+    stat -c '%g' "$1" 2>/dev/null || /usr/bin/stat -f '%g' "$1" 2>/dev/null
+}
+
+output=$(resolve_output_target "$requested_output") || exit $?
+output_dir="${output%/*}"
+output_name="${output##*/}"
+[ "$output_dir" != "$output" ] || output_dir="."
+case "$output_name" in
+    ''|.|..) printf 'invalid output path: %s\n' "$output" >&2; exit 64 ;;
+esac
+[ -d "$output_dir" ] || {
+    printf 'output directory does not exist: %s\n' "$output_dir" >&2
+    exit 66
+}
+
+umask 077
+tmp="$(mktemp "$output_dir/.${output_name}.tmp.XXXXXX")"
+cleanup() {
+    rc=$?
+    trap - EXIT
+    [ -z "${tmp:-}" ] || rm -f -- "$tmp" || true
+    exit "$rc"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+"$@" -o "$tmp"
+
+if [ -e "$output" ]; then
+    [ -f "$output" ] || {
+        printf 'output target is not a regular file: %s\n' "$output" >&2
+        exit 73
+    }
+    mode=$(file_mode "$output") || exit 74
+    uid=$(file_uid "$output") || exit 74
+    gid=$(file_gid "$output") || exit 74
+    tmp_uid=$(file_uid "$tmp") || exit 74
+    tmp_gid=$(file_gid "$tmp") || exit 74
+    if [ "$tmp_uid:$tmp_gid" != "$uid:$gid" ]; then
+        chown "$uid:$gid" "$tmp"
+    fi
+    # chown may clear setuid/setgid bits, so restore the saved mode last.
+    chmod "$mode" "$tmp"
+fi
+
+mv -f -- "$tmp" "$output"
+tmp=""
+trap - HUP INT TERM

--- a/scripts/secrets/refresh-shottr-license.sh
+++ b/scripts/secrets/refresh-shottr-license.sh
@@ -46,12 +46,22 @@ kc_license="$("$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_
     exit 1
 }
 export -n kc_license
+# defaults read 는 키가 없으면 non-zero 지만, 키가 있고 값이 빈 문자열이면 exit 0 이다(실측).
+# 빈 값을 그대로 암호화하면 정상 .age 를 빈 시크릿으로 덮어쓰므로 fail-closed 로 중단한다.
+[ -n "$kc_license" ] || {
+    printf 'kc-license is empty; refusing to overwrite the secret with an empty value.\n' >&2
+    exit 1
+}
 kc_vault="$("$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_DEADLINE" \
     "$defaults_bin" read cc.ffitch.shottr kc-vault)" || {
     printf 'kc-vault read failed or timed out; secret file was not changed.\n' >&2
     exit 1
 }
 export -n kc_vault
+[ -n "$kc_vault" ] || {
+    printf 'kc-vault is empty; refusing to overwrite the secret with an empty value.\n' >&2
+    exit 1
+}
 
 printf 'KC_LICENSE=%s\nKC_VAULT=%s\n' "$kc_license" "$kc_vault" \
     | "$atomic_helper" "$output" "$@"

--- a/scripts/secrets/refresh-shottr-license.sh
+++ b/scripts/secrets/refresh-shottr-license.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Read Shottr license values with a deadline and atomically encrypt stdin.
+set +x
+set -euo pipefail
+set +a
+unset kc_license kc_vault KC_LICENSE KC_VAULT
+umask 077
+
+if [ "$#" -lt 2 ]; then
+    printf 'usage: %s OUTPUT AGE_COMMAND [ARG...]\n' "${0##*/}" >&2
+    exit 64
+fi
+
+output="$1"
+shift
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+# shellcheck disable=SC1091 # Fixed sibling file in the deployed script bundle.
+. "$script_dir/shottr-deadlines.sh"
+# Internal hermetic-test seams, not operator-facing configuration knobs.
+atomic_helper="${SHOTTR_AGE_ENCRYPT_ATOMIC:-$script_dir/age-encrypt-atomic.sh}"
+defaults_bin="${SHOTTR_DEFAULTS_BIN:-/usr/bin/defaults}"
+timeout_bin="${SHOTTR_TIMEOUT_BIN:-}"
+
+if [ -z "$timeout_bin" ]; then
+    timeout_bin=$(command -v timeout) || {
+        printf 'GNU timeout is required; enter the repo devShell first.\n' >&2
+        exit 69
+    }
+fi
+[ -x "$timeout_bin" ] || {
+    printf 'timeout executable is unavailable: %s\n' "$timeout_bin" >&2
+    exit 69
+}
+[ -x "$defaults_bin" ] || {
+    printf 'defaults executable is unavailable: %s\n' "$defaults_bin" >&2
+    exit 69
+}
+[ -x "$atomic_helper" ] || {
+    printf 'atomic encryption helper is unavailable: %s\n' "$atomic_helper" >&2
+    exit 69
+}
+
+kc_license="$("$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_DEADLINE" \
+    "$defaults_bin" read cc.ffitch.shottr kc-license)" || {
+    printf 'kc-license read failed or timed out; secret file was not changed.\n' >&2
+    exit 1
+}
+export -n kc_license
+kc_vault="$("$timeout_bin" -k "$SHOTTR_DEFAULTS_KILL_AFTER" "$SHOTTR_DEFAULTS_DEADLINE" \
+    "$defaults_bin" read cc.ffitch.shottr kc-vault)" || {
+    printf 'kc-vault read failed or timed out; secret file was not changed.\n' >&2
+    exit 1
+}
+export -n kc_vault
+
+printf 'KC_LICENSE=%s\nKC_VAULT=%s\n' "$kc_license" "$kc_vault" \
+    | "$atomic_helper" "$output" "$@"

--- a/scripts/secrets/shottr-deadlines.sh
+++ b/scripts/secrets/shottr-deadlines.sh
@@ -1,0 +1,9 @@
+# Shared Shottr defaults safety bounds. This file is sourced by the manual
+# credential refresh helper and inlined into Home Manager activation entries.
+# shellcheck shell=bash
+# shellcheck disable=SC2034 # Both constants are consumed by sourcing callers.
+
+# These are safety bounds, not tuning knobs. Inherited variables must not
+# weaken the outer deadline that contains a possible TCC prompt.
+SHOTTR_DEFAULTS_KILL_AFTER=5s
+SHOTTR_DEFAULTS_DEADLINE=30s

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -789,6 +789,10 @@ let
           name = "Test D23b ${hostName}: Ghostty.app cask가 정확히 한 번 선언되어야 함";
           cond = hasHost && ghosttyCaskCount cfg == 1;
         }
+        {
+          name = "Test D27 ${hostName}: Shottr의 선언된 activation entries가 모두 존재해야 함";
+          cond = hasHost && hasShottrActivationEntries (shottrActivation cfg);
+        }
       ]
     ) expectedDarwinHosts
   );

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -293,6 +293,7 @@ run_test "claudex disabled Home Manager closure excludes enabled artifacts" test
 run_test "Shottr defaults helper bounds and short-circuits TCC access" test_shottr_defaults_helper_behavior
 run_test "Shottr secret writer uses stdin without argv exposure" test_shottr_secret_writer_uses_stdin_without_argv
 run_test "Shottr license refresh helper scrubs child environment" test_shottr_license_refresh_helper_scrubs_child_environment
+run_test "Shottr license refresh rejects empty value" test_shottr_license_refresh_rejects_empty_value
 run_test "Shottr age encryption replaces ciphertext atomically" test_shottr_age_encryption_is_atomic
 run_test "Shottr CFPreferences writer round-trips through defaults" test_shottr_cfpreferences_writer_round_trip
 

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -290,6 +290,11 @@ run_test "claudex Stage 1 status is sanitized" test_claudex_status_is_sanitized
 run_test "claudex Nix-generated command outputs are pinned" test_claudex_nix_generated_command_outputs_are_pinned
 run_test "claudex release layout verifier rejects drift" test_claudex_release_layout_verifier
 run_test "claudex disabled Home Manager closure excludes enabled artifacts" test_claudex_disabled_home_excludes_enabled_closure
+run_test "Shottr defaults helper bounds and short-circuits TCC access" test_shottr_defaults_helper_behavior
+run_test "Shottr secret writer uses stdin without argv exposure" test_shottr_secret_writer_uses_stdin_without_argv
+run_test "Shottr license refresh helper scrubs child environment" test_shottr_license_refresh_helper_scrubs_child_environment
+run_test "Shottr age encryption replaces ciphertext atomically" test_shottr_age_encryption_is_atomic
+run_test "Shottr CFPreferences writer round-trips through defaults" test_shottr_cfpreferences_writer_round_trip
 
 # codex-config fixture는 tomlkit이 필요하다. required CI의 run-all-tests는 prePushRuntime
 # profile로 항상 tomlkit을 제공하지만, 사용자가 직접 실행할 때는 미가용일 수 있다. 미가용이면

--- a/tests/suites/shottr-defaults.sh
+++ b/tests/suites/shottr-defaults.sh
@@ -379,6 +379,47 @@ EOF
     || fail "hostile environment fixture did not observe the secret re-export mutant"
 )
 
+# defaults read 는 키가 있고 값이 빈 문자열이면 exit 0 을 낸다(실측). 이때 refresh helper 가
+# 빈 값을 그대로 암호화하면 정상 .age 를 빈 시크릿으로 덮어쓴다. helper 가 fail-closed 로
+# 중단하고 기존 출력(있다면)을 건드리지 않는지 검증한다.
+test_shottr_license_refresh_rejects_empty_value() (
+  local sandbox helper deadlines fake_bin defaults_bin timeout_bin real_timeout
+  local output status
+  sandbox="$(new_sandbox)"
+  helper="$REPO_ROOT/scripts/secrets/refresh-shottr-license.sh"
+  deadlines="$REPO_ROOT/scripts/secrets/shottr-deadlines.sh"
+  fake_bin="$sandbox/bin"
+  defaults_bin="$fake_bin/defaults"
+  timeout_bin="$(command -v timeout)" || fail "GNU timeout is required"
+  output="$sandbox/shottr-license.age"
+  mkdir -p "$fake_bin"
+
+  # kc-license 는 정상, kc-vault 는 존재하지만 빈 문자열(exit 0)을 반환하는 defaults stub.
+  cat > "$defaults_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+last=""
+for arg in "$@"; do last="$arg"; done
+case "$last" in
+  kc-license) printf '%s\n' 'issue-1093-license-sentinel' ;;
+  kc-vault) printf '' ;;   # 키는 존재하나 값이 비어 있음 → exit 0
+  *) exit 64 ;;
+esac
+EOF
+  chmod +x "$defaults_bin"
+
+  # 기존 출력이 있으면 덮어쓰지 않아야 하므로 미리 심어 둔다.
+  printf 'pre-existing-ciphertext\n' > "$output"
+
+  status=0
+  SHOTTR_DEFAULTS_BIN="$defaults_bin" SHOTTR_TIMEOUT_BIN="$timeout_bin" \
+    bash "$helper" "$output" true 2>/dev/null || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "refresh helper accepted an empty kc-vault instead of failing closed"
+  [ "$(cat "$output")" = "pre-existing-ciphertext" ] \
+    || fail "refresh helper overwrote the existing secret with an empty value"
+)
+
 test_shottr_age_encryption_is_atomic() (
   local sandbox helper fake_age output old_ciphertext plaintext observed
   local old_mode old_uid old_gid target target_link target_mode target_uid target_gid

--- a/tests/suites/shottr-defaults.sh
+++ b/tests/suites/shottr-defaults.sh
@@ -1,0 +1,582 @@
+# tests/suites/shottr-defaults.sh — Shottr defaults deadline/circuit-breaker fixtures
+# shellcheck shell=bash
+# shellcheck disable=SC2154
+
+test_shottr_defaults_helper_behavior() {
+  local sandbox timeout_bin defaults_bin timeout_log defaults_log output helper
+  sandbox="$(new_sandbox)"
+  timeout_bin="$sandbox/timeout"
+  defaults_bin="$sandbox/defaults"
+  timeout_log="$sandbox/timeout.log"
+  defaults_log="$sandbox/defaults.log"
+  output="$sandbox/output.log"
+  helper="$REPO_ROOT/modules/darwin/programs/shottr/defaults-helper.sh"
+
+  cat >"$timeout_bin" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_TIMEOUT_LOG"
+if [ "${FAKE_TIMEOUT_STATUS:-0}" -ne 0 ]; then
+  exit "$FAKE_TIMEOUT_STATUS"
+fi
+[ "$1" = "-k" ] && [ "$2" = "5s" ] && [ "$3" = "30s" ] || exit 98
+shift 3
+exec "$@"
+EOF
+  cat >"$defaults_bin" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_DEFAULTS_LOG"
+if [ "${FAKE_DEFAULTS_STATUS:-0}" -ne 0 ]; then
+  exit "$FAKE_DEFAULTS_STATUS"
+fi
+if [ "$1" = "read" ]; then
+  printf '%s\n' '/declared/folder'
+fi
+EOF
+  chmod +x "$timeout_bin" "$defaults_bin"
+  : >"$timeout_log"
+  : >"$defaults_log"
+  export FAKE_TIMEOUT_LOG="$timeout_log" FAKE_DEFAULTS_LOG="$defaults_log"
+
+  # An inherited activation environment must not disable the TCC deadline.
+  export SHOTTR_DEFAULTS_KILL_AFTER=0 SHOTTR_DEFAULTS_DEADLINE=0
+  # shellcheck source=/dev/null
+  source "$helper"
+  [ "$SHOTTR_DEFAULTS_KILL_AFTER" = "5s" ] \
+    || fail "inherited environment changed the defaults kill-after bound"
+  [ "$SHOTTR_DEFAULTS_DEADLINE" = "30s" ] \
+    || fail "inherited environment changed the defaults deadline"
+
+  SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+  export FAKE_TIMEOUT_STATUS=124
+  shottr_defaults_read current_folder \
+    "$timeout_bin" "$defaults_bin" cc.ffitch.shottr defaultFolder >"$output"
+  [ "$SHOTTR_DEFAULTS_WRITES_BLOCKED" = "1" ] || fail "read timeout must block later writes"
+  unset FAKE_TIMEOUT_STATUS
+  shottr_defaults_write \
+    "$timeout_bin" "$defaults_bin" cc.ffitch.shottr saveFormat Auto >>"$output"
+  [ "$(wc -l <"$timeout_log" | tr -d '[:space:]')" = "1" ] \
+    || fail "blocked read must prevent a later defaults write"
+  assert_contains "$(cat "$output")" "defaults read defaultFolder timed out"
+
+  : >"$timeout_log"
+  : >"$defaults_log"
+  : >"$output"
+  SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+  export FAKE_TIMEOUT_STATUS=137
+  shottr_defaults_write \
+    "$timeout_bin" "$defaults_bin" cc.ffitch.shottr kc-license -string fixture-secret >"$output"
+  [ "$SHOTTR_DEFAULTS_WRITES_BLOCKED" = "1" ] || fail "write timeout must block later writes"
+  unset FAKE_TIMEOUT_STATUS
+  shottr_defaults_write \
+    "$timeout_bin" "$defaults_bin" cc.ffitch.shottr kc-vault -string second-secret >>"$output"
+  [ "$(wc -l <"$timeout_log" | tr -d '[:space:]')" = "1" ] \
+    || fail "blocked write must prevent a later defaults write"
+  assert_contains "$(cat "$output")" "defaults write kc-license timed out"
+  assert_not_contains "$(cat "$output")" "fixture-secret"
+  assert_not_contains "$(cat "$output")" "second-secret"
+
+  : >"$timeout_log"
+  : >"$defaults_log"
+  : >"$output"
+  SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+  export FAKE_DEFAULTS_STATUS=1
+  shottr_defaults_write \
+    "$timeout_bin" "$defaults_bin" cc.ffitch.shottr saveFormat Auto >"$output"
+  unset FAKE_DEFAULTS_STATUS
+  shottr_defaults_write \
+    "$timeout_bin" "$defaults_bin" cc.ffitch.shottr scrollingManualEnabled -bool true >>"$output"
+  [ "$SHOTTR_DEFAULTS_WRITES_BLOCKED" = "0" ] || fail "ordinary defaults failure must not trip TCC breaker"
+  [ "$(wc -l <"$defaults_log" | tr -d '[:space:]')" = "2" ] \
+    || fail "ordinary failure must allow the next declared write"
+  if grep -Fv -- '-k 5s 30s ' "$timeout_log" | grep -q .; then
+    fail "every defaults access must retain the outer deadline"
+  fi
+
+  for timeout_status in 124 137; do
+    : > "$timeout_log"
+    : > "$defaults_log"
+    : > "$output"
+    SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+    export FAKE_TIMEOUT_STATUS="$timeout_status"
+    shottr_defaults_write_stdin \
+      "$timeout_bin" "$defaults_bin" "$sandbox/preferences" kc-license \
+      < <(builtin printf '%s' 'stdin-timeout-secret') > "$output"
+    [ "$SHOTTR_DEFAULTS_WRITES_BLOCKED" = "1" ] \
+      || fail "stdin writer timeout $timeout_status must block later writes"
+    unset FAKE_TIMEOUT_STATUS
+    shottr_defaults_write_stdin \
+      "$timeout_bin" "$defaults_bin" "$sandbox/preferences" kc-vault \
+      < <(builtin printf '%s' 'stdin-blocked-secret') >> "$output"
+    [ "$(wc -l < "$timeout_log" | tr -d '[:space:]')" = "1" ] \
+      || fail "stdin writer timeout must prevent a later secret write"
+    assert_contains "$(cat "$output")" "defaults write kc-license timed out"
+    assert_not_contains "$(cat "$timeout_log")" "stdin-timeout-secret"
+    assert_not_contains "$(cat "$timeout_log")" "stdin-blocked-secret"
+  done
+
+  : > "$timeout_log"
+  : > "$defaults_log"
+  : > "$output"
+  SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+  export FAKE_DEFAULTS_STATUS=1
+  shottr_defaults_write_stdin \
+    "$timeout_bin" "$defaults_bin" "$sandbox/preferences" kc-license \
+    < <(builtin printf '%s' 'stdin-ordinary-failure') > "$output"
+  unset FAKE_DEFAULTS_STATUS
+  shottr_defaults_write_stdin \
+    "$timeout_bin" "$defaults_bin" "$sandbox/preferences" kc-vault \
+    < <(builtin printf '%s' 'stdin-next-write') >> "$output"
+  [ "$SHOTTR_DEFAULTS_WRITES_BLOCKED" = "0" ] \
+    || fail "ordinary stdin writer failure must not trip TCC breaker"
+  [ "$(wc -l < "$timeout_log" | tr -d '[:space:]')" = "2" ] \
+    || fail "ordinary stdin writer failure must allow the next declared write"
+}
+
+test_shottr_secret_writer_uses_stdin_without_argv() (
+  local sandbox timeout_bin writer_bin timeout_pid_file writer_pid_file
+  local received_file writer_env_file hold_file output helper sentinel call_pid timeout_pid writer_pid
+  local arg received
+  sandbox="$(new_sandbox)"
+  timeout_bin="$sandbox/timeout"
+  writer_bin="$sandbox/writer"
+  timeout_pid_file="$sandbox/timeout.pid"
+  writer_pid_file="$sandbox/writer.pid"
+  received_file="$sandbox/received"
+  writer_env_file="$sandbox/writer.env"
+  hold_file="$sandbox/hold"
+  output="$sandbox/output.log"
+  helper="$REPO_ROOT/modules/darwin/programs/shottr/defaults-helper.sh"
+  sentinel='issue-1093-secret-argv-sentinel'
+
+  # shellcheck disable=SC2329 # invoked by the EXIT trap on fixture failure
+  cleanup_shottr_secret_writer_fixture() {
+    local pid pid_file
+    rm -f "$hold_file"
+    for pid_file in "$writer_pid_file" "$timeout_pid_file"; do
+      [ -s "$pid_file" ] || continue
+      pid="$(cat "$pid_file")"
+      case "$pid" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      kill -TERM "$pid" 2>/dev/null || true
+    done
+    if [ -n "${call_pid:-}" ]; then
+      kill -TERM "$call_pid" 2>/dev/null || true
+      wait "$call_pid" 2>/dev/null || true
+    fi
+  }
+  trap cleanup_shottr_secret_writer_fixture EXIT
+
+  cat > "$timeout_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = "-k" ] && [ "$2" = "5s" ] && [ "$3" = "30s" ] || exit 98
+shift 3
+exec 3<&0
+"$@" <&3 &
+child=$!
+printf '%s\n' "$$" > "$FAKE_TIMEOUT_PID_FILE"
+wait "$child"
+EOF
+  cat > "$writer_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cat > "$FAKE_WRITER_RECEIVED_FILE"
+printf '%s\n' \
+  "kc_license=${kc_license+set}" \
+  "kc_vault=${kc_vault+set}" \
+  "KC_LICENSE=${KC_LICENSE+set}" \
+  "KC_VAULT=${KC_VAULT+set}" \
+  > "$FAKE_WRITER_ENV_FILE"
+printf '%s\n' "$$" > "$FAKE_WRITER_PID_FILE"
+while [ -e "$FAKE_WRITER_HOLD_FILE" ]; do
+  sleep 0.05
+done
+EOF
+  chmod +x "$timeout_bin" "$writer_bin"
+  : > "$hold_file"
+  export FAKE_TIMEOUT_PID_FILE="$timeout_pid_file"
+  export FAKE_WRITER_PID_FILE="$writer_pid_file"
+  export FAKE_WRITER_RECEIVED_FILE="$received_file"
+  export FAKE_WRITER_ENV_FILE="$writer_env_file"
+  export FAKE_WRITER_HOLD_FILE="$hold_file"
+  export kc_license="$sentinel" kc_vault="$sentinel"
+  export KC_LICENSE="$sentinel" KC_VAULT="$sentinel"
+  set -a
+
+  # shellcheck source=/dev/null
+  source "$helper"
+  declare -F shottr_defaults_write_stdin >/dev/null \
+    || fail "Shottr secret writer must expose the stdin-only public seam"
+  SHOTTR_DEFAULTS_WRITES_BLOCKED=0
+  (
+    shottr_defaults_write_stdin \
+      "$timeout_bin" "$writer_bin" "$sandbox/preferences" kc-license \
+      < <(builtin printf '%s' "$sentinel")
+  ) > "$output" 2>&1 &
+  call_pid=$!
+
+  for _ in {1..100}; do
+    [ -s "$timeout_pid_file" ] && [ -s "$writer_pid_file" ] && break
+    sleep 0.05
+  done
+  [ -s "$timeout_pid_file" ] && [ -s "$writer_pid_file" ] \
+    || fail "stdin writer fixture did not expose live supervisor and writer PIDs"
+  timeout_pid="$(cat "$timeout_pid_file")"
+  writer_pid="$(cat "$writer_pid_file")"
+
+  for pid in "$timeout_pid" "$writer_pid"; do
+    while IFS= read -r -d '' arg; do
+      case "$arg" in
+        *"$sentinel"*) fail "secret sentinel leaked into process argv for PID $pid" ;;
+      esac
+    done < <("$CLAUDE_RC_REAL_PID_ARGV_HELPER" "$pid")
+  done
+
+  received="$(cat "$received_file")"
+  [ "$received" = "$sentinel" ] || fail "stdin writer changed secret bytes"
+  [ "$(cat "$writer_env_file")" = $'kc_license=\nkc_vault=\nKC_LICENSE=\nKC_VAULT=' ] \
+    || fail "stdin writer inherited a secret-bearing activation variable"
+  set +a
+  unset kc_license kc_vault KC_LICENSE KC_VAULT
+  rm -f "$hold_file"
+  wait "$call_pid"
+  call_pid=""
+  trap - EXIT
+)
+
+test_shottr_license_refresh_helper_scrubs_child_environment() (
+  local sandbox helper deadlines mutant_script fake_bin
+  local defaults_bin nix_bin timeout_bin real_timeout output leak_log trace_log observed status
+  local SHOTTR_DEFAULTS_KILL_AFTER SHOTTR_DEFAULTS_DEADLINE
+  sandbox="$(new_sandbox)"
+  helper="$REPO_ROOT/scripts/secrets/refresh-shottr-license.sh"
+  deadlines="$REPO_ROOT/scripts/secrets/shottr-deadlines.sh"
+  mutant_script="$sandbox/refresh-shottr-license.mutant.sh"
+  fake_bin="$sandbox/bin"
+  defaults_bin="$fake_bin/defaults"
+  nix_bin="$fake_bin/nix"
+  timeout_bin="$sandbox/timeout bin/timeout"
+  real_timeout="$(command -v timeout)"
+  output="$sandbox/shottr-license.age"
+  leak_log="$sandbox/child-environment-leak.log"
+  trace_log="$sandbox/xtrace.log"
+  mkdir -p "$fake_bin" "$(dirname "$timeout_bin")"
+
+  # shellcheck disable=SC1090 # Repository-root path is supplied by the harness.
+  . "$deadlines"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -euo pipefail\n'
+    printf 'expected_kill_after=%q\n' "$SHOTTR_DEFAULTS_KILL_AFTER"
+    printf 'expected_deadline=%q\n' "$SHOTTR_DEFAULTS_DEADLINE"
+    printf 'real_timeout=%q\n' "$real_timeout"
+    cat <<'EOF'
+[ "$#" -ge 4 ] || exit 97
+[ "$1" = "-k" ] || exit 97
+[ "$2" = "$expected_kill_after" ] || exit 97
+[ "$3" = "$expected_deadline" ] || exit 97
+exec "$real_timeout" "$@"
+EOF
+  } > "$timeout_bin"
+
+  cat > "$defaults_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${kc_license+x}" = x ] \
+  || [ "${kc_vault+x}" = x ] \
+  || [ "${KC_LICENSE+x}" = x ] \
+  || [ "${KC_VAULT+x}" = x ]; then
+  printf 'secret-variable-present\n' >> "$FAKE_SHOTTR_LEAK_LOG"
+  exit 88
+fi
+last=""
+for arg in "$@"; do
+  last="$arg"
+done
+case "$last" in
+  kc-license) printf '%s\n' 'issue-1093-license-sentinel' ;;
+  kc-vault) printf '%s\n' 'issue-1093-vault-sentinel' ;;
+  *) exit 64 ;;
+esac
+EOF
+  cat > "$nix_bin" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${kc_license+x}" = x ] \
+  || [ "${kc_vault+x}" = x ] \
+  || [ "${KC_LICENSE+x}" = x ] \
+  || [ "${KC_VAULT+x}" = x ]; then
+  printf 'secret-variable-present\n' >> "$FAKE_SHOTTR_LEAK_LOG"
+  exit 88
+fi
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$output" ] || exit 64
+{
+  printf 'fixture-ciphertext\n'
+  cat
+} > "$output"
+EOF
+  chmod +x "$defaults_bin" "$nix_bin" "$timeout_bin"
+
+  awk '
+    { print }
+    /export -n kc_license/ { print "  export kc_license" }
+  ' "$helper" > "$mutant_script"
+  cp "$deadlines" "$sandbox/shottr-deadlines.sh"
+  chmod +x "$mutant_script"
+
+  run_hostile_refresh() {
+    local script="$1"
+    (
+      cd "$REPO_ROOT" || exit 1
+      set -a
+      export SHELLOPTS
+      kc_license='inherited-lower-license-sentinel'
+      kc_vault='inherited-lower-vault-sentinel'
+      KC_LICENSE='inherited-upper-license-sentinel'
+      KC_VAULT='inherited-upper-vault-sentinel'
+      env \
+        PATH="$fake_bin:$PATH" \
+        FAKE_SHOTTR_LEAK_LOG="$leak_log" \
+        SHOTTR_DEFAULTS_BIN="$defaults_bin" \
+        SHOTTR_AGE_ENCRYPT_ATOMIC="$REPO_ROOT/scripts/secrets/age-encrypt-atomic.sh" \
+        SHOTTR_TIMEOUT_BIN="$timeout_bin" \
+        PS4='+ ' bash -x "$script" "$output" "$nix_bin" 2> "$trace_log"
+    )
+  }
+
+  : > "$leak_log"
+  run_hostile_refresh "$helper" \
+    || fail "Shottr license refresh helper failed under hostile inherited environment"
+  [ ! -s "$leak_log" ] \
+    || fail "Shottr license refresh helper exposed a secret variable to a child environment"
+  assert_contains "$(cat "$trace_log")" "+ set +x"
+  assert_not_contains "$(cat "$trace_log")" "issue-1093-license-sentinel"
+  assert_not_contains "$(cat "$trace_log")" "issue-1093-vault-sentinel"
+  assert_not_contains "$(cat "$trace_log")" "inherited-lower-license-sentinel"
+  assert_not_contains "$(cat "$trace_log")" "inherited-lower-vault-sentinel"
+  assert_not_contains "$(cat "$trace_log")" "inherited-upper-license-sentinel"
+  assert_not_contains "$(cat "$trace_log")" "inherited-upper-vault-sentinel"
+  [ -f "$output" ] || fail "Shottr license refresh helper did not produce fixture ciphertext"
+  observed="$(cat "$output")"
+  assert_contains "$observed" "issue-1093-license-sentinel"
+  assert_contains "$observed" "issue-1093-vault-sentinel"
+
+  rm -f "$output"
+  : > "$leak_log"
+  status=0
+  run_hostile_refresh "$mutant_script" >/dev/null 2>&1 || status=$?
+  [ "$status" -ne 0 ] \
+    || fail "secret re-export mutant unexpectedly passed the hostile environment fixture"
+  [ -s "$leak_log" ] \
+    || fail "hostile environment fixture did not observe the secret re-export mutant"
+)
+
+test_shottr_age_encryption_is_atomic() (
+  local sandbox helper fake_age output old_ciphertext plaintext observed
+  local old_mode old_uid old_gid target target_link target_mode target_uid target_gid
+  local top_link absolute_link dangling_link loop_a loop_b loop_status
+  local mock_bin metadata_log real_stat real_chmod
+  sandbox="$(new_sandbox)"
+  helper="$REPO_ROOT/scripts/secrets/age-encrypt-atomic.sh"
+  fake_age="$sandbox/fake-age"
+  output="$sandbox/shottr-license.age"
+  old_ciphertext='existing-ciphertext-fixture'
+  plaintext='shottr-plaintext-fixture'
+
+  cat > "$fake_age" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+mode="$1"
+shift
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$output" ] || exit 64
+payload="$(cat)"
+printf 'encrypted:%s\n' "$payload" > "$output"
+[ "$mode" != "fail-after-write" ]
+EOF
+  chmod +x "$fake_age"
+  printf '%s\n' "$old_ciphertext" > "$output"
+  chmod 0644 "$output"
+  old_mode="$(stat -c '%a' "$output" 2>/dev/null || /usr/bin/stat -f '%Lp' "$output")"
+  old_uid="$(stat -c '%u' "$output" 2>/dev/null || /usr/bin/stat -f '%u' "$output")"
+  old_gid="$(stat -c '%g' "$output" 2>/dev/null || /usr/bin/stat -f '%g' "$output")"
+
+  if builtin printf '%s' "$plaintext" | "$helper" "$output" "$fake_age" fail-after-write; then
+    fail "failing age command unexpectedly replaced ciphertext"
+  fi
+  observed="$(cat "$output")"
+  [ "$observed" = "$old_ciphertext" ] \
+    || fail "failed age command changed existing ciphertext"
+  if find "$sandbox" -maxdepth 1 -name '.shottr-license.age.tmp.*' -print -quit | grep -q .; then
+    fail "failed age command left a plaintext-bearing temporary file"
+  fi
+
+  builtin printf '%s' "$plaintext" | "$helper" "$output" "$fake_age" success
+  observed="$(cat "$output")"
+  [ "$observed" = "encrypted:$plaintext" ] \
+    || fail "successful age command did not atomically replace ciphertext"
+  [ "$(stat -c '%a' "$output" 2>/dev/null || /usr/bin/stat -f '%Lp' "$output")" = "$old_mode" ] \
+    || fail "atomic replacement changed an existing output mode"
+  [ "$(stat -c '%u' "$output" 2>/dev/null || /usr/bin/stat -f '%u' "$output")" = "$old_uid" ] \
+    || fail "atomic replacement changed an existing output owner"
+  [ "$(stat -c '%g' "$output" 2>/dev/null || /usr/bin/stat -f '%g' "$output")" = "$old_gid" ] \
+    || fail "atomic replacement changed an existing output group"
+  if find "$sandbox" -maxdepth 1 -name '.shottr-license.age.tmp.*' -print -quit | grep -q .; then
+    fail "successful age command left a temporary file"
+  fi
+
+  mkdir -p "$sandbox/target"
+  target="$sandbox/target/shottr-license.age"
+  target_link="$sandbox/shottr-license-link.age"
+  printf '%s\n' "$old_ciphertext" > "$target"
+  chmod 0640 "$target"
+  ln -s 'target/shottr-license.age' "$target_link"
+  target_mode="$(stat -c '%a' "$target" 2>/dev/null || /usr/bin/stat -f '%Lp' "$target")"
+  target_uid="$(stat -c '%u' "$target" 2>/dev/null || /usr/bin/stat -f '%u' "$target")"
+  target_gid="$(stat -c '%g' "$target" 2>/dev/null || /usr/bin/stat -f '%g' "$target")"
+
+  builtin printf '%s' "$plaintext" | "$helper" "$target_link" "$fake_age" success
+  [ -L "$target_link" ] || fail "atomic replacement replaced the output symlink"
+  [ "$(readlink "$target_link")" = 'target/shottr-license.age' ] \
+    || fail "atomic replacement changed the output symlink target"
+  [ "$(cat "$target")" = "encrypted:$plaintext" ] \
+    || fail "atomic replacement did not update the symlink target"
+  [ "$(stat -c '%a' "$target" 2>/dev/null || /usr/bin/stat -f '%Lp' "$target")" = "$target_mode" ] \
+    || fail "symlink target replacement changed mode"
+  [ "$(stat -c '%u' "$target" 2>/dev/null || /usr/bin/stat -f '%u' "$target")" = "$target_uid" ] \
+    || fail "symlink target replacement changed owner"
+  [ "$(stat -c '%g' "$target" 2>/dev/null || /usr/bin/stat -f '%g' "$target")" = "$target_gid" ] \
+    || fail "symlink target replacement changed group"
+
+  top_link="$sandbox/shottr-license-top.age"
+  ln -s 'shottr-license-link.age' "$top_link"
+  if builtin printf '%s' 'must-not-replace' \
+      | "$helper" "$top_link" "$fake_age" fail-after-write; then
+    fail "failing age command unexpectedly replaced a multi-hop symlink target"
+  fi
+  [ -L "$top_link" ] && [ -L "$target_link" ] \
+    || fail "failing age command replaced a symlink hop"
+  [ "$(cat "$target")" = "encrypted:$plaintext" ] \
+    || fail "failing age command changed a multi-hop symlink target"
+  if find "$(dirname "$target")" -maxdepth 1 -name '.shottr-license.age.tmp.*' \
+      -print -quit | grep -q .; then
+    fail "failing multi-hop replacement left a target-directory temporary file"
+  fi
+
+  absolute_link="$sandbox/shottr-license-absolute.age"
+  ln -s "$top_link" "$absolute_link"
+  builtin printf '%s' 'absolute-hop-payload' \
+    | "$helper" "$absolute_link" "$fake_age" success
+  [ -L "$absolute_link" ] && [ "$(readlink "$absolute_link")" = "$top_link" ] \
+    || fail "atomic replacement changed an absolute symlink hop"
+  [ "$(cat "$target")" = 'encrypted:absolute-hop-payload' ] \
+    || fail "atomic replacement did not update the absolute multi-hop target"
+
+  dangling_link="$sandbox/shottr-license-dangling.age"
+  ln -s 'target/new-shottr-license.age' "$dangling_link"
+  builtin printf '%s' "$plaintext" | "$helper" "$dangling_link" "$fake_age" success
+  [ -L "$dangling_link" ] \
+    || fail "atomic replacement replaced a dangling output symlink"
+  [ "$(cat "$sandbox/target/new-shottr-license.age")" = "encrypted:$plaintext" ] \
+    || fail "atomic replacement did not create the dangling symlink target"
+  [ "$(stat -c '%a' "$sandbox/target/new-shottr-license.age" 2>/dev/null \
+      || /usr/bin/stat -f '%Lp' "$sandbox/target/new-shottr-license.age")" = "600" ] \
+    || fail "new dangling symlink target did not retain restrictive mode"
+
+  loop_a="$sandbox/loop-a.age"
+  loop_b="$sandbox/loop-b.age"
+  ln -s 'loop-b.age' "$loop_a"
+  ln -s 'loop-a.age' "$loop_b"
+  loop_status=0
+  builtin printf '%s' "$plaintext" \
+    | "$helper" "$loop_a" "$fake_age" success >/dev/null 2>&1 \
+    || loop_status=$?
+  [ "$loop_status" = "74" ] || fail "symlink loop returned $loop_status instead of 74"
+  [ -L "$loop_a" ] && [ -L "$loop_b" ] \
+    || fail "symlink loop handling replaced an output link"
+  if find "$sandbox" -maxdepth 2 -name '.*.tmp.*' -print -quit | grep -q .; then
+    fail "symlink loop handling left a temporary file"
+  fi
+
+  # Exercise the ownership-change branch without requiring root. The mock stat
+  # reports distinct target/temp ownership, while mock chown records success;
+  # chmod must run afterward because a real chown may clear special mode bits.
+  mock_bin="$sandbox/metadata-bin"
+  metadata_log="$sandbox/metadata.log"
+  real_stat="$(command -v stat)"
+  real_chmod="$(command -v chmod)"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%u" ]; then
+  case "$3" in *.tmp.*) echo 222 ;; *) echo 111 ;; esac
+  exit 0
+fi
+if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%g" ]; then
+  case "$3" in *.tmp.*) echo 444 ;; *) echo 333 ;; esac
+  exit 0
+fi
+exec "$REAL_STAT" "$@"
+EOF
+  cat > "$mock_bin/chown" <<'EOF'
+#!/usr/bin/env bash
+printf 'chown\n' >> "$METADATA_LOG"
+EOF
+  cat > "$mock_bin/chmod" <<'EOF'
+#!/usr/bin/env bash
+printf 'chmod\n' >> "$METADATA_LOG"
+exec "$REAL_CHMOD" "$@"
+EOF
+  chmod +x "$mock_bin/stat" "$mock_bin/chown" "$mock_bin/chmod"
+  : > "$metadata_log"
+  builtin printf '%s' "$plaintext" | env \
+    PATH="$mock_bin:$PATH" \
+    REAL_STAT="$real_stat" \
+    REAL_CHMOD="$real_chmod" \
+    METADATA_LOG="$metadata_log" \
+    "$helper" "$output" "$fake_age" success
+  [ "$(cat "$metadata_log")" = $'chown\nchmod' ] \
+    || fail "atomic replacement did not restore mode after ownership"
+)
+
+test_shottr_cfpreferences_writer_round_trip() {
+  local sandbox writer source target key sentinel timeout_bin observed
+  if [ "$(uname -s)" != "Darwin" ]; then
+    printf 'N/A: Shottr CFPreferences writer fixture requires Darwin; runner=%s\n' "$(uname -s)"
+    return 0
+  fi
+
+  sandbox="$(new_sandbox)"
+  writer="$sandbox/shottr-cfpreferences-writer"
+  source="$REPO_ROOT/modules/darwin/programs/shottr/cfpreferences-writer.c"
+  target="$sandbox/issue-1093-preferences"
+  key="fixture-key"
+  sentinel='issue-1093-cfpreferences-value'
+  timeout_bin="$(command -v timeout)" || fail "GNU timeout is required"
+
+  [ -f "$source" ] || fail "Shottr CFPreferences writer source is missing"
+  cc -std=c11 -O2 -Wall -Wextra -Werror \
+    "$source" -framework CoreFoundation -o "$writer"
+  builtin printf '%s' "$sentinel" | "$writer" "$target" "$key"
+  observed="$(
+    "$timeout_bin" -k 2s 10s /usr/bin/defaults read "$target" "$key" 2>/dev/null
+  )" || fail "CFPreferences writer value was not readable through defaults"
+  [ "$observed" = "$sentinel" ] || fail "CFPreferences writer round-trip mismatch"
+  "$timeout_bin" -k 2s 10s /usr/bin/defaults delete "$target" "$key" >/dev/null 2>&1 \
+    || fail "CFPreferences fixture cleanup failed"
+}


### PR DESCRIPTION
## Summary

- `nrs`/home-manager activation 중 Shottr가 유발하는 TCC hang을 deadline+circuit breaker로 자르고, 라이선스 값의 argv/env 노출을 제거합니다.

Closes #1175

## 이 PR은 #1133의 분할본입니다 (2/3)

**base가 `main`이 아니라 PR-A(#1177) 브랜치입니다** — PR-A 머지 후 base를 main으로 자동 전환됩니다. diff는 Shottr 변경만 보입니다.

이 변경은 #1093(원격 세션 TCC)과 **인과가 다릅니다**: #1093은 원격 도구 호출이 트리거이고, 이 건은 activation이 트리거입니다. plan 028 스스로 "두 사건의 evidence와 성공 판정을 섞지 않는다"고 명시합니다.

## 해결

**deadline과 circuit breaker**
- 모든 `defaults` read/write를 GNU `timeout`으로 감쌈 (read 5s / write 30s, `scripts/secrets/shottr-deadlines.sh` 단일 소스)
- 같은 activation 안에서 한 번 timeout이 나면 후속 write를 건너뜀 (prompt 뜬 상태에서 write 반복은 대기만 늘림)
- timeout이 나도 activation은 실패시키지 않고 계속 진행

**크레덴셜 노출 제거**
- `defaults write ... -string "$license"`는 값을 argv에 실어 `ps`로 노출됨. CFPreferences를 직접 호출하는 native writer 도입, 값은 stdin 전용, 버퍼는 `secure_zero`
- `refresh-shottr-license.sh`가 child environment에서도 값 제거
- age 재암호화는 성공한 임시 출력을 같은 디렉토리에서 atomic rename으로 교체 (`age-encrypt-atomic.sh` — 다른 `.age` 갱신에도 재사용 가능)

## 구현 상세

| 파일 | 변경 |
|---|---|
| `modules/darwin/programs/shottr/defaults-helper.sh` | timeout·circuit breaker 본체 (신규) |
| `modules/darwin/programs/shottr/cfpreferences-writer.c` | stdin 전용 CFPreferences writer + secure_zero (신규) |
| `scripts/secrets/{shottr-deadlines,refresh-shottr-license,age-encrypt-atomic}.sh` | deadline 상수 / env scrub / atomic 재암호화 |
| `libraries/constants.nix` | Shottr CFPreferences target 경로 (추가 2줄, 기존 값 무변경) |
| `tests/suites/shottr-defaults.sh` | 회귀 fixture 5건 |
| `tests/eval-tests.nix` | Test D27 (선언된 activation entries 존재) |

## 검증

- eval-tests 양쪽 통과
- 셸 스위트 245 통과 / 0 실패
- `cfpreferences-writer.c` 실측: argv는 경로·키만 받고 값은 `read(STDIN_FILENO)` 전용, `secure_zero` 3곳 호출 확인

## Notes

관련 과거 이슈 #242 (Shottr defaults write 샌드박스 오류로 HM activation 중단, CLOSED) — 같은 계열 증상의 근본 대응입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * Shottr 설정 쓰기/라이선스 갱신에 표준 입력 기반 전달 방식을 적용해 노출을 줄였습니다.
  * 라이선스/암호문 갱신은 원자적(atomic) 파일 교체로 실패 시 기존 파일을 보존하도록 개선했습니다.
  * Shottr “defaults” 작업에 시간 제한과 타임아웃 시 후속 쓰기 차단 규칙을 추가했습니다.
* **문서**
  * 라이선스 pre-fill/갱신 절차와 안전 동작(실패 시 중단, 평문 노출 최소화)을 문서로 업데이트했습니다.
* **테스트**
  * 시간 제한, 환경 격리, stdin 동작, 원자성, CFPreferences 라운드트립을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->