### PR TITLE
feat(gh): gh-stack 확장 선언 관리

### DIFF
--- a/modules/shared/programs/git/default.nix
+++ b/modules/shared/programs/git/default.nix
@@ -174,11 +174,17 @@ in
   # GitHub CLI
   programs.gh = {
     enable = true;
-    # 쿠키 전제(브라우저 + Keychain)가 macOS 데스크톱 전용이라 NixOS(MiniPC)는 제외한다.
-    # gh-difftool 동반 선언: Home Manager linkFarm이 extensions 디렉터리 전체를 소유한다.
-    # 첫 activation 시 기존 명령형 설치 디렉터리는 CLAUDE.md의 macOS 충돌 정책대로
-    # timestamped backup으로 이동된다 — 두 확장 모두 아래 선언에 있으므로 기능 손실 없음.
-    extensions = lib.optionals pkgs.stdenv.isDarwin [
+    # 동반 선언: Home Manager linkFarm이 extensions 디렉터리 전체를 소유하므로
+    # 모든 확장을 이 리스트에 함께 선언한다. 첫 activation 시 기존 명령형 설치
+    # 디렉터리는 CLAUDE.md의 macOS 충돌 정책대로 timestamped backup으로 이동된다
+    # — 모든 확장이 아래 선언에 있으므로 기능 손실 없음.
+    # gh-stack은 전 플랫폼 공용(linux asset은 static Go 바이너리 실측).
+    # gh-attach·gh-difftool은 쿠키 전제(브라우저 + Keychain)가 macOS 데스크톱
+    # 전용이라 NixOS(MiniPC)는 제외한다.
+    extensions = [
+      (import ./gh-stack-package.nix { inherit pkgs; })
+    ]
+    ++ lib.optionals pkgs.stdenv.isDarwin [
       (import ./gh-attach-package.nix { inherit pkgs; })
       (import ./gh-difftool-package.nix { inherit pkgs; })
     ];

--- a/modules/shared/programs/git/gh-stack-package.nix
+++ b/modules/shared/programs/git/gh-stack-package.nix
@@ -1,0 +1,58 @@
+# gh-stack — stacked branch/PR 관리 gh 확장 (github 공식 org). upstream prebuilt 핀
+# Home Manager linkFarm이 extensions 디렉터리 전체를 소유하므로 함께 선언해야 탈락하지 않는다.
+# nixpkgs는 0.0.4로 뒤처짐 실측(2026-07-31, 재검증: nix eval nixpkgs#gh-stack.version) —
+# 릴리스 주기가 약 2주로 빨라 upstream 최신을 직접 핀한다.
+# AI agent skill 부분은 선언 관리 스코프 제외 — 스킬은 vercel skills(symlink) 경로로 별도 관리.
+# 업데이트 시: version 변경 → 각 platform hash를
+#   `nix store prefetch-file https://github.com/github/gh-stack/releases/download/v<ver>/<asset>`
+#   실측값으로 갱신 → nrs
+{ pkgs }:
+let
+  inherit (pkgs) lib stdenvNoCC fetchurl;
+  version = "0.1.0";
+  platforms = {
+    "aarch64-darwin" = {
+      asset = "darwin-arm64";
+      hash = "sha256-XKmCQaJl1t4BgJXNrl88QNpcp4JFDuwOqRqo4+sYMQM=";
+    };
+    "x86_64-darwin" = {
+      asset = "darwin-amd64";
+      hash = "sha256-cSJmk5v0A0nc5siJMDe4jgRTM00w0GdQthzhpshkC7k=";
+    };
+    "x86_64-linux" = {
+      asset = "linux-amd64";
+      hash = "sha256-NYVS3X3OCkbOFT/hlicM7EgrhPCAlHiQqtQGGo1EvAs=";
+    };
+  };
+  platform =
+    platforms.${stdenvNoCC.hostPlatform.system}
+      or (throw "gh-stack: unsupported system ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "gh-stack";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/github/gh-stack/releases/download/v${version}/${platform.asset}";
+    hash = platform.hash;
+  };
+
+  dontUnpack = true;
+  # prebuilt 바이너리 선례(gh-difftool-package.nix)와 동일하게 Nix fixup이 서명·심볼을 건드리지 않게 차단한다.
+  # linux asset은 static Go 바이너리라 patchelf 불필요.
+  dontStrip = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    install -Dm755 "$src" "$out/bin/gh-stack"
+  '';
+
+  meta = {
+    description = "GitHub CLI extension for managing stacked branches and pull requests";
+    homepage = "https://github.com/github/gh-stack";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = builtins.attrNames platforms;
+    mainProgram = "gh-stack";
+  };
+}


### PR DESCRIPTION
## Summary

- `github/gh-stack` (GitHub 공식 stacked PR 관리 gh CLI extension) v0.1.0 prebuilt 바이너리를 `programs.gh.extensions`에 핀해 선언 관리한다.
- 기존 Darwin 전용이던 extensions 리스트를 재구성해 gh-stack만 전 플랫폼 공용(Mac 2대 + MiniPC)으로 설치한다.

## 기존 문제/배경

Home Manager linkFarm이 `~/.local/share/gh/extensions` 디렉터리 전체를 소유하므로, 이 저장소 환경에서 gh 확장은 명령형 `gh extension install`로 지속 설치할 수 없다 — 선언에 없는 확장은 activation에서 탈락한다. stacked PR 워크플로에 gh-stack을 도입하려면 `programs.gh.extensions` 선언 추가가 유일한 지속 경로다.

## CIR (Change Intent Record)

- **발견 경위**: stacked PR 워크플로 도구로 upstream `github/gh-stack`을 도입하기로 하고, 공급 경로·플랫폼 범위를 인터뷰로 확정했다.
- **공급 경로**: nixpkgs에 같은 upstream이 0.0.4로 패키징되어 있으나 실측 결과 upstream 최신 v0.1.0 대비 4개 릴리스 뒤처져 있고, upstream 릴리스 주기가 약 2주로 빠르다. 갱신 용이성을 우선해 upstream prebuilt 바이너리 핀을 채택했다.
- **플랫폼 범위**: 기존 확장 선례(Darwin 전용)와 달리 MiniPC 포함 전 플랫폼 공용으로 결정했다. upstream이 linux-amd64 asset을 제공하고, 해당 asset이 statically linked Go 바이너리임을 실측 확인해 NixOS에서 patchelf 없이 동작한다.
- **스코프 제외**: gh-stack이 제공하는 AI agent skill 부분은 선언 관리 대상에서 명시적으로 제외했다. 스킬은 저장소 밖 symlink 설치 경로로 별도 관리해 항상 최신을 유지한다 (프로젝트 내 스킬 버전 관리 부담 회피).

**trade-off**: prebuilt 핀은 소스 빌드 재현성(vendorHash 검증) 대신 갱신 단순성(version + hash 교체)을 택한 것이다. GitHub 공식 org 릴리스라 공급 신뢰는 hash 핀으로 충분하다고 판단했다.

## ADR

### 공급 경로

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| upstream prebuilt 핀 | 릴리스 asset을 fetchurl로 핀 (gh-difftool 선례) | 최신 버전 즉시, 갱신은 version+hash 교체로 끝 | 소스 빌드 아님 (hash 핀으로 완화) | ✅ |
| buildGoModule 소스 빌드 | 소스에서 직접 빌드 (gh-attach 선례) | 재현성 최고 | vendorHash 관리 + 빌드 시간, fork가 아니라 불필요한 비용 | ❌ |
| nixpkgs 패키지 | `pkgs.gh-stack` 사용 | 자체 패키지 파일 불필요 | 0.0.4로 4릴리스 뒤처짐, nixpkgs 갱신 주기 종속 | ❌ |

### 플랫폼 범위

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| 전 플랫폼 공용 | darwin arm64/amd64 + linux amd64 | MiniPC에서도 gh stack 사용 가능 | 관리 hash 3개 | ✅ |
| Darwin 전용 | 기존 extensions 선례와 동일 | 관리 포인트 최소 | MiniPC에서 사용 불가 | ❌ |

## 구현 상세

| 파일 | 변경 | 내용 |
|------|------|------|
| `modules/shared/programs/git/gh-stack-package.nix` | 신설 | v0.1.0 prebuilt 핀 (3개 플랫폼 asset 매핑 + 실측 hash, 갱신 절차 주석) |
| `modules/shared/programs/git/default.nix` | 수정 | extensions 리스트 재구성 — gh-stack 공용 + 기존 2개 Darwin 전용 유지 |

### 핵심 코드

```nix
# extensions 재구성: gh-stack만 공용, 기존 확장은 Darwin 전용 유지
extensions = [
  (import ./gh-stack-package.nix { inherit pkgs; })
]
++ lib.optionals pkgs.stdenv.isDarwin [
  (import ./gh-attach-package.nix { inherit pkgs; })
  (import ./gh-difftool-package.nix { inherit pkgs; })
];
```

```nix
# 플랫폼별 asset 매핑 — hash는 nix store prefetch-file 실측값
platforms = {
  "aarch64-darwin" = { asset = "darwin-arm64"; hash = "sha256-XKmC..."; };
  "x86_64-darwin" = { asset = "darwin-amd64"; hash = "sha256-cSJm..."; };
  "x86_64-linux" = { asset = "linux-amd64"; hash = "sha256-NYVS..."; };
};
```

## 참고 레퍼런스

- [github/gh-stack](https://github.com/github/gh-stack) — upstream (GitHub 공식 org, MIT, v0.1.0)
- PR #1122 — gh-attach 선언 관리 도입 (buildGoModule 선례, linkFarm 동반 선언 규칙)
- Issue #1118 — gh-attach 통합 인프라 (extensions linkFarm 소유 구조 실측)

## Human Test Plan

### 정상 동작 검증 (Mac)

1. `nrs` 실행 후 `gh extension list`를 확인한다.
   - **기대**: `gh attach`, `gh difftool`, `gh stack` 3개가 나열된다.
   - **실패 시**: `ls -la ~/.local/share/gh/extensions/`로 linkFarm symlink가 nix store의 gh-stack-0.1.0을 가리키는지 확인한다.

2. `gh stack --help`를 실행한다.
   - **기대**: stacked PR 사용법(`init`/`add`/`submit` 예시 포함)이 출력된다.
   - **실패 시**: `file ~/.local/share/gh/extensions/gh-stack/gh-stack`으로 바이너리 아키텍처가 현재 머신과 일치하는지 확인한다.

### MiniPC 검증 (다음 rebuild 시)

3. MiniPC에서 `nrs` 실행 후 `gh stack --help`를 확인한다.
   - **기대**: Mac과 동일하게 사용법이 출력된다 (static Go 바이너리라 patchelf 불필요).
   - **실패 시**: `file` 출력이 `statically linked`인지, x86_64-linux hash가 linux-amd64 asset과 일치하는지 확인한다.

### Regression 검증

4. Mac에서 `gh attach --help`와 `gh difftool --help`를 실행한다.
   - **기대**: extensions 리스트 재구성 후에도 기존 두 확장이 정상 동작한다.
   - **실패 시**: `default.nix`의 `lib.optionals isDarwin` 블록에 두 확장이 남아 있는지 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * `gh-stack` 확장을 추가해 모든 지원 플랫폼에서 사용할 수 있습니다.
  * macOS에서는 기존 `gh-attach` 및 `gh-difftool` 확장도 계속 제공됩니다.
  * 지원되는 플랫폼에 맞는 사전 빌드 바이너리가 자동으로 설치됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->