### PR TITLE
fix(darwin): awscli를 Homebrew formula로 이관 (nixpkgs libffi 실행 불가)

### DIFF
--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -66,7 +66,8 @@ identity 확인, bounded fixture, rollback, update/reboot 재검증 절차는
 ### Homebrew 관리
 
 `modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다.
-공통(모든 darwin 호스트: `ghostty` cask, `playwright-cli` formula)과 personal 전용(`hostType == "personal"` 가드)으로 분리되어 있습니다.
+공통(모든 darwin 호스트: `ghostty` cask, `awscli`·`playwright-cli` formula)과 personal 전용(`hostType == "personal"` 가드)으로 분리되어 있습니다.
+`awscli`는 nixpkgs darwin libffi가 macOS 27에서 깨져 Nix 경로가 실행 불가라 임시로 Homebrew에 둔 예외입니다 (이슈 #1194, 환원 조건은 `homebrew.nix` 주석 참조).
 
 ```nix
 # cleanup = "none" — 선언되지 않은 앱을 삭제하지 않음 (수동 설치 cask 보호)

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -385,7 +385,9 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 
 > `cleanup = "none"`이므로 cask 목록에서 제거해도 기존 `/Applications/Figma.app`은 삭제되지 않습니다.
 
-### Brew Formula
+### Brew Formula (personal 전용)
+
+공통 formula(`awscli`, `playwright-cli`)는 위 "GUI 앱 (Homebrew Casks)" 절의 공통 블록 설명을 참조하세요.
 
 | Formula                    | 용도                              |
 | -------------------------- | --------------------------------- |

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -323,7 +323,7 @@ fc-list | grep -i "D2Coding"
 
 `modules/darwin/programs/homebrew.nix`에서 선언적으로 관리됩니다.
 
-- 공통 + personal 분리: 공통 블록(모든 darwin 호스트 — `ghostty` cask, `playwright-cli` formula)과
+- 공통 + personal 분리: 공통 블록(모든 darwin 호스트 — `ghostty` cask, `awscli`·`playwright-cli` formula)과
   `lib.mkIf (hostType == "personal")` 가드의 personal 전용 블록(아래 Cask 목록)으로 구성
 - cleanup = "none": 선언되지 않은 앱을 자동 삭제하지 않음 (수동 설치 cask 보호)
 
