### PR TITLE
feat(darwin): 한국어 입력기 삭제 방식(글자 단위) 선언적 관리

### DIFF
--- a/modules/darwin/configuration.nix
+++ b/modules/darwin/configuration.nix
@@ -204,6 +204,15 @@ in
       appswitcher-all-displays = true;
     };
 
+    # 한국어 입력기(두벌식)의 삭제 방식을 '글자' 단위로 고정한다.
+    # 시스템 설정 > 키보드 > 입력 소스 > 두벌식의 '삭제 방식'이 '글자'인 상태에서
+    # 이 도메인의 plist를 실측해 DeleteBy = 2를 확인했다.
+    # macOS는 기본값을 plist에 기록하지 않으므로 이 키는 사용자가 값을 바꾼 경우에만 나타난다
+    # (같은 화면의 '서체 크기'·'입력 포맷'은 기본값이라 plist에 키가 없다).
+    CustomUserPreferences."com.apple.inputmethod.Korean" = {
+      DeleteBy = 2;
+    };
+
     # 키보드 단축키 (com.apple.symbolichotkeys)
     #
     # [주의] CustomUserPreferences가 아닌 postActivation에서 관리.

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -646,6 +646,11 @@ let
               cfg.system.defaults.CustomUserPreferences.NSGlobalDomain.ComputerUseAllowForbiddenTargets == true;
         }
         {
+          name = "Test D33 ${hostName}: 한국어 입력기 삭제 방식이 글자 단위(DeleteBy=2)로 선언되어야 함";
+          cond =
+            hasHost && cfg.system.defaults.CustomUserPreferences."com.apple.inputmethod.Korean".DeleteBy == 2;
+        }
+        {
           name = "Test D14 ${hostName}: claudex descriptor와 runtime library는 모든 Darwin host에 있어야 함";
           cond = hasClaudexDescriptor && builtins.hasAttr ".local/lib/claudex/runtime.sh" hm.home.file;
         }

--- a/tests/eval-tests.nix
+++ b/tests/eval-tests.nix
@@ -646,11 +646,6 @@ let
               cfg.system.defaults.CustomUserPreferences.NSGlobalDomain.ComputerUseAllowForbiddenTargets == true;
         }
         {
-          name = "Test D33 ${hostName}: 한국어 입력기 삭제 방식이 글자 단위(DeleteBy=2)로 선언되어야 함";
-          cond =
-            hasHost && cfg.system.defaults.CustomUserPreferences."com.apple.inputmethod.Korean".DeleteBy == 2;
-        }
-        {
           name = "Test D14 ${hostName}: claudex descriptor와 runtime library는 모든 Darwin host에 있어야 함";
           cond = hasClaudexDescriptor && builtins.hasAttr ".local/lib/claudex/runtime.sh" hm.home.file;
         }
@@ -874,6 +869,11 @@ let
         {
           name = "Test D27 ${hostName}: Shottr의 선언된 activation entries가 모두 존재해야 함";
           cond = hasHost && hasShottrActivationEntries (shottrActivation cfg);
+        }
+        {
+          name = "Test D33 ${hostName}: 한국어 입력기 삭제 방식이 글자 단위(DeleteBy=2)로 선언되어야 함";
+          cond =
+            hasHost && cfg.system.defaults.CustomUserPreferences."com.apple.inputmethod.Korean".DeleteBy == 2;
         }
       ]
     ) expectedDarwinHosts


### PR DESCRIPTION
## Summary

- 한국어 두벌식 입력기의 **삭제 방식 '글자' 설정**(`com.apple.inputmethod.Korean` / `DeleteBy = 2`)을 선언적 관리로 편입한다.
- 시스템 설정 UI에서 수동 지정해 쓰던 값이라 새 머신 셋업이나 설정 초기화 시 재현되지 않던 상태를 해소한다.
- eval test로 선언을 고정하고, 실제 적용 여부를 제거 → 재빌드 → 복구 절차로 실측 검증했다.

## 기존 문제/배경

macOS 한국어 입력기(두벌식)는 시스템 설정 > 키보드 > 입력 소스에서 **삭제 방식**을 '글자' 또는 자소 단위로 고를 수 있다. '글자'로 두면 backspace 한 번이 조합된 음절 전체를 지운다.

**AS-IS**: 이 값은 사용자가 UI에서 직접 바꿔 쓰고 있었지만 저장소 어디에도 선언이 없었다. 저장소 전체에서 `inputmethod` / `DeleteBy` 검색 결과는 0건이었다.

