### PR TITLE
fix(claudex): add safe credential replacement login

### DIFF
--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -119,7 +119,7 @@ git status --short --branch
 ### 검증 연결
 
 - `tests/suites/claudex.sh`: fake boundary, state mode, credential shape, wrapper scrub, wrapper-owned settings, 파생 runtime 계약, 실제 Nix-generated command output, layout drift, synthetic disabled Home Manager closure를 검증한다. fixture materialization 뒤 미치환 placeholder가 하나라도 남으면 실패한다.
-- `tests/shell-script-tests.sh`: 위 suite의 11개 테스트를 전체 shell suite에 등록한다.
+- `tests/shell-script-tests.sh`: 위 suite의 13개 테스트를 전체 shell suite에 등록한다.
 - `tests/eval-tests.nix`: descriptor, 실제·synthetic host 노출, pin, config, no-launchd/no-activation 계약과 portable Nix derivation 계약을 평가한다. 실제 command output 내용은 shell test가 build/read한다.
 - `lefthook.yml`과 `scripts/ai/check-lefthook-staged-config.sh`: JSON pin/template 변경이 eval 검증을 타도록 한다.
 

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -390,6 +390,7 @@ find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print 2>/dev/null | wc -l
 mixed 세션용 claude credential 추가는 `claudex-login --claude`로 수행한다 (동일 staging → 타입 검증 → 원자 승격 절차; 기존 codex credential은 건드리지 않는다).
 
 schema-valid credential의 upstream refresh가 거부되거나 실제 completion이 401로 실패하면, 자동 삭제 대신 provider별 명시적 replacement를 사용한다.
+replacement 전에는 foreground proxy와 service를 먼저 중지한다. 실행 중인 proxy가 기존 credential refresh를 뒤늦게 저장해 새 credential을 되돌리는 경쟁을 막기 위해 `claudex-login --replace`도 loopback proxy가 응답하면 fail-closed로 중단한다.
 
 ```bash
 # Codex credential만 교체

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -154,6 +154,9 @@ git status --short --branch
 10. user/project settings의 `fallbackModel`은 headless 고정 모델 계약을 우회하지 못하고, session effort는 wrapper-owned 값을 따른다 — 기본 `high`, 명시적 `claudex --effort` 인자(whitelist: low/medium/high/xhigh/max/ultra)만 이를 바꾸며 상속 환경값은 계속 scrub된다.
 11. inherited Claude host-auth bridge와 settings `env.CLAUDE_CODE_EXTRA_BODY`는 wrapper-owned loopback/model/request 계약을 우회하지 못해야 한다.
 12. request body의 `service_tier`는 wrapper-owned 값만 존재한다 — 기본은 필드 미전송(계정 기본 티어), 명시적 `claudex --fast` 인자만 pinned fast settings variant로 `"priority"`를 주입하며 상속 환경값은 계속 scrub된다.
+13. `claudex-login --replace`는 선택한 provider만 private staging에서 재인증한다. OAuth 전 canonical set 전체의 경로·내용 snapshot과 승격 직전 상태가 다르면 중단하고, 성공 시에도 sibling provider를 byte-for-byte 보존한다.
+14. replacement는 기존 canonical 경로를 같은 filesystem의 검증된 staged 파일로 원자 교체한다. CLIProxyAPI 7.2.73은 credential 파일명을 생성할 때 계정 정보를 반영하지만 loader는 auth-dir의 JSON 내용을 파싱하고 watcher identity는 경로를 기준으로 하므로, 기존 canonical 경로를 유지해 실행 중 watcher가 provider 삭제/추가로 오인하지 않게 한다.
+15. 교체 전 credential은 state 아래 `credential-backups/`에 mode `0600` private backup으로 보존한다. 자동 정리하지 않으며, 실패 시 자동 rollback에 사용한다. 성공 후 backup 삭제는 새 credential의 실제 completion 검증을 마친 운영자가 별도로 결정한다.
 
 ### 모드별 기대값 (default vs mixed)
 
@@ -380,11 +383,28 @@ find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print 2>/dev/null | wc -l
 ```
 
 - `0`: `claudex-login`을 실행한다.
-- `1`: `claudex-login`이 자체 schema 검증 후 ready로 종료하는지 확인한다.
+- `1`: `claudex-login`이 자체 schema 검증 후 `present and schema-valid; live validity was not checked`로 종료하는지 확인한다.
 - `2`: codex+claude 공존(mixed set)이면 정상이다 — `claudex-status`가 auth=ready를 보고하는지 확인한다. 같은 타입 2개거나 invalid면 아래 규칙을 따른다.
 - 타입별 중복 또는 invalid: 자동 삭제·선택하지 말고 중단한 뒤 사용자에게 보고한다.
 
 mixed 세션용 claude credential 추가는 `claudex-login --claude`로 수행한다 (동일 staging → 타입 검증 → 원자 승격 절차; 기존 codex credential은 건드리지 않는다).
+
+schema-valid credential의 upstream refresh가 거부되거나 실제 completion이 401로 실패하면, 자동 삭제 대신 provider별 명시적 replacement를 사용한다.
+
+```bash
+# Codex credential만 교체
+claudex-login --replace
+
+# Claude credential만 교체
+claudex-login --claude --replace
+```
+
+- replacement 대상 provider가 없으면 실패하며, 먼저 `--replace` 없는 일반 로그인을 안내한다.
+- OAuth 시작 전과 canonical mutation 직전에 credential set 전체를 비교한다. 그 사이 다른 프로세스가 어느 provider든 변경하면 staged 결과를 버리고 중단한다.
+- 새 credential의 schema와 private mode를 검증하기 전에는 canonical set을 바꾸지 않는다.
+- atomic replacement 또는 사후 검증이 실패하면 검증된 private backup으로 기존 credential을 복구한다.
+- staging과 backup의 credential 본문·파일명은 출력하지 않는다.
+- 실제 replacement OAuth는 계정 credential을 바꾸는 외부 상태 변경이므로 자동화 에이전트가 수행할 때 직전 사용자 승인이 필요하다.
 
 실행:
 
@@ -401,7 +421,7 @@ claudex-login
 find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print | wc -l
 ```
 
-기대 결과는 `canonical Codex credential is already ready`와 파일 수 `1`이다. credential JSON, access token, refresh token, client API key는 출력하지 않는다.
+기대 결과는 `canonical codex credential is present and schema-valid; live validity was not checked`와 파일 수 `1`이다. 이 문구는 upstream live validity를 증명하지 않는다. credential JSON, access token, refresh token, client API key는 출력하지 않는다.
 
 ## 10. Phase 4 — Foreground proxy와 completion
 

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -384,7 +384,7 @@ find "$auth_dir" -mindepth 1 -maxdepth 1 -type f -print 2>/dev/null | wc -l
 
 - `0`: `claudex-login`을 실행한다.
 - `1`: `claudex-login`이 자체 schema 검증 후 `present and schema-valid; live validity was not checked`로 종료하는지 확인한다.
-- `2`: codex+claude 공존(mixed set)이면 정상이다 — `claudex-status`가 auth=ready를 보고하는지 확인한다. 같은 타입 2개거나 invalid면 아래 규칙을 따른다.
+- `2`: codex+claude 공존(mixed set)이면 정상이다 — `claudex-status`가 `auth=ready`를 보고하는지 확인한다. 이 값은 로컬 credential set의 schema/file readiness만 뜻하며 upstream token 유효성은 확인하지 않는다. 같은 타입 2개거나 invalid면 아래 규칙을 따른다.
 - 타입별 중복 또는 invalid: 자동 삭제·선택하지 말고 중단한 뒤 사용자에게 보고한다.
 
 mixed 세션용 claude credential 추가는 `claudex-login --claude`로 수행한다 (동일 staging → 타입 검증 → 원자 승격 절차; 기존 codex credential은 건드리지 않는다).
@@ -467,7 +467,7 @@ proxy=ready
 catalog=ready
 ```
 
-Stage 1에는 서비스 유닛이 없으므로 darwin의 `service=missing`은 정상이다. linux에는 조회할 launchd 도메인 자체가 없어 `service=n/a`를 출력한다(값만 다르고 readiness 판정에는 관여하지 않는다). auth/proxy/catalog가 ready이면 status 명령은 exit `0`이며 foreground Stage 1 readiness gate로 사용할 수 있다.
+Stage 1에는 서비스 유닛이 없으므로 darwin의 `service=missing`은 정상이다. linux에는 조회할 launchd 도메인 자체가 없어 `service=n/a`를 출력한다(값만 다르고 readiness 판정에는 관여하지 않는다). auth/proxy/catalog가 ready이면 status 명령은 exit `0`이며 로컬 schema/file·proxy·catalog를 확인하는 foreground Stage 1 readiness gate로 사용할 수 있다. `auth=ready`는 upstream refresh token의 live validity를 증명하지 않으며, 실제 인증 성공은 아래 headless completion으로 확인한다.
 
 ### Headless completion
 

--- a/docs/claudex-poc-handoff.md
+++ b/docs/claudex-poc-handoff.md
@@ -119,7 +119,7 @@ git status --short --branch
 ### 검증 연결
 
 - `tests/suites/claudex.sh`: fake boundary, state mode, credential shape, wrapper scrub, wrapper-owned settings, 파생 runtime 계약, 실제 Nix-generated command output, layout drift, synthetic disabled Home Manager closure를 검증한다. fixture materialization 뒤 미치환 placeholder가 하나라도 남으면 실패한다.
-- `tests/shell-script-tests.sh`: 위 suite의 13개 테스트를 전체 shell suite에 등록한다.
+- `tests/shell-script-tests.sh`: 위 suite를 전체 shell suite에 등록한다.
 - `tests/eval-tests.nix`: descriptor, 실제·synthetic host 노출, pin, config, no-launchd/no-activation 계약과 portable Nix derivation 계약을 평가한다. 실제 command output 내용은 shell test가 build/read한다.
 - `lefthook.yml`과 `scripts/ai/check-lefthook-staged-config.sh`: JSON pin/template 변경이 eval 검증을 타도록 한다.
 

--- a/modules/shared/programs/claudex/default.nix
+++ b/modules/shared/programs/claudex/default.nix
@@ -147,6 +147,7 @@ let
     curlBin = "${pkgs.curl}/bin/curl";
     opensslBin = "${pkgs.openssl}/bin/openssl";
     cmpBin = "${pkgs.diffutils}/bin/cmp";
+    cpBin = "${pkgs.coreutils}/bin/cp";
     statBin = "${pkgs.coreutils}/bin/stat";
     chmodBin = "${pkgs.coreutils}/bin/chmod";
     mkdirBin = "${pkgs.coreutils}/bin/mkdir";

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -107,7 +107,12 @@ staging_config="$staging/config.yaml"
 cleanup_staging() {
   _claudex_quiet_rm -rf -- "$staging"
 }
