### PR TITLE
fix(skills): using-gh-attach의 존재하지 않는 gh repo view -R 지침 제거

### DIFF
--- a/modules/shared/programs/claude/files/skills/using-gh-attach/SKILL.md
+++ b/modules/shared/programs/claude/files/skills/using-gh-attach/SKILL.md
@@ -49,7 +49,7 @@ description: >-
 
 ## 단독 호출 branch
 
-1. 대상 확정과 repo 고정: 첨부할 이슈 또는 PR의 URL·번호를 확인한다. URL이면 URL에서 `OWNER_REPO`와 번호를 추출하고, 번호만 받았으면 현재 작업 디렉터리의 canonical repo(`gh repo view --json nameWithOwner -q .nameWithOwner`)를 `OWNER_REPO`로 사용한다. 추출한 repo가 현재 작업 디렉터리의 canonical repo와 다르면 진행하지 않고 거부한다 — cross-repo 첨부는 미지원이다 (업로드 asset의 접근 경계가 `-R` 지정 repo에 묶이므로, 대상 불일치는 잘못된 본문 조회·엉뚱한 저장소 게시로 이어진다). 대상이 불명확하면 진행 전에 확인을 요청한다. 이후 모든 조회·게시 명령에 같은 `-R "$OWNER_REPO"`를 명시한다.
+1. 대상 확정과 repo 고정: 첨부할 이슈 또는 PR의 URL·번호를 확인한다. URL이면 URL에서 `OWNER_REPO`와 번호를 추출하고, 번호만 받았으면 현재 작업 디렉터리의 canonical repo(`gh repo view --json nameWithOwner -q .nameWithOwner`)를 `OWNER_REPO`로 사용한다. 추출한 repo가 현재 작업 디렉터리의 canonical repo와 다르면 진행하지 않고 거부한다 — cross-repo 첨부는 미지원이다 (업로드 asset의 접근 경계가 `gh attach -R`로 지정한 repo에 묶이므로, 대상 불일치는 잘못된 본문 조회·엉뚱한 저장소 게시로 이어진다). 대상이 불명확하면 진행 전에 확인을 요청한다. 이후 모든 조회·게시 명령은 대상 repo를 명령 자체에 명시하되, 명시 문법은 명령마다 다르므로 [references/upload-and-reporting.md](references/upload-and-reporting.md) 3절의 표를 따른다.
 2. 기존 본문 조회·보존: surface별로 현재 본문을 조회해 보존한다 — 이슈는 `gh issue view <N> -R "$OWNER_REPO" --json body`, PR은 `gh pr view <N> -R "$OWNER_REPO" --json body`.
 3. 삽입 방식 선택: 본문(body) 수정과 comment 추가 중 하나를 정한다. 사용자가 지정하지 않았으면 기존 본문 훼손 위험이 없는 comment 추가를 권한다.
 4. 게시 의사 확정: 비가역 업로드 전에 대상, 삽입 방식, 게시 여부를 확정한다. 확정 전에는 업로드하지 않는다.

--- a/modules/shared/programs/claude/files/skills/using-gh-attach/references/preflight-gates.md
+++ b/modules/shared/programs/claude/files/skills/using-gh-attach/references/preflight-gates.md
@@ -100,10 +100,11 @@ exit code를 다음과 같이 처리한다 — `0`(정적 PNG): 직접 검사 �
 
 #### 비-PUBLIC repo 완화
 
-대상 repo의 visibility가 `PRIVATE` 또는 `INTERNAL`로 확인되면 위 사용자 확인을 생략하고 해당 후보를 다음 단계로 진행한다. 근거: 업로드 asset의 접근 경계가 `-R` 지정 repo에 묶이므로([../SKILL.md](../SKILL.md)의 cross-repo 거부와 같은 접근 모델) 노출 면이 repo 접근 권한자로 한정되고, 이때 확인 게이트의 비용이 방어 가치를 넘는다.
+대상 repo의 visibility가 `PRIVATE` 또는 `INTERNAL`로 확인되면 위 사용자 확인을 생략하고 해당 후보를 다음 단계로 진행한다. 근거: 업로드 asset의 접근 경계가 `gh attach -R`로 지정한 repo에 묶이므로([../SKILL.md](../SKILL.md)의 cross-repo 거부와 같은 접근 모델) 노출 면이 repo 접근 권한자로 한정되고, 이때 확인 게이트의 비용이 방어 가치를 넘는다.
 
