### PR TITLE
docs(cheat): nvim 터미널 치트시트 추가 — Ctrl+/ 플로팅 터미널과 Ex 명령 CLI 실행

### DIFF
--- a/modules/shared/programs/cheat/cheatsheets/nvim/custom
+++ b/modules/shared/programs/cheat/cheatsheets/nvim/custom
@@ -8,6 +8,9 @@ tags: [ neovim, lazyvim, custom, keymap ]
   <leader>yP    절대 경로 복사 (클립보드)
   jk            Esc (Insert 모드)
   Ctrl+\        터미널 Normal 모드
+  <leader>C     cheatsheet 브라우저 (fzf)
+
+  ※ 터미널 열기/CLI 실행 전반은 nvim/terminal 참조
 
 편집 도구
   gcc           줄 주석 토글

--- a/modules/shared/programs/cheat/cheatsheets/nvim/terminal
+++ b/modules/shared/programs/cheat/cheatsheets/nvim/terminal
@@ -12,14 +12,18 @@ tags: [ neovim, lazyvim, terminal, shell, snacks ]
   <leader>C     cheatsheet 브라우저 (fzf)
 
   Ctrl+/ 는 Normal/Terminal 양쪽에 매핑되어 있어 터미널 안에서 눌러도 접힌다.
-  숨겨도 프로세스는 살아 있으므로 다시 열면 하던 작업이 그대로 이어진다.
+  숨기는 것은 프로세스를 죽이지 않으므로 다시 열면 하던 작업이 그대로 이어진다.
+  단 셸에서 exit 하거나 실행한 명령이 스스로 끝나면 창이 닫히고 세션도 사라진다
+  (snacks 기본 auto_close) → 다음에 열면 새 세션.
 
   ※ 모노레포: 소문자(ft)는 LSP root(현재 패키지), 대문자(fT)는 cwd(전체)
 
 터미널 모드 ↔ Normal 모드
 
   Ctrl+\        Normal 모드로 탈출   (커스텀, Vim 순정은 <C-\><C-n> 두 번)
+  Esc Esc       Normal 모드로 탈출   (snacks 플로팅 터미널 한정, 200ms 안에 두 번)
   i / a         다시 입력(Terminal) 모드로
+  q             (Normal 모드에서) 플로팅 터미널 숨기기 = Ctrl+/
 
   Normal 모드로 나오면 hjkl 스크롤, y 복사, / 검색이 그대로 동작한다.
   → 긴 빌드 로그에서 에러 줄만 찾아 복사할 때 유용.
@@ -50,6 +54,10 @@ tags: [ neovim, lazyvim, terminal, shell, snacks ]
     Snacks.terminal("cheatsheet", { win = { style = "float" } })
   end, { desc = "Cheat sheets" })
 
-  Snacks.terminal("<명령>") 은 첫 인자가 같으면 같은 세션을 토글한다.
+  Snacks.terminal 의 세션 식별자는 cmd 단독이 아니라 cmd + cwd + env + count 조합이다.
+  위 예시처럼 cwd를 넘기지 않으면 현재 디렉터리 기준이라, 다른 프로젝트에서 같은 키를
+  눌러도 별도 세션이 열린다. 프로젝트 무관하게 하나로 묶으려면 cwd를 고정해서 넘긴다.
+  count는 키 앞에 숫자를 붙여 지정 — 2<leader>C 처럼 독립 창을 여러 개 띄울 수 있다.
+
   자주 쓰는 TUI(btop, pnpm dev 등)를 키에 붙여두면 Ctrl+/ 처럼 여닫을 수 있다.
   추가 위치: modules/shared/programs/neovim/files/nvim/lua/config/keymaps.lua