-trap cleanup_staging EXIT INT TERM
+cleanup_staging_on_exit() {
+  local exit_status=$?
+  cleanup_staging || _claudex_error "failed to remove the private login staging directory"
+  return "$exit_status"
+}
+trap cleanup_staging_on_exit EXIT INT TERM
 
 _claudex_ensure_private_dir "$staging_auth"
 (
@@ -117,6 +122,19 @@ _claudex_ensure_private_dir "$staging_auth"
 )
 
 echo "claudex-login: follow the $cred_type OAuth instructions printed by CLIProxyAPI"
+_claudex_filter_login_output() {
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "Authentication saved to "*)
+        printf '%s\n' "Authentication saved to private staging"
+        ;;
+      *)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done
+}
 set +e
 (
   cd "$staging"
@@ -131,8 +149,8 @@ set +e
       "$login_flag" \
       --no-browser \
       --local-model
-)
-login_rc=$?
+) 2>&1 | _claudex_filter_login_output
+login_rc="${PIPESTATUS[0]}"
 set -e
 if [ "$login_rc" -ne 0 ]; then
   _claudex_error "$cred_type login failed"
@@ -281,6 +299,12 @@ _claudex_promote_staged_credential() {
 }
 
 with_state_lock _claudex_promote_staged_credential
+if ! cleanup_staging; then
+  trap - EXIT INT TERM
+  _claudex_error "failed to remove the private login staging directory"
+  exit 1
+fi
+trap - EXIT INT TERM
 if [ "$replace" = true ]; then
   echo "claudex-login: canonical $cred_type credential was replaced and is schema-valid; live validity was not checked"
 else

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -97,9 +97,7 @@ case "$existing_rc" in
     ;;
 esac
 
-if [ "$replace" = true ] \
-  && "$CLAUDEX_CURL" --silent --show-error --output /dev/null \
-    --connect-timeout 1 --max-time 2 "$CLAUDEX_BASE_URL/v1/models" 2>/dev/null; then
+if [ "$replace" = true ] && _claudex_loopback_responding 2>/dev/null; then
   _claudex_error "stop the local claudex proxy before replacing credentials"
   exit 1
 fi
@@ -254,6 +252,14 @@ _claudex_promote_staged_credential() {
     _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null \
       && _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR"
     return
+  fi
+
+  # OAuth can take minutes. Re-probe while holding the state lock so a cooperating
+  # launcher that starts after the early check cannot race backup/replacement with an
+  # old credential lineage.
+  if _claudex_loopback_responding 2>/dev/null; then
+    _claudex_error "stop the local claudex proxy before replacing credentials"
+    return 1
   fi
 
   existing_rc=0

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -10,26 +10,38 @@ CLAUDEX_PROXY_BIN="@proxyBin@"
 CLAUDEX_CONFIG_TEMPLATE="@configTemplate@"
 
 # Type-routed login: the no-arg path keeps the original Codex device-code flow; --claude
-# adds the Anthropic OAuth credential that the --mixed session mode requires. Each path is
-# idempotent per credential type and never touches the other type's canonical entry.
+# adds the Anthropic OAuth credential that the --mixed session mode requires. --replace
+# explicitly replaces only the selected provider after a complete staged OAuth flow.
 cred_type=codex
 login_flag=--codex-device-login
-case "$#" in
-  0) ;;
-  1)
-    if [ "$1" = "--claude" ]; then
+replace=false
+seen_claude=false
+seen_replace=false
+for arg in "$@"; do
+  case "$arg" in
+    --claude)
+      if [ "$seen_claude" = true ]; then
+        echo "usage: claudex-login [--claude] [--replace]" >&2
+        exit 2
+      fi
+      seen_claude=true
       cred_type=claude
       login_flag=--claude-login
-    else
-      echo "usage: claudex-login [--claude]" >&2
+      ;;
+    --replace)
+      if [ "$seen_replace" = true ]; then
+        echo "usage: claudex-login [--claude] [--replace]" >&2
+        exit 2
+      fi
+      seen_replace=true
+      replace=true
+      ;;
+    *)
+      echo "usage: claudex-login [--claude] [--replace]" >&2
       exit 2
-    fi
-    ;;
-  *)
-    echo "usage: claudex-login [--claude]" >&2
-    exit 2
-    ;;
-esac
+      ;;
+  esac
+done
 
 prepare_state
 # The whole canonical directory must be well-formed before this command reports ready or
@@ -40,17 +52,29 @@ _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR" || {
   exit 1
 }
 existing_rc=0
+existing_path=""
+existing_fingerprint=""
+existing_set_fingerprint=""
 existing_path="$(_claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type")" || existing_rc=$?
 case "$existing_rc" in
   0)
-    if _claudex_credential_json_valid "$existing_path" "$cred_type"; then
-      echo "claudex-login: canonical $cred_type credential is already ready"
+    if ! _claudex_credential_json_valid "$existing_path" "$cred_type"; then
+      _claudex_error "canonical $cred_type credential is invalid; remove it explicitly before logging in again"
+      exit 1
+    fi
+    if [ "$replace" = false ]; then
+      echo "claudex-login: canonical $cred_type credential is present and schema-valid; live validity was not checked"
       exit 0
     fi
-    _claudex_error "canonical $cred_type credential is invalid; remove it explicitly before logging in again"
-    exit 1
+    existing_fingerprint="$(_claudex_credential_fingerprint "$existing_path")" || exit 1
+    existing_set_fingerprint="$(_claudex_credential_set_fingerprint "$CLAUDEX_AUTH_DIR")" || exit 1
     ;;
-  1) ;;
+  1)
+    if [ "$replace" = true ]; then
+      _claudex_error "canonical $cred_type credential is absent; run claudex-login without --replace first"
+      exit 1
+    fi
+    ;;
   *)
     _claudex_error "canonical auth directory holds duplicate $cred_type entries; refusing to choose or delete one"
     exit 1
@@ -107,38 +131,118 @@ _claudex_credential_json_valid "$staged_path" "$cred_type" || {
   exit 1
 }
 
+_claudex_rollback_replacement() {
+  local backup="$1" destination="$2"
+  "$CLAUDEX_MV" -f -- "$backup" "$destination" || {
+    _claudex_error "credential replacement failed and automatic rollback could not restore the private backup"
+    return 1
+  }
+  _claudex_credential_json_valid "$destination" "$cred_type" \
+    && _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR"
+}
+
 _claudex_promote_staged_credential() {
-  local staged destination existing_rc
+  local staged destination current_path current_fingerprint current_set_fingerprint backup_dir backup_path backup_fingerprint existing_rc
   # Validate the final state BEFORE moving anything: the canonical set must be well-formed
-  # (a malformed sibling means the move would only produce another invalid state) and must
-  # not already hold this type. The full default/mixed set contract is deliberately NOT
-  # asserted here — codex-only and claude-only are legitimate mid-login states (either
-  # login order is allowed); the per-mode contract is asserted at session start instead.
+  # (a malformed sibling means the move would only produce another invalid state). The full
+  # default/mixed set contract is deliberately NOT asserted here — codex-only and
+  # claude-only are legitimate mid-login states (either login order is allowed); the
+  # per-mode contract is asserted at session start instead.
   _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR" || {
     _claudex_error "canonical auth directory holds a malformed entry; staged credential was not promoted"
     return 1
   }
-  existing_rc=0
-  _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null || existing_rc=$?
-  if [ "$existing_rc" -ne 1 ]; then
-    _claudex_error "another login changed the canonical $cred_type credential; staged credential was not promoted"
-    return 1
-  fi
   staged="$(_claudex_single_credential_path "$staging_auth")" || return 1
   _claudex_credential_json_valid "$staged" "$cred_type" || return 1
-  destination="$CLAUDEX_AUTH_DIR/${staged##*/}"
-  if [ -e "$destination" ] || [ -L "$destination" ]; then
-    _claudex_error "refusing to overwrite an existing canonical credential"
+
+  if [ "$replace" = false ]; then
+    existing_rc=0
+    _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null || existing_rc=$?
+    if [ "$existing_rc" -ne 1 ]; then
+      _claudex_error "another login changed the canonical $cred_type credential; staged credential was not promoted"
+      return 1
+    fi
+    destination="$CLAUDEX_AUTH_DIR/${staged##*/}"
+    if [ -e "$destination" ] || [ -L "$destination" ]; then
+      _claudex_error "refusing to overwrite an existing canonical credential"
+      return 1
+    fi
+    "$CLAUDEX_MV" -n -- "$staged" "$destination" || return 1
+    if [ -e "$staged" ] || [ -L "$staged" ]; then
+      _claudex_error "atomic credential promotion did not complete"
+      return 1
+    fi
+    _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null \
+      && _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR"
+    return
+  fi
+
+  existing_rc=0
+  current_path="$(_claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type")" || existing_rc=$?
+  if [ "$existing_rc" -ne 0 ] || [ "$current_path" != "$existing_path" ]; then
+    _claudex_error "canonical $cred_type credential changed during OAuth; staged credential was not promoted"
     return 1
   fi
-  "$CLAUDEX_MV" -n -- "$staged" "$destination" || return 1
+  current_fingerprint="$(_claudex_credential_fingerprint "$current_path")" || return 1
+  current_set_fingerprint="$(_claudex_credential_set_fingerprint "$CLAUDEX_AUTH_DIR")" || return 1
+  if [ "$current_fingerprint" != "$existing_fingerprint" ] \
+    || [ "$current_set_fingerprint" != "$existing_set_fingerprint" ]; then
+    _claudex_error "canonical $cred_type credential changed during OAuth; staged credential was not promoted"
+    return 1
+  fi
+
+  backup_dir="$CLAUDEX_STATE_DIR/credential-backups"
+  _claudex_ensure_private_dir "$backup_dir" || return 1
+  backup_path="$($CLAUDEX_MKTEMP --suffix=.json "$backup_dir/$cred_type.XXXXXX")" || return 1
+  "$CLAUDEX_CHMOD" 600 -- "$backup_path" || {
+    "$CLAUDEX_RM" -f -- "$backup_path"
+    return 1
+  }
+  if ! "$CLAUDEX_CP" -- "$current_path" "$backup_path"; then
+    "$CLAUDEX_RM" -f -- "$backup_path"
+    return 1
+  fi
+  "$CLAUDEX_CHMOD" 600 -- "$backup_path" || {
+    "$CLAUDEX_RM" -f -- "$backup_path"
+    return 1
+  }
+  backup_fingerprint="$(_claudex_credential_fingerprint "$backup_path")" || {
+    "$CLAUDEX_RM" -f -- "$backup_path"
+    return 1
+  }
+  if [ "$backup_fingerprint" != "$existing_fingerprint" ] \
+    || ! _claudex_credential_json_valid "$backup_path" "$cred_type"; then
+    "$CLAUDEX_RM" -f -- "$backup_path"
+    _claudex_error "private credential backup verification failed"
+    return 1
+  fi
+
+  # CIR: pinned CLIProxyAPI 7.2.73 keys auth watcher state by path and explicitly
+  # treats a same-path rename as an atomic update. Preserve the canonical basename and
+  # replace it from staging on the same filesystem so a running watcher never sees a
+  # provider disappear between two renames. The verified private backup remains available.
+  destination="$current_path"
+  if ! "$CLAUDEX_MV" -f -- "$staged" "$destination"; then
+    "$CLAUDEX_RM" -f -- "$backup_path"
+    _claudex_error "atomic credential replacement failed; canonical credential was preserved"
+    return 1
+  fi
   if [ -e "$staged" ] || [ -L "$staged" ]; then