**문제**: 이 저장소의 목적은 개발 환경을 선언적으로 재현하는 것인데, 이 설정만 그 바깥에 있었다. 새 머신에서 빌드를 돌려도 복원되지 않고, 설정이 초기화되면 사용자가 UI에서 다시 찾아 바꿔야 한다. 매일 쓰는 한글 입력 동작이라 체감 비용이 낮지 않다.

또한 macOS는 **기본값을 plist에 기록하지 않는다**. 같은 설정 화면의 '서체 크기'·'입력 포맷'은 기본값이라 plist에 키 자체가 없고, `DeleteBy`만 존재했다 — 사용자가 값을 바꿨다는 증거다.

## CIR (Change Intent Record)

- **발견 경위** (이번 변경): 이 설정을 선언적으로 관리할 수 있는지 확인해 달라는 요청에서 출발했다. 조사 결과 `defaults domains`에 `com.apple.inputmethod.Korean` 도메인이 정식 등록돼 있고, 샌드박스 컨테이너가 아닌 일반 `~/Library/Preferences` 경로를 쓰므로 `defaults write` 대상으로 동작함을 확인했다.

- **값의 의미 확정**: `DeleteBy = 2` ↔ '글자' 대응은 시스템 설정 UI가 '글자'로 표시된 상태에서 plist를 읽어 확인했다. **반대 값(자소 단위)이 무엇인지는 확인하지 못했고, 주석에도 적지 않기로 결정했다.** 값을 바꿔보는 실험은 조사 범위를 넘고, 실측되지 않은 추측을 주석에 남기면 다음 세션이 그것을 근거로 삼을 위험이 있다.