-- 판정은 각 후보의 업로드 직전에, 업로드와 같은 실행기로 수행한다: `"$GH_EXEC" repo view -R "$OWNER_REPO" --json visibility -q .visibility`. 후보가 여럿이면 후보마다 판정한다 — 절차 도중 repo visibility가 바뀔 수 있고(org repo의 다른 admin 등), 이 스킬은 대상 repo가 개인 소유인지 검증하지 않는다(`../SKILL.md`의 repo 고정은 cwd canonical repo와의 일치만 강제한다). 판정과 업로드 사이 창을 원자적으로 없앨 수는 없으므로, 판정을 업로드에 붙여 노출 창을 최소화하는 것이 이 규칙의 목적이다.
+- 판정은 각 후보의 업로드 직전에, 업로드와 같은 실행기로 수행한다: `"$GH_EXEC" repo view "$OWNER_REPO" --json visibility -q .visibility`. `gh repo view`는 `-R`을 받지 않고 repo를 positional 인자로 받는다 ([upload-and-reporting.md](upload-and-reporting.md) 3절의 repo 명시 문법 표). 후보가 여럿이면 후보마다 판정한다 — 절차 도중 repo visibility가 바뀔 수 있고(org repo의 다른 admin 등), 이 스킬은 대상 repo가 개인 소유인지 검증하지 않는다(`../SKILL.md`의 repo 고정은 cwd canonical repo와의 일치만 강제한다). 판정과 업로드 사이 창을 원자적으로 없앨 수는 없으므로, 판정을 업로드에 붙여 노출 창을 최소화하는 것이 이 규칙의 목적이다.
 - 완화는 판정 결과가 정확히 `PRIVATE` 또는 `INTERNAL`일 때만 적용한다. 그 외 값(`PUBLIC`, 빈 출력, 알 수 없는 값)과 판정 실패는 전부 위 확인 게이트를 그대로 적용한다 — allowlist 밖은 모두 게이트 유지가 기본값이다 (fail-closed).
+- 게이트를 유지한 후보는 그 사유를 최종 보고에 구분해 명시한다 — 판정된 visibility 값(`PUBLIC` 등)인지, 판정 자체가 실패했는지(명령 오류·빈 출력·알 수 없는 값). 사유를 남기지 않으면 판정 명령이 고장 나 완화가 영구히 죽어 있어도 정상적인 `PUBLIC` 판정과 구별되지 않는다 (fail-closed라 안전 방향이지만 기능은 조용히 사망한다).
 - 완화 범위는 이 확인 게이트 하나뿐이다. 마스킹 게이트의 직접 검사와 `SKIPPED(SENSITIVE_CONTENT)` 처리, 게시 의사 확정, 업로드 비가역 취급은 visibility와 무관하게 유지된다.
 - 확인을 생략하더라도 현재 런타임에서 가용한 검사 수단(2절 표와 그 통과 요건의 "표에 없는 수단" 조항 기준)으로 부분 열람이 가능하면 best-effort로 열람하고, 민감정보가 보이면 `SKIPPED(SENSITIVE_CONTENT)`로 기록한다. 부분 열람은 통과 요건이 아니라 추가 방어선이다 — 수단이 없거나 실패해도 업로드는 진행한다.
 - 이 완화로 확인 없이 업로드한 후보는 최종 보고에 "내용 미검사 업로드 (비-PUBLIC 완화)"를 명시한다.