-    _claudex_error "atomic credential promotion did not complete"
+    _claudex_rollback_replacement "$backup_path" "$destination" || return 1
+    _claudex_error "atomic credential replacement did not complete; canonical credential was restored"
     return 1
   fi
-  _claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type" >/dev/null \
-    && _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR"
+  if ! _claudex_credential_json_valid "$destination" "$cred_type" \
+    || ! _claudex_assert_entries_wellformed "$CLAUDEX_AUTH_DIR"; then
+    _claudex_rollback_replacement "$backup_path" "$destination" || return 1
+    _claudex_error "replacement validation failed; canonical credential was restored"
+    return 1
+  fi
 }
 
 with_state_lock _claudex_promote_staged_credential
-echo "claudex-login: canonical $cred_type credential is ready"
+if [ "$replace" = true ]; then
+  echo "claudex-login: canonical $cred_type credential was replaced and is schema-valid; live validity was not checked"
+else
+  echo "claudex-login: canonical $cred_type credential is ready"
+fi

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -97,6 +97,13 @@ case "$existing_rc" in
     ;;
 esac
 
+if [ "$replace" = true ] \
+  && "$CLAUDEX_CURL" --silent --show-error --output /dev/null \
+    --connect-timeout 1 --max-time 2 "$CLAUDEX_BASE_URL/v1/models" 2>/dev/null; then
+  _claudex_error "stop the local claudex proxy before replacing credentials"
+  exit 1
+fi
+
 staging="$($CLAUDEX_MKTEMP -d "$CLAUDEX_STATE_DIR/auth.login.XXXXXX")"
 _claudex_quiet_chmod 700 -- "$staging" || {
   _claudex_error "failed to secure the private login staging directory"
@@ -123,17 +130,49 @@ _claudex_ensure_private_dir "$staging_auth"
 
 echo "claudex-login: follow the $cred_type OAuth instructions printed by CLIProxyAPI"
 _claudex_filter_login_output() {
-  local line
-  while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in
-      "Authentication saved to "*)
-        printf '%s\n' "Authentication saved to private staging"
-        ;;
-      *)
-        printf '%s\n' "$line"
-        ;;
-    esac
+  local buffer="" char private_prefix="$staging" redacting=false suffix
+  while IFS= read -r -n 1 char; do
+    # Bash read consumes the newline delimiter and returns an empty value for it.
+    [ -n "$char" ] || char=$'\n'
+    if [ "$redacting" = true ]; then
+      if [ "$char" = $'\n' ]; then
+        printf '\n'
+        redacting=false
+      fi
+      continue
+    fi
+
+    buffer+="$char"
+    while [ -n "$buffer" ]; do
+      # Hold only a possible prefix across reads. Everything else is forwarded
+      # immediately, including CLIProxyAPI's newline-free callback prompt.
+      case "$private_prefix" in
+        "$buffer"*) break ;;
+      esac
+      case "$buffer" in
+        "$private_prefix"*)
+          suffix="${buffer#"$private_prefix"}"
+          printf '%s' "[private login staging]"
+          buffer=""
+          if [ "$suffix" = $'\n' ]; then
+            printf '\n'
+            redacting=false
+          else
+            redacting=true
+          fi
+          ;;
+        *)
+          printf '%s' "${buffer:0:1}"
+          buffer="${buffer:1}"
+          ;;
+      esac
+    done
   done
