### PR TITLE
feat(brew): whatcable cask 선언 관리

### DIFF
--- a/.claude/skills/managing-macos/SKILL.md
+++ b/.claude/skills/managing-macos/SKILL.md
@@ -76,7 +76,7 @@ identity 확인, bounded fixture, rollback, update/reboot 재검증 절차는
 homebrew.casks = [
   "raycast" "rectangle"
   "hammerspoon" "homerow"
-  "fork" "monitorcontrol" "1password" "1password-cli"
+  "fork" "monitorcontrol" "whatcable" "1password" "1password-cli"
 ];
 homebrew.brews = [ "laishulu/homebrew/macism" "sox" ]; # Neovim 한영 전환, 오디오 처리
 # shottr → Nix 패키지로 관리 (libraries/packages.nix darwinOnly)

--- a/.claude/skills/managing-macos/references/features.md
+++ b/.claude/skills/managing-macos/references/features.md
@@ -347,6 +347,7 @@ brews = [ "laishulu/homebrew/macism" ];  # ✅ 전체 경로
 | Homerow        | 키보드 네비게이션          |
 | Fork           | Git GUI                    |
 | MonitorControl | 외부 모니터 밝기 조절      |
+| WhatCable      | USB-C 케이블 진단 메뉴바 앱 (auto_updates·CLI 포함 여부는 homebrew.nix 주석 참조) |
 | 1Password      | 비밀번호/SSH 키/PAT 관리   |
 | 1Password CLI  | `op` CLI (1password-cli cask) |
 
@@ -434,7 +435,7 @@ brew install --cask --adopt raycast:
 brew install --cask --adopt raycast
 
 # 여러 앱 일괄 adopt (Nix 패키지로 관리하는 shottr, vscode 제외)
-for cask in ghostty raycast rectangle hammerspoon homerow fork monitorcontrol 1password 1password-cli; do
+for cask in ghostty raycast rectangle hammerspoon homerow fork monitorcontrol whatcable 1password 1password-cli; do
   brew install --cask --adopt "$cask" || echo "FAILED: $cask"
 done
 

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -252,8 +252,9 @@ in
         "monitorcontrol"
         # whatcable: USB-C 케이블 진단 메뉴바 앱 (#1191). 공식 homebrew-cask, auto_updates
         # 특성이라 greedyCasks=false 정책과 결합해 자체 업데이터에 위임된다.
-        # CLI(whatcable-cli)는 개발자 개인 tap(darrylmorley/whatcable) 신뢰가 필요해
-        # 의도적으로 제외 — 실수요가 생기면 별도 판단한다.
+        # 개발자 개인 tap(darrylmorley/whatcable)과 그 CLI-only formula(whatcable-cli)는
+        # tap 신뢰(brew trust)가 필요해 의도적으로 제외. 단 이 공식 cask 자체가 앱 내장
+        # CLI(binary artifact → $HOMEBREW_PREFIX/bin/whatcable)를 설치하므로 CLI 기능은 포함된다.
         "whatcable"
         # 1Password 비밀번호/SSH 키/PAT 통합 (PRD #780 Phase 1)
         # - 1password: 데스크탑 앱 (vault, SSH agent, biometric)

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -252,6 +252,8 @@ in
         "monitorcontrol"
         # whatcable: USB-C 케이블 진단 메뉴바 앱 (#1191). 공식 homebrew-cask, auto_updates
         # 특성이라 greedyCasks=false 정책과 결합해 자체 업데이터에 위임된다.
+        # 요구사항: macOS 14+ / Apple Silicon 전용 cask — 이 repo의 darwin 시스템은
+        # aarch64-darwin 단일 정의(flake.nix)라 전 darwin 호스트에서 충족된다.
         # 개발자 개인 tap(darrylmorley/whatcable)과 그 CLI-only formula(whatcable-cli)는
         # tap 신뢰(brew trust)가 필요해 의도적으로 제외. 단 이 공식 cask 자체가 앱 내장
         # CLI(binary artifact → $HOMEBREW_PREFIX/bin/whatcable)를 설치하므로 CLI 기능은 포함된다.

--- a/modules/darwin/programs/homebrew.nix
+++ b/modules/darwin/programs/homebrew.nix
@@ -250,6 +250,11 @@ in
         "homerow"
         "fork"
         "monitorcontrol"
+        # whatcable: USB-C 케이블 진단 메뉴바 앱 (#1191). 공식 homebrew-cask, auto_updates
+        # 특성이라 greedyCasks=false 정책과 결합해 자체 업데이터에 위임된다.
+        # CLI(whatcable-cli)는 개발자 개인 tap(darrylmorley/whatcable) 신뢰가 필요해
+        # 의도적으로 제외 — 실수요가 생기면 별도 판단한다.
+        "whatcable"
         # 1Password 비밀번호/SSH 키/PAT 통합 (PRD #780 Phase 1)
         # - 1password: 데스크탑 앱 (vault, SSH agent, biometric)
         # - 1password-cli: op CLI (op_get helper + Shell Plugin 지원)


### PR DESCRIPTION
## Summary

