### PR TITLE
docs(hammerspoon): NocFree macOS F3 진단 정정

### DIFF
--- a/.claude/skills/automating-hammerspoon/references/hotkeys.md
+++ b/.claude/skills/automating-hammerspoon/references/hotkeys.md
@@ -114,22 +114,22 @@ grep -n "terminalOptKeys" modules/darwin/programs/hammerspoon/files/init.lua
 
 한계: 다른 외장 키보드를 연결하면 그 키보드의 볼륨 다운도 바탕화면 보기로 바뀝니다.
 
-### 펌웨어 쪽 제약 (Hammerspoon으로 처리 불가)
+### F3 입력 불일치와 해결
 
 이 키보드의 F키 대역은 펌웨어가 macOS 기본 레이아웃대로 할당해 두었지만, 일부 기능은 macOS에 신호가 도달하지 않거나 잘못 구현되어 있습니다. 키보드 설정 도구(`link.nocfree.com`)의 할당과 eventtap 실측을 대조한 결과:
 
 | 물리 키 | 펌웨어 할당 | macOS가 실제로 받는 신호 |
 | ------- | ----------- | ------------------------ |
 | `F1` / `F2` | 밝기 -/+ | 밝기 다운 / 밝기 업 (정상) |
-| `F3` | Mission Control | 없음 — 신호가 도달하지 않음 |
-| `F3` | 일반 `F3` 키로 교체 후 | `keycode=99 flags=[fn]` → Mission Control 정상 동작 |
+| `F3` | Mission Control | `Ctrl+Up` — 현재 macOS 단축키 설정과 불일치 |
+| `F3` | Basic의 일반 `F3`로 교체 후 | Mission Control 정상 동작 (유선/Bluetooth/2.4GHz) |
 | `F4` | Spotlight | `Cmd+S` (한글 입력 상태에서 "ㄴ"이 입력됨) |
 | `F5` | 키보드 백라이트 - | 없음 — 신호가 도달하지 않음 |
 | `F10` / `F11` / `F12` | 음소거 / Vol- / Vol+ | 음소거 / 볼륨 다운 / 볼륨 업 (정상) |
 
-`Mission Control`·`키보드 백라이트` 기능키는 macOS가 Apple 자체 키보드 경로로만 처리하는 것으로 보여, 서드파티 키보드가 보내면 무시됩니다 (같은 키보드의 밝기·볼륨은 정상 동작). macOS 쪽에 가로챌 이벤트가 없으므로 Hammerspoon으로도 처리할 수 없습니다.
+`Mission Control` 할당은 실제로 `Ctrl+Up`을 보내지만, 이 저장소는 macOS Mission Control 단축키를 `Fn+F3`(`AppleSymbolicHotKeys` 32번 = keycode 99 + fn 마스크 `0x800000`)로 선언합니다. 또한 `Ctrl+Up`은 Neovim 창 높이 조절에 사용하므로, 이를 전역 Mission Control 단축키로 되돌리거나 Hammerspoon에서 가로채면 기존 편집기 조작과 충돌합니다. 키보드 백라이트 F5는 기존 기록에서 신호가 관측되지 않았지만 이번 작업에서는 다시 검증하지 않았으므로 F3와 같은 원인이라고 단정하지 않습니다.
 
-해결: 설정 도구에서 그 자리를 일반 `F3` 키로 바꿉니다. 이 키보드는 F키를 보낼 때 `fn` 플래그를 붙이므로(`keycode=99 flags=[fn]`), macOS 기본 Mission Control 단축키(`AppleSymbolicHotKeys` 32번 = keycode 99 + fn 마스크 `0x800000`)에 그대로 걸립니다. 펌웨어 설정만으로 해결되며 Hammerspoon 개입이 필요 없습니다.
+해결: 설정 도구에서 `layer 1`의 물리 F3 한 자리만 선택하고 `Basic`의 일반 `F3`로 바꿉니다. 그러면 현재 macOS Mission Control 단축키와 맞아 정상 동작합니다. 유선에서 변경한 뒤 Bluetooth와 2.4GHz로 전환해도 설정이 유지되는 것을 실측했습니다. 펌웨어 설정만으로 해결되며 Hammerspoon 개입은 필요 없습니다.
 
 설정 도구는 키보드를 wired 모드로 전환한 뒤 `link.nocfree.com`에 접속해 사용합니다 (NocFree Lite의 Vial과 달리 이 모델은 전용 웹 도구를 사용). 같은 계열인 NocFree Lite 문서에는 유선/무선 설정이 분리 저장된다는 서술이 있으나, 이 모델에서는 유선으로 재할당한 뒤 도구를 닫고 Bluetooth로 되돌려도 설정이 유지되는 것을 실측 확인했습니다.
 