+  if [ "$buffer" = "$private_prefix" ]; then
+    printf '%s' "[private login staging]"
+  else
+    printf '%s' "$buffer"
+  fi
 }
 set +e
 (

--- a/modules/shared/programs/claudex/files/claudex-login.sh
+++ b/modules/shared/programs/claudex/files/claudex-login.sh
@@ -9,6 +9,22 @@ source "@runtimeLibrary@"
 CLAUDEX_PROXY_BIN="@proxyBin@"
 CLAUDEX_CONFIG_TEMPLATE="@configTemplate@"
 
+_claudex_quiet_chmod() {
+  "$CLAUDEX_CHMOD" "$@" 2>/dev/null
+}
+
+_claudex_quiet_cp() {
+  "$CLAUDEX_CP" "$@" 2>/dev/null
+}
+
+_claudex_quiet_mv() {
+  "$CLAUDEX_MV" "$@" 2>/dev/null
+}
+
+_claudex_quiet_rm() {
+  "$CLAUDEX_RM" "$@" 2>/dev/null
+}
+
 # Type-routed login: the no-arg path keeps the original Codex device-code flow; --claude
 # adds the Anthropic OAuth credential that the --mixed session mode requires. --replace
 # explicitly replaces only the selected provider after a complete staged OAuth flow.
@@ -82,11 +98,14 @@ case "$existing_rc" in
 esac
 
 staging="$($CLAUDEX_MKTEMP -d "$CLAUDEX_STATE_DIR/auth.login.XXXXXX")"
-"$CLAUDEX_CHMOD" 700 -- "$staging"
+_claudex_quiet_chmod 700 -- "$staging" || {
+  _claudex_error "failed to secure the private login staging directory"
+  exit 1
+}
 staging_auth="$staging/auth"
 staging_config="$staging/config.yaml"
 cleanup_staging() {
-  "$CLAUDEX_RM" -rf -- "$staging"
+  _claudex_quiet_rm -rf -- "$staging"
 }
 trap cleanup_staging EXIT INT TERM
 
@@ -133,7 +152,7 @@ _claudex_credential_json_valid "$staged_path" "$cred_type" || {
 
 _claudex_rollback_replacement() {
   local backup="$1" destination="$2"
-  "$CLAUDEX_MV" -f -- "$backup" "$destination" || {
+  _claudex_quiet_mv -f -- "$backup" "$destination" || {
     _claudex_error "credential replacement failed and automatic rollback could not restore the private backup"
     return 1
   }
@@ -167,7 +186,10 @@ _claudex_promote_staged_credential() {
       _claudex_error "refusing to overwrite an existing canonical credential"
       return 1
     fi
-    "$CLAUDEX_MV" -n -- "$staged" "$destination" || return 1
+    _claudex_quiet_mv -n -- "$staged" "$destination" || {
+      _claudex_error "atomic credential promotion failed"
+      return 1
+    }
     if [ -e "$staged" ] || [ -L "$staged" ]; then
       _claudex_error "atomic credential promotion did not complete"
       return 1
@@ -194,26 +216,44 @@ _claudex_promote_staged_credential() {
   backup_dir="$CLAUDEX_STATE_DIR/credential-backups"
   _claudex_ensure_private_dir "$backup_dir" || return 1
   backup_path="$($CLAUDEX_MKTEMP --suffix=.json "$backup_dir/$cred_type.XXXXXX")" || return 1
-  "$CLAUDEX_CHMOD" 600 -- "$backup_path" || {
-    "$CLAUDEX_RM" -f -- "$backup_path"
+  _claudex_quiet_chmod 600 -- "$backup_path" || {
+    _claudex_quiet_rm -f -- "$backup_path"
+    _claudex_error "failed to secure the private credential backup"
     return 1
   }
-  if ! "$CLAUDEX_CP" -- "$current_path" "$backup_path"; then
-    "$CLAUDEX_RM" -f -- "$backup_path"
+  if ! _claudex_quiet_cp -- "$current_path" "$backup_path"; then
+    _claudex_quiet_rm -f -- "$backup_path"
+    _claudex_error "failed to create the private credential backup"
     return 1
   fi
-  "$CLAUDEX_CHMOD" 600 -- "$backup_path" || {
-    "$CLAUDEX_RM" -f -- "$backup_path"
+  _claudex_quiet_chmod 600 -- "$backup_path" || {
+    _claudex_quiet_rm -f -- "$backup_path"
+    _claudex_error "failed to secure the private credential backup"
     return 1
   }
   backup_fingerprint="$(_claudex_credential_fingerprint "$backup_path")" || {
-    "$CLAUDEX_RM" -f -- "$backup_path"
+    _claudex_quiet_rm -f -- "$backup_path"
     return 1
   }
   if [ "$backup_fingerprint" != "$existing_fingerprint" ] \
     || ! _claudex_credential_json_valid "$backup_path" "$cred_type"; then
-    "$CLAUDEX_RM" -f -- "$backup_path"
+    _claudex_quiet_rm -f -- "$backup_path"
     _claudex_error "private credential backup verification failed"
+    return 1
+  fi
+
+  # The backup copy itself is outside CLIProxyAPI's lock protocol. Re-read the whole
+  # canonical set after the backup is verified and immediately before promotion so a
+  # writer that changed either provider during that window cannot be overwritten.
+  existing_rc=0
+  current_path="$(_claudex_credential_path_of_type "$CLAUDEX_AUTH_DIR" "$cred_type")" || existing_rc=$?
+  current_fingerprint="$(_claudex_credential_fingerprint "$current_path")" || existing_rc=$?
+  current_set_fingerprint="$(_claudex_credential_set_fingerprint "$CLAUDEX_AUTH_DIR")" || existing_rc=$?
+  if [ "$existing_rc" -ne 0 ] || [ "$current_path" != "$existing_path" ] \
+    || [ "$current_fingerprint" != "$existing_fingerprint" ] \
+    || [ "$current_set_fingerprint" != "$existing_set_fingerprint" ]; then
+    _claudex_quiet_rm -f -- "$backup_path"
+    _claudex_error "canonical credential set changed before replacement; staged credential was not promoted"
     return 1
   fi
 
@@ -222,8 +262,8 @@ _claudex_promote_staged_credential() {
   # replace it from staging on the same filesystem so a running watcher never sees a
   # provider disappear between two renames. The verified private backup remains available.
   destination="$current_path"
-  if ! "$CLAUDEX_MV" -f -- "$staged" "$destination"; then
-    "$CLAUDEX_RM" -f -- "$backup_path"
+  if ! _claudex_quiet_mv -f -- "$staged" "$destination"; then
+    _claudex_quiet_rm -f -- "$backup_path"
     _claudex_error "atomic credential replacement failed; canonical credential was preserved"
     return 1
   fi

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -170,18 +170,18 @@ _claudex_ensure_private_dir() {
 }
 
 _claudex_assert_private_file() {
-  local path="$1"
+  local path="$1" display_path="${2:-$1}"
   _claudex_reject_newline "$path" || return 1
   if [ -L "$path" ] || [ ! -f "$path" ]; then
-    _claudex_error "expected a real private file: $path"
+    _claudex_error "expected a real private file: $display_path"
     return 1
   fi
   if [ "$(_claudex_permission_triplet "$path")" != "600" ]; then
-    _claudex_error "file mode must be 0600: $path"
+    _claudex_error "file mode must be 0600: $display_path"
     return 1
   fi
   if [ "$(_claudex_file_owner "$path")" != "$($CLAUDEX_ID -u)" ]; then
-    _claudex_error "file owner does not match the current user: $path"
+    _claudex_error "file owner does not match the current user: $display_path"
     return 1
   fi
 }
@@ -391,7 +391,7 @@ _claudex_credential_json_valid() {
       return 1
       ;;
   esac
-  _claudex_assert_private_file "$path" || return 1
+  _claudex_assert_private_file "$path" "credential file" || return 1
   "$CLAUDEX_JQ" -e --arg credType "$cred_type" '
     type == "object"
     and .type == $credType
@@ -402,7 +402,7 @@ _claudex_credential_json_valid() {
 
 _claudex_credential_fingerprint() {
   local path="$1" digest
-  _claudex_assert_private_file "$path" || return 1
+  _claudex_assert_private_file "$path" "credential file" || return 1
   digest="$("$CLAUDEX_OPENSSL" dgst -sha256 < "$path")" || return 1
   digest="${digest##*= }"
   if [ "${#digest}" -ne 64 ]; then
@@ -424,7 +424,7 @@ _claudex_credential_set_fingerprint() {
   digest="$(
     shopt -s dotglob nullglob
     for entry in "$dir"/*; do
-      _claudex_assert_private_file "$entry" || exit 1
+      _claudex_assert_private_file "$entry" "credential file" || exit 1
       printf '%s\0%s\0' "${entry##*/}" "$(_claudex_credential_fingerprint "$entry")" || exit 1
     done | "$CLAUDEX_OPENSSL" dgst -sha256
   )" || return 1

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -14,7 +14,8 @@
 # Package-internal cross-file API (not stable for external callers):
 #   _claudex_error _claudex_read_api_key _claudex_render_runtime_config_unlocked
 #   _claudex_ensure_private_dir _claudex_single_credential_path
-#   _claudex_credential_json_valid _claudex_credential_type_of
+#   _claudex_credential_json_valid _claudex_credential_fingerprint
+#   _claudex_credential_set_fingerprint _claudex_credential_type_of
 #   _claudex_credential_path_of_type _claudex_assert_entries_wellformed
 #   _claudex_assert_safe_work_dir
 
@@ -23,6 +24,7 @@ if [ "@allowTestOverrides@" = "true" ]; then
   CLAUDEX_CURL="${CLAUDEX_CURL:-@curlBin@}"
   CLAUDEX_OPENSSL="${CLAUDEX_OPENSSL:-@opensslBin@}"
   CLAUDEX_CMP="${CLAUDEX_CMP:-@cmpBin@}"
+  CLAUDEX_CP="${CLAUDEX_CP:-@cpBin@}"
   CLAUDEX_STAT="${CLAUDEX_STAT:-@statBin@}"
   CLAUDEX_CHMOD="${CLAUDEX_CHMOD:-@chmodBin@}"
   CLAUDEX_MKDIR="${CLAUDEX_MKDIR:-@mkdirBin@}"
@@ -39,6 +41,7 @@ else
   CLAUDEX_CURL="@curlBin@"
   CLAUDEX_OPENSSL="@opensslBin@"
   CLAUDEX_CMP="@cmpBin@"
+  CLAUDEX_CP="@cpBin@"
   CLAUDEX_STAT="@statBin@"
   CLAUDEX_CHMOD="@chmodBin@"
   CLAUDEX_MKDIR="@mkdirBin@"
@@ -397,6 +400,48 @@ _claudex_credential_json_valid() {
   ' "$path" >/dev/null 2>&1
 }
 
+_claudex_credential_fingerprint() {
+  local path="$1" digest
+  _claudex_assert_private_file "$path" || return 1
+  digest="$("$CLAUDEX_OPENSSL" dgst -sha256 < "$path")" || return 1
+  digest="${digest##*= }"
+  if [ "${#digest}" -ne 64 ]; then
+    _claudex_error "credential fingerprint has an invalid length"
+    return 1
+  fi
+  case "$digest" in
+    *[!0-9a-fA-F]*)
+      _claudex_error "credential fingerprint has an invalid format"
+      return 1
+      ;;
+  esac
+  printf '%s' "$digest"
+}
+
+_claudex_credential_set_fingerprint() {
+  local dir="$1" digest
+  _claudex_assert_private_dir "$dir" || return 1
+  digest="$(
+    shopt -s dotglob nullglob
+    for entry in "$dir"/*; do
+      _claudex_assert_private_file "$entry" || exit 1
+      printf '%s\0%s\0' "${entry##*/}" "$(_claudex_credential_fingerprint "$entry")" || exit 1
+    done | "$CLAUDEX_OPENSSL" dgst -sha256
+  )" || return 1
+  digest="${digest##*= }"
+  if [ "${#digest}" -ne 64 ]; then
+    _claudex_error "credential set fingerprint has an invalid length"
+    return 1
+  fi
+  case "$digest" in
+    *[!0-9a-fA-F]*)
+      _claudex_error "credential set fingerprint has an invalid format"
+      return 1
+      ;;
+  esac
+  printf '%s' "$digest"
+}
+
 # Prints the declared .type of a credential file, or nothing when the file is not a
 # readable JSON object with a string type. Never fails the caller; type routing decisions
 # stay with the caller. Symlinks and non-regular entries (FIFO, directory) yield no type
@@ -423,7 +468,7 @@ _claudex_assert_entries_wellformed() (
     case "$cred_entry_type" in
       codex | claude) ;;
       *)
-        _claudex_error "unexpected credential entry in $dir: ${entry##*/}"
+        _claudex_error "canonical auth directory holds an unexpected credential entry"
         return 1
         ;;
     esac

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -17,7 +17,7 @@
 #   _claudex_credential_json_valid _claudex_credential_fingerprint
 #   _claudex_credential_set_fingerprint _claudex_credential_type_of
 #   _claudex_credential_path_of_type _claudex_assert_entries_wellformed
-#   _claudex_assert_safe_work_dir
+#   _claudex_assert_safe_work_dir _claudex_loopback_responding
 
 if [ "@allowTestOverrides@" = "true" ]; then
   CLAUDEX_JQ="${CLAUDEX_JQ:-@jqBin@}"
@@ -634,6 +634,28 @@ curl_loopback() (
         --max-time 5 \
         --request GET \
         --url "$CLAUDEX_BASE_URL$path"
+)
+
+_claudex_loopback_responding() (
+  # This is a listener-presence probe, not an authenticated readiness check: any HTTP
+  # response means replacement must stop. Keep the same proxy/config isolation as
+  # curl_loopback so ambient curl settings cannot bypass or spoof the loopback gate.
+  "$CLAUDEX_ENV" \
+    -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY \
+    -u http_proxy -u https_proxy -u all_proxy -u no_proxy \
+    NO_PROXY="$CLAUDEX_NO_PROXY" \
+    no_proxy="$CLAUDEX_NO_PROXY" \
+    "$CLAUDEX_CURL" \
+      -q \
+      --output /dev/null \
+      --silent \
+      --show-error \
+      --noproxy '*' \
+      --proto '=http' \
+      --connect-timeout 1 \
+      --max-time 2 \
+      --request GET \
+      --url "$CLAUDEX_BASE_URL/v1/models"
 )
 
 wait_for_proxy_ready() {

--- a/modules/shared/programs/claudex/files/claudex-runtime.sh
+++ b/modules/shared/programs/claudex/files/claudex-runtime.sh
@@ -419,13 +419,15 @@ _claudex_credential_fingerprint() {
 }
 
 _claudex_credential_set_fingerprint() {
-  local dir="$1" digest
+  local dir="$1" digest entry_digest
   _claudex_assert_private_dir "$dir" || return 1
   digest="$(
+    set -o pipefail
     shopt -s dotglob nullglob
     for entry in "$dir"/*; do
       _claudex_assert_private_file "$entry" "credential file" || exit 1
-      printf '%s\0%s\0' "${entry##*/}" "$(_claudex_credential_fingerprint "$entry")" || exit 1
+      entry_digest="$(_claudex_credential_fingerprint "$entry")" || exit 1
+      printf '%s\0%s\0' "${entry##*/}" "$entry_digest" || exit 1
     done | "$CLAUDEX_OPENSSL" dgst -sha256
   )" || return 1
   digest="${digest##*= }"

--- a/tests/shell-script-tests.sh
+++ b/tests/shell-script-tests.sh
@@ -298,6 +298,8 @@ run_test "claudex credential and loopback contract" test_claudex_credential_and_
 run_test "claudex wrapper pins provider model and argv" test_claudex_wrapper_pins_provider_model_and_argv
 run_test "claudex mixed mode contract" test_claudex_mixed_mode_contract
 run_test "claudex launcher and login use fake boundaries" test_claudex_launcher_and_login_use_fake_boundaries
+run_test "claudex login replaces one provider safely" test_claudex_login_replaces_one_provider_safely
+run_test "claudex login replacement fails closed" test_claudex_login_replacement_fails_closed
 run_test "claudex production execution boundaries are pinned" test_claudex_production_execution_boundaries
 run_test "claudex Stage 1 status is sanitized" test_claudex_status_is_sanitized
 run_test "claudex Nix-generated command outputs are pinned" test_claudex_nix_generated_command_outputs_are_pinned

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -488,6 +488,25 @@ test_claudex_credential_and_loopback_contract() {
     source "$1"; assert_credential_set "$CLAUDEX_AUTH_DIR" default
   ' _ "$runtime" || fail "valid Codex credential was rejected"
 
+  # Set fingerprints are a fail-closed concurrency boundary. A non-private entry or
+  # an individual credential digest failure must not be hidden by a successful final
+  # set digest on the right side of the pipeline.
+  chmod 644 "$state/auth/codex-test.json"
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
+    source "$1"; _claudex_credential_set_fingerprint "$CLAUDEX_AUTH_DIR"
+  ' _ "$runtime" >/dev/null 2>&1; then
+    fail "credential set fingerprint accepted a non-private entry"
+  fi
+  chmod 600 "$state/auth/codex-test.json"
+
+  if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" bash -c '
+    source "$1"
+    _claudex_credential_fingerprint() { return 91; }
+    _claudex_credential_set_fingerprint "$CLAUDEX_AUTH_DIR"
+  ' _ "$runtime" >/dev/null 2>&1; then
+    fail "credential set fingerprint hid an individual digest failure"
+  fi
+
   printf '%s' '{"type":"claude","access_token":"secret","refresh_token":"secret"}' \
     > "$state/auth/codex-test.json"
   chmod 600 "$state/auth/codex-test.json"
@@ -1192,7 +1211,7 @@ EOF
 }
 
 test_claudex_login_replacement_fails_closed() {
-  local sandbox state login jq_bin scenario output before after rc real_cp real_mv real_rm
+  local sandbox state login jq_bin scenario output before after rc real_cp real_mv real_rm CLAUDEX_CURL
   sandbox="$(new_sandbox)"
   state="$sandbox/state"
   login="$sandbox/generated/claudex-login"
@@ -1207,7 +1226,8 @@ test_claudex_login_replacement_fails_closed() {
 exit 7
 EOF
   chmod +x "$sandbox/no-proxy-curl"
-  export CLAUDEX_CURL="$sandbox/no-proxy-curl"
+  CLAUDEX_CURL="$sandbox/no-proxy-curl"
+  export CLAUDEX_CURL
   mkdir -p "$state/auth"
   chmod 700 "$state" "$state/auth"
 

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -93,6 +93,7 @@ _claudex_materialize_runtime() {
     -e "s|@curlBin@|$curl_bin|g" \
     -e "s|@opensslBin@|$(command -v openssl)|g" \
     -e "s|@cmpBin@|$(command -v cmp)|g" \
+    -e "s|@cpBin@|$(command -v cp)|g" \
     -e "s|@statBin@|$(command -v stat)|g" \
     -e "s|@chmodBin@|$(command -v chmod)|g" \
     -e "s|@mkdirBin@|$(command -v mkdir)|g" \
@@ -888,7 +889,7 @@ EOF
 }
 
 test_claudex_launcher_and_login_use_fake_boundaries() {
-  local sandbox state launcher login proxy_log jq_bin expected_work rc
+  local sandbox state launcher login proxy_log jq_bin expected_work output rc
   sandbox="$(new_sandbox)"
   state="$sandbox/state"
   launcher="$sandbox/generated/claudex-proxy-launcher"
@@ -988,8 +989,11 @@ EOF
     fail "login staging directory leaked after promotion"
   fi
   rm -f "$proxy_log"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" "$login" \
-    >/dev/null
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" "$login"
+  )"
+  [[ "$output" == "claudex-login: canonical codex credential is present and schema-valid; live validity was not checked" ]] \
+    || fail "existing codex credential was reported as live-ready: $output"
   [[ ! -e "$proxy_log" ]] || fail "existing canonical credential triggered another device login"
 
   # --claude adds the second provider credential next to the codex entry (mixed set).
@@ -1027,11 +1031,18 @@ EOF
 
   # Both login paths are idempotent per credential type once their entry exists.
   rm -f "$proxy_log"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
-    "$login" --claude >/dev/null
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --claude
+  )"
+  [[ "$output" == "claudex-login: canonical claude credential is present and schema-valid; live validity was not checked" ]] \
+    || fail "existing claude credential was reported as live-ready: $output"
   [[ ! -e "$proxy_log" ]] || fail "existing claude credential triggered another claude login"
-  HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
-    "$login" >/dev/null
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" "$login"
+  )"
+  [[ "$output" == "claudex-login: canonical codex credential is present and schema-valid; live validity was not checked" ]] \
+    || fail "coexisting codex credential was reported as live-ready: $output"
   [[ ! -e "$proxy_log" ]] || fail "coexisting claude credential broke the no-arg login no-op"
 
   # Usage hygiene: unknown or extra arguments are rejected.
@@ -1068,6 +1079,311 @@ EOF
     fail "codex login proceeded despite a malformed sibling entry"
   fi
   rm "$state/auth/gemini-bad.json"
+}
+
+test_claudex_login_replaces_one_provider_safely() {
+  local sandbox state login proxy_log jq_bin output sibling_before codex_before backup_path
+  sandbox="$(new_sandbox)"
+  state="$sandbox/state"
+  login="$sandbox/generated/claudex-login"
+  proxy_log="$sandbox/proxy.log"
+  jq_bin="$(command -v jq)"
+  _claudex_fixture "$sandbox"
+  mkdir -p "$state/auth"
+  chmod 700 "$state" "$state/auth"
+  _claudex_add_valid_credential "$state"
+  printf '%s' '{"type":"claude","access_token":"sibling-access","refresh_token":"sibling-refresh"}' \
+    > "$state/auth/claude-sibling.json"
+  chmod 600 "$state/auth/claude-sibling.json"
+  sibling_before="$(sha256sum "$state/auth/claude-sibling.json")"
+
+  cat > "$sandbox/fake-cli-proxy-api" <<EOF
+#!/usr/bin/env bash
+printf 'arg=%s\n' "\$@" > "$proxy_log"
+config=''
+cred_type=codex
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    --config) config="\$2"; shift 2 ;;
+    --claude-login) cred_type=claude; shift ;;
+    *) shift ;;
+  esac
+done
+auth_dir="\$("$jq_bin" -r '.["auth-dir"]' "\$config")"
+mkdir -p "\$auth_dir"
+chmod 700 "\$auth_dir"
+if [ "\$cred_type" = codex ]; then
+  printf '%s' '{"type":"codex","access_token":"replacement-access","refresh_token":"replacement-refresh"}'
+else
+  printf '%s' '{"type":"claude","access_token":"replacement-claude-access","refresh_token":"replacement-claude-refresh"}'
+fi > "\$auth_dir/upstream-generated-name.json"
+chmod 600 "\$auth_dir/upstream-generated-name.json"
+EOF
+  _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
+  chmod +x "$sandbox/fake-cli-proxy-api"
+  _claudex_materialize_command \
+    "$REPO_ROOT/modules/shared/programs/claudex/files/claudex-login.sh" \
+    "$login" "$sandbox/generated/claudex-runtime.sh" \
+    "$sandbox/fake-cli-proxy-api" "$sandbox/generated/config-template.json" \
+    "$sandbox/generated/wrapper-settings.json"
+  chmod +x "$login"
+
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --replace 2>&1
+  )"
+  [[ "$output" == "claudex-login: follow the codex OAuth instructions printed by CLIProxyAPI"$'\n'"claudex-login: canonical codex credential was replaced and is schema-valid; live validity was not checked" ]] \
+    || fail "Codex replacement output drifted or exposed private data: $output"
+  assert_file_contains "$proxy_log" "arg=--codex-device-login"
+  [[ -f "$state/auth/codex-test.json" ]] \
+    || fail "Codex replacement did not preserve the canonical credential path"
+  [[ ! -e "$state/auth/upstream-generated-name.json" ]] \
+    || fail "Codex replacement adopted the staging filename and changed watcher identity"
+  jq -e '.type == "codex" and .access_token == "replacement-access"' \
+    "$state/auth/codex-test.json" >/dev/null || fail "Codex replacement was not promoted"
+  [[ "$(sha256sum "$state/auth/claude-sibling.json")" == "$sibling_before" ]] \
+    || fail "Codex replacement changed the Claude sibling"
+  [[ "$(stat -c '%a' "$state/credential-backups")" == "700" ]] \
+    || fail "credential backup directory is not private"
+  backup_path="$(find "$state/credential-backups" -mindepth 1 -maxdepth 1 -type f -print -quit)"
+  [[ -n "$backup_path" && "$(stat -c '%a' "$backup_path")" == "600" ]] \
+    || fail "replaced Codex credential did not leave one private backup"
+  jq -e '.type == "codex" and .access_token == "test-access"' "$backup_path" >/dev/null \
+    || fail "Codex backup does not hold the pre-replacement credential"
+
+  # The symmetric Claude path preserves the already-replaced Codex credential.
+  codex_before="$(sha256sum "$state/auth/codex-test.json")"
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --replace --claude 2>&1
+  )"
+  [[ "$output" == "claudex-login: follow the claude OAuth instructions printed by CLIProxyAPI"$'\n'"claudex-login: canonical claude credential was replaced and is schema-valid; live validity was not checked" ]] \
+    || fail "Claude replacement output drifted or exposed private data: $output"
+  assert_file_contains "$proxy_log" "arg=--claude-login"
+  [[ -f "$state/auth/claude-sibling.json" ]] \
+    || fail "Claude replacement did not preserve the canonical credential path"
+  jq -e '.type == "claude" and .access_token == "replacement-claude-access"' \
+    "$state/auth/claude-sibling.json" >/dev/null || fail "Claude replacement was not promoted"
+  [[ "$(sha256sum "$state/auth/codex-test.json")" == "$codex_before" ]] \
+    || fail "Claude replacement changed the Codex sibling"
+  [[ "$(find "$state/credential-backups" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "2" ]] \
+    || fail "provider replacements did not retain one backup per operation"
+  find "$state/credential-backups" -mindepth 1 -maxdepth 1 -type f -exec \
+    "$jq_bin" -e 'select(.type == "claude" and .access_token == "sibling-access")' {} + \
+    >/dev/null || fail "Claude backup does not hold the pre-replacement credential"
+  if find "$state" -maxdepth 1 -name 'auth.login.*' | grep -q .; then
+    fail "replacement staging directory leaked after promotion"
+  fi
+}
+
+test_claudex_login_replacement_fails_closed() {
+  local sandbox state login jq_bin scenario output before after rc real_mv
+  sandbox="$(new_sandbox)"
+  state="$sandbox/state"
+  login="$sandbox/generated/claudex-login"
+  jq_bin="$(command -v jq)"
+  scenario="$sandbox/scenario"
+  real_mv="$(command -v mv)"
+  _claudex_fixture "$sandbox"
+  mkdir -p "$state/auth"
+  chmod 700 "$state" "$state/auth"
+
+  _reset_replacement_credentials() {
+    rm -rf "$state/auth" "$state/credential-backups"
+    mkdir -p "$state/auth"
+    chmod 700 "$state/auth"
+    printf '%s' '{"type":"codex","access_token":"original-secret-access","refresh_token":"original-secret-refresh"}' \
+      > "$state/auth/private-codex-account.json"
+    printf '%s' '{"type":"claude","access_token":"sibling-secret-access","refresh_token":"sibling-secret-refresh"}' \
+      > "$state/auth/private-claude-account.json"
+    chmod 600 "$state/auth/"*.json
+  }
+
+  _canonical_digest() {
+    find "$state/auth" -mindepth 1 -maxdepth 1 -type f -exec sha256sum {} + | sort
+  }
+
+  _assert_login_args_rejected() {
+    if HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" "$login" "$@" >/dev/null 2>&1; then
+      fail "claudex-login accepted hostile argv: $*"
+    fi
+  }
+
+  cat > "$sandbox/fake-cli-proxy-api" <<EOF
+#!/usr/bin/env bash
+config=''
+while [ "\$#" -gt 0 ]; do
+  if [ "\$1" = '--config' ]; then config="\$2"; shift 2; else shift; fi
+done
+case "\$(<"$scenario")" in
+  oauth-fail) exit 19 ;;
+esac
+auth_dir="\$("$jq_bin" -r '.["auth-dir"]' "\$config")"
+mkdir -p "\$auth_dir"
+chmod 700 "\$auth_dir"
+case "\$(<"$scenario")" in
+  invalid-stage)
+    printf '%s' '{"type":"codex","access_token":"","refresh_token":"staged-secret-refresh"}' \
+      > "\$auth_dir/private-staged-account.json"
+    ;;
+  *)
+    printf '%s' '{"type":"codex","access_token":"staged-secret-access","refresh_token":"staged-secret-refresh"}' \
+      > "\$auth_dir/private-staged-account.json"
+    ;;
+esac
+chmod 600 "\$auth_dir/private-staged-account.json"
+case "\$(<"$scenario")" in
+  concurrent-target)
+    printf '%s' '{"type":"codex","access_token":"concurrent-secret-access","refresh_token":"concurrent-secret-refresh"}' \
+      > "$state/auth/private-codex-account.json"
+    chmod 600 "$state/auth/private-codex-account.json"
+    ;;
+  concurrent-sibling)
+    printf '%s' '{"type":"claude","access_token":"concurrent-sibling-access","refresh_token":"concurrent-sibling-refresh"}' \
+      > "$state/auth/private-claude-account.json"
+    chmod 600 "$state/auth/private-claude-account.json"
+    ;;
+esac
+EOF
+  _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
+  chmod +x "$sandbox/fake-cli-proxy-api"
+  _claudex_materialize_command \
+    "$REPO_ROOT/modules/shared/programs/claudex/files/claudex-login.sh" \
+    "$login" "$sandbox/generated/claudex-runtime.sh" \
+    "$sandbox/fake-cli-proxy-api" "$sandbox/generated/config-template.json" \
+    "$sandbox/generated/wrapper-settings.json"
+  chmod +x "$login"
+
+  for scenario_name in oauth-fail invalid-stage; do
+    _reset_replacement_credentials
+    printf '%s' "$scenario_name" > "$scenario"
+    before="$(_canonical_digest)"
+    set +e
+    output="$(
+      HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+        "$login" --replace 2>&1
+    )"
+    rc=$?
+    set -e
+    [[ "$rc" != 0 ]] || fail "$scenario_name replacement unexpectedly succeeded"
+    [[ "$(_canonical_digest)" == "$before" ]] \
+      || fail "$scenario_name replacement changed the canonical credential set"
+    assert_not_contains "$output" "secret-"
+    assert_not_contains "$output" "private-"
+  done
+
+  # A valid concurrent mutation anywhere in the canonical set invalidates the snapshot.
+  for scenario_name in concurrent-target concurrent-sibling; do
+    _reset_replacement_credentials
+    printf '%s' "$scenario_name" > "$scenario"
+    set +e
+    output="$(
+      HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+        "$login" --replace 2>&1
+    )"
+    rc=$?
+    set -e
+    [[ "$rc" != 0 ]] || fail "$scenario_name mutation did not stop replacement"
+    jq -e '.access_token != "staged-secret-access"' \
+      "$state/auth/private-codex-account.json" >/dev/null \
+      || fail "$scenario_name mutation was overwritten by the staged credential"
+    assert_not_contains "$output" "secret-"
+    assert_not_contains "$output" "private-"
+  done
+
+  # A failed atomic move leaves the canonical set byte-identical and no redundant backup.
+  _reset_replacement_credentials
+  printf '%s' success > "$scenario"
+  cat > "$sandbox/fail-replacement-mv" <<EOF
+#!/usr/bin/env bash
+if [ "\${1-}" = "-f" ] && [[ "\${3-}" == *"/auth.login."*"/auth/"* ]]; then
+  exit 91
+fi
+exec "$real_mv" "\$@"
+EOF
+  chmod +x "$sandbox/fail-replacement-mv"
+  before="$(_canonical_digest)"
+  set +e
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_MV="$sandbox/fail-replacement-mv" "$login" --replace 2>&1
+  )"
+  rc=$?
+  set -e
+  [[ "$rc" != 0 && "$(_canonical_digest)" == "$before" ]] \
+    || fail "failed atomic replacement changed the canonical credential set"
+  [[ -z "$(find "$state/credential-backups" -mindepth 1 -maxdepth 1 -type f -print -quit)" ]] \
+    || fail "failed atomic replacement retained a redundant backup"
+  assert_not_contains "$output" "secret-"
+  assert_not_contains "$output" "private-"
+
+  # Corruption after the rename triggers automatic rollback from the verified backup.
+  _reset_replacement_credentials
+  cat > "$sandbox/corrupt-replacement-mv" <<EOF
+#!/usr/bin/env bash
+"$real_mv" "\$@" || exit
+if [ "\${1-}" = "-f" ] && [[ "\${3-}" == *"/auth.login."*"/auth/"* ]]; then
+  printf '%s' '{"type":"codex","access_token":"","refresh_token":""}' > "\${4}"
+  chmod 600 "\${4}"
+fi
+EOF
+  chmod +x "$sandbox/corrupt-replacement-mv"
+  before="$(_canonical_digest)"
+  set +e
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_MV="$sandbox/corrupt-replacement-mv" "$login" --replace 2>&1
+  )"
+  rc=$?
+  set -e
+  after="$(_canonical_digest)"
+  [[ "$rc" != 0 && "$after" == "$before" ]] \
+    || fail "post-rename validation failure did not restore the canonical credential set"
+  assert_not_contains "$output" "secret-"
+  assert_not_contains "$output" "private-"
+
+  # Missing providers, malformed/duplicate state, and hostile argv fail without OAuth or deletion.
+  _reset_replacement_credentials
+  rm "$state/auth/private-claude-account.json"
+  if output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --claude --replace 2>&1
+  )"; then
+    fail "replacement accepted a missing Claude credential"
+  fi
+  assert_contains "$output" "run claudex-login without --replace first"
+  assert_not_contains "$output" "private-"
+
+  _assert_login_args_rejected --replace --replace
+  _assert_login_args_rejected --claude --claude
+  _assert_login_args_rejected --hostile
+  _assert_login_args_rejected positional
+
+  printf '%s' '{"type":"gemini","access_token":"malformed-secret-access","refresh_token":"malformed-secret-refresh"}' \
+    > "$state/auth/private-malformed-account.json"
+  chmod 600 "$state/auth/private-malformed-account.json"
+  if output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --replace 2>&1
+  )"; then
+    fail "replacement accepted a malformed canonical entry"
+  fi
+  assert_not_contains "$output" "secret-"
+  assert_not_contains "$output" "private-"
+  rm "$state/auth/private-malformed-account.json"
+
+  cp "$state/auth/private-codex-account.json" "$state/auth/private-codex-duplicate.json"
+  chmod 600 "$state/auth/private-codex-duplicate.json"
+  if output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --replace 2>&1
+  )"; then
+    fail "replacement accepted duplicate Codex credentials"
+  fi
+  [[ "$(find "$state/auth" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')" == "2" ]] \
+    || fail "duplicate rejection deleted a canonical credential"
+  assert_not_contains "$output" "secret-"
+  assert_not_contains "$output" "private-"
 }
 
 test_claudex_production_execution_boundaries() {

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -1310,6 +1310,33 @@ EOF
   [[ -z "$(find "$state" -maxdepth 1 -name 'auth.login.*' -print -quit)" ]] \
     || fail "running-proxy rejection created a login staging directory"
 
+  # A proxy that starts during OAuth is caught by the second probe under the
+  # promotion state lock, before backup or canonical mutation.
+  cat > "$sandbox/proxy-starts-during-oauth-curl" <<EOF
+#!/usr/bin/env bash
+count=0
+if [ -f "$sandbox/curl-count" ]; then read -r count < "$sandbox/curl-count"; fi
+count=\$((count + 1))
+printf '%s' "\$count" > "$sandbox/curl-count"
+if [ "\$count" -ge 2 ]; then exit 0; fi
+exit 7
+EOF
+  chmod +x "$sandbox/proxy-starts-during-oauth-curl"
+  _reset_replacement_credentials
+  printf '%s' success > "$scenario"
+  before="$(_canonical_digest)"
+  if output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_CURL="$sandbox/proxy-starts-during-oauth-curl" "$login" --replace 2>&1
+  )"; then
+    fail "replacement continued after the proxy started during OAuth"
+  fi
+  [[ "$(_canonical_digest)" == "$before" ]] \
+    || fail "late proxy rejection changed the canonical credential set"
+  [[ ! -d "$state/credential-backups" ]] \
+    || fail "late proxy rejection created a credential backup"
+  assert_contains "$output" "stop the local claudex proxy before replacing credentials"
+
   for scenario_name in oauth-fail save-error invalid-stage invalid-stage-mode; do
     _reset_replacement_credentials
     printf '%s' "$scenario_name" > "$scenario"

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -1089,6 +1089,11 @@ test_claudex_login_replaces_one_provider_safely() {
   proxy_log="$sandbox/proxy.log"
   jq_bin="$(command -v jq)"
   _claudex_fixture "$sandbox"
+  cat > "$sandbox/no-proxy-curl" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+  chmod +x "$sandbox/no-proxy-curl"
   mkdir -p "$state/auth"
   chmod 700 "$state" "$state/auth"
   _claudex_add_valid_credential "$state"
@@ -1118,7 +1123,14 @@ else
   printf '%s' '{"type":"claude","access_token":"replacement-claude-access","refresh_token":"replacement-claude-refresh"}'
 fi > "\$auth_dir/upstream-generated-name.json"
 chmod 600 "\$auth_dir/upstream-generated-name.json"
+printf '%s' 'Paste the callback URL if manual fallback is required: '
+printf 'Saving credentials to %s\n' "\$auth_dir/upstream-generated-name.json"
 printf 'Authentication saved to %s\n' "\$auth_dir/upstream-generated-name.json"
+if [ "\$cred_type" = codex ]; then
+  printf '%s\n' 'Codex device authentication successful!'
+else
+  printf '%s\n' 'Claude authentication successful!'
+fi
 EOF
   _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
   chmod +x "$sandbox/fake-cli-proxy-api"
@@ -1131,9 +1143,10 @@ EOF
 
   output="$(
     HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_CURL="$sandbox/no-proxy-curl" \
       "$login" --replace 2>&1
   )"