--- a/modules/shared/programs/claude/files/skills/using-gh-attach/references/upload-and-reporting.md
+++ b/modules/shared/programs/claude/files/skills/using-gh-attach/references/upload-and-reporting.md
@@ -18,7 +18,7 @@ LOGIN=$("$GH_EXEC" api user --jq .login)
 - 브라우저 쿠키 자동 탐색이 명시적으로 실패하면 업로드가 발생하지 않은 것을 확인한 뒤 [cookie-discovery.md](cookie-discovery.md)의 절차로 로그인 프로필을 특정해 재시도한다 (auto 탐색이 실패하는 구조적 사유는 그 문서 1절 참조). 조사의 자율 경계(메타데이터 한정)와 박제 금지 원칙도 그 문서를 따른다.
 - 계정, repo, 확장 공급 원점 또는 무결성 상태가 불명확하면 업로드하지 않고 `FAILED(PREUPLOAD)`으로 기록한다.
 
-`OWNER_REPO`를 고정한 뒤의 모든 조회·게시·업로드 명령은 대상 repo를 명령 자체에 명시한다. 명시 문법은 명령마다 다르므로(플래그로 받는 명령과 positional 인자로 받는 명령이 섞여 있다) 아래 표 밖의 명령은 실행 전 `--help`로 확인한다.
+`OWNER_REPO`를 고정한 뒤, 대상 이슈·PR·repo·asset을 다루는 repo-scoped 조회·게시·업로드 명령은 대상 repo를 명령 자체에 명시한다. 위 `api user`·`extension list`처럼 repo를 대상으로 하지 않는 계정·확장 조회는 이 규칙의 대상이 아니다. 명시 문법은 명령마다 다르므로(플래그로 받는 명령과 positional 인자로 받는 명령이 섞여 있다) 아래 표 밖의 repo-scoped 명령은 실행 전 `--help`로 확인한다.
 
 | 명령 | repo 명시 문법 |
 |------|----------------|
@@ -29,10 +29,24 @@ LOGIN=$("$GH_EXEC" api user --jq .login)
 
 `gh repo view`는 이 스킬에서 두 용도로 쓰이고 인자 유무가 서로 다르다 — 뒤섞으면 검증이 무력화된다.
 