- **관리 경로 선택**: 같은 파일에는 `com.apple.symbolichotkeys`를 `CustomUserPreferences`로 관리하지 **않는다**는 반대 결정이 주석으로 남아 있다 (PR #98). 그 도메인은 빌드 도구가 `AppleSymbolicHotKeys` dict 전체를 교체해 기존 항목을 날리기 때문이다. 이번 대상 도메인이 같은 함정에 걸리는지 확인한 결과, plist에 키가 `DeleteBy` 하나뿐이라 교체로 잃을 항목이 없다. 실측에서도 재빌드 후 값이 정상 복구됐다.

- **범위 제한 결정**: 조사 중 인접 항목 두 가지를 함께 발견했으나 의도적으로 이번 변경에서 제외했다.
  - `com.apple.keyboard.fnState`의 선언값과 실제 시스템 값이 어긋난 상태 — 사용자가 보류를 선택했다. 다음 재빌드 때 선언값이 적용되어 현재 체감 동작이 바뀐다는 점을 인지한 결정이다.
  - F3 키로 Mission Control을 띄우는 요구 — 키 이벤트를 실측한 결과 사용 중인 외장 키보드가 macOS에 F3이 아니라 `Cmd+Tab`을 전송하고 있었다. macOS는 F3을 받은 적이 없으므로 어떤 설정으로도 해결할 수 없고, 키보드 펌웨어 수정이 선행되어야 한다. 이 저장소 범위 밖이다.

**trade-off**: 이 선언은 단일 사용자의 입력 습관을 저장소에 고정한다. 삭제 방식 취향이 바뀌면 UI에서 바꾼 뒤 저장소도 함께 고쳐야 하며, 그러지 않으면 다음 재빌드가 값을 되돌린다. 재현성을 얻는 대신 UI 단독 변경의 자유를 잃는 교환이다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `CustomUserPreferences` 선언 | 기존 블록 옆에 도메인 항목 추가 | 인접 항목들과 동일한 패턴, 코드 2줄, 빌드 시스템이 적용 시점 관리 | 도메인 dict를 통째로 쓰므로 키가 여럿인 도메인에는 부적합 | ✅ |
| 활성화 스크립트에서 `defaults write` | 재빌드 후처리 단계에서 개별 키만 기록 | 같은 도메인에 다른 키가 있어도 안전 | 이 도메인엔 키가 하나뿐이라 불필요한 복잡성, 인접 패턴과 불일치 | ❌ |
| 선언하지 않고 수동 유지 | 현상 유지 | 변경 없음 | 재현성 없음 — 해결하려는 문제 그 자체 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/darwin/configuration.nix` | 수정 | `com.apple.inputmethod.Korean` 도메인의 `DeleteBy = 2` 선언 추가 |
| `tests/eval-tests.nix` | 수정 | 위 선언을 검증하는 per-host eval test 추가 |

### 핵심 코드

```nix
# 한국어 입력기(두벌식)의 삭제 방식을 '글자' 단위로 고정한다.
# 시스템 설정 > 키보드 > 입력 소스 > 두벌식의 '삭제 방식'이 '글자'인 상태에서
# 이 도메인의 plist를 실측해 DeleteBy = 2를 확인했다.
# macOS는 기본값을 plist에 기록하지 않으므로 이 키는 사용자가 값을 바꾼 경우에만 나타난다
# (같은 화면의 '서체 크기'·'입력 포맷'은 기본값이라 plist에 키가 없다).
CustomUserPreferences."com.apple.inputmethod.Korean" = {
  DeleteBy = 2;
};
```

**BEFORE**: 저장소에 선언 없음 → `~/Library/Preferences/com.apple.inputmethod.Korean.plist`의 값은 사용자가 UI에서 바꾼 결과로만 존재.
**AFTER**: 재빌드가 `DeleteBy = 2`를 기록 → 키가 사라져도 다음 재빌드에서 복구.

## 참고 레퍼런스

- Issue #1096 / PR #1097 — `CustomUserPreferences`로 typed schema 밖 defaults를 선언하는 패턴의 선례. 이번 변경도 같은 2파일 구성(설정 + eval test)을 따랐다.
- PR #98 — `com.apple.symbolichotkeys`를 `CustomUserPreferences`가 아닌 활성화 스크립트에서 관리하기로 한 결정. 이번 도메인이 같은 함정에 해당하는지 검토하는 기준이 됐다.

## Human Test Plan

### 정상 동작 검증

1. 재빌드를 실행한 뒤 `defaults read com.apple.inputmethod.Korean DeleteBy`를 실행한다.
   - **기대**: `2`가 출력된다.
   - **실패 시**: 재빌드 로그의 `user defaults...` 단계가 실행됐는지 확인한다. 값이 없으면 선언이 반영되지 않은 것이므로 `system.defaults.CustomUserPreferences` 트리에 도메인 키가 올바른 문자열로 들어갔는지 확인한다.

2. 한글로 "한글"을 입력하고 backspace를 한 번 누른다.
   - **기대**: "한"만 남는다 (음절 전체가 지워짐).
   - **실패 시**: 자소 단위로 지워진다면(`한그`) 입력기 프로세스가 아직 이전 값을 들고 있는 것이다. 로그아웃 후 재로그인하여 재확인한다.

### Negative 검증 (선언이 실제로 적용되는지)

3. `defaults delete com.apple.inputmethod.Korean DeleteBy`로 키를 지우고 `plutil -p ~/Library/Preferences/com.apple.inputmethod.Korean.plist`로 빈 상태(`{}`)를 확인한 뒤, 재빌드를 실행한다.
   - **기대**: 값이 `2`로 되살아난다. 이 절차는 실제로 수행해 확인했으며 재로그인 없이 복구됐다.
   - **실패 시**: 값이 돌아오지 않으면 선언이 빌드 결과에 반영되지 않은 것이다. 빌드가 워크트리가 아닌 다른 경로를 대상으로 실행되지 않았는지 확인한다.
   - **주의**: 이 단계 진행 중에는 한글 삭제가 일시적으로 자소 단위로 동작한다.

### Regression 검증

4. 인접한 기존 `CustomUserPreferences` 항목이 영향을 받지 않았는지 확인한다.
   - `defaults read com.apple.desktopservices DSDontWriteNetworkStores` → **기대**: `1`
   - `defaults read com.apple.Dock appswitcher-all-displays` → **기대**: `1`
   - **실패 시**: 새 도메인 추가가 기존 항목 직렬화를 깨뜨린 경우이므로 빌드 결과의 해당 활성화 단계를 확인한다.

5. 키보드 단축키가 그대로인지 확인한다.
   - `defaults read com.apple.symbolichotkeys AppleSymbolicHotKeys | head -20` → **기대**: 기존 항목들이 그대로 존재한다 (스크린샷 관련 항목 포함).
   - **실패 시**: dict 전체 교체가 일어난 것이므로 이번 변경이 의도치 않게 해당 도메인 관리 방식에 영향을 준 것인지 확인한다.

6. eval test를 실행한다.
   - **기대**: 모든 테스트가 통과한다 (IFD 경로와 no-IFD 경로 모두).
   - **실패 시**: 실패한 테스트 이름으로 해당 조건식과 실제 선언값을 대조한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - macOS 한국어 두벌식 입력기에서 삭제 동작을 글자 단위로 고정했습니다.

- **테스트**
  - 모든 Darwin 호스트에서 해당 입력기 설정이 올바르게 선언되었는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->