-  [[ "$output" == "claudex-login: follow the codex OAuth instructions printed by CLIProxyAPI"$'\n'"Authentication saved to private staging"$'\n'"claudex-login: canonical codex credential was replaced and is schema-valid; live validity was not checked" ]] \
+  [[ "$output" == "claudex-login: follow the codex OAuth instructions printed by CLIProxyAPI"$'\n'"Paste the callback URL if manual fallback is required: Saving credentials to [private login staging]"$'\n'"Authentication saved to [private login staging]"$'\n'"Codex device authentication successful!"$'\n'"claudex-login: canonical codex credential was replaced and is schema-valid; live validity was not checked" ]] \
     || fail "Codex replacement output drifted or exposed private data: $output"
   assert_file_contains "$proxy_log" "arg=--codex-device-login"
   [[ -f "$state/auth/codex-test.json" ]] \
@@ -1156,9 +1169,10 @@ EOF
   codex_before="$(sha256sum "$state/auth/codex-test.json")"
   output="$(
     HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_CURL="$sandbox/no-proxy-curl" \
       "$login" --replace --claude 2>&1
   )"
-  [[ "$output" == "claudex-login: follow the claude OAuth instructions printed by CLIProxyAPI"$'\n'"Authentication saved to private staging"$'\n'"claudex-login: canonical claude credential was replaced and is schema-valid; live validity was not checked" ]] \
+  [[ "$output" == "claudex-login: follow the claude OAuth instructions printed by CLIProxyAPI"$'\n'"Paste the callback URL if manual fallback is required: Saving credentials to [private login staging]"$'\n'"Authentication saved to [private login staging]"$'\n'"Claude authentication successful!"$'\n'"claudex-login: canonical claude credential was replaced and is schema-valid; live validity was not checked" ]] \
     || fail "Claude replacement output drifted or exposed private data: $output"
   assert_file_contains "$proxy_log" "arg=--claude-login"
   [[ -f "$state/auth/claude-sibling.json" ]] \
