### PR TITLE
fix(secrets): 시크릿 교체 전파 트리거 추가 + flake source 결합 정정

### DIFF
--- a/modules/nixos/programs/caddy.nix
+++ b/modules/nixos/programs/caddy.nix
@@ -22,6 +22,13 @@ let
 
   envFilePath = "/run/caddy/env";
 
+  # 암호문의 개별 store path — 재시작 트리거용. 문자열 보간이 필수다:
+  # .file을 path 값 그대로 리스트에 넣으면 toString 경로를 타서 flake source 전체
+  # (/nix/store/<hash>-source/secrets/...)에 결합되고, 무관한 커밋마다 Caddy가 재시작된다
+  # (= 전체 리버스 프록시 순간 단절). "${...}"는 그 파일 하나를 개별 store 객체로 복사해
+  # 암호문 내용에만 의존한다 (실측 확인).
+  tokenCiphertext = "${config.age.secrets.cloudflare-dns-api-token.file}";
+
   # 보안 헤더 (모든 virtualHost에 공통 적용)
   securityHeaders = import ../lib/caddy-security-headers.nix;
 
@@ -52,6 +59,11 @@ in
       description = "Generate Caddy environment file with Cloudflare token";
       wantedBy = [ "caddy.service" ];
       before = [ "caddy.service" ];
+      # envScript는 시크릿의 런타임 '경로'(/run/agenix/...)만 담으므로 .age를 재암호화해도
+      # store path가 그대로다. 암호문을 트리거로 걸어야 토큰 교체가 env 파일 재생성으로 이어진다.
+      # 이게 없으면 RemainAfterExit=true라 소비 서비스를 재시작해도 이 유닛은 재실행되지 않아
+      # 구 토큰이 계속 유효하다.
+      restartTriggers = [ tokenCiphertext ];
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;
@@ -139,6 +151,9 @@ in
         "tailscaled.service"
         "caddy-env.service"
       ];
+      # env 파일 내용은 유닛 정의에 들어가지 않고 경로만 들어간다. 암호문을 트리거로 걸어야
+      # 토큰 교체가 Caddy 재시작(새 env 파일 로드)으로 이어진다. Caddy는 env를 시작 시점에만 읽는다.
+      restartTriggers = [ tokenCiphertext ];
       serviceConfig = {
         ExecStartPre = import ../lib/tailscale-wait.nix { inherit pkgs; };
         EnvironmentFile = envFilePath;

--- a/modules/nixos/programs/docker/copyparty.nix
+++ b/modules/nixos/programs/docker/copyparty.nix
@@ -16,6 +16,11 @@ let
 
   configPath = "${dockerData}/copyparty/config/copyparty.conf";
   passwordPath = config.age.secrets.copyparty-password.path;
+  # 암호문의 개별 store path — 재시작 트리거용. 문자열 보간이 필수다:
+  # .file을 path 값 그대로 리스트에 넣으면 toString 경로를 타서 flake source 전체
+  # (/nix/store/<hash>-source/secrets/...)에 결합되고, 무관한 커밋마다 재시작이 발생한다.
+  # "${...}"는 그 파일 하나를 개별 store 객체로 복사해 암호문 내용에만 의존한다 (실측 확인).
+  passwordCiphertext = "${config.age.secrets.copyparty-password.file}";
 
   # 비밀번호를 주입한 설정 파일 생성
   # <<'CONF' (quoted heredoc)로 셸 해석 방지 + printf로 비밀번호만 안전 삽입
@@ -73,7 +78,7 @@ in
       before = [ "podman-copyparty.service" ];
       # configScript는 비밀번호 '경로'만 담으므로 .age를 재암호화해도 store path가 그대로다.
       # 암호문 자체를 트리거로 걸어야 비밀번호 교체가 conf 재생성으로 이어진다.
-      restartTriggers = [ config.age.secrets.copyparty-password.file ];
+      restartTriggers = [ passwordCiphertext ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = configScript;
@@ -123,7 +128,7 @@ in
       # (copyparty는 시작 시점에만 conf를 읽는다).
       restartTriggers = [
         configScript
-        config.age.secrets.copyparty-password.file
+        passwordCiphertext
       ];
     };
   };