- 2026-07-27 수동 설치된 whatcable(USB-C 케이블 진단 메뉴바 앱)을 nix-darwin homebrew 선언에 추가해 선언-현실 drift를 해소한다.
- 개발자 개인 tap(`darrylmorley/whatcable`)과 CLI-only formula는 신뢰 결정(brew trust)이 따라오므로 의도적으로 제외한다 — 단 공식 cask 자체가 앱 내장 CLI를 설치하므로 CLI 기능은 포함된다.

Closes #1191

## 기존 문제/배경

whatcable을 Homebrew로 수동 설치(`/opt/homebrew/Caskroom/whatcable/1.2.1`, 2026-07-27)한 뒤 nix 선언에 반영하지 않아, 이 저장소의 선언적 관리 원칙과 실제 설치 상태가 어긋나 있었다. `cleanup="none"` 정책이라 삭제되지는 않지만, 새 Mac 재현 시 이 앱만 누락되고 brew bundle의 관리 범위 밖에 남는다.

## CIR (Change Intent Record)

- **v1** (이번 변경): cask만 선언. 앱은 이미 설치돼 있어 brew bundle의 `--adopt` 경로로 자동 편입된다. CLI는 개발자 개인 tap의 별도 formula(`whatcable-cli`)로만 존재한다고 보고 "CLI 제외"로 주석을 작성했다.
- **v1 정정** (이번 변경): 리뷰 과정에서 공식 cask 메타데이터에 `binary` artifact(`WhatCable.app/Contents/Helpers/whatcable` → `$HOMEBREW_PREFIX/bin/whatcable`)가 선언돼 있음을 확인 — 로컬 실측으로 symlink 실재도 검증했다. "CLI 제외" 서술은 사실과 달라, "tap/CLI-only formula 제외, cask 내장 CLI는 포함"으로 정정했다. 선언-문서 정합화 관례(#1029 계열, 머지된 5828be8c)에 따라 managing-macos 스킬 문서 3곳도 동기화했다.

**trade-off**: 개인 tap을 신뢰하지 않는 대신, CLI 업데이트 채널이 앱 자체 업데이터(auto_updates)에 묶인다. 이 저장소의 greedyCasks=false 정책과 일치하는 방향이다.

## ADR

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| cask만 선언 | 공식 homebrew-cask만 추가 | 서드파티 신뢰 불필요, 1줄, 앱 내장 CLI도 확보 | tap의 CLI-only formula는 미관리 | ✅ |
| cask + tap + CLI formula | `darrylmorley/whatcable` tap 추가 + `whatcable-cli` 선언 | CLI 독립 관리 | 개인 개발자 tap 신뢰(brew trust) = 새 공격 표면, cask 내장 CLI와 중복 | ❌ |
| 선언하지 않음 (현상 유지) | 수동 설치 상태 방치 | 작업 0 | 선언-현실 drift 지속, 새 Mac 재현 누락 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/darwin/programs/homebrew.nix` | personal casks에 `"whatcable"` 추가 + 포함/제외 근거 주석 |
| `.claude/skills/managing-macos/SKILL.md` | personal cask 예시에 whatcable 추가 |
| `.claude/skills/managing-macos/references/features.md` | Cask 목록 표에 WhatCable 행 추가, 일괄 adopt 명령에 whatcable 추가 |

핵심 선언:

```nix
# whatcable: USB-C 케이블 진단 메뉴바 앱 (#1191). 공식 homebrew-cask, auto_updates
# 특성이라 greedyCasks=false 정책과 결합해 자체 업데이터에 위임된다.
# 개발자 개인 tap(darrylmorley/whatcable)과 그 CLI-only formula(whatcable-cli)는
# tap 신뢰(brew trust)가 필요해 의도적으로 제외. 단 이 공식 cask 자체가 앱 내장
# CLI(binary artifact → $HOMEBREW_PREFIX/bin/whatcable)를 설치하므로 CLI 기능은 포함된다.
"whatcable"
```

## 참고 레퍼런스

- Closes #1191 — whatcable brew 설치 nix로 관리하기
- 머지된 5828be8c — cask 변경 시 homebrew.nix와 managing-macos 문서를 함께 정합화한 선례
- [Homebrew cask 메타데이터](https://formulae.brew.sh/api/cask/whatcable.json) — `binary` artifact 선언 (CLI 포함 근거)

## Human Test Plan

1. `nrs` 실행 → activation 중 brew bundle이 whatcable을 adopt (이미 설치된 동일 버전이라 에러 없이 통과 기대).
   - 실패 시: 버전 불일치 adopt 거부라면 앱을 최신으로 올린 뒤 재시도 (`homebrew.nix` 주석의 adopt 가이드 참조).
2. `brew list --cask | grep whatcable` → 출력 존재.
3. `ls -l /opt/homebrew/bin/whatcable` → `WhatCable.app/Contents/Helpers/whatcable`로 향하는 symlink 존재 (cask 내장 CLI).
4. work 호스트에는 미설치가 정상 (personal 전용 블록).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 개인용 macOS Homebrew 관리 목록에 WhatCable 앱을 추가했습니다.
  * GUI 앱 일괄 관리 및 adopt 대상에 WhatCable을 포함했습니다.
  * WhatCable의 앱 특성과 CLI 포함 여부를 안내하는 설명을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->