@@ -1188,6 +1202,12 @@ test_claudex_login_replacement_fails_closed() {
   real_mv="$(command -v mv)"
   real_rm="$(command -v rm)"
   _claudex_fixture "$sandbox"
+  cat > "$sandbox/no-proxy-curl" <<'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+  chmod +x "$sandbox/no-proxy-curl"
+  export CLAUDEX_CURL="$sandbox/no-proxy-curl"
   mkdir -p "$state/auth"
   chmod 700 "$state" "$state/auth"
 
@@ -1224,6 +1244,11 @@ esac
 auth_dir="\$("$jq_bin" -r '.["auth-dir"]' "\$config")"
 mkdir -p "\$auth_dir"
 chmod 700 "\$auth_dir"
+if [ "\$(<"$scenario")" = save-error ]; then
+  printf 'failed to save credential: open %s: permission denied\n' \
+    "\$auth_dir/private-staged-account.json" >&2
+  exit 18
+fi
 case "\$(<"$scenario")" in
   invalid-stage | invalid-stage-mode)
     printf '%s' '{"type":"codex","access_token":"","refresh_token":"staged-secret-refresh"}' \
@@ -1263,7 +1288,29 @@ EOF
     "$sandbox/generated/wrapper-settings.json"
   chmod +x "$login"
 