--- a/modules/nixos/programs/docker/karakeep.nix
+++ b/modules/nixos/programs/docker/karakeep.nix
@@ -27,10 +27,8 @@ let
   # 넣으면 toString 경로를 타서 flake source 전체(/nix/store/<hash>-source/secrets/...)에
   # 결합되고, 무관한 커밋마다 재시작이 발생한다. "${...}"는 그 파일 하나를 개별 store 객체로
   # 복사해 암호문 내용에만 의존한다 (실측 확인).
-  sharedSecretCiphertexts = [
-    "${config.age.secrets.karakeep-nextauth-secret.file}"
-    "${config.age.secrets.karakeep-meili-master-key.file}"
-  ];
+  nextauthCiphertext = "${config.age.secrets.karakeep-nextauth-secret.file}";
+  meiliCiphertext = "${config.age.secrets.karakeep-meili-master-key.file}";
   openaiSecretCiphertext = "${config.age.secrets.karakeep-openai-key.file}";
 
   # agenix 시크릿에서 공통 환경변수 파일 생성 (karakeep + meilisearch)
@@ -98,7 +96,11 @@ in
       before = [ "podman-karakeep.service" ];
       # 생성 스크립트는 시크릿의 런타임 '경로'만 담으므로 .age를 재암호화해도 store path가
       # 그대로다. 암호문을 트리거로 걸어야 시크릿 교체가 env 파일 재생성으로 이어진다.