--- a/modules/shared/programs/cheat/cheatsheets/nvim/terminal
+++ b/modules/shared/programs/cheat/cheatsheets/nvim/terminal
@@ -1,0 +1,55 @@
+---
+tags: [ neovim, lazyvim, terminal, shell, snacks ]
+---
+터미널 / 셸 명령 실행
+
+플로팅 터미널 (snacks.nvim)
+
+  Ctrl+/        플로팅 터미널 토글 (Root Dir 기준) — 한 번 더 누르면 숨김
+  <leader>ft    플로팅 터미널 (Root Dir)        = Ctrl+/
+  <leader>fT    플로팅 터미널 (cwd)             모노레포 전체 기준
+  <leader>gg    lazygit 열기
+  <leader>C     cheatsheet 브라우저 (fzf)
+
+  Ctrl+/ 는 Normal/Terminal 양쪽에 매핑되어 있어 터미널 안에서 눌러도 접힌다.
+  숨겨도 프로세스는 살아 있으므로 다시 열면 하던 작업이 그대로 이어진다.
+
+  ※ 모노레포: 소문자(ft)는 LSP root(현재 패키지), 대문자(fT)는 cwd(전체)
+
+터미널 모드 ↔ Normal 모드
+
+  Ctrl+\        Normal 모드로 탈출   (커스텀, Vim 순정은 <C-\><C-n> 두 번)
+  i / a         다시 입력(Terminal) 모드로
+
+  Normal 모드로 나오면 hjkl 스크롤, y 복사, / 검색이 그대로 동작한다.
+  → 긴 빌드 로그에서 에러 줄만 찾아 복사할 때 유용.
+
+  터미널 모드에서는 한글 IM 자동 전환을 적용하지 않는다 (입력 의도 존중).
+
+윈도우로 터미널 열기 (플로팅 대신 split 차지)
+
+  :terminal     현재 윈도우를 터미널로        :term 로 축약 가능
+  :sp | term    가로 분할에 터미널
+  :vsp | term   세로 분할에 터미널
+
+  split 간 이동은 일반 윈도우 이동(<C-h>/<C-l>)과 동일. 상세는 nvim/buffer 참조.
+
+에디터를 벗어나지 않고 CLI 실행 (Ex 명령)
+
+  :!ls -al          한 번 실행하고 결과만 표시 (Enter로 복귀)
+  :!node %          % = 현재 파일 경로   %:p 절대경로, %:h 디렉터리
+  :r !date          명령 출력을 커서 아래 줄에 삽입 (read)
+  :%!jq .           버퍼 전체를 명령에 통과시켜 결과로 치환 (필터)
+  :!sort -u         Visual 선택 영역만 필터 (V로 선택 후 : 누르면 '<,'> 자동 입력)
+
+  실전 필터: :%!jq .  (JSON 정렬) / :%!sort -u  (줄 정렬+중복제거)
+
+특정 명령을 전용 토글 창으로 (커스텀 추가법)
+
+  vim.keymap.set("n", "<leader>C", function()
+    Snacks.terminal("cheatsheet", { win = { style = "float" } })
+  end, { desc = "Cheat sheets" })
+
+  Snacks.terminal("<명령>") 은 첫 인자가 같으면 같은 세션을 토글한다.
+  자주 쓰는 TUI(btop, pnpm dev 등)를 키에 붙여두면 Ctrl+/ 처럼 여닫을 수 있다.
+  추가 위치: modules/shared/programs/neovim/files/nvim/lua/config/keymaps.lua


### PR DESCRIPTION
## Summary

- `nvim/terminal` 치트시트를 신규 추가 — 플로팅 터미널 토글(`Ctrl+/`, `<leader>ft`/`fT`), 터미널↔Normal 모드 전환, split 터미널, Ex 명령 CLI 실행(`:!`, `:r !`, `:%!` 필터), `Snacks.terminal` 커스텀 키맵 추가법
- `nvim/custom`에 실제 존재하나 목록에서 누락돼 있던 `<leader>C`(cheatsheet 브라우저)를 보강하고 `nvim/terminal` 크로스레퍼런스 추가

## 기존 문제/배경

nvim 치트시트 10종에 터미널 관련 항목이 사실상 비어 있었다. 전수 확인 결과 관련 항목은 두 줄뿐이었다.

- `nvim/custom`: `Ctrl+\  터미널 Normal 모드`
- `nvim/git`: `<leader>gg  lazygit 열기`

즉 **터미널에서 나오는 키는 있는데 터미널을 여는 키가 없는** 상태였다. LazyVim이 제공하는 `Ctrl+/`(플로팅 터미널 토글), `<leader>ft`/`<leader>fT`가 어디에도 기재돼 있지 않아, `cheat nvim/...`으로는 "nvim 안에서 셸 명령을 어떻게 실행하는가"라는 가장 기본적인 질문에 답할 수 없었다.

Ex 명령 계열(`:!`, `:r !`, `:%!`)도 마찬가지로 부재했다. 이쪽은 플러그인 없이 동작하는 Vim 순정 기능이라 조회 수요가 오히려 높은 축인데, 기존 시트는 편집/이동/검색 위주로만 채워져 있었다.

## CIR (Change Intent Record)

**발견 경위**: "neovim 안에서 터미널이나 CLI 명령을 실행하려면?"이라는 질문에 답하는 과정에서, 답변에 쓴 `Ctrl+/` 항목이 정작 본인 치트시트에 있는지 확인하려다 부재를 확인했다. 이어서 `nvim/` 시트 10종을 전수 확인해 터미널 항목 전반이 빠져 있음을 파악했다.

**설계 의도**: 누락된 한 줄을 기존 시트에 끼워넣는 대신, 터미널을 독립 주제로 세웠다. 실제로 빠진 것이 `Ctrl+/` 하나가 아니라 "터미널 열기 → 모드 전환 → 명령 실행 → 결과 활용"이라는 흐름 전체였기 때문이다. 기존 시트의 분할 기준도 기능 축(buffer/search/lsp/surround/dap)이므로 여기에 terminal이 들어가는 것이 일관적이다.