-  for scenario_name in oauth-fail invalid-stage invalid-stage-mode; do
+  # Replacement refuses to start OAuth while a loopback proxy responds, because a
+  # refresh already in flight could persist the old credential lineage afterward.
+  cat > "$sandbox/responding-proxy-curl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$sandbox/responding-proxy-curl"
+  _reset_replacement_credentials
+  printf '%s' success > "$scenario"
+  before="$(_canonical_digest)"
+  if output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_CURL="$sandbox/responding-proxy-curl" "$login" --replace 2>&1
+  )"; then
+    fail "replacement started while the local proxy was responding"
+  fi
+  [[ "$(_canonical_digest)" == "$before" ]] \
+    || fail "running-proxy rejection changed the canonical credential set"
+  assert_contains "$output" "stop the local claudex proxy before replacing credentials"
+  [[ -z "$(find "$state" -maxdepth 1 -name 'auth.login.*' -print -quit)" ]] \
+    || fail "running-proxy rejection created a login staging directory"
+
+  for scenario_name in oauth-fail save-error invalid-stage invalid-stage-mode; do
     _reset_replacement_credentials
     printf '%s' "$scenario_name" > "$scenario"
     before="$(_canonical_digest)"

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -1177,12 +1177,13 @@ EOF
 }
 
 test_claudex_login_replacement_fails_closed() {
-  local sandbox state login jq_bin scenario output before after rc real_mv
+  local sandbox state login jq_bin scenario output before after rc real_cp real_mv
   sandbox="$(new_sandbox)"
   state="$sandbox/state"
   login="$sandbox/generated/claudex-login"
   jq_bin="$(command -v jq)"
   scenario="$sandbox/scenario"
+  real_cp="$(command -v cp)"
   real_mv="$(command -v mv)"
   _claudex_fixture "$sandbox"
   mkdir -p "$state/auth"
@@ -1222,7 +1223,7 @@ auth_dir="\$("$jq_bin" -r '.["auth-dir"]' "\$config")"
 mkdir -p "\$auth_dir"
 chmod 700 "\$auth_dir"
 case "\$(<"$scenario")" in
-  invalid-stage)
+  invalid-stage | invalid-stage-mode)
     printf '%s' '{"type":"codex","access_token":"","refresh_token":"staged-secret-refresh"}' \
       > "\$auth_dir/private-staged-account.json"
     ;;
@@ -1232,6 +1233,11 @@ case "\$(<"$scenario")" in
     ;;
 esac
 chmod 600 "\$auth_dir/private-staged-account.json"
+if [ "\$(<"$scenario")" = invalid-stage-mode ]; then
+  printf '%s' '{"type":"codex","access_token":"staged-secret-access","refresh_token":"staged-secret-refresh"}' \
+    > "\$auth_dir/private-staged-account.json"
+  chmod 644 "\$auth_dir/private-staged-account.json"
+fi
 case "\$(<"$scenario")" in
   concurrent-target)
     printf '%s' '{"type":"codex","access_token":"concurrent-secret-access","refresh_token":"concurrent-secret-refresh"}' \
@@ -1254,7 +1260,7 @@ EOF
     "$sandbox/generated/wrapper-settings.json"
   chmod +x "$login"
 
-  for scenario_name in oauth-fail invalid-stage; do
+  for scenario_name in oauth-fail invalid-stage invalid-stage-mode; do
     _reset_replacement_credentials
     printf '%s' "$scenario_name" > "$scenario"
     before="$(_canonical_digest)"
@@ -1271,6 +1277,18 @@ EOF
     assert_not_contains "$output" "secret-"
     assert_not_contains "$output" "private-"
   done
+
+  # A canonical credential permission failure is generic and does not expose its
+  # account-derived filename before OAuth starts.
+  _reset_replacement_credentials
+  chmod 644 "$state/auth/private-codex-account.json"
+  if output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      "$login" --replace 2>&1
+  )"; then
+    fail "replacement accepted a non-private canonical credential"
+  fi
+  assert_not_contains "$output" "private-"
 
   # A valid concurrent mutation anywhere in the canonical set invalidates the snapshot.
   for scenario_name in concurrent-target concurrent-sibling; do
@@ -1291,12 +1309,59 @@ EOF
     assert_not_contains "$output" "private-"
   done
 
+  # A non-cooperating writer that changes the target while the private backup is copied
+  # is detected by the final pre-promotion snapshot check.
+  _reset_replacement_credentials
+  printf '%s' success > "$scenario"
+  cat > "$sandbox/mutate-after-backup-cp" <<EOF
+#!/usr/bin/env bash
+"$real_cp" "\$@" || exit
+printf '%s' '{"type":"codex","access_token":"post-backup-concurrent-access","refresh_token":"post-backup-concurrent-refresh"}' \
+  > "$state/auth/private-codex-account.json"
+chmod 600 "$state/auth/private-codex-account.json"
+EOF
+  chmod +x "$sandbox/mutate-after-backup-cp"
+  set +e
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_CP="$sandbox/mutate-after-backup-cp" "$login" --replace 2>&1
+  )"
+  rc=$?
+  set -e
+  [[ "$rc" != 0 ]] || fail "post-backup canonical mutation did not stop replacement"
+  jq -e '.access_token == "post-backup-concurrent-access"' \
+    "$state/auth/private-codex-account.json" >/dev/null \
+    || fail "post-backup concurrent credential was overwritten"
+  [[ -z "$(find "$state/credential-backups" -mindepth 1 -maxdepth 1 -type f -print -quit)" ]] \
+    || fail "post-backup mutation retained a stale backup"
+  assert_not_contains "$output" "private-"
+
+  # Operand-bearing coreutils diagnostics are suppressed before a generic error is printed.
+  _reset_replacement_credentials
+  cat > "$sandbox/noisy-fail-cp" <<'EOF'
+#!/usr/bin/env bash
+printf 'cp operand=%s\n' "$@" >&2
+exit 92
+EOF
+  chmod +x "$sandbox/noisy-fail-cp"
+  set +e
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_CP="$sandbox/noisy-fail-cp" "$login" --replace 2>&1
+  )"
+  rc=$?
+  set -e
+  [[ "$rc" != 0 ]] || fail "failed backup copy unexpectedly allowed replacement"
+  assert_contains "$output" "failed to create the private credential backup"
+  assert_not_contains "$output" "private-"
+
   # A failed atomic move leaves the canonical set byte-identical and no redundant backup.
   _reset_replacement_credentials
   printf '%s' success > "$scenario"
   cat > "$sandbox/fail-replacement-mv" <<EOF
 #!/usr/bin/env bash
 if [ "\${1-}" = "-f" ] && [[ "\${3-}" == *"/auth.login."*"/auth/"* ]]; then
+  printf 'mv operand=%s\n' "\$@" >&2
   exit 91
 fi
 exec "$real_mv" "\$@"

--- a/tests/suites/claudex.sh
+++ b/tests/suites/claudex.sh
@@ -1118,6 +1118,7 @@ else
   printf '%s' '{"type":"claude","access_token":"replacement-claude-access","refresh_token":"replacement-claude-refresh"}'
 fi > "\$auth_dir/upstream-generated-name.json"
 chmod 600 "\$auth_dir/upstream-generated-name.json"
+printf 'Authentication saved to %s\n' "\$auth_dir/upstream-generated-name.json"
 EOF
   _claudex_pin_proxy_shebang "$sandbox/fake-cli-proxy-api"
   chmod +x "$sandbox/fake-cli-proxy-api"
@@ -1132,7 +1133,7 @@ EOF
     HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
       "$login" --replace 2>&1
   )"
-  [[ "$output" == "claudex-login: follow the codex OAuth instructions printed by CLIProxyAPI"$'\n'"claudex-login: canonical codex credential was replaced and is schema-valid; live validity was not checked" ]] \
+  [[ "$output" == "claudex-login: follow the codex OAuth instructions printed by CLIProxyAPI"$'\n'"Authentication saved to private staging"$'\n'"claudex-login: canonical codex credential was replaced and is schema-valid; live validity was not checked" ]] \
     || fail "Codex replacement output drifted or exposed private data: $output"
   assert_file_contains "$proxy_log" "arg=--codex-device-login"
   [[ -f "$state/auth/codex-test.json" ]] \
@@ -1157,7 +1158,7 @@ EOF
     HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
       "$login" --replace --claude 2>&1
   )"
