### PR TITLE
feat(hammerspoon): split 키보드 F11 → 바탕화면 보기

### DIFF
--- a/.claude/skills/automating-hammerspoon/references/hotkeys.md
+++ b/.claude/skills/automating-hammerspoon/references/hotkeys.md
@@ -6,6 +6,7 @@ Hammerspoon을 사용한 키보드 자동화 및 단축키 설정입니다.
 
 - [터미널 Ctrl/Opt 단축키 (한글 입력소스 문제 해결)](#터미널-ctrlopt-단축키-한글-입력소스-문제-해결)
 - [Finder → Ghostty 터미널 열기](#finder--ghostty-터미널-열기)
+- [Split 키보드(NocFree &) F키](#split-키보드nocfree--f키)
 
 ---
 
@@ -97,3 +98,41 @@ grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
 - 설정 리로드 완료 시 macOS 알림 표시
 
 > 참고: 구현 과정에서 발생한 문제와 해결 방법은 [`references/troubleshooting.md`의 "Hammerspoon 관련"](troubleshooting.md#hammerspoon-관련) 섹션을 참고하세요.
+
+## Split 키보드(NocFree &) F키
+
+`NocFree &` split 키보드는 펌웨어가 F10~F12를 macOS 미디어키로 내보냅니다. Hammerspoon은 그중 수식키 없는 F11만 가로채 "바탕화면 보기"로 바꿉니다.
+
+| 입력 | 동작 | 처리 주체 |
+| ---- | ---- | --------- |
+| `F11` | 바탕화면 보기 | Hammerspoon eventtap |
+| `Shift+F10` | 음소거 | 키보드 펌웨어 (통과) |
+| `Shift+F11` | 볼륨 다운 | 키보드 펌웨어 (통과) |
+| `Shift+F12` | 볼륨 업 | 키보드 펌웨어 (통과) |
+
+내장 키보드 영향 없음: 미디어키 이벤트는 `keyboardType`이 0으로 들어와 장치를 구분할 수 없지만(일반 키 이벤트는 split=40 / 내장=91), 내장 키보드는 `fnState=true` 때문에 볼륨 조절 시 `fn` 플래그가 붙습니다 (내장 `fn+F11` → `SOUND_DOWN flags=[fn]`). 수식키가 전혀 없는 `SOUND_DOWN`만 가로채므로 내장 키보드의 볼륨 조절은 그대로 유지됩니다.
+
+한계: 다른 외장 키보드를 연결하면 그 키보드의 볼륨 다운도 바탕화면 보기로 바뀝니다.
+
+### 펌웨어 쪽 제약 (Hammerspoon으로 처리 불가)
+
+이 키보드의 F키 대역은 펌웨어가 macOS 기본 레이아웃대로 할당해 두었지만, 일부 기능은 macOS에 신호가 도달하지 않거나 잘못 구현되어 있습니다. 키보드 설정 도구(`link.nocfree.com`)의 할당과 eventtap 실측을 대조한 결과:
+
+| 물리 키 | 펌웨어 할당 | macOS가 실제로 받는 신호 |
+| ------- | ----------- | ------------------------ |
+| `F1` / `F2` | 밝기 -/+ | 밝기 다운 / 밝기 업 (정상) |
+| `F3` | Mission Control | 없음 — 신호가 도달하지 않음 |
+| `F3` | 일반 `F3` 키로 교체 후 | `keycode=99 flags=[fn]` → Mission Control 정상 동작 |
+| `F4` | Spotlight | `Cmd+S` (한글 입력 상태에서 "ㄴ"이 입력됨) |
+| `F5` | 키보드 백라이트 - | 없음 — 신호가 도달하지 않음 |
+| `F10` / `F11` / `F12` | 음소거 / Vol- / Vol+ | 음소거 / 볼륨 다운 / 볼륨 업 (정상) |
+
+`Mission Control`·`키보드 백라이트` 기능키는 macOS가 Apple 자체 키보드 경로로만 처리하는 것으로 보여, 서드파티 키보드가 보내면 무시됩니다 (같은 키보드의 밝기·볼륨은 정상 동작). macOS 쪽에 가로챌 이벤트가 없으므로 Hammerspoon으로도 처리할 수 없습니다.
+
+해결: 설정 도구에서 그 자리를 일반 `F3` 키로 바꿉니다. 이 키보드는 F키를 보낼 때 `fn` 플래그를 붙이므로(`keycode=99 flags=[fn]`), macOS 기본 Mission Control 단축키(`AppleSymbolicHotKeys` 32번 = keycode 99 + fn 마스크 `0x800000`)에 그대로 걸립니다. 펌웨어 설정만으로 해결되며 Hammerspoon 개입이 필요 없습니다.
+
+설정 도구는 키보드를 wired 모드로 전환한 뒤 `link.nocfree.com`에 접속해 사용합니다 (NocFree Lite의 Vial과 달리 이 모델은 전용 웹 도구를 사용). 유선 모드와 무선 모드의 키 설정은 분리 저장되므로, 재할당 후 무선 모드로 되돌린 상태에서 동작을 다시 확인합니다.
+
+> F11도 같은 방식(일반 `F11` 키로 교체)으로 macOS 기본 "데스크탑 보기" 단축키에 걸릴 가능성이 있습니다. 다만 현재는 펌웨어가 `Vol -`를 보내는 상태를 전제로 위의 eventtap이 처리하며, 이쪽이 실측 검증을 마친 경로입니다.
+
+> 미디어키 이벤트의 `data1` 디코딩: `NX_KEYTYPE = data1 >> 16` (0=볼륨 업, 1=볼륨 다운, 2=밝기 업, 3=밝기 다운, 7=음소거)

--- a/.claude/skills/automating-hammerspoon/references/hotkeys.md
+++ b/.claude/skills/automating-hammerspoon/references/hotkeys.md
@@ -134,5 +134,5 @@ grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
 설정 도구는 키보드를 wired 모드로 전환한 뒤 `link.nocfree.com`에 접속해 사용합니다 (NocFree Lite의 Vial과 달리 이 모델은 전용 웹 도구를 사용). 같은 계열인 NocFree Lite 문서에는 유선/무선 설정이 분리 저장된다는 서술이 있으나, 이 모델에서는 유선으로 재할당한 뒤 도구를 닫고 Bluetooth로 되돌려도 설정이 유지되는 것을 실측 확인했습니다.
 
 > F11도 같은 방식(일반 `F11` 키로 교체)으로 macOS 기본 "데스크탑 보기" 단축키에 걸릴 가능성이 있습니다. 다만 현재는 펌웨어가 `Vol -`를 보내는 상태를 전제로 위의 eventtap이 처리하며, 이쪽이 실측 검증을 마친 경로입니다.
-
+>
 > 미디어키 이벤트의 `data1` 디코딩: `NX_KEYTYPE = data1 >> 16` (0=볼륨 업, 1=볼륨 다운, 2=밝기 업, 3=밝기 다운, 7=음소거)

--- a/.claude/skills/automating-hammerspoon/references/hotkeys.md
+++ b/.claude/skills/automating-hammerspoon/references/hotkeys.md
@@ -131,7 +131,7 @@ grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
 
 해결: 설정 도구에서 그 자리를 일반 `F3` 키로 바꿉니다. 이 키보드는 F키를 보낼 때 `fn` 플래그를 붙이므로(`keycode=99 flags=[fn]`), macOS 기본 Mission Control 단축키(`AppleSymbolicHotKeys` 32번 = keycode 99 + fn 마스크 `0x800000`)에 그대로 걸립니다. 펌웨어 설정만으로 해결되며 Hammerspoon 개입이 필요 없습니다.
 
-설정 도구는 키보드를 wired 모드로 전환한 뒤 `link.nocfree.com`에 접속해 사용합니다 (NocFree Lite의 Vial과 달리 이 모델은 전용 웹 도구를 사용). 유선 모드와 무선 모드의 키 설정은 분리 저장되므로, 재할당 후 무선 모드로 되돌린 상태에서 동작을 다시 확인합니다.
+설정 도구는 키보드를 wired 모드로 전환한 뒤 `link.nocfree.com`에 접속해 사용합니다 (NocFree Lite의 Vial과 달리 이 모델은 전용 웹 도구를 사용). 같은 계열인 NocFree Lite 문서에는 유선/무선 설정이 분리 저장된다는 서술이 있으나, 이 모델에서는 유선으로 재할당한 뒤 도구를 닫고 Bluetooth로 되돌려도 설정이 유지되는 것을 실측 확인했습니다.
 
 > F11도 같은 방식(일반 `F11` 키로 교체)으로 macOS 기본 "데스크탑 보기" 단축키에 걸릴 가능성이 있습니다. 다만 현재는 펌웨어가 `Vol -`를 보내는 상태를 전제로 위의 eventtap이 처리하며, 이쪽이 실측 검증을 마친 경로입니다.
 

--- a/modules/darwin/programs/hammerspoon/files/init.lua
+++ b/modules/darwin/programs/hammerspoon/files/init.lua
@@ -233,8 +233,11 @@ splitKeyboardShowDesktopTap = hs.eventtap.new(
             if pressed then return false end
         end
 
-        -- 실행은 keyDown 에서만. keyUp 도 소비해야 볼륨이 내려가지 않는다.
-        if sd.down then
+        -- 실행은 첫 keyDown 에서만. keyUp 도 소비해야 볼륨이 내려가지 않는다.
+        -- 키를 누르고 있으면 auto-repeat keyDown 이 이어지는데, 이때마다 토글하면
+        -- 바탕화면이 깜빡인다. repeat 은 Lua 예약어라 sd["repeat"] 로 접근한다
+        -- (sd.repeat 는 "<name> expected near 'repeat'" 컴파일 에러).
+        if sd.down and not sd["repeat"] then
             hs.spaces.toggleShowDesktop()
         end
         return true

--- a/modules/darwin/programs/hammerspoon/files/init.lua
+++ b/modules/darwin/programs/hammerspoon/files/init.lua
@@ -201,6 +201,47 @@ hs.urlevent.bind("claude-fork", function(eventName, params)
 end)
 
 --------------------------------------------------------------------------------
+-- Split 키보드(NocFree &) F11 → 바탕화면 보기
+--------------------------------------------------------------------------------
+-- 이 키보드는 펌웨어가 F10~F12를 macOS 미디어키로 내보낸다
+-- (F10=음소거, F11=볼륨 다운, F12=볼륨 업). Shift 조합도 같은 미디어키로 오므로
+-- Shift+F10/F11/F12 = 음소거/볼륨 다운/볼륨 업은 이미 동작한다.
+-- 여기서는 수식키 없는 F11(볼륨 다운)만 가로채 "바탕화면 보기"로 바꾼다.
+--
+-- 키보드 식별: 미디어키 이벤트는 keyboardType이 0으로 들어와 장치를 구분할 수 없다
+-- (일반 키 이벤트는 split=40 / 내장=91로 구분된다). 대신 내장 키보드는
+-- fnState=true 때문에 볼륨 조절 시 fn 플래그가 붙으므로(내장 fn+F11 →
+-- SOUND_DOWN flags=[fn]), 수식키가 전혀 없는 SOUND_DOWN만 가로채면 내장 키보드의
+-- 볼륨 조절은 영향받지 않는다.
+-- 한계: 다른 외장 키보드를 연결하면 그 키보드의 볼륨 다운도 여기에 걸린다.
+--
+-- 참고: 같은 키보드의 F3는 여기서 처리하지 않는다. 펌웨어에 "Mission Control" 기능키를
+-- 할당하면 신호가 macOS에 도달하지 않지만(Apple 자체 키보드 경로로만 처리되는 기능),
+-- 설정 도구에서 일반 F3 키로 바꾸면 이 키보드가 fn 플래그를 붙여 보내므로
+-- (keycode=99 flags=[fn]) macOS 기본 Mission Control 단축키에 그대로 걸린다.
+-- 즉 펌웨어 설정만으로 해결되며 Hammerspoon 개입이 필요 없다.
+
+-- eventtap은 참조가 사라지면 GC되므로 전역에 보관한다
+splitKeyboardShowDesktopTap = hs.eventtap.new(
+    {hs.eventtap.event.types.systemDefined},
+    function(e)
+        local sd = e:systemKey()
+        if not sd or sd.key ~= "SOUND_DOWN" then return false end
+
+        -- 수식키가 하나라도 눌려 있으면 원래 동작(볼륨 다운)을 유지한다
+        for _, pressed in pairs(e:getFlags()) do
+            if pressed then return false end
+        end
+
+        -- 실행은 keyDown 에서만. keyUp 도 소비해야 볼륨이 내려가지 않는다.
+        if sd.down then
+            hs.spaces.toggleShowDesktop()
+        end
+        return true
+    end)
+splitKeyboardShowDesktopTap:start()
+
+--------------------------------------------------------------------------------
 -- 설정 로드 완료 알림
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `NocFree &` split 키보드에서 수식키 없는 `F11`을 가로채 "바탕화면 보기"로 바꾼다 (기존에는 볼륨 다운으로 새고 있었다).
- 내장 키보드와 Shift 조합은 건드리지 않는다 — 미디어키 이벤트의 수식키 유무로 갈라내며, eventtap 실측으로 확인했다.
- 같은 키보드의 F키 대역 실측 매핑과 펌웨어 쪽 제약(F3·F5 신호 미도달, F4 오매핑)을 스킬 문서에 기록한다.

## 기존 문제/배경

`NocFree &` split 키보드에서 아래 동작을 원했으나, F3와 F11이 의도대로 동작하지 않았다.

| 원하는 동작 | 조사 전 상태 |
| --- | --- |
| `F3` → Mission Control | 아무 반응 없음 |
| `F11` → 바탕화면 보기 | 볼륨 다운으로 동작 |
| `Shift+F10/F11/F12` → 음소거/볼륨 다운/볼륨 업 | (미확인) |

eventtap으로 실제 이벤트를 실측하고 키보드 설정 도구의 할당과 대조한 결과, 이 키보드는 펌웨어가 F키 대역을 macOS 기본 레이아웃대로 할당해 두었으나 일부 기능은 신호가 macOS에 도달하지 않고 있었다.

| 물리 키 | 펌웨어 할당 | macOS가 실제로 받는 신호 |
| --- | --- | --- |
| `F1` / `F2` | 밝기 -/+ | 밝기 다운 / 밝기 업 (정상) |
| `F3` | Mission Control | 없음 — 신호가 도달하지 않음 |
| `F4` | Spotlight | `Cmd+S` (한글 입력 상태에서 "ㄴ"이 입력됨) |
| `F5` | 키보드 백라이트 - | 없음 — 신호가 도달하지 않음 |
| `F10` / `F11` / `F12` | 음소거 / Vol- / Vol+ | 음소거 / 볼륨 다운 / 볼륨 업 (정상) |

따라서 요청 5건 중 `Shift+F10/F11/F12` 3건은 펌웨어가 보내는 그대로 이미 충족되어 있었고, 코드로 손댈 것은 `F11` 하나였다.

`F3`는 조사 중 코드 없이 해결되어 이 PR에 구현이 없다. Mission Control 기능키는 macOS가 Apple 자체 키보드 경로로만 처리하는 것으로 보여 서드파티 키보드의 신호가 무시되지만(같은 키보드의 밝기·볼륨은 정상 동작), 설정 도구에서 그 자리를 일반 `F3` 키로 바꾸면 이 키보드가 `fn` 플래그를 붙여 보내므로(`keycode=99 flags=[fn]`) macOS 기본 Mission Control 단축키(`AppleSymbolicHotKeys` 32번 = keycode 99 + fn 마스크 `0x800000`)에 그대로 걸린다. 실측으로 확인했으며 매핑표와 함께 문서에 기록했다.

<img width="1587" height="1098" alt="image" src="https://github.com/user-attachments/assets/2b10eb94-a5ca-4f24-a31e-7e59bbf241ef" />


## CIR (Change Intent Record)

발견 경위: split 키보드 한정으로 F3/F11 동작을 바꿀 수 있는지 조사하는 과정에서 시작했다. "가능한가"부터 확인해야 했으므로 Hammerspoon에 임시 진단 eventtap을 걸어 실제 이벤트를 관측했다.

설계 의도와 조사 중 방향 전환:

- 처음에는 장치 식별자로 키보드를 구분하려 했다. 이 키보드는 Bluetooth LE 연결이고 VendorID/ProductID가 모두 `0x0`이라 그 둘로는 내장 키보드와 구분할 수 없었다.
- 이벤트의 `keyboardType` 필드가 split=40 / 내장=91로 갈리는 것을 실측해 구분 근거로 삼으려 했으나, 정작 대상인 미디어키(systemDefined) 이벤트에서는 이 값이 `0`으로 들어와 쓸 수 없었다.
- 최종적으로 수식키 플래그를 판별 기준으로 채택했다. 내장 키보드는 `fnState=true` 설정 때문에 볼륨 조절 시 `fn` 플래그가 붙는다 (내장 `fn+F11` → `SOUND_DOWN flags=[fn]`). split 키보드의 F11은 플래그가 비어 있다. 수식키가 전혀 없는 `SOUND_DOWN`만 가로채면 내장 키보드와 Shift 조합이 동시에 보호된다.

조사 중 바로잡은 오판: 진단 초기에 F3가 `systemDefined subtype=7 data1=1` 이벤트를 만든다고 판단했으나, 마우스 입력을 포함해 재측정한 결과 그것은 마우스 좌클릭이었다 (`data1`이 버튼 비트마스크: 1=좌, 2=우, 4=휠). 그대로 구현했다면 클릭할 때마다 Mission Control이 열렸을 것이다. 이 때문에 진단 로거에서 subtype 7을 노이즈로 제외하고 다시 측정했으며, 그 결과 F3는 어떤 이벤트도 만들지 않는다는 결론에 도달했다.

미디어키 판별에 쓴 디코딩: `NX_KEYTYPE = data1 >> 16` (0=볼륨 업, 1=볼륨 다운, 2=밝기 업, 3=밝기 다운, 7=음소거). 볼륨·음소거 실측값으로 교차 검증했다.

## ADR (Architecture Decision Record)

### 결정 1 — 어떤 계층에서 처리할 것인가

| 대안 | 설명 | 장점 | 단점 | 결정 |
| --- | --- | --- | --- | --- |
| 시스템 단축키 변경 | `system.defaults`의 symbolic hotkey를 조정 | 선언이 가장 단순 | 키보드별 분기가 원천적으로 불가능 — 내장 키보드에도 동일 적용됨 | ❌ |
| Karabiner-Elements | `device_if` 조건으로 장치별 분기 | 장치 식별이 확실 (`device_address` 조건 지원) | cask 추가 + DriverKit 시스템 확장 수동 승인 필요, 기존 리매핑과 중첩, 하드웨어 교체 시 주소 변경 | ❌ |
| Hammerspoon eventtap | 기존 `init.lua`에 systemDefined 탭 추가 | 이미 쓰는 인프라라 추가 설치가 없음, 필요한 API가 모두 실재 | 미디어키 이벤트에서 장치 식별 불가 → 별도 판별 근거 필요 | ✅ |

### 결정 2 — split 키보드를 어떻게 골라낼 것인가

| 대안 | 설명 | 장점 | 단점 | 결정 |
| --- | --- | --- | --- | --- |
| Vendor/Product ID | HID 장치 식별자로 분기 | 표준적인 방법 | 이 키보드는 둘 다 `0x0` — 내장 키보드와 구분 불가 | ❌ |
| `keyboardType` 필드 | 이벤트의 키보드 타입 값으로 분기 | 일반 키 이벤트에서는 split=40 / 내장=91로 명확히 갈림 | 대상인 미디어키 이벤트에서는 `0`으로 들어와 사용 불가 | ❌ |
| 수식키 플래그 | 플래그가 비어 있는 `SOUND_DOWN`만 처리 | 내장 키보드(`fn` 부착)와 Shift 조합을 한 조건으로 동시에 배제 | 다른 외장 키보드를 연결하면 그 볼륨 다운도 걸림 | ✅ |

수식키 플래그 방식의 한계는 인지하고 수용했다. 현재 연결되는 외장 키보드가 이 한 대뿐이라 실사용 문제가 없고, 필요해지면 그때 판별 조건을 좁히는 편이 낫다고 판단했다.

## 구현 상세

| 파일 | 변경 |
| --- | --- |
| `modules/darwin/programs/hammerspoon/files/init.lua` | systemDefined eventtap 추가 (+38줄) |
| `.claude/skills/automating-hammerspoon/references/hotkeys.md` | 실측 매핑표·판별 근거·펌웨어 제약 문서화 (+32줄) |

핵심 코드:

```lua
-- eventtap은 참조가 사라지면 GC되므로 전역에 보관한다
splitKeyboardShowDesktopTap = hs.eventtap.new(
    {hs.eventtap.event.types.systemDefined},
    function(e)
        local sd = e:systemKey()
        if not sd or sd.key ~= "SOUND_DOWN" then return false end

        -- 수식키가 하나라도 눌려 있으면 원래 동작(볼륨 다운)을 유지한다
        for _, pressed in pairs(e:getFlags()) do
            if pressed then return false end
        end

        -- 실행은 keyDown 에서만. keyUp 도 소비해야 볼륨이 내려가지 않는다.
        if sd.down then
            hs.spaces.toggleShowDesktop()
        end
        return true
    end)
splitKeyboardShowDesktopTap:start()
```

동작 시 유의점 두 가지를 코드에 반영했다.

- `keyUp`도 함께 소비한다 (`return true`). down 이벤트만 소비하면 up 이벤트가 통과해 볼륨이 함께 내려간다.
- eventtap 객체를 전역에 보관한다. 지역 변수에 두면 참조가 끊겨 GC 대상이 되고 탭이 조용히 죽는다.

`hs.spaces.toggleShowDesktop()`이 현재 macOS 버전에서 정상 동작함을 반영 전에 호출로 확인했다.

## 참고 레퍼런스

- [Karabiner-Elements `device_if` 조건 문서](https://karabiner-elements.pqrs.org/docs/json/complex-modifications-manipulator-definition/conditions/device/) — 대안 검토 시 확인한 장치 식별자 필드 목록
- [Karabiner-Elements issue #3515](https://github.com/pqrs-org/Karabiner-Elements/issues/3515) — Bluetooth 키보드의 vendor/product id가 0으로 보고되는 사례
- [NocFree FAQ](https://www.nocfree.com/pages/nocfree-faq) — 키 재할당은 유선 모드로 전환한 뒤 전용 웹 도구에서 수행한다는 안내. 같은 계열의 NocFree Lite 문서에는 유선/무선 설정이 분리 저장된다는 서술이 있으나, 이 모델에서는 유선으로 재할당한 뒤 도구를 닫고 Bluetooth로 되돌려도 설정이 유지되는 것을 실측 확인했다

## Human Test Plan

사전 조건: `nrs` 반영 완료, split 키보드가 연결된 상태.

| # | 단계 | 기대 동작 |
| --- | --- | --- |
| 1 | split 키보드에서 `F11` | 바탕화면이 보인다. 한 번 더 누르면 원래 창으로 돌아온다. 볼륨은 변하지 않는다 |
| 2 | split 키보드에서 `Shift+F11` | 볼륨이 내려간다 (바탕화면이 보이면 안 됨) |
| 3 | split 키보드에서 `Shift+F10` / `Shift+F12` | 음소거 / 볼륨 업 |
| 4 | 내장 키보드에서 `fn+F11` | 볼륨이 내려간다 (바탕화면이 보이면 안 됨) |
| 5 | 내장 키보드에서 `F11` | 기존 동작 그대로 (변화 없음) |
| 6 | split 키보드에서 `F3` | Mission Control이 열린다 (펌웨어를 일반 `F3` 키로 바꾼 상태 전제. 이 PR의 코드와 무관하게 macOS 기본 단축키로 동작하므로 회귀 감시용) |

실패 시 진단:

- 아무 반응이 없으면 탭이 살아 있는지 확인한다: Hammerspoon 콘솔에서 `splitKeyboardShowDesktopTap:isEnabled()`가 `true`여야 한다. `false`거나 `nil`이면 `init.lua` 반영 여부(`~/.hammerspoon/init.lua`)와 Hammerspoon 재시작을 확인한다.
- 2·3·4번에서 바탕화면이 보인다면 수식키 플래그가 이벤트에 실리지 않은 것이다. 진단용 eventtap으로 해당 입력의 `getFlags()` 값을 확인한다.
- 1번에서 볼륨까지 함께 내려가면 `keyUp` 이벤트가 통과하고 있는 것이다 — 콜백이 항상 `true`를 반환하는지 확인한다.
- 바탕화면 토글 자체가 동작하지 않으면 Hammerspoon 콘솔에서 `hs.spaces.toggleShowDesktop()`을 직접 호출해 API 쪽 문제인지 가른다.

미포함 항목: `F3`는 펌웨어 설정만으로 해결되어 이 PR에 코드가 없다. `F4`의 `Cmd+S` 오매핑과 `F5` 무반응은 그대로 남아 있으며, 필요해지면 설정 도구에서 같은 방식으로 재할당하면 된다.

후속 여지: 이 PR의 eventtap은 펌웨어가 F11 자리에서 `Vol -`를 보내는 상태를 전제한다. F3처럼 그 자리를 일반 `F11` 키로 바꾸면 macOS 기본 "데스크탑 보기" 단축키에 걸려 이 코드가 불필요해질 가능성이 있다. 다만 현재 경로가 실측 검증을 마친 쪽이고, 펌웨어 설정은 저장소에 선언으로 남지 않는다는 점을 고려해 현 구성을 유지한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 외장 분할 키보드의 특정 키를 사용해 macOS 바탕화면 보기를 전환할 수 있습니다.
  * 수식키를 함께 누르면 기존의 볼륨 낮추기 동작이 유지됩니다.

* **문서**
  * 분할 키보드의 F키·미디어키 동작과 관련 설정 방법을 추가로 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