--- a/modules/darwin/programs/hammerspoon/files/init.lua
+++ b/modules/darwin/programs/hammerspoon/files/init.lua
@@ -215,11 +215,12 @@ end)
 -- 볼륨 조절은 영향받지 않는다.
 -- 한계: 다른 외장 키보드를 연결하면 그 키보드의 볼륨 다운도 여기에 걸린다.
 --
--- 참고: 같은 키보드의 F3는 여기서 처리하지 않는다. 펌웨어에 "Mission Control" 기능키를
--- 할당하면 신호가 macOS에 도달하지 않지만(Apple 자체 키보드 경로로만 처리되는 기능),
--- 설정 도구에서 일반 F3 키로 바꾸면 이 키보드가 fn 플래그를 붙여 보내므로
--- (keycode=99 flags=[fn]) macOS 기본 Mission Control 단축키에 그대로 걸린다.
--- 즉 펌웨어 설정만으로 해결되며 Hammerspoon 개입이 필요 없다.
+-- 참고: 같은 키보드의 F3는 여기서 처리하지 않는다. NocFree Link의 기본
+-- "Mission Control" 할당은 Ctrl+Up을 보내지만, 이 Mac은 Mission Control을
+-- Fn+F3(AppleSymbolicHotKeys 32번)로 선언하고 Ctrl+Up은 Neovim 창 크기 조절에
+-- 남겨 두므로 서로 맞지 않는다. Link에서 물리 F3 하나만 Basic의 일반 F3로
+-- 바꾸면 선언된 단축키와 맞아 Mission Control이 동작한다. 유선/Bluetooth/2.4GHz
+-- 모두 실측했으며 Hammerspoon 개입은 필요 없다.
 
 -- eventtap은 참조가 사라지면 GC되므로 전역에 보관한다
 splitKeyboardShowDesktopTap = hs.eventtap.new(


### PR DESCRIPTION
## Summary

- PR #1210의 F11 바탕화면 보기 구현은 유지하고, NocFree &의 F3 원인과 해결 방법을 실제 입력·연결 모드 검증 결과에 맞게 정정한다.
- 기본 `Mission Control` 할당은 신호가 없는 것이 아니라 `Ctrl+Up`을 보내며, 이 저장소가 선언한 `Fn+F3` 단축키와 맞지 않았음을 문서화한다.
- 실행 로직은 변경하지 않는다. NocFree Link에서 `layer 1`의 물리 F3만 `Basic > F3`로 바꾼 뒤 유선/Bluetooth/2.4GHz에서 정상 동작을 확인했다.

Related: #1210

## 기존 문제/배경

NocFree &를 macOS 레이아웃으로 사용해도 물리 F3가 Mission Control을 열지 않아, F11 처리를 추가한 PR #1210 전체를 되돌리는 방안을 검토했다.

현재 `main`과 PR #1210의 변경을 다시 확인한 결과, 두 키는 서로 다른 경로였다.

| 입력 | 실제 원인 | 현재 해결 |
| --- | --- | --- |
| `F3` | NocFree 기본 할당은 `Ctrl+Up`을 보내지만 macOS 설정은 `Fn+F3`를 Mission Control로 선언 | NocFree Link에서 물리 F3만 일반 `F3`로 변경 |
| `F11` | NocFree가 수식키 없는 `SOUND_DOWN`을 전송 | PR #1210의 Hammerspoon eventtap 유지 |

PR #1210을 되돌리면 F3는 해결되지 않고 정상 동작하는 F11만 다시 볼륨 다운으로 돌아간다. 또한 `Ctrl+Up`은 Neovim 창 높이 조절에 사용 중이므로 이를 macOS 전역 Mission Control 단축키로 바꾸거나 Hammerspoon에서 가로채는 것도 기존 조작과 충돌한다.

## CIR (Change Intent Record)

발견 경위:

- NocFree가 Windows 레이아웃이라 F3/F11이 동작하지 않는다고 처음 추정했으나, 연결 장치와 실제 입력을 확인한 결과 macOS 레이아웃이었다.
- PR #1210은 F11의 `SOUND_DOWN`만 처리하며 F3 실행 코드는 추가하지 않았다.
- 변경 전 NocFree 기본 `Mission Control` 할당의 raw HID 입력은 `Left Ctrl + Up`이었다. 반면 이 저장소의 `AppleSymbolicHotKeys` 32번은 keycode 99와 fn 마스크 `0x800000`으로 선언되어 있었다.

장치 변경 과정:

- NocFree Link에서 8개 레이어의 키 할당 110개씩을 읽어 변경 전 상태를 보존했다.
- 초기화나 macOS 템플릿 재적용 없이 `layer 1`의 물리 F3 한 자리만 `Mission Control`에서 `Basic > F3`로 바꿨다.
- 진단용 Hammerspoon eventtap을 켠 상태에서는 F3가 동작하지 않는 관찰자 효과가 확인되어 즉시 중지·제거했다. 최종 검증은 입력 기록기 없이 화면 동작과 기존 단축키 동작으로 수행했다.

방향 전환:

- 처음 검토한 전체 롤백 대신 F11 구현을 보존했다.
- macOS 전역 단축키나 Hammerspoon 로직을 추가하지 않고, 키보드의 F3 할당을 현재 선언과 맞추는 가장 좁은 해결을 선택했다.
- 기존 문서의 “F3 신호가 macOS에 도달하지 않는다”는 설명을 `Ctrl+Up`과 `Fn+F3`의 불일치로 정정했다.

## ADR (Architecture Decision Record)

| 대안 | 장점 | 단점 | 결정 |
| --- | --- | --- | --- |
| PR #1210 전체 롤백 | 변경을 한 번에 제거 | F3는 해결되지 않고 정상인 F11만 회귀 | ❌ |
| macOS Mission Control을 전역 `Ctrl+Up`으로 변경 | NocFree 기본 할당을 그대로 사용 | Neovim `Ctrl+Up` 창 높이 조절과 충돌하고 다른 키보드에도 전역 적용 | ❌ |
| Hammerspoon에서 NocFree `Ctrl+Up` 처리 | 저장소에 선언 가능 | 물리 F3와 실제 `Ctrl+Up`을 구분할 수 없어 편집기 조작을 가로챔 | ❌ |
| NocFree Link에서 물리 F3만 일반 `F3`로 변경 | 영향 범위가 한 키로 제한되고 기존 F11·Ctrl+Up을 보존 | 기기 설정이라 초기화 후 재설정이 필요할 수 있음 | ✅ |

저장소에는 장치 설정 자체를 선언할 수 없으므로, 재현 가능한 설정 경로와 실측 결과를 Hammerspoon 주석 및 스킬 레퍼런스에 남긴다.

## 구현 상세

| 파일 | 변경 |
| --- | --- |
| `modules/darwin/programs/hammerspoon/files/init.lua` | F3를 Hammerspoon에서 처리하지 않는 실제 이유와 NocFree Link 해결 경로를 주석으로 정정 |
| `.claude/skills/automating-hammerspoon/references/hotkeys.md` | F3 입력표를 `Ctrl+Up`으로 정정하고, `layer 1 > Basic > F3` 절차 및 연결 모드별 실측 결과 기록 |

실행 코드 변경은 없다. PR #1210의 `splitKeyboardShowDesktopTap`과 macOS `AppleSymbolicHotKeys` 설정도 그대로 유지한다.

F5는 기존 기록에서 신호가 관측되지 않았지만 이번 작업에서는 재검증하지 않았다. F3와 동일한 원인이라고 확대 해석하지 않도록 문서에서 명시적으로 분리했다.

## 참고 레퍼런스

- #1210 — 기존 NocFree F11 바탕화면 보기 구현과 최초 F키 조사
- [NocFree Link](https://link.nocfree.com/) — `layer 1` 물리 F3를 `Basic > F3`로 변경한 공식 설정 도구
- [NocFree & Manual](https://www.nocfree.com/pages/nocfree-and-manual) — 키보드 연결 및 사용 안내
- `modules/darwin/configuration.nix` — Mission Control용 `AppleSymbolicHotKeys` 32번 선언
- Neovim 키맵 레퍼런스 — `Ctrl+Up` 창 높이 조절 사용 확인

관련 GitHub issue 검색 결과는 없었다.

## Human Test Plan

- [x] NocFree Link에서 변경 전 8개 레이어 × 110키 할당을 읽고, `layer 1`의 F3만 변경되는지 확인
- [x] 유선 모드: `F3` → Mission Control, `F11` → 바탕화면 보기
- [x] Bluetooth 모드: `F3` → Mission Control, `F11` → 바탕화면 보기
- [x] 2.4GHz 동글 모드: `F3` → Mission Control, `F11` → 바탕화면 보기
- [x] Neovim 가로 분할에서 `Ctrl+Up` → 창 높이 증가
- [x] `Shift+F11` → 볼륨 다운, 바탕화면 보기는 실행되지 않음
- [x] `luac -p modules/darwin/programs/hammerspoon/files/init.lua`
- [x] `./scripts/ai/check-skill-noise.sh .claude/skills`
- [x] `./scripts/ai/verify-ai-compat.sh` — 통과, 기존 `managing-vscode` description 길이 경고 1건만 발생
- [x] `git diff --check`

실행 로직이 바뀌지 않았으므로 `nrs` 재빌드는 수행하지 않았다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * F3 키 입력이 macOS Mission Control 단축키와 일치하도록 설정하는 방법을 안내합니다.
  * 유선, Bluetooth, 2.4GHz 연결에서 일반 F3 설정 시 Mission Control이 정상 작동함을 반영했습니다.
  * F5 키 동작은 추가 검증 전까지 F3과 동일한 원인으로 단정하지 않도록 내용을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->