**작성 기준**: 기재한 키맵은 추정하지 않고 실제 소스에서 확인했다. `Ctrl+/`·`<leader>ft`/`fT`는 설치된 LazyVim의 `lua/lazyvim/config/keymaps.lua`에서, `Ctrl+\`·`<leader>C`는 이 저장소의 `config/keymaps.lua`에서 대조했다.

**부수 발견**: 대조 과정에서 `<leader>C`(cheatsheet fzf 브라우저)가 실제 커스텀 키맵인데 `nvim/custom` 목록에 없다는 것을 확인해 함께 채웠다. 치트시트를 찾는 키가 치트시트에 없던 셈이라 같은 성격의 누락으로 판단했다.

**Snacks.terminal 스니펫 포함 이유**: 단순 키 목록을 넘어 커스텀 추가법까지 넣은 것은, 이 저장소의 `<leader>C`가 이미 그 패턴의 실사용 예시이기 때문이다. 새 TUI를 토글 키로 붙이고 싶을 때 참고할 곳이 소스 파일밖에 없었다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 신규 `nvim/terminal` 시트 | 터미널을 독립 주제로 분리 | 기존 기능축 분할 기준과 일관, 누락된 흐름 전체를 담을 수 있음, `cheat -t terminal`로 태그 조회 가능 | 시트 수 1개 증가 | ✅ |
| `nvim/custom`에 `Ctrl+/` 한 줄 추가 | 최소 변경 | diff 최소 | `Ctrl+/`는 LazyVim 기본 키맵이라 "커스텀" 시트에 두면 분류가 어긋남. Ex 명령 계열은 여전히 갈 곳 없음 | ❌ |
| `nvim/buffer`에 터미널 섹션 추가 | 윈도우/split 시트에 편입 | split 터미널과 인접 | 플로팅 터미널·Ex 명령은 윈도우 주제가 아님. 이미 긴 시트가 더 비대해짐 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/shared/programs/cheat/cheatsheets/nvim/terminal` | 신규 (56줄) |
| `modules/shared/programs/cheat/cheatsheets/nvim/custom` | `<leader>C` 항목 + `nvim/terminal` 크로스레퍼런스 |

태그는 기존 관례(`neovim`, `lazyvim` 공통 + 주제 태그)를 따랐다.

```
---
tags: [ neovim, lazyvim, terminal, shell, snacks ]
---
```

`cheat` 설정의 cheatpath가 저장소 디렉터리를 직접 가리키므로(`programs/cheat/default.nix`), 파일 추가만으로 즉시 조회된다 — 재빌드가 필요 없다.

## 참고 레퍼런스

- 상위 키맵 출처: LazyVim `lua/lazyvim/config/keymaps.lua`의 floating terminal 매핑 (`<leader>fT`, `<leader>ft`, `<c-/>`, `<c-_>`)
- 저장소 커스텀 키맵: `modules/shared/programs/neovim/files/nvim/lua/config/keymaps.lua` — 터미널 모드 탈출(`Ctrl+\`), cheatsheet 토글(`<leader>C`)
- 한글 IM 정책: `modules/shared/programs/neovim/files/nvim/lua/config/autocmds.lua` — Terminal 모드는 자동 전환 제외
- cheatpath 설정: `modules/shared/programs/cheat/default.nix`

## Human Test Plan

1. **새 시트 조회**
   `cheat nvim/terminal`
   → 터미널 치트시트가 출력된다. 실패 시 `cheat -l -t neovim`으로 목록에 `nvim/terminal`이 잡히는지 확인 — 안 잡히면 `~/.config/cheat/conf.yml`의 cheatpath가 이 저장소 경로를 가리키는지 본다.

2. **태그 조회**
   `cheat -l -t terminal`
   → `nvim/terminal` 한 줄이 나온다.

3. **크로스레퍼런스 확인**
   `cheat nvim/custom`
   → `<leader>C` 항목과 "터미널 열기/CLI 실행 전반은 nvim/terminal 참조" 줄이 보인다.

4. **기재 내용 실측 (nvim에서)**
   - `Ctrl+/` → 플로팅 터미널이 뜬다. 한 번 더 누르면 숨고, 다시 누르면 이전 상태 그대로 돌아온다.
   - 터미널에서 `Ctrl+\` → Normal 모드로 나와 `hjkl` 스크롤이 된다. `i`로 다시 입력 모드.
   - 아무 JSON 파일에서 `:%!jq .` → 버퍼가 정렬된 JSON으로 치환된다. (`u`로 되돌리기)
   - `:r !date` → 커서 아래 줄에 현재 시각이 삽입된다.
   - 기대와 다르면 `Ctrl+/`는 터미널 에뮬레이터가 키를 어떻게 보내느냐에 따라 `<c-_>`로 전달될 수 있는데 LazyVim이 양쪽 모두 매핑해 두었으므로, 그래도 안 되면 `:verbose map <c-/>`로 실제 바인딩을 확인한다.

5. **fzf 브라우저**
   nvim에서 `<leader>C` → cheatsheet 브라우저가 뜨고 목록에 `nvim/terminal`이 포함된다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * Neovim 치트시트에 `cheatsheet 브라우저`를 실행하는 `<leader>C` 단축키 안내를 추가했습니다.

* **문서**
  * Neovim에서 플로팅 터미널, 셸 명령, 터미널 모드 전환 및 출력 필터 사용 방법을 정리했습니다.
  * 자주 사용하는 터미널 명령과 전용 토글 창 설정 예시를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->