-      restartTriggers = sharedSecretCiphertexts;
+      # 이 파일에는 두 시크릿이 모두 쓰이므로 둘 다 건다.
+      restartTriggers = [
+        nextauthCiphertext
+        meiliCiphertext
+      ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = sharedEnvScript;
@@ -253,7 +255,11 @@ in
       # env 파일 내용은 컨테이너 유닛에 들어가지 않고 경로만 들어간다. 소비하는 두 env 파일의
       # 원천 암호문을 모두 트리거로 걸어야 시크릿 교체가 컨테이너 재시작으로 이어진다
       # (env 파일은 시작 시점에만 읽힌다). 생성 유닛에만 걸면 파일만 갱신되고 프로세스는 옛 값을 유지한다.
-      restartTriggers = sharedSecretCiphertexts ++ [ openaiSecretCiphertext ];
+      restartTriggers = [
+        nextauthCiphertext
+        meiliCiphertext
+        openaiSecretCiphertext
+      ];
       unitConfig = {
         ConditionPathExists = nextauthSecretPath;
         RequiresMountsFor = mediaData;
@@ -274,9 +280,10 @@ in
         "create-karakeep-network.service"
         "karakeep-env.service"
       ];
-      # shared env 파일(MEILI_MASTER_KEY)만 소비하므로 그 원천 암호문만 트리거로 건다.
+      # shared env 파일에서 실제 사용하는 credential은 MEILI_MASTER_KEY뿐이므로 그 암호문만
+      # 트리거로 건다 — nextauth 교체로 검색 서비스가 재시작될 이유가 없다.
       # karakeep-chrome은 environmentFiles가 없어 트리거 대상이 아니다.
-      restartTriggers = sharedSecretCiphertexts;
+      restartTriggers = [ meiliCiphertext ];
       unitConfig = {
         RequiresMountsFor = mediaData;
       };

--- a/modules/nixos/programs/docker/karakeep.nix
+++ b/modules/nixos/programs/docker/karakeep.nix
@@ -22,6 +22,17 @@ let
   sharedEnvFilePath = "/run/karakeep-env";
   openaiEnvFilePath = "/run/karakeep-openai-env";
 
+  # 암호문의 개별 store path — 재시작 트리거용. 위 *Path(런타임 복호화 경로 /run/agenix/...)와
+  # 달리 .age 내용이 바뀌면 값이 바뀐다. 문자열 보간이 필수다: .file을 path 값 그대로 리스트에
+  # 넣으면 toString 경로를 타서 flake source 전체(/nix/store/<hash>-source/secrets/...)에
+  # 결합되고, 무관한 커밋마다 재시작이 발생한다. "${...}"는 그 파일 하나를 개별 store 객체로
+  # 복사해 암호문 내용에만 의존한다 (실측 확인).
+  sharedSecretCiphertexts = [
+    "${config.age.secrets.karakeep-nextauth-secret.file}"
+    "${config.age.secrets.karakeep-meili-master-key.file}"
+  ];
+  openaiSecretCiphertext = "${config.age.secrets.karakeep-openai-key.file}";
+
   # agenix 시크릿에서 공통 환경변수 파일 생성 (karakeep + meilisearch)
   sharedEnvScript = pkgs.writeShellScript "karakeep-env-gen" ''
     set -euo pipefail
@@ -85,6 +96,9 @@ in
       description = "Generate Karakeep shared environment file from agenix secrets";
       wantedBy = [ "podman-karakeep.service" ];
       before = [ "podman-karakeep.service" ];
+      # 생성 스크립트는 시크릿의 런타임 '경로'만 담으므로 .age를 재암호화해도 store path가
+      # 그대로다. 암호문을 트리거로 걸어야 시크릿 교체가 env 파일 재생성으로 이어진다.
+      restartTriggers = sharedSecretCiphertexts;
       serviceConfig = {
         Type = "oneshot";
         ExecStart = sharedEnvScript;
@@ -97,6 +111,8 @@ in
       description = "Generate Karakeep OpenAI environment file from agenix secrets";
       wantedBy = [ "podman-karakeep.service" ];
       before = [ "podman-karakeep.service" ];
+      # karakeep-env와 동일한 계약 — 암호문 변경이 env 파일 재생성으로 이어진다.
+      restartTriggers = [ openaiSecretCiphertext ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = openaiEnvScript;
@@ -234,6 +250,10 @@ in
         "karakeep-env.service"
         "karakeep-openai-env.service"
       ];
+      # env 파일 내용은 컨테이너 유닛에 들어가지 않고 경로만 들어간다. 소비하는 두 env 파일의
+      # 원천 암호문을 모두 트리거로 걸어야 시크릿 교체가 컨테이너 재시작으로 이어진다
+      # (env 파일은 시작 시점에만 읽힌다). 생성 유닛에만 걸면 파일만 갱신되고 프로세스는 옛 값을 유지한다.
+      restartTriggers = sharedSecretCiphertexts ++ [ openaiSecretCiphertext ];
       unitConfig = {
         ConditionPathExists = nextauthSecretPath;
         RequiresMountsFor = mediaData;
@@ -254,6 +274,9 @@ in
         "create-karakeep-network.service"
         "karakeep-env.service"
       ];
+      # shared env 파일(MEILI_MASTER_KEY)만 소비하므로 그 원천 암호문만 트리거로 건다.
+      # karakeep-chrome은 environmentFiles가 없어 트리거 대상이 아니다.
+      restartTriggers = sharedSecretCiphertexts;
       unitConfig = {
         RequiresMountsFor = mediaData;
       };


### PR DESCRIPTION
## Summary

- agenix 시크릿 재암호화가 caddy·karakeep 런타임 파일과 실행 중인 서비스에 반영되지 않던 문제를 해결한다 (Closes #1208)
- copyparty에 먼저 도입됐던 `restartTriggers`의 결합 범위 결함을 정정한다 — 기존 형태는 flake source 전체에 결합되어 무관한 커밋마다 컨테이너가 재시작됐다
- 트리거 값을 문자열 보간(`"${...file}"`)으로 통일해 암호문 내용에만 의존하게 한다

## 기존 문제/배경

이 저장소는 "agenix 시크릿 → oneshot 유닛이 런타임 설정/env 파일 생성 → 소비 서비스가 시작 시 1회 읽음" 구조를 세 서비스(copyparty, caddy, karakeep)에서 쓴다. 생성 스크립트는 시크릿의 런타임 경로(`/run/agenix/...`)만 담으므로 `.age`를 재암호화해도 스크립트의 store path가 불변이고, 생성 유닛은 `RemainAfterExit=true`라 소비 서비스를 재시작해도 재실행되지 않는다. 결과적으로 문서화된 교체 절차(`agenix -e` 후 `nrs`)를 따라도 구 credential이 계속 유효했다 — 노출된 시크릿을 폐기하려는 상황에서 조용히 무효가 되는 경로다.

copyparty는 직전 작업(#1209)에서 암호문 파일을 `restartTriggers`로 걸어 이 문제를 먼저 해결했다. 그런데 이번 작업 중 그 트리거 값에 별개의 결함이 있음을 발견했다: `.file`을 path 값 그대로 리스트에 넣으면 `toString` 경로를 타서 `/nix/store/<hash>-source/secrets/...` 형태로 평가된다. 이 값은 flake source 전체 해시에 결합되므로, **저장소의 tracked 파일이 하나라도 바뀌면 트리거 값이 바뀌어 서비스가 재시작된다.** 실측으로 확증했다 — README.md에 한 줄을 추가하자 `podman-copyparty`의 트리거 값이 변했다. 같은 형태를 caddy에 복제했다면 모든 커밋 후 `nrs`마다 리버스 프록시가 단절될 뻔했다.

## CIR (Change Intent Record)

**발견 경위**: #1208의 이행 가이드를 작성하고 독립 감사를 돌리던 중, 감사가 "`.file` 트리거가 flake source 전체에 결합될 수 있다"고 지적했다. 처음에는 `nix eval --raw '...file'`이 개별 store path를 반환하는 것을 근거로 기각했으나, 그 측정이 틀렸음이 드러났다 — `--raw` 단독 평가는 파일을 개별 store 객체로 복사하지만, `restartTriggers` 리스트 안에서 path 값이 `toString`될 때는 source 하위 경로가 된다. 무관한 파일 변경 실험으로 재검증하자 값이 바뀌었고, 지적이 옳았음을 확인했다.

**해법 선택**: 문자열 보간 `"${config.age.secrets.<name>.file}"`을 표준 형태로 확정했다. Nix에서 path를 문자열에 보간하면 그 파일 하나가 개별 store 객체로 복사되어(`/nix/store/<hash>-<name>.age`) 값이 암호문 내용에만 의존한다. 세 가지 후보를 실측 비교한 결과다 — `toString`(source 결합, 탈락), 보간(개별 객체, 채택), `builtins.hashFile`(내용 해시라 동작하지만 store path가 더 관용적이라 탈락).

**양쪽 유닛에 거는 이유**: 생성 유닛에만 걸면 파일은 갱신되지만 실행 중인 프로세스가 옛 값을 유지하고, 소비 유닛에만 걸면 파일이 옛 값이라 재시작해도 소용없다. env/conf 파일은 시작 시점에만 읽힌다.

**리뷰 중 반영한 결정**: meilisearch의 트리거를 shared 시크릿 묶음에서 `MEILI_MASTER_KEY` 암호문 하나로 좁혔다. shared env 파일에는 nextauth도 담기지만 meilisearch가 실제 사용하는 credential은 master key뿐이라, nextauth 교체로 검색 서비스가 재시작될 이유가 없다. 이 판단에 맞춰 묶음 바인딩을 시크릿별 개별 바인딩으로 분해했다.

**반영하지 않은 것**: 트리거 변수의 이름을 `*StorePath`로 바꾸자는 제안은 기각됐다 — 인접 주석이 값의 실체("암호문의 개별 store path")를 명시하고 있고 변수가 지역 범위에서 `restartTriggers`에만 쓰여 현실적 오수정 경로가 없다.

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| `.file` 직접 참조 (기존 copyparty 형태) | path 값을 리스트에 그대로 | 코드가 짧다 | `toString` 경로로 flake source 전체에 결합 — 무관한 커밋마다 재시작 (실측 확증) | ❌ |
| 문자열 보간 `"${...file}"` | 파일을 개별 store 객체로 복사 | 암호문 내용에만 의존, store path라 diff로 변경 시점 추적 가능 | 보간이 필수라는 사실이 비자명 (주석으로 보완) | ✅ |
| `builtins.hashFile "sha256"` | 내용 해시를 트리거로 | 내용에만 의존 | 동작은 같으나 store path 대비 비관용적, 평가 시 파일 읽기 필요 | ❌ |
| 시크릿별 개별 바인딩 | nextauth/meili/openai 각각 | 유닛마다 실제 의존만 나열 가능 (meilisearch over-trigger 제거) | 바인딩 수 증가 | ✅ |
| 공통 헬퍼 모듈 | 세 파일의 패턴을 추상화 | 중복 제거 | 호출처 3곳에 과설계, 파일별 독립 이해 저해 | ❌ |

## 구현 상세

| 파일 | 변경 |
|------|------|
| `modules/nixos/programs/docker/copyparty.nix` | 기존 트리거 2곳을 보간 형태(`passwordCiphertext`)로 정정 |
| `modules/nixos/programs/caddy.nix` | `caddy-env`·`caddy`에 `tokenCiphertext` 트리거 신설 |
| `modules/nixos/programs/docker/karakeep.nix` | 시크릿별 바인딩 3개 + 유닛 4곳(`karakeep-env`, `karakeep-openai-env`, `podman-karakeep`, `podman-karakeep-meilisearch`) 트리거 신설 |

핵심 형태 (세 파일 공통):

```nix
# 암호문의 개별 store path — 재시작 트리거용. 문자열 보간이 필수다:
# .file을 path 값 그대로 리스트에 넣으면 toString 경로를 타서 flake source 전체
# (/nix/store/<hash>-source/secrets/...)에 결합되고, 무관한 커밋마다 재시작이 발생한다.
tokenCiphertext = "${config.age.secrets.cloudflare-dns-api-token.file}";
```

시크릿→유닛 매핑 (`nix eval`로 전수 확인):

| 암호문 | 트리거가 걸린 유닛 |
|--------|--------------------|
| cloudflare-dns-api-token | `caddy-env`, `caddy` |
| copyparty-password | `copyparty-config`, `podman-copyparty` |
| karakeep-nextauth-secret | `karakeep-env`, `podman-karakeep` |
| karakeep-meili-master-key | `karakeep-env`, `podman-karakeep`, `podman-karakeep-meilisearch` |
| karakeep-openai-key | `karakeep-openai-env`, `podman-karakeep` |

`karakeep-chrome`은 `environmentFiles`가 없어 대상이 아니다. 암호문 store path는 agenix가 이미 시스템 closure에 넣는 값이라 트리거 노출이 표면을 넓히지 않는다.

## 참고 레퍼런스

- #1208 — 이 PR이 닫는 이슈 (caddy·karakeep 교체 무효)
- #1209 — copyparty에 트리거를 먼저 도입한 PR. 그 트리거의 결합 범위를 이 PR이 정정한다
- caddy.nix의 `(copyparty-config 패턴)` 주석 — 세 서비스가 같은 구조를 공유함을 명시. 이 PR로 세 인스턴스의 동작이 다시 동등해진다

## Human Test Plan

**첫 배포는 중단성 작업이다.** 트리거가 새로 추가/변경되어 시크릿이 그대로여도 첫 `nrs`에서 Caddy·copyparty·karakeep·meilisearch가 같은 activation에서 재시작된다. Caddy 재시작 동안 모든 HTTPS 경로가 순간 단절되고, Caddy와 백엔드 간 시작 순서 보장이 없어 재시작 직후 짧은 502 구간이 있을 수 있다. copyparty는 재시작 시 재스캔을 수행한다(dhash 가속으로 수 초). **사용량이 낮은 시간대에 적용한다.**

1. **배포 전 트리거 평가 확인** (Mac에서 가능, 재시작 없음)

```bash
nix eval --json '.#nixosConfigurations.greenhead-minipc.config.systemd.services.caddy.restartTriggers'
```

기대: `["/nix/store/<hash>-cloudflare-dns-api-token.age"]` — `-source/`가 포함되어 있으면 결합 결함이 재발한 것.

2. **배포** (MiniPC)

```bash
nrs
```

기대: preview에 `X-Restart-Triggers-caddy` 등 8개 유닛의 트리거 항목이 나타나고, 위 서비스들이 재시작된다. 배포 후 `curl -s -o /dev/null -w '%{http_code}' https://copyparty.greenhead.dev` → 200.

3. **over-triggering 해소 확인** (무관한 커밋 후)

다음 무관한 변경을 머지·배포할 때 이 서비스들이 재시작되지 **않는지** 확인한다. `nrs` preview에 `X-Restart-Triggers-*` 변경이 없어야 정상이다. 이전 형태에서는 매 커밋마다 나타났다.

4. **시크릿 교체 전파 확인** (실제 교체가 필요해질 때)

```bash
(cd secrets && agenix -e karakeep-openai-key.age)   # 값 변경
nrs
systemctl show karakeep-openai-env podman-karakeep -p ActiveEnterTimestamp
```

기대: 두 유닛의 시각이 배포 시각으로 갱신. meilisearch는 재시작되지 않아야 한다(openai 키를 소비하지 않으므로).

**실패 시 진단**: 유닛이 재시작되지 않으면 `systemctl cat <유닛> | grep X-Restart-Triggers`로 트리거에 해당 암호문 store path가 들어있는지 확인한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Cloudflare, Copyparty, Karakeep 관련 보안 비밀값이 변경되면 해당 환경 설정이 자동으로 갱신됩니다.
  - 변경된 비밀값을 적용하기 위해 관련 서비스와 컨테이너가 자동으로 재시작됩니다.
  - Caddy, Copyparty, Karakeep 및 Meilisearch의 설정 적용 상태가 더욱 일관되게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->