-- cwd canonical repo를 탐지할 때는 위 코드블록처럼 인자 없이 호출한다. 여기에 `"$OWNER_REPO"`를 넣으면 "추출한 repo가 cwd canonical repo와 같은가"라는 검증이 자기 입력을 되돌려받는 순환이 되어 cross-repo 거부([../SKILL.md](../SKILL.md))가 무력화된다.
+- cwd canonical repo를 탐지할 때는 위 코드블록처럼 인자 없이 호출한다. 여기에 `"$OWNER_REPO"`를 넣으면 "추출한 repo가 cwd canonical repo와 같은가"라는 검증이 자기 입력을 되돌려받는 순환이 되어 cross-repo 거부([../SKILL.md](../SKILL.md#단독-호출-branch) 단독 호출 branch 1단계)가 무력화된다.
 - 이미 고정된 대상 repo를 조회할 때는(visibility 판정 등) `"$OWNER_REPO"`를 positional로 명시한다.
 
-표는 gh 2.96.0 실측이다 — 재검증은 `gh <명령> --help`의 `-R, --repo` 유무와 `USAGE` 줄의 positional 자리를 대조한다. `gh attach`는 gh CLI가 아니라 fork한 확장(`greenheadHQ/gh-attach`)이 제공하므로 gh 버전과 무관하게 `gh attach --help`로 따로 확인한다.
+표는 gh 2.96.0 실측이다. 재검증은 3단계에서 고정한 같은 실행기로 수행하고, 각 출력의 `-R, --repo` 유무와 `USAGE` 줄의 positional 자리를 표와 대조한다.
+
+```bash
+"$GH_EXEC" --version
+"$GH_EXEC" issue view --help
+"$GH_EXEC" issue edit --help
+"$GH_EXEC" issue comment --help
+"$GH_EXEC" pr view --help
+"$GH_EXEC" pr edit --help
+"$GH_EXEC" pr comment --help
+"$GH_EXEC" repo view --help
+"$GH_EXEC" attach --help
+```
+
+마지막 `attach`는 gh CLI가 아니라 fork한 확장(`greenheadHQ/gh-attach`)이 제공하므로 gh 버전 스탬프의 적용 대상이 아니다 — 확장을 업그레이드하면 이 명령으로 따로 확인한다.
 
 ## 4. 업로드와 본문 삽입
 

--- a/modules/shared/programs/claude/files/skills/using-gh-attach/references/upload-and-reporting.md
+++ b/modules/shared/programs/claude/files/skills/using-gh-attach/references/upload-and-reporting.md
@@ -18,6 +18,22 @@ LOGIN=$("$GH_EXEC" api user --jq .login)
 - 브라우저 쿠키 자동 탐색이 명시적으로 실패하면 업로드가 발생하지 않은 것을 확인한 뒤 [cookie-discovery.md](cookie-discovery.md)의 절차로 로그인 프로필을 특정해 재시도한다 (auto 탐색이 실패하는 구조적 사유는 그 문서 1절 참조). 조사의 자율 경계(메타데이터 한정)와 박제 금지 원칙도 그 문서를 따른다.
 - 계정, repo, 확장 공급 원점 또는 무결성 상태가 불명확하면 업로드하지 않고 `FAILED(PREUPLOAD)`으로 기록한다.
 
+`OWNER_REPO`를 고정한 뒤의 모든 조회·게시·업로드 명령은 대상 repo를 명령 자체에 명시한다. 명시 문법은 명령마다 다르므로(플래그로 받는 명령과 positional 인자로 받는 명령이 섞여 있다) 아래 표 밖의 명령은 실행 전 `--help`로 확인한다.
+
+| 명령 | repo 명시 문법 |
+|------|----------------|
+| `gh issue view`·`gh issue edit`·`gh issue comment` | `-R "$OWNER_REPO"` |
+| `gh pr view`·`gh pr edit`·`gh pr comment` | `-R "$OWNER_REPO"` |
+| `gh attach` | `-R "$OWNER_REPO"` |
+| `gh repo view` | positional — `gh repo view "$OWNER_REPO"` (`-R`을 받지 않는다) |
+
+`gh repo view`는 이 스킬에서 두 용도로 쓰이고 인자 유무가 서로 다르다 — 뒤섞으면 검증이 무력화된다.
+
+- cwd canonical repo를 탐지할 때는 위 코드블록처럼 인자 없이 호출한다. 여기에 `"$OWNER_REPO"`를 넣으면 "추출한 repo가 cwd canonical repo와 같은가"라는 검증이 자기 입력을 되돌려받는 순환이 되어 cross-repo 거부([../SKILL.md](../SKILL.md))가 무력화된다.
+- 이미 고정된 대상 repo를 조회할 때는(visibility 판정 등) `"$OWNER_REPO"`를 positional로 명시한다.
+
+표는 gh 2.96.0 실측이다 — 재검증은 `gh <명령> --help`의 `-R, --repo` 유무와 `USAGE` 줄의 positional 자리를 대조한다. `gh attach`는 gh CLI가 아니라 fork한 확장(`greenheadHQ/gh-attach`)이 제공하므로 gh 버전과 무관하게 `gh attach --help`로 따로 확인한다.
+
 ## 4. 업로드와 본문 삽입
 
 각 파일을 30초 timeout으로 한 번만 업로드한다. 업로드 대상은 사전 게이트 7단계([preflight-gates.md](preflight-gates.md))에서 고정한 staging 사본 경로다 — 원본 경로를 다시 읽지 않는다. `command`는 shell builtin이므로 `timeout 30 command gh ...` 형태를 사용하지 않는다.


### PR DESCRIPTION
## Summary

- `using-gh-attach` 스킬이 repo visibility 판정 명령으로 지시하던 `gh repo view -R "$OWNER_REPO"`를 정정한다 — `gh repo view`는 `-R/--repo`를 받지 않고 repo를 positional 인자로 받는다.
- 재발 원인인 "이후 모든 조회·게시 명령에 같은 `-R`을 명시한다"는 과잉 일반화를 명령별 실측 문법 표로 교체하고, 그 표를 references 1곳의 SSOT로 둔다.
- 게이트를 유지한 사유(판정된 visibility 값 vs 판정 실패)를 보고에 구분해 명시하도록 해서, 판정 명령이 고장 나도 정상 판정과 구별되지 않는 조용한 기능 사망을 드러낸다.

## 기존 문제/배경

`references/preflight-gates.md`의 "비-PUBLIC repo 완화" 절차는 각 후보의 업로드 직전에 대상 repo의 visibility를 판정하고, `PRIVATE`·`INTERNAL`이면 검사 불가 파일의 사용자 확인 게이트를 생략한다. 그 판정 명령이 다음과 같이 적혀 있었다.

```bash
"$GH_EXEC" repo view -R "$OWNER_REPO" --json visibility -q .visibility
```

그러나 `gh repo view`에는 `-R/--repo` 플래그가 없다. 실측 (gh 2.96.0):

```text
$ gh repo view -R greenheadHQ/nixos-config --json visibility -q .visibility
unknown shorthand flag: 'R' in -R

Usage:  gh repo view [<repository>] [flags]
```

이 명령은 실행될 때마다 exit 1로 실패한다. 즉 비-PUBLIC 완화는 도입 이후 한 번도 적용된 적이 없다.

문제를 오래 살아남게 만든 것은 실패 자체가 아니라 **실패가 보이지 않았다는 점**이다. 같은 문서가 "그 외 값(`PUBLIC`, 빈 출력, 알 수 없는 값)과 판정 실패는 전부 확인 게이트를 그대로 적용한다 (fail-closed)"라고 규정하므로, 판정이 깨져도 동작은 안전한 쪽(사용자 확인 요구)으로 수렴한다. 사용자 입장에서는 "PUBLIC repo라 확인을 요구하는구나"와 "판정 명령이 아예 고장 났구나"가 똑같이 보인다. 안전 방향이라 사고는 나지 않고, 대신 기능이 죽은 채로 묻혔다.

실제로 이 결함은 별개의 첨부 작업 중 명령이 에러를 내면서 드러났고, 그 세션에서는 첫 실패 직후 문서 오류보다 gh 버전 차이 가능성을 먼저 의심해 진단이 한 단계 돌아갔다.

## CIR (Change Intent Record)

- **v1** (PR #1122): 증빙 첨부 절차를 최초 선언화했다. 이 시점의 단독 호출 경로는 `gh issue view <N> --json body`처럼 repo 지정 없이 조회했다.
- **v2** (PR #1124): 정본을 독립 스킬로 승격했고, 이 PR의 리뷰 피드백 반영 과정에서 "단독 호출 대상 repo 고정 — URL에서 `OWNER_REPO` 추출, cwd canonical repo 불일치 시 거부(cross-repo 미지원), 모든 조회·게시 명령에 `-R` 명시"가 도입됐다. 당시 이 규칙이 걸리는 명령은 `gh issue view`·`gh pr view`·`gh attach`뿐이었고 셋 다 `-R`을 지원하므로 일반화가 성립했다.
- **v3** (PR #1144): 비-PUBLIC repo 완화를 신설하며 visibility 판정 명령을 추가했고, 이때 v2의 `-R` 일반화를 `gh repo view`에 그대로 적용해 결함이 유입됐다. 같은 PR의 ADR은 "visibility 판정 실패는 PUBLIC 취급으로 fail-closed"를 의도적 결정으로 기록하고 있다.
- **v4** (이번 변경): 판정 명령을 positional 형식으로 정정하고, 재발을 유도한 일반화 문구를 명령별 실측 문법 표로 교체한다. fail-closed 동작 자체는 v3의 의도적 결정이므로 유지하되, 게이트를 유지한 사유를 보고에 남기게 해 같은 종류의 조용한 사망이 다음에는 드러나도록 한다.

제거 대상과 그 도입 근거: 이번 변경이 걷어내는 "모든 조회·게시 명령에 `-R`" 문구는 PR #1124(`e70ef77e`)에서 외부 코드리뷰 지적을 반영해 의도적으로 도입된 것이다. 그 의도는 "repo를 ambient 컨텍스트가 아니라 명령 자체에 명시적으로 고정한다"였고, `-R`은 당시 대상 명령 집합에서 그 의도를 실현하는 수단이었다. 이번 변경은 **의도를 보존하고 수단만 명령별로 정확화**한다 — repo 명시 요구 자체는 그대로 남는다.

trade-off: 실측 표는 gh CLI가 문법을 바꾸면 낡는다. 재검증을 실행 가능한 코드블록으로 병기해 갱신 비용을 낮췄지만, 자동 검증 장치는 두지 않았다. 따라서 같은 종류의 미검증 CLI 문법이 새로 유입되는 것을 기계적으로 막지는 못한다.

## ADR

| 결정 축 | 대안 | 장점 | 단점 | 결정 |
|---------|------|------|------|------|
| 일반화 문구 대체 형태 | 원칙 문장 + 명령별 실측 표 | 바로 복붙할 구체 문법과, 표 밖 명령을 커버하는 원칙을 둘 다 가짐 | 표가 gh 변화에 따라 낡을 수 있음 | ✅ |
| | 원칙만 서술 (문법은 매번 `--help`) | 낡을 여지가 없음 | 복붙할 구체 문법이 없어 매 호출 확인 비용 | ❌ |
| | 명령별 표만 (원칙 없음) | 가장 간결 | 표에 없는 명령을 만났을 때 지침이 없어 같은 미검증 추정이 재발 | ❌ |
| | 기존 문장 유지 + `gh repo view` 예외 한 줄 | diff 최소 | "기본은 `-R`"이라는 틀린 멘탈모델이 그대로 남음 | ❌ |
| visibility 판정 명령 경로 | `repo view "$OWNER_REPO" --json visibility` (positional) | 대상 repo 명시라는 원래 의도 유지, 기존 대문자 allowlist 그대로 성립 | 없음 | ✅ |
| | `gh api repos/<owner>/<repo> --jq .visibility` | repo를 경로에 직접 넣어 `-R` 논쟁이 사라짐 | 반환값이 소문자(`public`)라 문서의 `PRIVATE`/`INTERNAL` 정확 일치 allowlist와 어긋남 — 채택하면 완화가 영영 적용되지 않는 조용한 회귀 | ❌ |
| | `repo view --json visibility` (인자 없음, cwd 기준) | 최소 변경 | cross-repo 거부 덕에 결과는 같지만 "대상 repo를 명시한다"는 원칙과 어긋남 | ❌ |
| 표의 SSOT 위치 | `references/upload-and-reporting.md` 3절 | SKILL.md가 스스로 선언한 역할 분담(본문은 라우팅·불변식·단계 요약)과 일치하고, repo 고정 절차와 같은 곳에 모임 | 단독 호출 흐름에서 한 단계 더 들어가야 보임 | ✅ |
| | SKILL.md에 인라인 | 진입 흐름에서 바로 보임 | SKILL.md가 명령 상세를 다시 떠안아 문서 역할 분담이 흐려짐 | ❌ |
| | 양쪽 중복 게재 | 어느 진입점에서도 보임 | SSOT가 둘로 갈라져 한쪽만 갱신되는 drift 위험 | ❌ |
| 재발 방지 범위 | 문서 정정만 | 원인(과잉 일반화 문구) 자체를 제거 | 새 미검증 문법 유입을 기계적으로 막지는 못함 | ✅ |
| | 스킬 문서 CLI 플래그 자동 lint 추가 | 기계적 재발 차단 | 저장소 전체 스킬 문서를 `--help`와 전수 대조한 결과 실제 오류는 이 1건뿐이고, 한국어 조사가 붙은 플래그(`--body-file은`)가 오탐으로 잡힘. gh 버전에 따라 결과가 달라지는 환경 의존 검사가 됨 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `references/preflight-gates.md` | 수정 | visibility 판정 명령을 positional 형식으로 교체 + 문법 표 역참조. 게이트 유지 사유를 보고에 구분 명시하는 규칙 추가. cross-repo 접근 모델 설명의 `-R`을 `gh attach -R`로 특정 |
| `references/upload-and-reporting.md` | 수정 | 3절에 repo 명시 문법 표(SSOT) 신설. `gh repo view`의 두 용법 구분, 실행 가능한 재검증 코드블록 추가 |
| `SKILL.md` | 수정 | 단독 호출 branch 1단계의 `-R` 일반화를 제거하고 문법 표 참조로 교체. cross-repo 근거의 `-R`을 `gh attach -R`로 특정 |

### 핵심 변경

```diff
- `"$GH_EXEC" repo view -R "$OWNER_REPO" --json visibility -q .visibility`
+ `"$GH_EXEC" repo view "$OWNER_REPO" --json visibility -q .visibility`
```

```diff
- 이후 모든 조회·게시 명령에 같은 `-R "$OWNER_REPO"`를 명시한다.
+ 이후 모든 조회·게시 명령은 대상 repo를 명령 자체에 명시하되, 명시 문법은
+ 명령마다 다르므로 references/upload-and-reporting.md 3절의 표를 따른다.
```

새로 추가한 표 (gh 2.96.0 실측):

| 명령 | repo 명시 문법 |
|------|----------------|
| `gh issue view`·`gh issue edit`·`gh issue comment` | `-R "$OWNER_REPO"` |
| `gh pr view`·`gh pr edit`·`gh pr comment` | `-R "$OWNER_REPO"` |
| `gh attach` | `-R "$OWNER_REPO"` |
| `gh repo view` | positional — `gh repo view "$OWNER_REPO"` (`-R`을 받지 않는다) |

표와 함께 `gh repo view`의 두 용법을 구분 명시했다. cwd canonical repo를 **탐지**할 때는 인자 없이 호출해야 하고(여기에 `$OWNER_REPO`를 넣으면 "추출한 repo가 cwd canonical repo와 같은가"라는 검증이 자기 입력을 되돌려받는 순환이 되어 cross-repo 거부가 무력화된다), 이미 고정된 대상 repo를 **조회**할 때만 positional로 명시한다.

게이트 유지 사유 보고 규칙:

```text
- 게이트를 유지한 후보는 그 사유를 최종 보고에 구분해 명시한다 — 판정된 visibility
  값(`PUBLIC` 등)인지, 판정 자체가 실패했는지(명령 오류·빈 출력·알 수 없는 값).
  사유를 남기지 않으면 판정 명령이 고장 나 완화가 영구히 죽어 있어도 정상적인
  PUBLIC 판정과 구별되지 않는다.
```

## 참고 레퍼런스

- Issue #1118 — gh-attach 증빙 첨부 통합. 이 스킬 계보의 출발점이며 D1 결정(독립 스킬 기각) 기록을 담고 있다
- PR #1122 — 증빙 첨부 절차 최초 선언화
- PR #1124 (`e70ef77e`) — `attaching-evidence` 정본을 `using-gh-attach` 독립 스킬로 승격. `-R` 일반화 문구가 이 PR의 리뷰 반영 과정에서 도입됐다
- PR #1144 — 비-PUBLIC 확인 게이트 완화 도입. 이번 결함의 유입 지점이자, "판정 실패는 fail-closed" 결정의 출처
- [gh repo view manual](https://cli.github.com/manual/gh_repo_view) — `gh repo view [<repository>] [flags]`, `--repo` 플래그 부재

## Human Test Plan

### 정상 동작 검증

1. 문서에 새로 기재된 판정 명령을 그대로 실행한다.

   ```bash
   GH_EXEC="$(command -v gh)"
   OWNER_REPO=$("$GH_EXEC" repo view --json nameWithOwner -q .nameWithOwner)
   "$GH_EXEC" repo view "$OWNER_REPO" --json visibility -q .visibility
   ```

   - **기대**: `PUBLIC` 출력, exit 0.
   - **실패 시**: `"$GH_EXEC" repo view --help`의 `USAGE` 줄을 확인한다. repo가 positional 자리에 있는지, `-R/--repo`가 FLAGS에 없는지 대조한다.

2. 문서의 재검증 코드블록(`upload-and-reporting.md` 3절)을 그대로 실행한다.
   - **기대**: 9개 명령이 모두 정상 종료하고, `gh issue`/`gh pr` 계열과 `gh attach`는 `-R, --repo`가 출력에 있으며 `gh repo view`에만 없다.
   - **실패 시**: gh 버전이 문서 스탬프(2.96.0)와 다른지 `"$GH_EXEC" --version`으로 확인하고, 달라진 문법을 표에 반영한다.

### Negative 검증 (old 값 부재)

3. 저장소에서 잘못된 문법이 완전히 사라졌는지 확인한다.

   ```bash
   grep -rn 'repo view -R' modules/shared/programs/claude/files/skills/
   ```

   - **기대**: 매치 0건.
   - **실패 시**: 남은 위치를 positional 형식으로 정정한다.

4. 옛 일반화 문구가 남아 있지 않은지 확인한다.

   ```bash
   grep -rn '모든 조회·게시 명령에 같은' modules/shared/programs/claude/files/skills/
   ```

   - **기대**: 매치 0건.
   - **실패 시**: 해당 위치를 문법 표 참조로 교체한다.

### 인접 기능 regression 검증

5. 이 스킬을 참조하는 소비자 스킬(`create-issue`, `create-pr`)의 게시 명령이 이번 변경의 영향을 받지 않는지 확인한다.
   - **기대**: `create-issue`의 `gh issue create`, `create-pr`의 `gh pr create`/`edit`은 여전히 각 스킬 문서의 지시대로 동작한다. 새 규칙은 `using-gh-attach`가 소유한 repo-scoped 명령에만 적용되며, 이슈/PR 생성과 본문 작성은 `SKILL.md`가 명시적으로 범위 밖으로 선언한 영역이다.
   - **실패 시**: `upload-and-reporting.md` 3절의 적용 범위 문장이 소비자 소유 명령까지 포괄하도록 읽히는지 재검토한다.

6. 스킬 문서 lint가 통과하는지 확인한다.
   - **기대**: 커밋 시 `skill-noise-check`(bold 잔존 0건)와 `ai-skills-consistency`가 통과한다.
   - **실패 시**: 보고된 위치의 강조 표기를 산문으로 바꾼다.

### 엣지 케이스

7. 대상이 비-PUBLIC repo인 상황을 가정해 완화 분기를 확인한다.
   - **기대**: 판정이 `PRIVATE` 또는 `INTERNAL`을 반환하면 검사 불가 파일의 사용자 확인이 생략되고, 최종 보고에 "내용 미검사 업로드 (비-PUBLIC 완화)"가 표시된다.
   - **실패 시**: 판정 명령의 출력이 대문자인지 확인한다. 소문자(`private`)가 나오면 `gh api` 경로를 쓰고 있는 것이므로 `repo view` 경로로 되돌린다.

8. 판정 명령이 실패하는 상황(네트워크 단절, 권한 없음)을 가정한다.
   - **기대**: 완화가 적용되지 않고 확인 게이트가 유지되며, 최종 보고에 사유가 "판정 실패"로 표시되어 `PUBLIC` 판정과 구별된다.
   - **실패 시**: 보고에 사유 구분이 없으면 `preflight-gates.md`의 게이트 유지 사유 명시 규칙이 반영됐는지 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서 업데이트**
  * 저장소 대상 조회·게시·업로드 명령의 저장소 지정 방식 안내를 명확히 했습니다.
  * 저장소 공개 범위 확인 절차와 비공개 저장소 예외 처리 기준을 보강했습니다.
  * 확인 실패 시 사용자 확인을 유지하고, 최종 보고서에 처리 사유를 구분해 표시하도록 안내합니다.
  * 명령별 도움말 검증 절차와 첨부 기능의 버전 관리 범위를 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->