-  [[ "$output" == "claudex-login: follow the claude OAuth instructions printed by CLIProxyAPI"$'\n'"claudex-login: canonical claude credential was replaced and is schema-valid; live validity was not checked" ]] \
+  [[ "$output" == "claudex-login: follow the claude OAuth instructions printed by CLIProxyAPI"$'\n'"Authentication saved to private staging"$'\n'"claudex-login: canonical claude credential was replaced and is schema-valid; live validity was not checked" ]] \
     || fail "Claude replacement output drifted or exposed private data: $output"
   assert_file_contains "$proxy_log" "arg=--claude-login"
   [[ -f "$state/auth/claude-sibling.json" ]] \
@@ -1177,7 +1178,7 @@ EOF
 }
 
 test_claudex_login_replacement_fails_closed() {
-  local sandbox state login jq_bin scenario output before after rc real_cp real_mv
+  local sandbox state login jq_bin scenario output before after rc real_cp real_mv real_rm
   sandbox="$(new_sandbox)"
   state="$sandbox/state"
   login="$sandbox/generated/claudex-login"
@@ -1185,6 +1186,7 @@ test_claudex_login_replacement_fails_closed() {
   scenario="$sandbox/scenario"
   real_cp="$(command -v cp)"
   real_mv="$(command -v mv)"
+  real_rm="$(command -v rm)"
   _claudex_fixture "$sandbox"
   mkdir -p "$state/auth"
   chmod 700 "$state" "$state/auth"
@@ -1238,6 +1240,7 @@ if [ "\$(<"$scenario")" = invalid-stage-mode ]; then
     > "\$auth_dir/private-staged-account.json"
   chmod 644 "\$auth_dir/private-staged-account.json"
 fi
+printf 'Authentication saved to %s\n' "\$auth_dir/private-staged-account.json"
 case "\$(<"$scenario")" in
   concurrent-target)
     printf '%s' '{"type":"codex","access_token":"concurrent-secret-access","refresh_token":"concurrent-secret-refresh"}' \
@@ -1406,6 +1409,34 @@ EOF
     || fail "post-rename validation failure did not restore the canonical credential set"
   assert_not_contains "$output" "secret-"
   assert_not_contains "$output" "private-"
+
+  # Success is not reported until the private staging directory has been removed. A
+  # path-bearing rm diagnostic is suppressed and replaced with a generic failure.
+  _reset_replacement_credentials
+  printf '%s' success > "$scenario"
+  cat > "$sandbox/fail-staging-cleanup-rm" <<EOF
+#!/usr/bin/env bash
+if [ "\${1-}" = "-rf" ] && [[ "\${3-}" == *"/auth.login."* ]]; then
+  printf 'rm operand=%s\n' "\$@" >&2
+  exit 93
+fi
+exec "$real_rm" "\$@"
+EOF
+  chmod +x "$sandbox/fail-staging-cleanup-rm"
+  set +e
+  output="$(
+    HOME="$sandbox/home" CLAUDEX_STATE_DIR="$state" CLAUDEX_FLOCK="$sandbox/fake-flock" \
+      CLAUDEX_RM="$sandbox/fail-staging-cleanup-rm" "$login" --replace 2>&1
+  )"
+  rc=$?
+  set -e
+  [[ "$rc" != 0 ]] || fail "replacement reported success after staging cleanup failed"
+  jq -e '.access_token == "staged-secret-access"' \
+    "$state/auth/private-codex-account.json" >/dev/null \
+    || fail "staging cleanup failure obscured the completed replacement state"
+  assert_contains "$output" "failed to remove the private login staging directory"
+  assert_not_contains "$output" "auth.login."
+  assert_not_contains "$output" "private-staged-account"
 
   # Missing providers, malformed/duplicate state, and hostile argv fail without OAuth or deletion.
   _reset_replacement_credentials


### PR DESCRIPTION
## Summary

- `claudex-login --replace`와 `claudex-login --claude --replace`를 추가해 요청한 provider credential 하나만 명시적으로 교체합니다.
- OAuth 산출물을 private staging에서 검증하고, canonical credential set의 동시 변경과 proxy 실행을 차단한 뒤 기존 경로에 원자 교체합니다.
- 교체 실패 시 private backup으로 rollback하고 sibling provider credential을 보존하며, 계정 정보가 포함될 수 있는 staging 경로는 출력에서 redaction합니다.
- `claudex-login`과 `claudex-status`의 ready 메시지를 local schema/file readiness로 한정하고 live validity는 headless completion으로 확인하도록 문서화합니다.

Closes #1188

## 기존 문제 / 배경

기존 `claudex-login`은 credential JSON의 타입, 토큰 문자열, 파일 권한이 정상이라면 `already ready`로 종료했습니다. 따라서 upstream에서 refresh token이 폐기되어 실제 요청은 401로 실패해도 안전한 재로그인 경로가 없었고, 사용자가 credential 파일을 직접 옮겨야 했습니다.

기존 안전 계약은 자동 삭제와 조용한 overwrite를 금지합니다. 또한 mixed mode에서는 Codex와 Claude credential이 함께 존재할 수 있으므로 한 provider를 복구하면서 sibling credential을 변경하면 안 됩니다.

## Context & Implementation Rationale (CIR)

- PR #1107에서 private staging, 정확히 하나의 OAuth 산출물, 기존 credential 무단 overwrite 금지를 도입했습니다.
- PR #1129와 이슈 #1127에서 Codex/Claude credential 공존과 provider별 상태 계약을 도입했습니다.
- 이번 변경은 자동 복구 대신 사용자가 선택하는 `--replace`만 허용하고, 일반 로그인은 live validity를 추측하지 않습니다.
- pinned CLIProxyAPI의 watcher가 경로 identity를 기준으로 상태를 추적하므로 새 upstream filename을 승격하지 않고 기존 canonical 경로를 유지합니다.
- 교체 직전 전체 credential set과 대상 파일 snapshot을 다시 비교하고, proxy loopback 응답 여부도 state lock 아래에서 재확인합니다.

이 설계는 private backup 보존과 stop-first 운영 절차라는 비용이 있지만, sibling 손상·중복 credential·실행 중 watcher race를 피하면서 invalidated credential을 복구할 수 있습니다.

## Architecture Decision Record (ADR)

| 대안 | 결정 | 이유 |
| --- | --- | --- |
| 기존 credential 자동 삭제 후 재로그인 | ❌ | 파괴적이며 OAuth 실패 시 복구가 어렵고 sibling 선택 오류 위험이 있습니다. |
| 일반 로그인 때마다 live token probe | ❌ | 네트워크/서비스 오류와 credential 무효를 구분하기 어렵고 login 자체에 외부 요청 부작용을 추가합니다. |
| 새 OAuth가 만든 filename을 canonical에 그대로 추가 | ❌ | 중복 credential이 생기고 watcher가 provider 삭제/추가로 오인할 수 있습니다. |
| 명시적 provider 교체 + snapshot/backup/rollback + 기존 경로 유지 | ✅ | 사용자의 의도를 요구하면서 canonical set과 watcher identity를 보존합니다. |
| proxy가 응답 중이어도 교체 허용 | ❌ | 실행 중 loader/watcher와 credential 교체가 경쟁할 수 있으므로 OAuth 전과 승격 직전에 차단합니다. |

## 구현 상세

| 파일 | 변경 |
| --- | --- |
| `modules/shared/programs/claudex/files/claudex-login.sh` | strict argv parsing, replacement staging, 출력 sanitizer, snapshot/recheck, backup/rollback, proxy gate |
| `modules/shared/programs/claudex/files/claudex-runtime.sh` | credential set snapshot과 loopback readiness helper |
| `modules/shared/programs/claudex/default.nix` | replacement runtime이 사용하는 `curl` 의존성 주입 |
| `tests/suites/claudex.sh` | provider별 성공/실패, concurrency, rollback, hostile output, proxy race fixture |
| `tests/shell-script-tests.sh` | 새 suite 계약 연결 |
| `docs/claudex-poc-handoff.md` | 운영 절차, live-readiness 경계, backup retention 문서화 |

사용자 진입점은 다음 두 가지입니다.

```bash
claudex-login --replace
claudex-login --claude --replace
```

교체 경로의 핵심 순서는 다음과 같습니다.

```text
proxy stopped 확인
→ canonical credential set snapshot
→ private staging OAuth 및 산출물 검증
→ state lock 아래 snapshot/proxy 재확인
→ private backup
→ 기존 canonical 경로에 원자 교체
→ post-replace 검증, 실패 시 rollback
```

## References

- #1188
- #1108
- #1127
- #1107
- #1129
- [CLIProxyAPI v7.2.73](https://github.com/router-for-me/CLIProxyAPI/tree/v7.2.73)

## Human Test Plan

1. foreground proxy와 관련 서비스를 중지하고 canonical auth 디렉터리에 요청 provider credential이 정확히 하나인지 확인합니다. 토큰과 filename은 출력하지 않습니다.
2. 기존 credential이 있는 상태에서 `claudex-login`을 실행합니다.
   - OAuth를 시작하지 않고 schema-valid/present라고 알립니다.
   - live validity는 확인하지 않았다는 메시지가 표시됩니다.
3. Codex 복구는 `claudex-login --replace`, Claude 복구는 `claudex-login --claude --replace`로 수행합니다.
   - OAuth 진행 중 account-derived staging 경로가 출력되지 않습니다.
   - 기존 canonical basename이 유지됩니다.
   - 다른 provider credential의 hash는 바뀌지 않습니다.
   - private backup 하나가 mode `0600`으로 남고 임시 login 디렉터리는 정리됩니다.
4. proxy를 실행한 상태에서 같은 replacement 명령을 다시 시도합니다.
   - OAuth 전에 실패하며 기존 credential set은 변하지 않아야 합니다.
5. 실제 invalidated-token 복구 후 다음처럼 headless completion을 실행해 live auth를 확인합니다.

   ```bash
   printf '%s\n' 'Reply with exactly OK and nothing else.' \
     | timeout 120 claudex -p --output-format text
   ```

6. 회귀 검증은 다음 명령으로 실행합니다.

   ```bash
   CI=1 nix develop --command bash tests/run-all-tests.sh
   ```

실제 OAuth와 invalidated-token E2E는 외부 credential을 변경하므로 자동 테스트에서는 실행하지 않았고, fake proxy fixture로 교체 및 실패 경로를 검증했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - `claudex-login --replace`로 기존 인증 정보를 안전하게 교체할 수 있습니다.
  - 교체 전 기존 인증 정보를 백업하고, 문제가 발생하면 자동으로 복구합니다.
  - 교체 과정에서 인증 정보와 임시 파일이 외부에 노출되지 않도록 보호합니다.

- **개선 사항**
  - 프록시 응답, 인증 실패, 동시 변경 등 비정상 상황에서 작업을 중단하고 기존 상태를 유지합니다.
  - `claudex-status`의 준비 상태와 인증 정보 유효성 의미를 더욱 명확히 안내합니다.

- **문서**
  - 로그인 및 인증 정보 교체 절차와 실패 조건에 대한 안내를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->