@@ -493,7 +493,11 @@ cat ~/Library/Logs/folder-actions/*.log
 
 `libraries/packages.nix`의 `darwinOnly` 리스트에서 관리됩니다.
 
-Homebrew가 GUI 앱(Cask)을 담당하는 반면, CLI 도구는 Nix로 선언적 관리합니다.
+Homebrew가 GUI 앱(Cask)을 담당하는 반면, CLI 도구는 원칙적으로 Nix로 선언적 관리합니다.
+
+예외는 Nix 경로가 실제로 동작하지 않는 도구뿐이며, 각 예외는 `homebrew.nix` 주석에 사유와 환원 조건을 함께 남깁니다.
+현재 예외: `awscli` (nixpkgs darwin libffi가 macOS 27에서 dlopen 실패 → 이슈 #1194. upstream 수정 시 `pkgs.awscli2`로 환원),
+`playwright-cli` (nixpkgs 미수록).
 
 | 패키지 | 용도 |
 |--------|------|

--- a/libraries/packages.nix
+++ b/libraries/packages.nix
@@ -40,6 +40,8 @@
   darwinOnly = [
     # ghostty: Homebrew Cask로 관리 (homebrew.nix)
     # pkgs.ghostty-bin은 CLI 바이너리만 제공하고 macOS .app 번들을 포함하지 않음
+    # awscli: Homebrew formula로 관리 (homebrew.nix)
+    # pkgs.awscli2/awscli는 nixpkgs darwin libffi가 macOS 27에서 깨져 실행 불가 — 사유는 homebrew.nix 참조
     pkgs.imagemagick # 이미지 처리
     pkgs.rar # 압축
     pkgs.shottr # 스크린샷 (GUI, macOS 전용)

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -168,6 +168,7 @@ in
       #     nix run --inputs-from . nixpkgs#awscli2 -- --version
       brews = [
         "awscli" # AWS CLI v2 (aarch64 네이티브)
+        # playwright-cli: nixpkgs 미수록 (playwright/-driver/-mcp/-test만 존재). 수록되면 Nix로 환원한다.
         "playwright-cli" # AI 에이전트 브라우저 자동화 CLI (Playwright 기반, 토큰 효율적)
       ];
 

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -147,7 +147,22 @@ in
       enable = true;
 
       # Homebrew Formula (CLI 도구) — 공통
+      #
+      # [Nix 전환이 불가능한 도구]
+      # awscli: nixpkgs darwin의 libffi(Apple libffi-40 기반)가 macOS 27에서 실행 불가.
+      #   nixpkgs는 purity를 위해 시스템 /usr/lib/libffi-trampolines.dylib 대신 자기 자신의
+      #   trampolines dylib을 dlopen하도록 closures.c를 패치하는데(postPatch의 /usr/lib → $out/lib),
+      #   그 dylib은 trampoline.S만으로 링크된 특수 형태라 macOS 27 dyld의 chained fixups 검증에
+      #   걸린다 ("seg_count exceeds number of segments"). dlopen이 실패하면 closures.c의
+      #   assert(trampoline_handle)에서 abort하므로, nix python의 ctypes/cffi 콜백을 쓰는 패키지가
+      #   통째로 죽는다 (awscli2·awscli v1 모두 `aws --version`조차 실행 불가).
+      #   nixpkgs-unstable에도 아직 수정이 없고, libffi overlay로 고치면 508개 파생물을 소스
+      #   빌드해야 해 이 저장소의 cache hit 최우선 정책(flake.nix CIR)과 충돌한다.
+      #   Homebrew bottle은 arm64 네이티브 + 시스템 dyld 경로라 정상 동작한다.
+      #   재검토: nixpkgs가 이 libffi 문제를 고치면 pkgs.awscli2로 되돌린다.
+      #     nix run nixpkgs#awscli2 -- --version
       brews = [
+        "awscli" # AWS CLI v2 (aarch64 네이티브)
         "playwright-cli" # AI 에이전트 브라우저 자동화 CLI (Playwright 기반, 토큰 효율적)
       ];
 

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -148,7 +148,10 @@ in
 
       # Homebrew Formula (CLI 도구) — 공통
       #
-      # [Nix 전환이 불가능한 도구]
+      # [일시적 Homebrew 우회 — upstream 수정 시 Nix로 환원]
+      # 아래 casks의 [Nix 전환이 불가능한 앱]과 달리, 이 항목은 영구 제약이 아니라
+      # upstream 버그가 고쳐지면 되돌리는 임시 예외다.
+      #
       # awscli: nixpkgs darwin의 libffi(Apple libffi-40 기반)가 macOS 27에서 실행 불가.
       #   nixpkgs는 purity를 위해 시스템 /usr/lib/libffi-trampolines.dylib 대신 자기 자신의
       #   trampolines dylib을 dlopen하도록 closures.c를 패치하는데(postPatch의 /usr/lib → $out/lib),
@@ -159,8 +162,10 @@ in
       #   nixpkgs-unstable에도 아직 수정이 없고, libffi overlay로 고치면 508개 파생물을 소스
       #   빌드해야 해 이 저장소의 cache hit 최우선 정책(flake.nix CIR)과 충돌한다.
       #   Homebrew bottle은 arm64 네이티브 + 시스템 dyld 경로라 정상 동작한다.
-      #   재검토: nixpkgs가 이 libffi 문제를 고치면 pkgs.awscli2로 되돌린다.
-      #     nix run nixpkgs#awscli2 -- --version
+      #   재검토(이슈 #1194): nixpkgs가 이 libffi 문제를 고치면 pkgs.awscli2로 되돌린다.
+      #   저장소 루트에서 아래를 실행해 버전이 출력되면 해결된 것이다. `--inputs-from .`이 없으면
+      #   flake registry의 nixpkgs를 평가해 이 저장소가 고정한 revision과 다른 것을 검사하게 된다:
+      #     nix run --inputs-from . nixpkgs#awscli2 -- --version
       brews = [
         "awscli" # AWS CLI v2 (aarch64 네이티브)
         "playwright-cli" # AI 에이전트 브라우저 자동화 CLI (Playwright 기반, 토큰 효율적)


### PR DESCRIPTION
## Summary

- macOS 27에서 nixpkgs darwin libffi가 로드되지 않아 `pkgs.awscli2`/`pkgs.awscli`가 `--version`조차 실행하지 못한다. awscli를 Homebrew formula로 이관해 복구한다.
- 영구 전환이 아니라 upstream 수정 시 되돌리는 **임시 우회**임을 주석·관리 문서에 명시하고, 저장소가 고정한 nixpkgs를 검사하는 재검토 명령을 함께 남긴다.
- 근본 원인은 이 저장소에서 고칠 수 없어 별도 추적 이슈로 분리했다 (#1194 — 이 PR은 그 이슈를 닫지 않는다).

## 기존 문제/배경

nix로 설치한 aws CLI가 실행 즉시 abort한다.

```
Assertion failed: (trampoline_handle), function ffi_trampoline_table_alloc_block_invoke, file closures.c, line 258.
```

`awscli2`와 `awscli` v1 모두 동일하다. 즉 특정 패키지 버그가 아니라 그 아래 python/libffi 계층 문제다.

nixpkgs darwin의 libffi(Apple libffi-40 기반)는 purity를 위해 시스템 `/usr/lib/libffi-trampolines.dylib` 대신 **자기 자신의 trampolines dylib을 dlopen**하도록 `closures.c`를 패치한다(`postPatch`의 `/usr/lib` → `$out/lib` 치환). 그런데 그 dylib은 `trampoline.S`만으로 링크된 특수 형태라, macOS 27 dyld의 chained fixups 검증에 걸려 로드가 거부된다.

```
dlopen(<nix store>/lib/libffi-trampolines.dylib):
  chained fixups, seg_count exceeds number of segments
```

`closures.c`는 이 dlopen 결과를 `assert(trampoline_handle)`로 검사하므로, 실패하면 프로세스가 통째로 죽는다. 시스템 python3는 OS 내장 libffi를 쓰므로 같은 코드가 정상 동작한다 — OS 문제가 아니라 nixpkgs 쪽 문제다.

| 대상 | ctypes 콜백 생성 |
|------|------------------|
| 시스템 python3 | 성공 |
| nix python3.14 | abort |
| nix awscli2 / awscli v1 | abort |
| Homebrew awscli 2.36.11 (arm64 bottle) | 정상 |

## CIR (Change Intent Record)

- **v0** (이전 상태): aws CLI가 저장소 선언 밖에서 관리되고 있었다. 공식 인스톨러로 설치된 x86_64 빌드가 `/usr/local`에 있었고, OS가 macOS 27로 올라가며 Rosetta 변환이 동작하지 않아 `bad CPU type`으로 실행 불가가 됐다. 저장소에 선언이 없으니 `nrs`로 복구되지도 않았다.
- **v1** (이번 변경 초안): 선언적 관리로 되돌리기 위해 `libraries/packages.nix`에 `pkgs.awscli2`를 추가 → 이번에는 libffi dlopen 실패로 여전히 실행 불가. Nix 경로 자체가 현재 OS에서 막혀 있음을 확인.
- **v2** (이번 변경): Homebrew formula로 이관. 이 저장소가 CLI를 원칙적으로 Nix로 관리하는 만큼 예외임을 명시하고, upstream 수정 시 환원하도록 사유·조건·검증 명령을 코드 옆에 남긴다.

같은 방향의 선례가 있다 — PR #367에서 zed를 nixpkgs에서 Homebrew cask로 옮겼고, 그때도 host scope를 공통으로 맞추는 조정을 거쳤다. 이번에도 두 Mac 호스트 공통 `brews`에 둔다.

**trade-off**: Homebrew formula는 nixpkgs처럼 해시로 고정되지 않아 재현성이 낮아진다. 그럼에도 채택한 이유는 (a) 현재 Nix 경로가 실행 자체가 불가능하고, (b) 대안인 libffi overlay가 이 저장소의 cache hit 최우선 정책과 정면 충돌하기 때문이다. 재현성 손실을 임시로 감수하는 대신, 환원 조건을 코드와 문서 양쪽에 박아 되돌릴 시점을 놓치지 않도록 했다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `pkgs.awscli2` 유지 | 기존 선언 방식 그대로 | 재현성·선언성 최상 | 현재 OS에서 실행 자체가 불가 (abort) | ❌ |
| `flake.lock` 업데이트 | 상류 수정을 받아 해결 | 코드 변경 불필요 | nixpkgs-unstable 시점에도 동일 `postPatch`가 그대로라 해결되지 않음 | ❌ |
| libffi overlay | `postPatch` 제거 또는 링크 플래그 조정으로 직접 수정 | 근본 해결, Nix 경로 유지 | libffi 해시 변경으로 python 계열 전체 캐시 미스 — awscli2 기준만도 508개 파생물 소스 빌드 + 1.8GiB 추가 다운로드. `flake.nix` 채널 선택 CIR의 cache hit 최우선 정책과 충돌 | ❌ |
| 공식 배포본을 nix derivation으로 직핀 | codex CLI와 같은 self-maintained overlay 패턴 (PR #893) | 해시 고정, 선언성 유지 | codex는 단일 정적 바이너리 tarball이라 fetch+install로 끝나지만, AWS CLI v2 macOS 배포는 `.pkg` 인스톨러뿐이라(aarch64 zip 미제공) xar/cpio 해체와 python 번들 재배치가 필요. 임시 우회에 쓰기엔 유지보수 부담이 과다 | ❌ |
| Homebrew formula | 공통 `brews`에 추가 | arm64 네이티브 bottle, 시스템 dyld 경로라 정상 동작. 저장소가 이미 formula를 선언적으로 관리 중 | 해시 고정 없음(재현성 저하), Nix 순수성 저하 | ✅ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/programs/homebrew.nix` | 수정 | 공통 `brews`에 `awscli` 추가 + 임시 우회 사유·환원 조건·검증 명령 주석. `playwright-cli`에도 Nix 미수록 사유와 환원 조건 명시 |
| `libraries/packages.nix` | 수정 | `darwinOnly`에 Nix 전환 불가 사유 포인터 주석 |
| `.claude/skills/managing-macos/SKILL.md` | 수정 | 공통 Homebrew 목록에 `awscli` 반영 + 예외 사유 |
| `.claude/skills/managing-macos/references/features.md` | 수정 | 공통 목록 동기화, "CLI는 Nix" 원칙에 예외 규정 추가, `Brew Formula` 표 범위를 personal 전용으로 한정 |

### 재검토 명령의 pin 고정

환원 시점을 판별하는 명령은 저장소가 고정한 nixpkgs를 검사해야 한다.

```bash
# 잘못된 형태: `nixpkgs`가 flake registry로 해석되어
# 이 저장소의 flake.lock revision이 아닌 다른 nixpkgs를 검사한다
nix run nixpkgs#awscli2 -- --version

# 채택: 저장소 input을 registry entry로 넘겨 고정 (저장소 루트에서 실행)
nix run --inputs-from . nixpkgs#awscli2 -- --version
```

`flake.nix`의 채널 선택 주석도 같은 함정을 이미 경고하고 있다 — "registry가 아니라 이 저장소의 input을 평가".

## 참고 레퍼런스

- Issue #1194 — 이 PR이 우회하는 근본 원인(nixpkgs libffi) 추적. 상류 수정 시 환원 트리거
- PR #367 — nixpkgs에서 Homebrew로 옮긴 선례(zed). host scope를 공통으로 맞춘 조정 포함
- PR #893 — 비-nixpkgs 도구를 self-maintained nix derivation으로 핀한 선례(codex CLI). 이번 ADR에서 대안으로 검토
- PR #814 — 공급 경로 변경 시 managing-macos 문서를 함께 갱신한 선례
- [nixpkgs `pkgs/os-specific/darwin/by-name/li/libffi/package.nix`](https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/pkgs/os-specific/darwin/by-name/li/libffi/package.nix) — 문제의 `postPatch`와 trampolines dylib 수동 링크
- [apple-oss-distributions/libffi `src/closures.c:257-258`](https://github.com/apple-oss-distributions/libffi/blob/main/src/closures.c#L257-L258) — `dlopen(...)` 직후 `assert(trampoline_handle)`. dlopen 실패가 곧 abort로 이어지는 지점

## Human Test Plan

### 정상 동작 검증

1. `nrs`를 실행한다.
   - **기대**: Homebrew 단계에서 `awscli`가 설치되고 activation이 실패 없이 끝난다.
   - **실패 시**: `brew list awscli`로 설치 여부를 확인하고, `nix eval --json .#darwinConfigurations.<호스트>.config.homebrew.brews`에 `awscli`가 들어 있는지 대조한다.

2. 새 셸에서 `aws --version`을 실행한다.
   - **기대**: `aws-cli/2.x … source/arm64` 형태로 버전이 출력된다.
   - **실패 시**: `which -a aws`로 어떤 경로가 잡히는지 확인한다. `/opt/homebrew/bin/aws`가 최우선이어야 한다.

3. 자격 증명이 설정된 환경에서 읽기 전용 호출을 한 번 해본다 (예: `aws sts get-caller-identity`).
   - **기대**: 정상 응답. libffi assertion으로 abort하지 않는다.
   - **실패 시**: 출력에 `trampoline_handle` assertion이 보이면 Nix 쪽 aws가 잡힌 것이므로 PATH 우선순위를 다시 확인한다.

### Negative 검증 (구 경로 잔존 확인)

4. `which -a aws`와 `ls /usr/local/aws-cli` 를 확인한다.
   - **기대**: `aws`는 Homebrew 경로 하나만 나오고, `/usr/local/aws-cli`·`/usr/local/bin/aws`·`/usr/local/bin/aws_completer`는 존재하지 않는다.
   - **실패 시**: 남아 있다면 과거 공식 인스톨러 잔재이므로 그 세 경로를 제거한다(관리자 권한 필요). 남겨두면 PATH 순서가 바뀌었을 때 실행 불가한 x86_64 바이너리가 다시 잡힌다.

5. Nix 경로가 여전히 막혀 있음을 확인한다(= 우회가 아직 필요함).
   - **기대**: 저장소 루트에서 `nix run --inputs-from . nixpkgs#awscli2 -- --version`이 `trampoline_handle` assertion으로 abort한다.
   - **성공(버전 출력)하면**: upstream이 고쳐진 것이다. #1194에 따라 `pkgs.awscli2`로 환원하고 이 예외 주석·문서를 되돌린다.

### 인접 기능 regression

6. 같은 Homebrew 블록의 기존 항목이 영향을 받지 않았는지 본다.
   - **기대**: `playwright-cli` formula와 `ghostty` cask가 그대로 설치·동작한다. personal 호스트에서는 `macism`·`sox`도 유지된다.
   - **실패 시**: `brew list --formula`와 `brew list --cask` 출력을 선언 목록과 대조한다.

7. 다른 Mac 호스트에서도 `nrs`를 실행한다(공통 `brews`이므로 양쪽에 설치된다).
   - **기대**: 그 호스트에서도 `aws --version`이 정상 출력된다.
   - **실패 시**: 해당 호스트의 Homebrew prefix와 PATH 우선순위를 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - macOS 환경에서 AWS CLI를 Homebrew formula로 설치할 수 있습니다.
  - 공통으로 관리되는 Homebrew 항목에 AWS CLI와 Playwright CLI가 포함됩니다.
  - 개인용 환경에서는 추가 Homebrew 항목을 별도로 관리합니다.

- **문서**
  - Homebrew와 Nix 패키지 관리 기준을 업데이트했습니다.
  - macOS 27에서 AWS CLI를 Homebrew로 제공하는 이유와 예외 조건을 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->